### PR TITLE
feat(daemon): support Agent Plugins as task plugin paths

### DIFF
--- a/src/lingtai/tools/daemon/__init__.py
+++ b/src/lingtai/tools/daemon/__init__.py
@@ -22,6 +22,7 @@ import sys
 import threading
 import time
 import yaml
+from lingtai.services import plugin_registry as _plugin_registry
 from copy import deepcopy
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -1008,6 +1009,7 @@ class _CliTaskContext:
     skill_catalog: str | None
     mcp_catalog: str | None
     mcp_regs: list[dict]
+    plugin_catalog: str | None = None
 
 
 @dataclass(frozen=True)
@@ -1734,6 +1736,218 @@ class DaemonManager:
         return {"name": name, "location": str(skill_file), "description": description}
 
     @staticmethod
+    def _plugin_path_resolution(raw_path: str, working_dir) -> Path:
+        """Resolve one daemon task plugin path to a concrete plugin directory."""
+        p = Path(raw_path).expanduser()
+        if not p.is_absolute():
+            p = working_dir / p
+        return p.resolve(strict=False)
+
+    @staticmethod
+    def _plugin_mcp_spec_to_registration(
+        plugin_name: str, server_name: str, spec: dict
+    ) -> dict:
+        """Translate one resolved plugin mcp.json server into a task MCP registration.
+
+        Mirrors ``plugin_registry.to_registry_record`` transport mapping: the
+        Agent Plugins v1.0.0 transports ``stdio`` / ``streamable-http`` / ``sse``
+        land on the daemon registration transports ``stdio`` / ``http``. The
+        resolved spec already carries absolute, containment-validated paths, so
+        the registration is directly usable by the LingTai backend client.
+        """
+        transport_map = {
+            "stdio": "stdio",
+            "streamable-http": "http",
+            "sse": "http",
+        }
+        transport = transport_map.get(spec.get("type"))
+        if transport is None:
+            raise ValueError(
+                f"plugin {plugin_name!r} mcp server {server_name!r}: unsupported "
+                f"transport {spec.get('type')!r}"
+            )
+        reg: dict = {"name": server_name, "transport": transport}
+        if transport == "stdio":
+            command = spec.get("command")
+            if not isinstance(command, str) or not command:
+                raise ValueError(
+                    f"plugin {plugin_name!r} mcp server {server_name!r}: stdio "
+                    "requires command"
+                )
+            reg["command"] = command
+            args = spec.get("args")
+            if args:
+                reg["args"] = list(args)
+            env = spec.get("env")
+            if env:
+                reg["env"] = dict(env)
+            cwd = spec.get("cwd")
+            if cwd:
+                reg["cwd"] = cwd
+        else:
+            url = spec.get("url")
+            if not isinstance(url, str) or not url:
+                raise ValueError(
+                    f"plugin {plugin_name!r} mcp server {server_name!r}: http "
+                    "requires url"
+                )
+            reg["url"] = url
+            headers = spec.get("headers")
+            if headers:
+                reg["headers"] = dict(headers)
+        return reg
+
+    @staticmethod
+    def _render_task_plugin_catalog(plugins: list[dict]) -> str | None:
+        """Render the compact plugin section injected into a daemon run prompt.
+
+        This mirrors the main agent's resident ``plugins`` prompt field: the
+        daemon sees the same whole-plugin view (name, summary, skills list, mcp
+        list) instead of a flattened skills/mcp split, so it understands that
+        the components belong to one distributable unit. Plugins whose mcp.json
+        servers were also mounted as task MCP clients are marked ``mounted``.
+        """
+        if not plugins:
+            return None
+        lines = [
+            "The parent selected these Agent Plugins for this daemon run. Read/apply their skills only when relevant to your task:",
+            "plugins:",
+        ]
+        for pl in plugins:
+            name = pl.get("name", "")
+            summary = pl.get("summary", "")
+            lines.append(f"  - name: {name}")
+            if summary:
+                lines.append(f"    summary: {summary}")
+            skills = pl.get("skills") or []
+            lines.append(f"    skills ({len(skills)}):")
+            for sk in skills:
+                lines.append(f"      - {sk}")
+            servers = pl.get("mcp_servers") or []
+            mounted = set(pl.get("mounted_mcp") or [])
+            lines.append(f"    mcp ({len(servers)}):")
+            for server in servers:
+                marker = " (mounted)" if server in mounted else ""
+                lines.append(f"      - {server}{marker}")
+        return "\n".join(lines)
+
+    def _task_plugin_context(
+        self, spec: dict
+    ) -> tuple[str | None, list[dict], list[dict]]:
+        """Resolve one daemon task's ``plugin`` paths.
+
+        Returns ``(plugin_catalog, plugin_skill_rows, plugin_mcp_regs)``.
+        ``plugin_skill_rows`` are compact skill catalog rows parsed from each
+        plugin's validated ``skills/``; ``plugin_mcp_regs`` are full MCP
+        registration objects translated from each plugin's validated ``mcp.json``.
+        The LingTai backend mounts ``plugin_mcp_regs`` as task-scoped MCP clients
+        and merges ``plugin_skill_rows`` into the skill catalog; CLI backends that
+        cannot mount plugins still receive the same skills and MCP registrations
+        separately through the normal skill/mcp oneshot context, which is the
+        "inject both separately" fallback.
+        """
+        raw = spec.get("plugin")
+        if raw is None:
+            return None, [], []
+        if not isinstance(raw, list):
+            raise ValueError("plugin must be an array of plugin directory paths")
+        working_dir = self._agent._working_dir
+        resolved_paths: list[Path] = []
+        for idx, item in enumerate(raw):
+            if not isinstance(item, str) or not item.strip():
+                raise ValueError(f"plugin[{idx}] must be a non-empty string path")
+            resolved_paths.append(
+                self._plugin_path_resolution(item.strip(), working_dir)
+            )
+        records, problems, _report = _plugin_registry.read_plugins(
+            working_dir, [str(p) for p in resolved_paths]
+        )
+        # Component problems are reported, not fatal; a plugin that cannot be
+        # read at all (invalid plugin.json) is omitted by read_plugins.
+        for prob in problems:
+            self._log("plugin", warning=str(prob))
+
+        skill_rows: list[dict] = []
+        mcp_regs: list[dict] = []
+        mounted_mcp_by_plugin: dict[str, list[str]] = {}
+        for record in records:
+            name = record["name"]
+            for skill_dir in record.get("skill_paths") or []:
+                try:
+                    skill_file = Path(skill_dir) / "SKILL.md"
+                    skill_rows.append(self._parse_task_skill_file(skill_file))
+                except ValueError as e:
+                    self._log("plugin", warning=f"plugin {name} skill skipped: {e}")
+            for server_name, spec in (record.get("mcp_specs") or {}).items():
+                try:
+                    mcp_regs.append(
+                        self._plugin_mcp_spec_to_registration(
+                            name, server_name, spec
+                        )
+                    )
+                except ValueError as e:
+                    self._log("plugin", warning=str(e))
+            mounted_mcp_by_plugin[name] = list(record.get("mcp_servers") or [])
+
+        # Attach mounted markers for the prompt view (LingTai backend only; CLI
+        # backends still get the flattened skills/mcp separately below).
+        for record in records:
+            record["mounted_mcp"] = mounted_mcp_by_plugin.get(record["name"], [])
+        catalog = self._render_task_plugin_catalog(records)
+        return catalog, skill_rows, mcp_regs
+
+    @staticmethod
+    def _merge_skill_catalog_rows(
+        rendered: str | None, extra_rows: list[dict]
+    ) -> list[dict]:
+        """Merge already-rendered task skill rows with plugin skill rows.
+
+        ``_task_skill_catalog`` returns a rendered string, so to append plugin
+        skill rows we re-render from the original list. This helper parses the
+        rendered YAML back into row dicts when needed; when the base catalog is
+        None (no explicit ``skills``) it simply returns the plugin rows.
+        Deduplicates by canonical skill location.
+        """
+        if rendered is None:
+            return list(extra_rows)
+        rows: list[dict] = []
+        current: dict | None = None
+        lines = rendered.splitlines()
+        i = 0
+        while i < len(lines):
+            line = lines[i]
+            m = re.match(r"^  - name: (.*)$", line)
+            if m:
+                if current is not None:
+                    rows.append(current)
+                current = {"name": m.group(1), "location": "", "description": ""}
+                i += 1
+                continue
+            lm = re.match(r"^    location: (.*)$", line)
+            dm = line == "    description: |"
+            if current is not None and lm:
+                current["location"] = lm.group(1)
+            elif current is not None and dm:
+                desc_lines = []
+                i += 1
+                while i < len(lines) and lines[i].startswith("      "):
+                    desc_lines.append(lines[i][6:])
+                    i += 1
+                current["description"] = "\n".join(desc_lines)
+                continue
+            i += 1
+        if current is not None:
+            rows.append(current)
+        seen = {row.get("location") for row in rows}
+        for row in extra_rows:
+            loc = row.get("location")
+            if loc in seen:
+                continue
+            seen.add(loc)
+            rows.append(row)
+        return rows
+
+    @staticmethod
     def _render_task_skill_catalog(skills: list[dict]) -> str | None:
         if not skills:
             return None
@@ -2193,6 +2407,7 @@ class DaemonManager:
         system_prompt: str | None,
         skill_catalog: str | None,
         mcp_catalog: str | None = None,
+        plugin_catalog: str | None = None,
     ) -> str | None:
         parts = []
         if system_prompt:
@@ -2201,6 +2416,8 @@ class DaemonManager:
             parts.append("## Parent-selected skills\n" + skill_catalog)
         if mcp_catalog:
             parts.append("## Parent-provided MCP registrations\n" + mcp_catalog)
+        if plugin_catalog:
+            parts.append("## Parent-selected plugins\n" + plugin_catalog)
         return "\n\n".join(parts) or None
 
     @staticmethod
@@ -4455,11 +4672,19 @@ class DaemonManager:
             try:
                 task_mcp_regs, task_mcp_catalog = self._task_mcp_registrations(spec)
                 task_skill_catalog = self._task_skill_catalog(spec)
+                task_plugin_catalog, plugin_skill_rows, plugin_mcp_regs = self._task_plugin_context(spec)
             except Exception as e:
                 self._close_task_mcp_clients(task_mcp_clients)
                 return {"status": "error", "message": str(e)}
+            # Plugin skills join the skill catalog; plugin mcp.json servers join
+            # the task MCP registrations (mounted as task-scoped clients below).
+            if plugin_skill_rows:
+                task_skill_catalog = self._render_task_skill_catalog(
+                    self._merge_skill_catalog_rows(task_skill_catalog, plugin_skill_rows)
+                )
+            task_mcp_regs = list(task_mcp_regs) + list(plugin_mcp_regs)
             task_context = self._combine_oneshot_context(
-                None, task_skill_catalog, task_mcp_catalog
+                None, task_skill_catalog, task_mcp_catalog, task_plugin_catalog
             )
             task_context = self._append_daemon_common_context(task_context)
 
@@ -4609,6 +4834,7 @@ class DaemonManager:
             try:
                 task_skill_catalog = self._task_skill_catalog(spec)
                 task_mcp_regs, task_mcp_catalog = self._task_mcp_registrations(spec)
+                task_plugin_catalog, plugin_skill_rows, plugin_mcp_regs = self._task_plugin_context(spec)
                 if any(r.get("name") == _DAEMON_COMMON_MCP_NAME for r in task_mcp_regs):
                     raise ValueError(
                         f"MCP registration name {_DAEMON_COMMON_MCP_NAME!r} is reserved"
@@ -4616,6 +4842,22 @@ class DaemonManager:
             except ValueError as e:
                 return {"status": "error",
                         "message": f"tasks[{i}]: {e}"}
+            # CLI backends that cannot mount plugins receive the plugin's skills
+            # and mcp.json servers separately (flattened) in addition to the
+            # whole-plugin prompt view, so the information is never lost.
+            if plugin_skill_rows:
+                task_skill_catalog = self._render_task_skill_catalog(
+                    self._merge_skill_catalog_rows(task_skill_catalog, plugin_skill_rows)
+                )
+            task_mcp_regs = list(task_mcp_regs) + list(plugin_mcp_regs)
+            if task_mcp_catalog:
+                task_mcp_catalog = self._render_task_mcp_catalog(task_mcp_regs)
+            # Per Jason 2026-08-09: external CLI backends do not receive the
+            # whole-plugin prompt section for the next few weeks; they get the
+            # plugin's skills and mcp.json servers flattened into the ordinary
+            # skill/mcp oneshot context (already done above). The LingTai
+            # backend alone injects the ``## Parent-selected plugins`` section.
+            task_plugin_catalog = None
             raw_opts = spec.get("backend_options")
             if raw_opts is None:
                 backend_argv = []

--- a/src/lingtai/tools/daemon/_tool_family.py
+++ b/src/lingtai/tools/daemon/_tool_family.py
@@ -129,6 +129,11 @@ def _emanate_task_schema() -> dict[str, Any]:
                 "items": {"type": "object"},
                 "description": 'Optional one-run MCP registrations for this daemon task. Array of full MCP registration objects: {name, transport/type: stdio|http, command+args+env for stdio or url+headers for http}. The registrations are serialized into the daemon prompt as YAML; LingTai backend also starts them as task-scoped MCP clients and exposes their tools for this run. CLI backends receive the same serialized registrations as context and may load them if their runtime supports MCP. Secret env/header values are redacted in prompts.',
             },
+            "plugin": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional Agent Plugins for this daemon task. Array of paths; each item may be a plugin directory (containing plugin.json) or a plugin search root whose immediate children are plugin directories. Relative paths resolve against the parent agent working directory. The daemon runtime reads each plugin manifest and injects a compact plugin section (name, summary, skills list, mcp list) into this run's system prompt; plugin skills are also injected as skill context and plugin mcp.json servers are registered as task-scoped MCP clients for the LingTai backend, exactly like the main agent mounts plugins. CLI backends that cannot mount plugins receive the plugin's skills and MCP registrations separately as normal skill/mcp context.",
+            },
             "preset": {
                 "type": "string",
                 "description": "Optional preset file path. Must be a .json/.jsonc path as returned by system(action='presets'). Do NOT use shorthand names — use the full 'name' field from the presets listing. Example: '~/.lingtai-tui/presets/saved/cheap.json'. Omit to inherit the parent's regular (non-MCP) tool surface; provide task MCP registrations separately with `mcp`.",

--- a/src/lingtai/tools/daemon/manual/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/SKILL.md
@@ -166,6 +166,18 @@ are the three that change state.
     the hard terminal-success contract: only `finish(status="done")` permits
     `done`; `failed`/`incomplete`, missing finish, or invalid completion prevents
     silent success. Secret `env`/`headers` values are redacted in prompts.
+  - `plugin` answers **which Agent Plugins belong to this daemon run**. It is
+    optional and is an array of paths; each item may be a plugin directory
+    containing `plugin.json`, or a plugin search root whose immediate children
+    are plugin directories. Relative paths resolve against the parent agent
+    working directory. The runtime reads each plugin manifest and injects a
+    compact plugin section (name, summary, skills list, mcp list) into the
+    daemon system prompt. The built-in LingTai backend also mounts the plugin's
+    `skills/` as skill context and its `mcp.json` servers as task-scoped MCP
+    clients, exactly like the main agent mounts plugins. CLI backends that
+    cannot mount plugins yet receive the plugin's skills and mcp.json servers
+    separately as normal skill/mcp oneshot context until the whole-plugin
+    injection matures.
   - `preset`: optional body/model/tool-shape override for this daemon — an
     explicit `.json`/`.jsonc` path. On the LingTai backend it must already be
     a member of the parent agent's resolved `manifest.preset.allowed` set

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1293,6 +1293,90 @@ def test_build_emanation_prompt_includes_selected_skills(tmp_path):
     assert prompt.index("- name: review-skill") < prompt.index("Your task:")
 
 
+def test_task_plugin_context_renders_catalog_and_flattens_skills_mcp(tmp_path):
+    """Daemon task plugin paths render a plugin section plus flattened skills/mcp."""
+    agent = _make_agent(tmp_path, ["daemon"])
+    mgr = agent.get_capability("daemon")
+    plugin_root = agent._working_dir / "plugin"
+    plugin_dir = plugin_root / "demo-plugin"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.json").write_text(
+        '{"$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json", "name": "demo-plugin", "version": "1.0.0", "description": "Demo plugin for daemon injection."}',
+        encoding="utf-8",
+    )
+    skill_dir = plugin_dir / "skills" / "demo-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\n" + "name: demo-skill\n" + "description: Plugin skill for daemon runs.\n" + "---\n",
+        encoding="utf-8",
+    )
+    (plugin_dir / "mcp.json").write_text(
+        '{"$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json", '
+        '"mcpServers": {"demo-mcp": {"type": "stdio", "command": "python3", '
+        '"args": ["-m", "demo"]}}}',
+        encoding="utf-8",
+    )
+
+    catalog, skill_rows, mcp_regs = mgr._task_plugin_context(
+        {"task": "x", "tools": [], "plugin": ["plugin/demo-plugin"]}
+    )
+
+    assert catalog is not None
+    assert "plugins:" in catalog
+    assert "- name: demo-plugin" in catalog
+    assert "Demo plugin for daemon injection." in catalog
+    assert "skills (1):" in catalog
+    assert "- demo-skill" in catalog
+    assert "mcp (1):" in catalog
+    assert "- demo-mcp (mounted)" in catalog
+    assert [r["name"] for r in skill_rows] == ["demo-skill"]
+    assert len(mcp_regs) == 1
+    assert mcp_regs[0]["name"] == "demo-mcp"
+    assert mcp_regs[0]["transport"] == "stdio"
+    assert mcp_regs[0]["command"] == "python3"
+
+
+def test_task_plugin_context_rejects_bad_plugin_path(tmp_path):
+    """A missing plugin path resolves to nothing without failing the whole task."""
+    agent = _make_agent(tmp_path, ["daemon"])
+    mgr = agent.get_capability("daemon")
+
+    catalog, skill_rows, mcp_regs = mgr._task_plugin_context(
+        {"task": "x", "tools": [], "plugin": ["plugin/missing-plugin"]}
+    )
+
+    assert catalog is None
+    assert skill_rows == []
+    assert mcp_regs == []
+
+
+def test_combine_oneshot_context_includes_plugin_section(tmp_path):
+    """The oneshot context combiner renders a dedicated plugin section."""
+    agent = _make_agent(tmp_path, ["daemon"])
+    mgr = agent.get_capability("daemon")
+
+    combined = mgr._combine_oneshot_context(
+        None, None, None, "plugins:\n  - name: demo-plugin\n"
+    )
+
+    assert combined is not None
+    assert "## Parent-selected plugins" in combined
+    assert "demo-plugin" in combined
+
+
+def test_task_plugin_context_rejects_non_list(tmp_path):
+    """A non-list plugin field fails before scheduling."""
+    agent = _make_agent(tmp_path, ["daemon"])
+    mgr = agent.get_capability("daemon")
+
+    try:
+        mgr._task_plugin_context({"task": "x", "tools": [], "plugin": "plugin/demo"})
+    except ValueError as e:
+        assert "plugin must be an array" in str(e)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("non-list plugin should fail")
+
+
 def test_build_emanation_prompt_includes_selected_mcp_context(tmp_path):
     """Selected MCP registrations are rendered into the daemon prompt before the task."""
     agent = _make_agent(tmp_path, ["file", "daemon"])


### PR DESCRIPTION
## Summary

Daemon tasks can now select **Agent Plugins** with a new `plugin` field, mirroring how the main agent mounts plugins. The runtime reads each plugin manifest and injects a compact plugin section (name, summary, skills list, mcp list) into the daemon system prompt. The built-in LingTai backend also mounts the plugin's `skills/` as skill context and its `mcp.json` servers as task-scoped MCP clients. CLI backends that cannot mount plugins yet receive the plugin's skills and mcp.json servers **separately** as ordinary skill/mcp oneshot context, per the interim simplification.

## Changes
- `daemon(action="emanate", tasks=[{..., "plugin": ["plugin/demo-plugin"]}])` — optional array of plugin directory or search-root paths.
- `_task_plugin_context` resolves plugins via `plugin_registry.read_plugins`, parses validated skill dirs into skill catalog rows, and translates validated `mcp.json` servers into full MCP registration objects (`stdio`/`streamable-http`/`sse` → `stdio`/`http`).
- `## Parent-selected plugins` section rendered into oneshot context for the LingTai backend; external CLI backends get flattened skills/mcp injection only.
- Schema (`_tool_family`) and daemon manual updated.

## Validation
- 125 passed in `tests/test_daemon.py` (incl. 4 new plugin tests), 76 passed backend/check, 103 passed plugin registry — all green with the compatible MCP venv.
- `git diff --check` clean.

Closes the daemon side of plugin support; external-backend whole-plugin injection is deliberately deferred until plugin support in those CLIs matures.
