### PR TITLE
fix(base_agent): log turn-boundary housekeeping errors instead of silent swallow (#657)

### DIFF
--- a/src/lingtai/kernel/base_agent/turn.py
+++ b/src/lingtai/kernel/base_agent/turn.py
@@ -1083,19 +1083,22 @@ def _turn_boundary_housekeeping(agent) -> None:
        so the trio's order and error-handling contract are unchanged.
 
     Steps 2 and 3 are best-effort and must never abort the turn, so each is
-    guarded independently. This deliberately excludes the standalone
-    IDLE-boundary notification check in ``_run_loop``, which has different
-    control flow and must not be folded in here.
+    guarded independently and its failures are logged as structured events
+    (``turn_boundary_notification_sync_error`` /
+    ``turn_boundary_rescan_error``) instead of being silently swallowed.
+    This deliberately excludes the standalone IDLE-boundary notification
+    check in ``_run_loop``, which has different control flow and must not be
+    folded in here.
     """
     _check_molt_pressure(agent)
     try:
         agent._sync_notifications()
-    except Exception:
-        pass
+    except Exception as e:
+        agent._log("turn_boundary_notification_sync_error", error=str(e))
     try:
         agent._rescan_large_tool_results()
-    except Exception:
-        pass
+    except Exception as e:
+        agent._log("turn_boundary_rescan_error", error=str(e))
 
 
 def _is_context_molt_call(tc) -> bool:

--- a/tests/test_turn_boundary_housekeeping.py
+++ b/tests/test_turn_boundary_housekeeping.py
@@ -3,13 +3,15 @@
 Before consolidation, three turn.py branches inlined the same trio:
 
     _check_molt_pressure(agent)          # bare — errors propagate
-    try: agent._sync_notifications()     # guarded — errors swallowed
-    except Exception: pass
-    try: agent._rescan_large_tool_results()  # guarded — errors swallowed
-    except Exception: pass
+    try: agent._sync_notifications()     # guarded — errors logged
+    except Exception as e: agent._log("turn_boundary_notification_sync_error", ...)
+    try: agent._rescan_large_tool_results()  # guarded — errors logged
+    except Exception as e: agent._log("turn_boundary_rescan_error", ...)
 
-These tests pin that exact contract on `_turn_boundary_housekeeping` so the
-refactor cannot silently change which step swallows errors or the call order.
+These tests pin that contract on `_turn_boundary_housekeeping` so the
+refactor cannot silently change which step swallows errors, drops the
+observability log, or reorders the calls (issue #657: notification sync
+errors were previously swallowed with zero logging).
 """
 
 import pytest
@@ -20,6 +22,7 @@ from lingtai.kernel.base_agent import turn
 class _FakeAgent:
     def __init__(self):
         self.calls = []
+        self.logged = []
         # No "context" intrinsic → real _check_molt_pressure returns early,
         # but tests monkeypatch it anyway to assert it is invoked first.
         self._intrinsics = {}
@@ -36,6 +39,9 @@ class _FakeAgent:
         if self.rescan_raises:
             raise RuntimeError("boom-rescan")
 
+    def _log(self, event_type: str, **fields) -> None:
+        self.logged.append((event_type, fields))
+
 
 def test_runs_trio_in_order(monkeypatch):
     agent = _FakeAgent()
@@ -44,22 +50,29 @@ def test_runs_trio_in_order(monkeypatch):
     turn._turn_boundary_housekeeping(agent)
     assert molt_called == [agent]
     assert agent.calls == ["sync", "rescan"]
+    assert agent.logged == []
 
 
-def test_sync_error_is_swallowed_and_rescan_still_runs(monkeypatch):
+def test_sync_error_is_logged_and_rescan_still_runs(monkeypatch):
     agent = _FakeAgent()
     agent.sync_raises = True
     monkeypatch.setattr(turn, "_check_molt_pressure", lambda a: None)
     turn._turn_boundary_housekeeping(agent)  # must not raise
     assert agent.calls == ["sync", "rescan"]
+    assert agent.logged == [
+        ("turn_boundary_notification_sync_error", {"error": "boom-sync"})
+    ]
 
 
-def test_rescan_error_is_swallowed(monkeypatch):
+def test_rescan_error_is_logged(monkeypatch):
     agent = _FakeAgent()
     agent.rescan_raises = True
     monkeypatch.setattr(turn, "_check_molt_pressure", lambda a: None)
     turn._turn_boundary_housekeeping(agent)  # must not raise
     assert agent.calls == ["sync", "rescan"]
+    assert agent.logged == [
+        ("turn_boundary_rescan_error", {"error": "boom-rescan"})
+    ]
 
 
 def test_molt_pressure_error_propagates(monkeypatch):


### PR DESCRIPTION
Fixes #657.

## Problem

`_turn_boundary_housekeeping()` in `src/lingtai/kernel/base_agent/turn.py` guarded `_sync_notifications()` and `_rescan_large_tool_results()` with bare `except Exception: pass` — zero observability. A persistent notification-sync defect would silently disable notification delivery with no signal for operators, even though the helper runs on every turn boundary.

## Change

- `_turn_boundary_housekeeping()`: replace both bare `except Exception: pass` blocks with logged exceptions, emitting structured events `turn_boundary_notification_sync_error` and `turn_boundary_rescan_error` (with `error=` field) via the existing `agent._log(...)` API — the same convention already used by the IDLE-boundary check (`idle_notification_check_error`).
- Best-effort semantics are unchanged: failures still never abort the turn, and the trio call order is preserved.
- Updated `tests/test_turn_boundary_housekeeping.py` to pin the new logged-error contract (fake agent now records `_log` events; error-path tests assert the emitted event types/fields).

## Tests

```
$ PYTHONPATH=src python3 -m pytest tests/test_turn_boundary_housekeeping.py tests/test_notification_sync.py -q
73 passed in 1.56s
```

(5 housekeeping parity tests + 68 notification-sync tests, all green; changed files also pass `python3 -m py_compile`.)