### PR TITLE
fix(claude-code): handle tools=None in ClaudeCodeChatSession constructor; fix contract mock signature (#1238)

### DIFF
--- a/src/lingtai/llm/claude_code/adapter.py
+++ b/src/lingtai/llm/claude_code/adapter.py
@@ -225,7 +225,7 @@ class ClaudeCodeChatSession(ChatSession):
         adapter: "ClaudeCodeAdapter",
         model: str,
         system_prompt: str,
-        tools: list[FunctionSchema],
+        tools: list[FunctionSchema] | None,
         interface: ChatInterface,
         context_window: int,
         effort_argv: list[str] | None = None,
@@ -233,7 +233,9 @@ class ClaudeCodeChatSession(ChatSession):
         self._adapter = adapter
         self._model = model
         self._system_prompt = system_prompt
-        self._tools = tools
+        # Normalized the same way ``update_tools`` already normalizes later
+        # updates, so ``_system_block_digest`` can always iterate ``_tools``.
+        self._tools = list(tools) if tools else []
         self._interface = interface
         self._context_window = context_window
         # Frozen at construction, never re-read from mutable adapter state.

--- a/tests/contracts/llm_conversation_input/regimes.py
+++ b/tests/contracts/llm_conversation_input/regimes.py
@@ -359,7 +359,7 @@ def _build_claude_code() -> tuple[Any, Any]:
     # ``adapter._invoke(prompt, model)``. Mock only that seam; capture the prompt.
     calls: list[str] = []
 
-    def _fake_invoke(prompt, model):
+    def _fake_invoke(prompt, model, **kwargs):
         calls.append(prompt)
         return (
             {"action": "final", "text": "ok"},


### PR DESCRIPTION
Fixes #1238

## Problem

`ClaudeCodeChatSession.__init__` stored the `tools` argument as-is (`self._tools = tools`). When called with `tools=None`, `_system_block_digest` iterated `self._tools` and crashed with `TypeError: 'NoneType' object is not iterable`, breaking the 3 contract tests in `tests/contracts/llm_conversation_input/`. `update_tools` already normalizes this way (`list(tools) if tools else []`), so the constructor was inconsistent.

Additionally, the contract test mock `_fake_invoke(prompt, model)` had a signature incompatible with the real `_invoke(self, prompt, model, *, resume_session_id=None)`, which `send()` calls with the `resume_session_id` keyword.

## Changes

- `src/lingtai/llm/claude_code/adapter.py`: widen the `tools` type hint to `list[FunctionSchema] | None` and normalize in the constructor: `self._tools = list(tools) if tools else []`.
- `tests/contracts/llm_conversation_input/regimes.py`: make the fake `_fake_invoke(prompt, model, **kwargs)` accept the extra keyword.

## Validation

- Pre-fix reproduction (main HEAD): the 3 target tests fail with `TypeError: 'NoneType' object is not iterable` at `adapter.py:332`.
- Post-fix: all 3 target tests pass.
- Full contract + adapter suite: `pytest tests/contracts/ tests/test_claude_code_adapter.py` → **223 passed** in 2.06s.
- `tests/test_architecture_documents.py::test_every_tracked_file_climbs_the_anatomy_graph` fails on main before this change too (pre-existing: untracked test files in the anatomy graph and a missing `src/lingtai/daemon_supervisor/supervisor.py`); unrelated to this PR.
