### PR TITLE
fix(kernel): agent session started_at is ISO-8601 in all rebuild tiers

### DIFF
--- a/src/lingtai/kernel/agent_session.py
+++ b/src/lingtai/kernel/agent_session.py
@@ -293,7 +293,7 @@ def _rebuild_via_sqlite(
     row = agg[0] if agg else {}
     return AgentSession(
         molt_count=molt_count,
-        started_at=_iso_from_ts(boundary_ts) if boundary_ts else None,
+        started_at=_iso_from_ts(boundary_ts),
         boundary_source=boundary_source,
         boundary_offset=boundary_offset,
         api_calls=int(row.get("n") or 0),
@@ -362,7 +362,7 @@ def _rebuild_via_reverse_scan(
 
     return AgentSession(
         molt_count=molt_count,
-        started_at=str(boundary_ts) if boundary_ts is not None else None,
+        started_at=_iso_from_ts(boundary_ts),
         boundary_source=boundary_source,
         boundary_offset=None,
         api_calls=api_calls,
@@ -417,7 +417,7 @@ def _rebuild_via_full_scan(events_file: Path, molt_count: int) -> AgentSession:
 
     return AgentSession(
         molt_count=molt_count,
-        started_at=str(boundary_ts) if boundary_ts is not None else None,
+        started_at=_iso_from_ts(boundary_ts),
         boundary_source=boundary_source,
         boundary_offset=None,
         api_calls=api_calls,
@@ -458,7 +458,16 @@ def _read_tail_lines(path: Path, max_bytes: int) -> tuple[list[str], bool]:
     return lines, hit_start
 
 
-def _iso_from_ts(ts: float) -> str | None:
+def _iso_from_ts(ts: Any) -> str | None:
+    """Convert a wall-clock epoch (float, int, or numeric string) to ISO-8601 UTC.
+
+    Returns ``None`` for falsy, missing, or unusable input so callers can pass
+    raw JSONL ``ts`` values (``Any``) straight through without pre-checks.
+    """
+    try:
+        ts = float(ts or 0.0)
+    except (TypeError, ValueError):
+        return None
     if not ts:
         return None
     try:

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -18,6 +18,7 @@ from lingtai.kernel.agent_session import (
     TOKEN_EVENT,
     AgentSession,
     RuntimeSession,
+    _iso_from_ts,
     _rebuild_via_full_scan,
     _rebuild_via_reverse_scan,
     _rebuild_via_sqlite,
@@ -328,3 +329,92 @@ def test_reverse_scan_defers_to_full_scan_when_boundary_beyond_bound(tmp_path):
     # Full scan still recovers the correct aggregate.
     full = _rebuild_via_full_scan(events_path, molt_count=1)
     assert full.api_calls == 50
+
+
+# ---------------------------------------------------------------------------
+# started_at format: ISO-8601 UTC "...Z" in every tier (issue #750)
+# ---------------------------------------------------------------------------
+
+
+BOUNDARY_TS = 1751704872.0  # 2025-07-05T09:21:12Z UTC
+
+
+def _expected_iso(ts: float) -> str:
+    from datetime import datetime, timezone
+
+    return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat().replace(
+        "+00:00", "Z"
+    )
+
+
+def test_reverse_scan_started_at_is_iso8601(tmp_path):
+    events = [
+        _molt_ev(BOUNDARY_TS, 1),
+        _token_ev(BOUNDARY_TS + 1.0, 1000, 200, 700),
+    ]
+    events_path = _write_events(tmp_path, events)
+
+    rev = _rebuild_via_reverse_scan(events_path, molt_count=1)
+
+    assert rev.started_at == _expected_iso(BOUNDARY_TS)
+    assert rev.started_at.endswith("Z")
+    assert rev.started_at != str(BOUNDARY_TS)
+
+
+def test_full_scan_started_at_is_iso8601(tmp_path):
+    events = [
+        _molt_ev(BOUNDARY_TS, 1),
+        _token_ev(BOUNDARY_TS + 1.0, 1000, 200, 700),
+    ]
+    events_path = _write_events(tmp_path, events)
+
+    full = _rebuild_via_full_scan(events_path, molt_count=1)
+
+    assert full.started_at == _expected_iso(BOUNDARY_TS)
+    assert full.started_at.endswith("Z")
+    assert full.started_at != str(BOUNDARY_TS)
+
+
+def test_started_at_format_consistent_across_tiers(tmp_path):
+    events = [
+        _token_ev(1.0, 500, 100, 300),
+        _molt_ev(2.0, 1),
+        _token_ev(3.0, 1000, 200, 700),
+        _molt_ev(BOUNDARY_TS, 2),
+        _token_ev(BOUNDARY_TS + 1.0, 1234, 200, 800),
+    ]
+    events_path = _write_events(tmp_path, events)
+    _build_sqlite(tmp_path, events)
+
+    t1 = rebuild_agent_session_from_events(tmp_path, molt_count=2)
+    assert t1.rebuild_tier == "sqlite"
+    t2 = _rebuild_via_reverse_scan(events_path, molt_count=2)
+    t3 = _rebuild_via_full_scan(events_path, molt_count=2)
+
+    expected = _expected_iso(BOUNDARY_TS)
+    assert t1.started_at == expected
+    assert t2.started_at == expected
+    assert t3.started_at == expected
+
+
+def test_started_at_none_when_no_boundary(tmp_path):
+    events = [
+        _token_ev(1.0, 500, 100, 300),
+        _token_ev(2.0, 500, 100, 300),
+    ]
+    events_path = _write_events(tmp_path, events)
+
+    rev = _rebuild_via_reverse_scan(events_path, molt_count=0)
+    full = _rebuild_via_full_scan(events_path, molt_count=0)
+
+    assert rev.started_at is None
+    assert full.started_at is None
+
+
+def test_iso_from_ts_handles_bad_input():
+    assert _iso_from_ts(None) is None
+    assert _iso_from_ts(0) is None
+    assert _iso_from_ts(0.0) is None
+    assert _iso_from_ts("garbage") is None
+    assert _iso_from_ts([]) is None
+    assert _iso_from_ts("1751704872.0") == _expected_iso(BOUNDARY_TS)


### PR DESCRIPTION
Fixes #750

## Problem

`AgentSession.started_at` was formatted differently depending on which rebuild tier produced it: the sqlite tier (Tier 1) emitted ISO-8601 UTC (`2026-07-05T08:41:12Z`-style via `_iso_from_ts`), while the two fallback JSONL scan tiers (Tier 2 reverse scan, Tier 3 full scan) stringified the raw epoch float (`"1751704872.391"`). Consumers therefore saw a format that depended on incidental runtime conditions (whether the `log.sqlite` sidecar existed), not on any contract.

## Fix (all in `src/lingtai/kernel/agent_session.py`)

1. Hardened `_iso_from_ts` to accept raw JSONL `ts` values: signature is now `def _iso_from_ts(ts: Any) -> str | None`, coercing via `float(ts or 0.0)` and returning `None` on `TypeError`/`ValueError` (missing, `None`, garbage, or non-numeric values) instead of raising.
2. Tier 2 (`_rebuild_via_reverse_scan`) now sets `started_at=_iso_from_ts(boundary_ts)` instead of `str(boundary_ts)`.
3. Tier 3 (`_rebuild_via_full_scan`) now sets `started_at=_iso_from_ts(boundary_ts)` instead of `str(boundary_ts)`.
4. Tier 1 (`_rebuild_via_sqlite`) simplified to `started_at=_iso_from_ts(boundary_ts)`; the redundant `if boundary_ts else None` guard is gone, which also unifies the zero/absent-boundary edge case (all tiers map it to `None`).

No persisted data migration is needed: the field is rebuilt fresh at every startup/refresh, and no consumer reads `AgentSession.started_at` outside this module (verified by grep: `Session.agent_session_token_usage` does not surface it).

## Tests

Added 5 tests to `tests/test_agent_session.py`:

- `test_reverse_scan_started_at_is_iso8601`
- `test_full_scan_started_at_is_iso8601`
- `test_started_at_format_consistent_across_tiers` (sqlite + both scan tiers produce the identical ISO string for the same boundary `ts`)
- `test_started_at_none_when_no_boundary`
- `test_iso_from_ts_handles_bad_input` (`None`, `0`, `0.0`, `"garbage"`, `[]` -> `None`; `"1751704872.0"` -> ISO string)

Results:

```
$ python3 -m pytest tests/test_agent_session.py -q
22 passed in 0.14s

$ python3 -m pytest tests/test_agent_session.py tests/test_agent_session_wiring.py tests/test_session.py tests/test_services_logging.py -q
116 passed, 1 warning in 1.94s
```

(Pre-existing, unrelated collection errors in wechat/whatsapp test files come from an incompatible `mcp` package in the local site-packages and are untouched by this change.)