### PR TITLE
fix: never probe localhost for schemeless preset base_url (#741)

### DIFF
--- a/src/lingtai/kernel/preset_connectivity.py
+++ b/src/lingtai/kernel/preset_connectivity.py
@@ -86,6 +86,30 @@ def _resolve_url(provider: str | None, base_url: str | None) -> str | None:
     return None
 
 
+def _parse_probe_target(url: str) -> tuple[str, int] | None:
+    """Parse a base_url into the (host, port) pair to TCP-probe.
+
+    Schemeless URLs (``api.openai.com``, ``myhost:8080``) are treated as
+    https. This matters because ``urlparse`` is hostile to them: it swallows
+    a bare ``host:port`` string as a bogus scheme and returns
+    ``hostname=None``, and ``socket.create_connection((None, ...))`` would
+    silently resolve to loopback — probing localhost instead of the
+    configured endpoint. Returns None when no hostname can be extracted
+    (e.g. ``https://`` or a non-numeric port) so the caller can fail loudly
+    rather than probing whatever ``getaddrinfo(None, ...)`` fancies.
+    """
+    if "://" not in url:
+        url = f"https://{url}"
+    parsed = urlparse(url)
+    if not parsed.hostname:
+        return None
+    try:
+        port = parsed.port  # raises ValueError on e.g. "host:notaport"
+    except ValueError:
+        return None
+    return parsed.hostname, port or (443 if parsed.scheme == "https" else 80)
+
+
 def check_connectivity(
     provider: str | None,
     base_url: str | None,
@@ -100,6 +124,11 @@ def check_connectivity(
          "checked_at": "<ISO timestamp>",
          "latency_ms": int (only on ok),
          "error": str | None}
+
+    Schemeless base URLs (``api.openai.com``, ``myhost:8080``) are probed as
+    https (port 443). A base URL with no extractable hostname yields
+    ``"unreachable"`` with an ``invalid base_url`` error rather than a
+    silent localhost probe.
     """
     # Local CLI-login providers (e.g. claude-code) have no network
     # endpoint and no API key — they authenticate through a local CLI/login
@@ -145,9 +174,15 @@ def check_connectivity(
             "error": f"no base_url and no default URL for provider {provider!r}",
         }
 
-    parsed = urlparse(url)
-    host = parsed.hostname
-    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    target = _parse_probe_target(url)
+    if target is None:
+        return {
+            "status": "unreachable",
+            "checked_at": datetime.now(timezone.utc).isoformat(),
+            "latency_ms": None,
+            "error": f"invalid base_url {url!r}: cannot determine host to probe",
+        }
+    host, port = target
 
     try:
         latency_ms = _probe_host(host, port, _PROBE_TIMEOUT_S)

--- a/tests/test_preset_connectivity.py
+++ b/tests/test_preset_connectivity.py
@@ -268,3 +268,94 @@ def test_kimi_code_missing_module_is_actionable(monkeypatch):
     assert result["status"] == "no_credentials"
     assert "kimi-code" in (result.get("error") or "")
     assert "no base_url" not in (result.get("error") or "")
+
+
+# ---------------------------------------------------------------------------
+# Schemeless / malformed base_url must never silently probe localhost
+# ---------------------------------------------------------------------------
+
+
+def test_schemeless_base_url_probed_as_https(monkeypatch):
+    """A bare hostname like `api.openai.com` is probed as https (port 443),
+    not resolved to localhost via getaddrinfo(None, ...)."""
+    from lingtai.kernel import preset_connectivity
+    captured = {}
+    def fake_probe(host, port, timeout):
+        captured["host"] = host
+        captured["port"] = port
+        return 12
+    with patch.object(preset_connectivity, "_probe_host", side_effect=fake_probe):
+        result = preset_connectivity.check_connectivity(
+            provider=None,
+            base_url="api.openai.com",
+            api_key_env=None,
+        )
+    assert captured == {"host": "api.openai.com", "port": 443}
+    assert result["status"] == "ok"
+    assert result["latency_ms"] == 12
+
+
+def test_schemeless_host_port_base_url_keeps_port(monkeypatch):
+    """`myhost:8080` is the urlparse scheme-swallowing case: the port must be
+    preserved and the host must not be dropped."""
+    from lingtai.kernel import preset_connectivity
+    captured = {}
+    def fake_probe(host, port, timeout):
+        captured["host"] = host
+        captured["port"] = port
+        return 7
+    with patch.object(preset_connectivity, "_probe_host", side_effect=fake_probe):
+        result = preset_connectivity.check_connectivity(
+            provider=None,
+            base_url="myhost:8080",
+            api_key_env=None,
+        )
+    assert captured == {"host": "myhost", "port": 8080}
+    assert result["status"] == "ok"
+
+
+@pytest.mark.parametrize("bad_url", ["https://", "http://host:notaport"])
+def test_invalid_base_url_reports_error_without_probing(bad_url):
+    """Hostless or non-numeric-port base URLs fail loud with an explicit
+    `invalid base_url` error — and never call the probe (no localhost
+    fallback, no escaping ValueError)."""
+    from lingtai.kernel import preset_connectivity
+    with patch.object(preset_connectivity, "_probe_host") as probe:
+        result = preset_connectivity.check_connectivity(
+            provider=None,
+            base_url=bad_url,
+            api_key_env=None,
+        )
+    assert result["status"] == "unreachable"
+    assert "invalid base_url" in result["error"]
+    probe.assert_not_called()
+
+
+def test_http_scheme_still_defaults_to_port_80(monkeypatch):
+    """Explicit http:// URLs keep their port-80 default — normalization must
+    not disturb explicit-scheme handling."""
+    from lingtai.kernel import preset_connectivity
+    captured = {}
+    def fake_probe(host, port, timeout):
+        captured["host"] = host
+        captured["port"] = port
+        return 3
+    with patch.object(preset_connectivity, "_probe_host", side_effect=fake_probe):
+        result = preset_connectivity.check_connectivity(
+            provider=None,
+            base_url="http://myhost",
+            api_key_env=None,
+        )
+    assert captured == {"host": "myhost", "port": 80}
+    assert result["status"] == "ok"
+
+
+def test_urlparse_schemeless_assumptions():
+    """Canary for Python's urlparse semantics that this fix relies on: a bare
+    host:port string yields hostname=None, and the whole string would be
+    treated as a scheme. If a future Python changes this, the tests above
+    surface it visibly."""
+    from urllib.parse import urlparse
+    assert urlparse("api.openai.com").hostname is None
+    assert urlparse("myhost:8080").scheme == "myhost"
+    assert urlparse("myhost:8080").hostname is None


### PR DESCRIPTION
Fixes #741

## Problem

`check_connectivity()` parsed a preset's `base_url` with `urlparse()` and passed `parsed.hostname` straight to `socket.create_connection()`, with no guard on `hostname is None`. For a schemeless `base_url` — `api.openai.com` or `myhost:8080`, both natural to type in a hand-authored manifest — `urlparse` returns `hostname=None` (the string lands in `path`, or the host is swallowed as a bogus scheme). `create_connection((None, 80))` then resolves to **loopback** via `getaddrinfo(None, ...)`, so the probe silently tested `localhost:80` instead of the configured endpoint:

- **False positive:** anything listening locally on port 80 makes the preset report `"ok"` with a tiny `latency_ms` — the agent confidently swaps into a preset whose real endpoint may be down. Exactly the failure the module's no-caching design exists to prevent.
- **Misleading negative:** with nothing local, the user gets `"unreachable"` / `Connection refused`, which reads as "the API host refused me" and sends them debugging firewalls instead of a missing `https://`.
- The `http://host:notaport` case even let a `ValueError` from `parsed.port` escape `check_connectivity` entirely.

Verified on current main (`df2b523db810`) with a recording `_probe_host` stub:

```
base_url='api.openai.com'           probe=(None, 80)                     status=ok
base_url='myhost:8080'              probe=(None, 80)                     status=ok
base_url='http://host:notaport'     RAISED ValueError: Port could not be cast to integer value as 'notaport'
base_url='https://api.example.com'  probe=('api.example.com', 443)       status=ok
```

## Fix

A new `_parse_probe_target()` in `src/lingtai/kernel/preset_connectivity.py` normalizes a schemeless URL to `https` before parsing (the scheme test is `"://" not in url`, not `scheme == ""`, because `myhost:8080` yields a non-empty bogus scheme), catches the non-numeric-port `ValueError`, and returns `None` — **never a localhost fallback** — when no host can be extracted. `check_connectivity` then fails loud with an explicit `invalid base_url` `"unreachable"` result. The return schema is unchanged, so `check_many()` and `intrinsics/system/preset.py` need no changes; well-formed `http(s)://` URLs take exactly the same path as before (`http://host` → port 80 preserved).

After the fix:

```
base_url='api.openai.com'           probe=('api.openai.com', 443)        status=ok
base_url='myhost:8080'              probe=('myhost', 8080)               status=ok
base_url='https://'                 probe=None   status=unreachable error="invalid base_url 'https://': ..."
base_url='http://host:notaport'     probe=None   status=unreachable error="invalid base_url 'http://host:notaport': ..."
base_url='http://myhost'            probe=('myhost', 80)                 status=ok
```

## Validation

```
$ python -m pytest tests/test_preset_connectivity.py -q
23 passed in 0.93s

$ python -m pytest tests/test_presets.py tests/test_activate_preset.py -q
102 passed in 0.46s

$ git diff --check
(no output)
```

New regression tests: schemeless bare hostname → probed as https:443; `myhost:8080` → host+port preserved; hostless / non-numeric-port URLs → `unreachable` with `invalid base_url` and no probe call; explicit `http://` → port 80 preserved; plus a `urlparse` semantics canary.
