### PR TITLE
fix(retention): parse Z-suffixed finished_at as UTC regardless of host TZ

### DIFF
--- a/src/lingtai/kernel/maintenance/retention.py
+++ b/src/lingtai/kernel/maintenance/retention.py
@@ -1007,9 +1007,15 @@ def _parse_iso(value: object) -> datetime | None:
     for fmt in ("%Y-%m-%dT%H:%M:%SZ", "%Y-%m-%dT%H:%M:%S%z"):
         try:
             parsed = datetime.strptime(value, fmt)
-            return parsed.astimezone(timezone.utc)
         except ValueError:
             continue
+        if parsed.tzinfo is None:
+            # "Z" means UTC (RFC 3339); the daemon writer always emits UTC.
+            # Stamping instead of astimezone keeps the value independent of
+            # the host's local timezone (astimezone on a naive datetime would
+            # interpret it as local time and shift it by the UTC offset).
+            return parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
     return None
 
 

--- a/tests/test_retention_report.py
+++ b/tests/test_retention_report.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import json
 import os
+import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
 
 from lingtai.kernel.maintenance import RetentionOptions, TargetError, report_to_dict, scan_retention
+from lingtai.kernel.maintenance.retention import _parse_iso
 
 
 NOW = datetime(2026, 6, 27, 12, 0, 0, tzinfo=timezone.utc)
@@ -336,3 +338,68 @@ def test_json_report_is_deterministic(tmp_path):
     second = report_to_dict(scan_retention(agent, RetentionOptions(), _now=NOW))
 
     assert json.dumps(first, sort_keys=True) == json.dumps(second, sort_keys=True)
+
+
+def _set_tz(monkeypatch, tz: str) -> None:
+    """Switch the process local timezone for naive-datetime semantics."""
+    if not hasattr(time, "tzset"):
+        pytest.skip("time.tzset() unavailable on this platform")
+    monkeypatch.setenv("TZ", tz)
+    time.tzset()
+
+
+def test_parse_iso_z_suffix_is_utc_regardless_of_local_tz(monkeypatch):
+    _set_tz(monkeypatch, "Asia/Shanghai")
+    assert _parse_iso("2026-06-05T12:00:00Z") == datetime(
+        2026, 6, 5, 12, 0, 0, tzinfo=timezone.utc
+    )
+    _set_tz(monkeypatch, "America/New_York")
+    assert _parse_iso("2026-06-05T12:00:00Z") == datetime(
+        2026, 6, 5, 12, 0, 0, tzinfo=timezone.utc
+    )
+
+
+def test_parse_iso_explicit_offset_normalized_to_utc(monkeypatch):
+    _set_tz(monkeypatch, "Asia/Shanghai")
+    assert _parse_iso("2026-06-05T20:00:00+08:00") == datetime(
+        2026, 6, 5, 12, 0, 0, tzinfo=timezone.utc
+    )
+
+
+def test_parse_iso_non_string_and_garbage_return_none():
+    assert _parse_iso(None) is None
+    assert _parse_iso(123) is None
+    assert _parse_iso("garbage") is None
+
+
+def test_daemon_finished_at_near_cutoff_not_shifted_by_host_tz(tmp_path, monkeypatch):
+    # 4 hours inside the 30-day window: the run is 29d20h old, so it must be
+    # protected as newer_than_cutoff. Before the fix, a UTC+8 host read the
+    # Z timestamp 8 hours early and misclassified it as a candidate.
+    _set_tz(monkeypatch, "Asia/Shanghai")
+    agent = _agent(tmp_path)
+    _daemon(agent, finished_at=NOW - timedelta(days=30) + timedelta(hours=4))
+
+    data = _report(agent)
+
+    assert data["classes"]["terminal_daemon_run"]["candidates"] == 0
+    assert data["classes"]["terminal_daemon_run"]["protected"] == 1
+    reasons = {item["reason"] for item in data["protected"]}
+    assert "newer_than_cutoff" in reasons
+
+
+def test_daemon_age_fields_match_finished_at(tmp_path, monkeypatch):
+    _set_tz(monkeypatch, "Asia/Shanghai")
+    agent = _agent(tmp_path)
+    finished_at = NOW - timedelta(days=45)
+    run = _daemon(agent, finished_at=finished_at)
+
+    data = _report(agent)
+
+    candidates = [c for c in data["candidates"] if Path(c["path"]) == run]
+    assert len(candidates) == 1
+    candidate = candidates[0]
+    assert candidate["age_source"] == "daemon_finished_at"
+    assert candidate["timestamp"] == finished_at.strftime("%Y-%m-%dT%H:%M:%SZ")
+    assert candidate["age_seconds"] == pytest.approx(45 * 86400.0, abs=1.0)
+    assert candidate["age_days"] == pytest.approx(45.0, abs=0.01)


### PR DESCRIPTION
Fixes #729.

## Problem

`_parse_iso` in `src/lingtai/kernel/maintenance/retention.py` parsed the daemon `finished_at` format `%Y-%m-%dT%H:%M:%SZ` into a **naive** datetime and then called `.astimezone(timezone.utc)`, which per Python semantics interprets the naive value as **local time**. Since the daemon writer always emits UTC "Z" strings, every daemon run-dir age derived from `finished_at` was shifted by the host's UTC offset (e.g. 8 hours early on a UTC+8 host), flipping run dirs across the `older_than_days` cutoff and skewing the report's `age_seconds`, `age_days`, and `timestamp` fields.

## Fix

Naive parses (the `Z`-literal branch, which matches every string the writer produces) are now stamped with `replace(tzinfo=timezone.utc)` instead of `astimezone(...)`; aware parses (explicit offsets) keep `astimezone(timezone.utc)` normalization. This mirrors the writer contract and the convention already used by `_parse_mail_id_time` / `_parse_run_id_time`. No schema or on-disk format changes.

## Tests

Added to `tests/test_retention_report.py` (5 new tests):

- `test_parse_iso_z_suffix_is_utc_regardless_of_local_tz` — unit test on `_parse_iso` under `TZ=Asia/Shanghai` and `TZ=America/New_York` (via `time.tzset()`)
- `test_parse_iso_explicit_offset_normalized_to_utc` — guards the aware branch that must keep `astimezone`
- `test_parse_iso_non_string_and_garbage_return_none` — regression guard
- `test_daemon_finished_at_near_cutoff_not_shifted_by_host_tz` — integration: a run 4h inside the 30-day cutoff stays `newer_than_cutoff` under a UTC+8 host (failed before the fix, passes after)
- `test_daemon_age_fields_match_finished_at` — candidate `timestamp` round-trips the written `finished_at`, `age_seconds`/`age_days` match the true UTC delta under a non-UTC TZ

Results (local, Python 3.14):

```
$ python3 -m pytest tests/test_retention_report.py -q
24 passed in 0.43s
```

Also ran the suite under `TZ=America/New_York` and `TZ=Asia/Tokyo`: 24 passed in each. `ruff check` passes on both changed files.