### PR TITLE
fix(llm): disambiguate worker-raised TimeoutError in watchdog via future.done()

### DIFF
--- a/src/lingtai/kernel/llm_utils.py
+++ b/src/lingtai/kernel/llm_utils.py
@@ -50,7 +50,13 @@ def _send(
     retry_timeout: float,
     agent_name: str,
 ) -> LLMResponse:
-    """Send a message to the LLM. Single attempt with timeout."""
+    """Send a message to the LLM. Single attempt with timeout.
+
+    Note: on Python >= 3.11, ``except TimeoutError`` alone cannot distinguish a
+    wait-slice expiry from a worker-raised builtin ``TimeoutError`` (``socket
+    .timeout`` / ``asyncio.TimeoutError`` are aliases of it); ``future.done()``
+    is the discriminator and must stay part of this loop.
+    """
     future: Future = submit_fn()
     t0 = time.monotonic()
     while True:
@@ -63,6 +69,14 @@ def _send(
         try:
             return future.result(timeout=wait)
         except TimeoutError:
+            if future.done():
+                # The worker settled: either it raised its own TimeoutError
+                # (socket.timeout / asyncio.TimeoutError / concurrent.futures
+                # TimeoutError are all the builtin TimeoutError on >=3.11) or it
+                # finished during the race after our wait expired. Either way
+                # the worker is gone and its cleanup already ran — surface the
+                # real outcome instead of misreading it as "not responding".
+                return future.result(timeout=0)
             elapsed = time.monotonic() - t0
             if elapsed >= retry_timeout:
                 _wait_for_worker_settle(future, elapsed, agent_name)
@@ -84,10 +98,22 @@ def _wait_for_worker_settle(future: Future, elapsed: float, agent_name: str) -> 
     If the worker is still running after the grace period, raise a distinct
     WorkerStillRunningError. AED must not treat this as an ordinary timeout
     because the provider worker may still mutate the shared ChatInterface.
+
+    A worker that settled with its own builtin ``TimeoutError`` (``socket
+    .timeout`` / ``asyncio.TimeoutError`` / ``concurrent.futures.TimeoutError``
+    are all the same class on >= 3.11) is NOT still running: its except-block
+    already ran ``drop_trailing``. Use ``future.done()`` to tell the two apart
+    rather than ``except TimeoutError`` alone.
     """
     try:
         future.result(timeout=_WORKER_SETTLE_GRACE)
     except TimeoutError:
+        if future.done():
+            # The worker settled with its own TimeoutError (socket.timeout,
+            # asyncio.TimeoutError, and concurrent.futures.TimeoutError are all
+            # the builtin TimeoutError on >=3.11). Its except-block already ran
+            # drop_trailing — same as any other worker error.
+            return
         _logger.error(
             "[%s] LLM worker thread still running after %.0fs + %.0fs grace — "
             "interface state may be inconsistent. Refusing AED retry.",

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -9,6 +9,7 @@ from lingtai.kernel.llm_utils import (
     track_llm_usage,
     execute_tools_batch,
     send_with_timeout,
+    _send,
     _SubmitFn,
     _wait_for_worker_settle,
 )
@@ -231,3 +232,121 @@ def test_send_with_timeout_raises_worker_still_running_when_worker_never_settles
     finally:
         blocker.set()
         pool.shutdown(wait=True)
+
+
+# --- Worker-raised builtin TimeoutError disambiguation --------------------
+# On Python >= 3.11, socket.timeout / asyncio.TimeoutError / concurrent
+# futures TimeoutError are all the builtin TimeoutError. `except TimeoutError`
+# around future.result(timeout=...) therefore catches BOTH a wait-slice
+# expiry AND a worker that settled with its own TimeoutError. future.done()
+# is the discriminator; these tests pin that behavior.
+
+
+def test_wait_for_worker_settle_returns_when_worker_raised_timeout():
+    """A worker that settled with its own builtin TimeoutError (e.g. a raw
+    socket.timeout from the HTTP layer) is NOT a still-running worker: its
+    except-block already ran drop_trailing. Must return None instead of
+    raising WorkerStillRunningError."""
+    future = Future()
+    future.set_exception(TimeoutError("worker socket timeout"))
+
+    assert _wait_for_worker_settle(future, elapsed=10.0, agent_name="test") is None
+
+
+def test_send_surfaces_worker_timeout_immediately():
+    """A worker-raised builtin TimeoutError surfaces from _send promptly as
+    an ordinary TimeoutError, never as a WorkerStillRunningError (the old
+    misclassification busy-looped until retry_timeout, then poisoned the
+    ChatInterface for a worker that already finished)."""
+    import socket
+    import time as _time
+
+    pool = ThreadPoolExecutor(max_workers=1)
+
+    def worker():
+        _time.sleep(0.05)
+        raise socket.timeout("worker socket timeout")
+
+    def submit_fn():
+        return pool.submit(worker)
+
+    t0 = _time.monotonic()
+    try:
+        _send(submit_fn, pool, retry_timeout=30.0, agent_name="test")
+        raise AssertionError("expected TimeoutError from the worker")
+    except WorkerStillRunningError as exc:
+        raise AssertionError(f"worker TimeoutError misclassified: {exc}")
+    except TimeoutError:
+        pass  # plain worker TimeoutError - the correct classification
+    elapsed = _time.monotonic() - t0
+    pool.shutdown(wait=True)
+
+    # The worker raises at ~0.05s; surfacing must happen well before the 30s
+    # retry_timeout (a hot busy-loop would peg a core until then).
+    assert elapsed < 2.0, f"worker timeout not surfaced promptly: {elapsed:.2f}s"
+
+
+def test_send_worker_timeout_produces_no_warning_spam(caplog):
+    """A worker-raised TimeoutError must not trigger the 'LLM API not
+    responding' warning spam: the future is already done, so _send surfaces
+    it on the first iteration."""
+    import logging
+    import socket
+    import time as _time
+
+    pool = ThreadPoolExecutor(max_workers=1)
+
+    def worker():
+        _time.sleep(0.05)
+        raise socket.timeout("worker socket timeout")
+
+    def submit_fn():
+        return pool.submit(worker)
+
+    with caplog.at_level(logging.WARNING):
+        try:
+            _send(submit_fn, pool, retry_timeout=30.0, agent_name="test")
+        except TimeoutError:
+            pass
+    pool.shutdown(wait=True)
+
+    spam = [
+        r for r in caplog.records
+        if "LLM API not responding" in r.getMessage()
+    ]
+    assert len(spam) == 0, f"expected no 'not responding' warnings, got {len(spam)}"
+
+
+class _SettledRaceFuture(Future):
+    """Reproduces the wait-expiry race deterministically: the first
+    result(timeout=...) call raises TimeoutError as if the wait slice
+    expired, while the future is in fact already done. Models the instant
+    after future.result(timeout=wait) raises when the worker settles before
+    the watchdog re-checks future.done()."""
+
+    def __init__(self, value):
+        super().__init__()
+        self.set_result(value)
+        self._first_result_call = True
+
+    def result(self, timeout=None):
+        if self._first_result_call:
+            self._first_result_call = False
+            raise TimeoutError("simulated wait-slice expiry")
+        return super().result(timeout=timeout)
+
+
+def test_send_returns_value_when_future_settles_during_race():
+    """If the worker settles in the instant after the wait slice expires,
+    _send surfaces the settled value instead of logging a spurious warning
+    or waiting out retry_timeout."""
+    pool = ThreadPoolExecutor(max_workers=1)
+    value = FakeLLMResponse()
+
+    def submit_fn():
+        return _SettledRaceFuture(value)
+
+    result = _send(submit_fn, pool, retry_timeout=30.0, agent_name="test")
+    pool.shutdown(wait=True)
+
+    assert result is value


### PR DESCRIPTION
Fixes #738.

## Problem

On Python >= 3.11 (the repo floor), `concurrent.futures.TimeoutError`, `socket.timeout` and `asyncio.TimeoutError` are all the builtin `TimeoutError`. The watchdog in `src/lingtai/kernel/llm_utils.py` used `except TimeoutError:` around `future.result(timeout=...)` to mean "future not settled yet" — but that clause equally catches a **settled** future whose worker raised its own builtin `TimeoutError` (e.g. a raw `socket.timeout` from the HTTP layer). Consequences:

- `_send` busy-loops logging "LLM API not responding" warnings (no sleep, a done future never waits) until `retry_timeout` expires.
- `_wait_for_worker_settle` converts the worker's own `TimeoutError` into a spurious `WorkerStillRunningError`, which poisons the ChatInterface and forces the agent ASLEEP even though the worker already finished and ran its cleanup (`drop_trailing`).

## Fix

Check `future.done()` first inside both `except TimeoutError` blocks:

- `_send`: if the future is done, surface the settled outcome directly with `future.result(timeout=0)` (re-raises a worker-raised `TimeoutError` as an ordinary exception; returns the value in the wait-expiry race).
- `_wait_for_worker_settle`: if the future is done, return — the worker's own `TimeoutError` already ran its cleanup, same as the existing `except Exception` branch.

Genuine hangs still escalate to `WorkerStillRunningError` (existing tests unchanged). Docstrings note the ambiguity so the idiom is not reintroduced.

## Tests

4 new tests in `tests/test_llm_utils.py`:
- `test_wait_for_worker_settle_returns_when_worker_raised_timeout`
- `test_send_surfaces_worker_timeout_immediately` (prompt, <2s, not WorkerStillRunningError)
- `test_send_worker_timeout_produces_no_warning_spam` (caplog)
- `test_send_returns_value_when_future_settles_during_race`

Run on Python 3.14.6:
- `pytest tests/test_llm_utils.py` → **12 passed** (8 existing + 4 new)
- `pytest tests/test_aed_recovery.py tests/test_tc_wake_chat_not_ready.py` → **20 passed**
- `pytest tests/test_retroactive_history_compaction.py tests/test_llm_adapter_timeouts.py tests/test_llm_service.py` → **59 passed**

Total **91 passed**, 0 failures.