### PR TITLE
fix(kernel): redact spilled tool-result artifact files

### DIFF
--- a/src/lingtai/kernel/tool_result_artifacts.py
+++ b/src/lingtai/kernel/tool_result_artifacts.py
@@ -4,8 +4,10 @@ Two related concerns live here:
 
 1. **Preventive spill** (``spill_oversized_result``) — called by ``ToolExecutor``
    on every newly-built tool result.  If serialized content exceeds
-   ``PREVENTIVE_MAX_CHARS`` (200_000 hard ceiling), the full original is written to
-   ``<workdir>/tmp/tool-results/<…>.{json,txt}`` and a compact manifest dict
+   ``PREVENTIVE_MAX_CHARS`` (200_000 hard ceiling), the content is written to
+   ``<workdir>/tmp/tool-results/<…>.{json,txt}`` redacted through
+   ``redact_for_trajectory`` (same durable-surface treatment as events.jsonl
+   and chat-history archives) and a compact manifest dict
    (``status="spilled"``, ``artifact="lingtai_tool_result_spill"``) replaces
    the wire-bound content.
 
@@ -39,6 +41,7 @@ from typing import Any, Callable
 
 from .workdir import workdir_layout
 from ._fsutil import atomic_write_text
+from .trace_redaction import redact_for_trajectory
 
 # Stable, namespaced literal stamped into every manifest produced by this
 # module.  Detectors require it for new manifests; older manifests that
@@ -233,7 +236,9 @@ def spill_oversized_result(
     history may have been compacted in a previous pass).  If the serialized
     length is ``<= max_chars``, returns ``result`` unchanged.
 
-    Otherwise writes the *full* canonical serialization to
+    Otherwise writes the canonical serialization — redacted through
+    ``redact_for_trajectory`` exactly like other durable trajectory surfaces
+    (events.jsonl, chat-history archives) — to
     ``<working_dir>/tmp/tool-results/<timestamp>-<tool>-<id>-<uuid>.<ext>``
     and returns a small dict containing a warning, the artifact paths (both
     workdir-relative and absolute), original size, cap, tool/call metadata,
@@ -290,8 +295,17 @@ def spill_oversized_result(
     if working_dir is not None:
         wd = Path(working_dir)
         spill_dir = workdir_layout(wd).tool_results_dir
+        # Durable-surface redaction: the artifact file must carry the same
+        # redaction as events.jsonl / chat-history archives.  Redact the
+        # serialized text itself (not the pre-serialization object) so results
+        # that are not JSON-native (dataclasses, custom objects serialized via
+        # ``default=str``) also have their stringified secrets covered.  The
+        # manifest's size fields and the wire-bound preview intentionally stay
+        # on the raw original (the preview is LLM-visible ephemeral content,
+        # redacted again at every durable write).
+        artifact_text = redact_for_trajectory(serialized_text)
         spill_path_str, spill_path_abs, spill_failed = write_artifact_file(
-            serialized_text,
+            artifact_text,
             directory=spill_dir,
             working_dir=wd,
             filename=filename,

--- a/tests/test_tool_result_spill.py
+++ b/tests/test_tool_result_spill.py
@@ -190,6 +190,54 @@ def test_spill_oversized_dict_writes_artifact(tmp_path):
     assert on_disk == payload
 
 
+def test_spill_string_artifact_redacts_secrets(tmp_path):
+    """Spilled string artifacts must be redacted like other durable surfaces (#626)."""
+    api_key = "sk-ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+    assert len(api_key) > 22, "shape guard: sk- + 20+ token chars"
+    big = f'cat config.json -> {{"api_key": "{api_key}"}}\n' + ("x" * (CAP * 2))
+
+    out = _spill_oversized_result(
+        big,
+        max_chars=CAP,
+        tool_name="read",
+        tool_call_id="tc-redact-str",
+        working_dir=tmp_path,
+    )
+
+    assert out["status"] == "spilled"
+    artifact = tmp_path / out["spill_path"]
+    on_disk = artifact.read_text(encoding="utf-8")
+    assert api_key not in on_disk, "spill artifact must not store the raw secret"
+    assert "<REDACTED:" in on_disk, "artifact must carry a redaction placeholder"
+    # Non-secret bulk content must survive redaction untouched.
+    assert "x" * 100 in on_disk
+
+
+def test_spill_dict_artifact_redacts_secrets(tmp_path):
+    """JSON-serialized dict artifacts must also be redacted (#626)."""
+    token = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+    assert len(token) > 33, "shape guard: ghp_ + 30+ token chars"
+    payload = {
+        "status": "ok",
+        "output": f"token={token}",
+        "blob": "Y" * (CAP * 2),
+    }
+
+    out = _spill_oversized_result(
+        payload,
+        max_chars=CAP,
+        tool_name="read",
+        tool_call_id="tc-redact-dict",
+        working_dir=tmp_path,
+    )
+
+    assert out["status"] == "spilled"
+    artifact = tmp_path / out["spill_path"]
+    on_disk = artifact.read_text(encoding="utf-8")
+    assert token not in on_disk, "spill artifact must not store the raw token"
+    assert "<REDACTED:" in on_disk, "artifact must carry a redaction placeholder"
+
+
 def test_spill_handles_missing_working_dir():
     """When working_dir is None the manifest still returns, with spill_error."""
     big = "Z" * (CAP * 2)


### PR DESCRIPTION
Fixes #626

## Problem

Oversized tool results spilled to sidecar artifact files (`<workdir>/tmp/tool-results/`) were written **without redaction**. Every other durable trajectory surface applies `redact_for_trajectory()` before persisting — `services/logging.py:626` (events.jsonl) and `base_agent/__init__.py:2292` (chat-history archive) — but `spill_oversized_result()` in `tool_result_artifacts.py` wrote the raw JSON serialization of the result directly to disk. A tool result containing secrets (e.g. a read of a config file with API keys) that exceeded the spill threshold left the raw secret in plaintext on disk, defeating the redaction system for oversized results.

## Fix

Redact the serialized text **before** writing the artifact, using the same `redact_for_trajectory()` entry point as the other durable surfaces:

```python
artifact_text = redact_for_trajectory(serialized_text)
spill_path_str, spill_path_abs, spill_failed = write_artifact_file(
    artifact_text, ...
)
```

Design notes:
- Redacting the **serialized text** (not the pre-serialization object) also covers results that are not JSON-native (dataclasses / custom objects serialized via `default=str`) whose stringification may embed secrets — `redact_for_trajectory` walks `str`/`Mapping`/`tuple`/`list`/`bytes` and passes other objects through unchanged.
- `original_char_count` / `original_byte_count` and the size-cap threshold intentionally stay on the **raw** original, so spill decisions and manifest size reporting are unchanged.
- The manifest `preview` stays on the raw original: it is LLM-visible ephemeral wire content (consistent with non-spilled results, which the live conversation sees raw) and is redacted again at every durable write (events.jsonl / chat-history / SQLite indexes).
- Redaction is applied in `spill_oversized_result()` only — the shared `write_artifact_file()` primitive is untouched, so the web-search artifact envelope (`tools/web_search/_spill.py`) behavior is unchanged.
- The fix covers all three spill sources: preventive (`tool_executor.py`), retroactive compaction (`compact_oversized_history`), and `recovered_from_events` (`tool_result_recovery.py`, which re-spills from already-redacted events.jsonl).

## Tests

Added two regression tests in `tests/test_tool_result_spill.py` (string result with an `sk-` API key; dict result with a `ghp_` GitHub token) asserting the artifact file no longer contains the raw secret and carries a `<REDACTED:...>` placeholder, while non-secret bulk content survives untouched.

```
$ python3 -m pytest tests/test_tool_result_spill.py tests/test_retroactive_history_compaction.py tests/test_tool_result_recovery.py tests/test_web_output_spill.py tests/test_expired_spill_messaging.py tests/test_read_continuation.py tests/test_resolved_manifest_artifact.py tests/test_trace_redaction.py -q
145 passed, 1 failed, 1 warning in 8.85s
```

The single failure (`test_resolved_manifest_artifact.py::test_artifact_redacts_api_key_like_secrets`, `KeyError: 'web_search'`) is **pre-existing on clean main** (verified via `git stash` + rerun) and unrelated to this change — it concerns a preset manifest capabilities dict in the refresh-watcher path.

Focused new tests:
```
$ python3 -m pytest tests/test_tool_result_spill.py -k 'redacts_secrets' -v
2 passed
```
