### PR TITLE
fix: release workdir lease even when teardown raises

### DIFF
--- a/src/lingtai/kernel/base_agent/lifecycle.py
+++ b/src/lingtai/kernel/base_agent/lifecycle.py
@@ -256,6 +256,11 @@ def _stop(agent, timeout: float = 5.0) -> None:
     ThreadPoolExecutor workers and external CLI process groups can otherwise
     keep this interpreter visible in `ps` after heartbeat/lock are gone, which
     makes refresh watchers race the duplicate-process guard.
+
+    The workdir lease release is unconditional: every teardown step after the
+    main-loop join runs inside a ``try`` whose ``finally`` releases the lease,
+    so a raising intermediate step (session close, manifest write, heartbeat
+    stop, …) can never wedge ``.agent.lock`` (issue #661).
     """
     agent._log("agent_stop")
     agent._cancel_soul_timer()
@@ -283,28 +288,34 @@ def _stop(agent, timeout: float = 5.0) -> None:
             pass
     if agent._thread:
         agent._thread.join(timeout=timeout)
-    _shutdown_daemon_runtime(agent, reason="agent_stop")
-    agent._session.close()
+    try:
+        _shutdown_daemon_runtime(agent, reason="agent_stop")
+        agent._session.close()
 
-    # Stop MailService if configured
-    if agent._mail_service is not None:
-        try:
-            agent._mail_service.stop()
-        except Exception:
-            pass
+        # Stop MailService if configured
+        if agent._mail_service is not None:
+            try:
+                agent._mail_service.stop()
+            except Exception:
+                pass
 
-    # Close the event journal if configured.
-    if agent._event_journal is not None:
-        try:
-            agent._event_journal.close()
-        except Exception:
-            pass
+        # Close the event journal if configured.
+        if agent._event_journal is not None:
+            try:
+                agent._event_journal.close()
+            except Exception:
+                pass
 
-    # Persist final state, stop heartbeat, release the workdir lease — order
-    # matters. See docstring above; heartbeat must remain fresh until this point.
-    agent._workdir.write_manifest(agent._build_manifest())
-    _stop_heartbeat(agent)
-    agent._workdir_lease.release()
+        # Persist final state, stop heartbeat, release the workdir lease — order
+        # matters. See docstring above; heartbeat must remain fresh until this point.
+        agent._workdir.write_manifest(agent._build_manifest())
+        _stop_heartbeat(agent)
+    finally:
+        # The workdir lease MUST be released even when an intermediate teardown
+        # step raises (session close, manifest write, heartbeat stop, …).
+        # Otherwise .agent.lock stays wedged and the agent cannot restart
+        # without manual intervention (issue #661).
+        agent._workdir_lease.release()
 
 
 def _shutdown_daemon_runtime(agent, *, reason: str) -> None:

--- a/tests/test_lifecycle_daemon_shutdown.py
+++ b/tests/test_lifecycle_daemon_shutdown.py
@@ -12,6 +12,8 @@ import threading
 from concurrent.futures import Future
 from types import SimpleNamespace
 
+import pytest
+
 
 def test_daemon_shutdown_for_agent_stop_reclaims_pools_and_cli_processes(tmp_path, monkeypatch):
     from lingtai.tools import daemon as daemon_module
@@ -253,3 +255,81 @@ def test_daemon_shutdown_waits_for_cli_ask_future_before_releasing_liveness(tmp_
     assert waits == [({primary_done, ask_done}, 2.5)]
     assert report["ask_futures_shutdown"] == 1
     assert report["futures_remaining"] == 0
+
+
+def test_stop_releases_workdir_lease_when_intermediate_teardown_raises(monkeypatch):
+    """Issue #661: an unwrapped teardown failure must not wedge ``.agent.lock``.
+
+    ``_stop`` releases the workdir lease in a ``finally``, so a raise from any
+    intermediate step (session close, manifest write, heartbeat stop) still
+    leaves the directory acquirable. The exception propagates so the caller
+    still sees the teardown failure.
+    """
+    from lingtai.kernel.base_agent import lifecycle
+    import lingtai.tools.soul.flow as soul_flow
+
+    released = []
+
+    class FakeLease:
+        def release(self):
+            released.append(True)
+
+    class ExplodingSession:
+        def close(self):
+            raise RuntimeError("session close boom")
+
+    agent = SimpleNamespace(
+        _log=lambda event, **fields: None,
+        _shutdown=threading.Event(),
+        _thread=None,
+        _session=ExplodingSession(),
+        _mail_service=None,
+        _event_journal=None,
+        _workdir=SimpleNamespace(write_manifest=lambda m: None),
+        _workdir_lease=FakeLease(),
+        _build_manifest=lambda: {"agent": "test"},
+        get_capability=lambda name: None,
+    )
+    agent._cancel_soul_timer = lambda: None
+    monkeypatch.setattr(soul_flow, "_cancel_soul_timer", lambda a: None)
+
+    with pytest.raises(RuntimeError, match="session close boom"):
+        lifecycle._stop(agent, timeout=0.01)
+
+    assert released == [True]
+
+
+def test_stop_releases_workdir_lease_when_manifest_write_raises(monkeypatch):
+    """Issue #661: a raise at the LAST teardown step still releases the lease."""
+    from lingtai.kernel.base_agent import lifecycle
+    import lingtai.tools.soul.flow as soul_flow
+
+    released = []
+
+    class FakeLease:
+        def release(self):
+            released.append(True)
+
+    class ExplodingWorkdir:
+        def write_manifest(self, manifest):
+            raise OSError("disk full")
+
+    agent = SimpleNamespace(
+        _log=lambda event, **fields: None,
+        _shutdown=threading.Event(),
+        _thread=None,
+        _session=SimpleNamespace(close=lambda: None),
+        _mail_service=None,
+        _event_journal=None,
+        _workdir=ExplodingWorkdir(),
+        _workdir_lease=FakeLease(),
+        _build_manifest=lambda: {"agent": "test"},
+        get_capability=lambda name: None,
+    )
+    agent._cancel_soul_timer = lambda: None
+    monkeypatch.setattr(soul_flow, "_cancel_soul_timer", lambda a: None)
+
+    with pytest.raises(OSError, match="disk full"):
+        lifecycle._stop(agent, timeout=0.01)
+
+    assert released == [True]


### PR DESCRIPTION
Fixes #661.

## Problem

`_stop()` in `base_agent/lifecycle.py` runs session close, manifest write, heartbeat stop and the workdir-lease release as unwrapped sequential steps. If any intermediate step raises (session/db cleanup error, disk I/O failure, heartbeat stop failure), `agent._workdir_lease.release()` is never reached and `.agent.lock` stays wedged — the agent cannot restart without manual `.agent.lock` deletion. This contradicts the codebase's own best-effort teardown pattern (mail_service/event_journal shutdown are already wrapped in try/except).

## Fix

Wrap all teardown steps after the main-loop join in a `try` block whose `finally` always calls `agent._workdir_lease.release()`. The lease release is now unconditional:

- success path: order is unchanged (daemon shutdown → session close → services → manifest → heartbeat stop → lease release)
- failure path: the lease is still released, and the original exception still propagates to the caller (`cli.py` already swallows `stop()` errors in its own `finally`), so real teardown failures stay visible while the directory never stays wedged
- `release()` is documented and implemented as idempotent and non-raising in both the POSIX and Windows `WorkdirLeasePort` adapters, so calling it in `finally` cannot mask the original error

## Tests

Reproduced on current main (HEAD `df2b523d`): when `agent._session.close()` raises, `lease.release()` was NOT called (lock wedge confirmed). After the fix the same script reports `lease.release() called: True`.

Added regression tests pinning the guarantee:

```
tests/test_lifecycle_daemon_shutdown.py:7 passed in 0.36s
```

- `test_stop_releases_workdir_lease_when_intermediate_teardown_raises` — session close raises; lease released, exception propagates
- `test_stop_releases_workdir_lease_when_manifest_write_raises` — last-step manifest write raises; lease released, exception propagates

Additional sweep:

```
tests/test_workdir_lease.py tests/test_workdir.py: 36 passed, 9 skipped in 2.19s
tests/test_agent.py -k starts_and_stops: 1 passed
```
