### PR TITLE
fix(llm): count ToolResultBlock.metadata in context estimate (#1013)

### DIFF
--- a/src/lingtai/kernel/llm/interface.py
+++ b/src/lingtai/kernel/llm/interface.py
@@ -963,6 +963,11 @@ class ChatInterface:
         Uses the canonical entries (not provider-specific formats), so the
         estimate is provider-agnostic.  Falls back to current_system_prompt
         and current_tools if explicit args are not provided.
+
+        ``ToolResultBlock.metadata`` sidecars are counted because wire
+        converters project them into the provider payload — omitting them
+        makes the estimate understate stateless full-replay requests
+        (issue #1013).
         """
         from ..token_counter import count_tokens
         import json
@@ -997,6 +1002,14 @@ class ChatInterface:
                         else json.dumps(block.content, default=str)
                     )
                     total += count_tokens(content_str)
+                    # The runtime metadata sidecar is projected into the
+                    # provider payload by every wire converter
+                    # (interface_converters._project_tool_result), so it must
+                    # be counted here too — otherwise stateless full replay
+                    # can overflow while the estimate reports a low context
+                    # usage (issue #1013).
+                    if isinstance(block.metadata, dict) and block.metadata:
+                        total += count_tokens(json.dumps(block.metadata, default=str))
                 elif isinstance(block, ThinkingBlock):
                     total += count_tokens(block.text)
 

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -155,6 +155,41 @@ class TestEstimateContextTokens:
         estimate = iface.estimate_context_tokens()
         assert estimate > 100  # 1000 chars / ~8 = ~125 tokens (Gemini) or ~4 = ~250 tokens (tiktoken)
 
+    def test_counts_tool_result_metadata_sidecar(self):
+        """Metadata sidecars must count toward the estimate (issue #1013).
+
+        Wire converters project ``ToolResultBlock.metadata`` into the
+        provider payload, so omitting it makes the estimate understate the
+        stateless-replay request size and can let /clear report a low
+        context usage while the next request overflows.
+        """
+
+        def _build(metadata: dict | None) -> ChatInterface:
+            iface = ChatInterface()
+            iface.add_system("You are a helpful assistant.")
+            iface.add_user_message("search")
+            iface.add_assistant_message(
+                [ToolCallBlock(id="call_1", name="search", args={"q": "x"})],
+            )
+            iface.add_tool_results(
+                [
+                    ToolResultBlock(
+                        id="call_1",
+                        name="search",
+                        content="small result",
+                        metadata=metadata or {},
+                    )
+                ]
+            )
+            return iface
+
+        plain = _build(None)
+        with_meta = _build({"agent_meta": {"guidance": "g" * 2000}})
+        assert plain.estimate_context_tokens() > 0
+        # The metadata-bearing history must estimate strictly larger than the
+        # identical history without the sidecar.
+        assert with_meta.estimate_context_tokens() > plain.estimate_context_tokens()
+
 
 # ---------------------------------------------------------------------------
 # Tests — Context-pressure metadata in BaseAgent._handle_request


### PR DESCRIPTION
Fixes #1013.

## Problem

`ChatInterface.estimate_context_tokens()` counts `ToolResultBlock.content` but omits the runtime `ToolResultBlock.metadata` sidecar, while every wire converter (`interface_converters._project_tool_result`, used by the chat-completions, Responses, and Anthropic converters) projects that sidecar into the provider payload. For stateless Responses sessions (custom OpenAI-compatible providers) this makes the canonical/local estimate understate the actual replayed request — `/clear` can report low context usage while the next full replay already exceeds the provider's context window, and AED retries cannot make progress because it only compacts `block.content`.

## Fix

Count the `ToolResultBlock.metadata` sidecar in `estimate_context_tokens()` when it is non-empty, so the estimate reflects the payload the wire actually sends (issue #1013). This is the smallest, unambiguous part of the reported gap; the zero-progress AED retry storm and the bounded-replay representation remain tracked by #713 / #712 respectively.

## Test evidence

- New unit test `TestEstimateContextTokens::test_counts_tool_result_metadata_sidecar` (tests/test_compaction.py): a history with a 2000-char metadata sidecar now estimates strictly larger than the identical history without it.
- Manual repro (issue scenario: tool results carrying `agent_meta.guidance` + `notifications` sidecars, 3 turns):
  - before fix: metadata-heavy history estimated ~= plain history (sidecar excluded) while the Responses-wire render was ~80x larger;
  - after fix: estimate = 3880 tokens vs wire render = 4194 tokens (93% of the exact rendered representation).
- Regression suites: `tests/test_compaction.py`, `tests/test_interface.py`, `tests/test_responses_converter.py`, `tests/test_session.py`, `tests/test_context_pressure_streak.py`, `tests/test_soul_consultation.py`, `tests/test_meta_block.py`, `tests/test_aed_recovery.py`, `tests/test_aed_tool_pairing.py`, `tests/test_molt_notification_persistence.py`, `tests/test_post_molt_notification.py`, `tests/test_codex_standalone_compaction.py` — all pass (451 tests, 0 failures).
