### PR TITLE
fix(messaging): unread counters drain — telegram counts incoming only; wechat reply marks read

### DIFF
--- a/src/lingtai/mcp_servers/telegram/SKILL.md
+++ b/src/lingtai/mcp_servers/telegram/SKILL.md
@@ -106,7 +106,8 @@ setup readiness checklist are **not** here — they belong to `mcp-manual`
 
 ## READING: read / check / search
 
-- `check`: list recent conversations with unread counts.
+- `check`: list recent conversations with unread counts. Unread counts
+  incoming messages only — your own outgoing replies are never counted.
 - `read`: read messages from one chat (`chat_id`; optional `limit`). Reading
   marks messages read and clears the wake notification mirror.
 - `search`: regex search over message text/sender/update type (`query`;

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -3879,7 +3879,14 @@ class TelegramManager:
                     "taskcard": taskcard,
                 }
             conversations[cid]["total"] += 1
-            if msg.get("id") and msg["id"] not in read_ids:
+            # Unread counts incoming messages only: sent records (which carry
+            # a "to" field) are messages the agent itself produced and must
+            # not inflate the counter (same rule the WeChat addon documents).
+            if (
+                msg.get("id")
+                and not msg.get("to")
+                and msg["id"] not in read_ids
+            ):
                 conversations[cid]["unread"] += 1
 
         return {

--- a/src/lingtai/mcp_servers/wechat/manager.py
+++ b/src/lingtai/mcp_servers/wechat/manager.py
@@ -688,7 +688,14 @@ class WechatManager:
         if not user_id:
             return {"error": "Cannot determine user_id from message"}
 
-        return self._handle_send({"user_id": user_id, "text": text})
+        result = self._handle_send({"user_id": user_id, "text": text})
+        # Replying handles the message: mark it read so the unread counter
+        # drains after a reply (mirrors the Telegram addon's reply handler).
+        # Only mark when the send actually succeeded.
+        if result.get("status") == "ok":
+            self._read_ids.add(message_id)
+            self._save_read()
+        return result
 
     def _handle_search(self, args: dict) -> dict:
         query = args.get("query", "")

--- a/tests/test_telegram_unread_count.py
+++ b/tests/test_telegram_unread_count.py
@@ -1,0 +1,162 @@
+"""Regression tests: Telegram check() unread counts incoming messages only.
+
+Issue #715: the bot's own outgoing replies were counted as unread (merged
+inbox + sent history against read_ids), so every reply inflated the counter
+and a fully-handled chat never drained to zero. Unread must count incoming
+messages only, matching the WeChat addon's documented rule.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from lingtai.mcp_servers.telegram.manager import TelegramManager
+from tests._notification_store_helpers import notification_store_for
+
+
+class _FakeAccount:
+    alias = "main"
+
+    def send_message(self, chat_id: int, text: str, **_kwargs: Any) -> dict[str, Any]:
+        return {"message_id": 9001, "chat": {"id": chat_id}, "text": text}
+
+    def set_message_reaction(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    def send_chat_action(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+
+class _FakeService:
+    default_account = _FakeAccount()
+
+    def get_account(self, _alias: str) -> _FakeAccount:
+        return self.default_account
+
+    def list_accounts(self) -> list[str]:
+        return ["main"]
+
+
+def _manager(workdir: Path) -> TelegramManager:
+    return TelegramManager(
+        _FakeService(),
+        working_dir=workdir,
+        on_inbound=lambda _event: None,
+        notification_store=notification_store_for(workdir),
+    )
+
+
+def _write_inbox_message(
+    workdir: Path,
+    *,
+    account: str = "main",
+    chat_id: int = 123,
+    message_id: int = 53,
+    text: str = "hello",
+) -> str:
+    compound_id = f"{account}:{chat_id}:{message_id}"
+    msg_dir = workdir / "telegram" / account / "inbox" / f"uuid-{chat_id}-{message_id}"
+    msg_dir.mkdir(parents=True, exist_ok=True)
+    (msg_dir / "message.json").write_text(
+        json.dumps(
+            {
+                "id": compound_id,
+                "from": {"username": "alice"},
+                "chat": {"id": chat_id, "type": "private"},
+                "date": f"2026-05-21T23:{message_id % 60:02d}:00Z",
+                "text": text,
+                "media": None,
+                "callback_query": None,
+                "reply_to_message_id": None,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return compound_id
+
+
+def _write_sent_message(
+    workdir: Path,
+    *,
+    account: str = "main",
+    chat_id: int = 123,
+    message_id: int = 9001,
+    text: str = "my reply",
+) -> str:
+    compound_id = f"{account}:{chat_id}:{message_id}"
+    msg_dir = workdir / "telegram" / account / "sent" / f"uuid-{chat_id}-{message_id}"
+    msg_dir.mkdir(parents=True, exist_ok=True)
+    (msg_dir / "message.json").write_text(
+        json.dumps(
+            {
+                "id": compound_id,
+                "to": {"chat_id": chat_id},
+                "date": "2026-05-21T23:59:00Z",
+                "text": text,
+                "status": "sent",
+            }
+        ),
+        encoding="utf-8",
+    )
+    return compound_id
+
+
+def _chat_by_id(check_result: dict, chat_id: int) -> dict:
+    return next(
+        conv for conv in check_result["messages"] if conv["chat_id"] == chat_id
+    )
+
+
+def test_check_counts_only_incoming_messages_as_unread(tmp_path: Path) -> None:
+    workdir = tmp_path / "agent"
+    _write_inbox_message(workdir, message_id=53, text="question 1")
+    _write_inbox_message(workdir, message_id=54, text="question 2")
+    _write_sent_message(workdir, message_id=9001, text="answer 1")
+    _write_sent_message(workdir, message_id=9002, text="answer 2")
+    _write_sent_message(workdir, message_id=9003, text="answer 3")
+
+    manager = _manager(workdir)
+    check = manager._check({"account": "main"})
+
+    conv = _chat_by_id(check, 123)
+    # Total merges inbox + sent (post-molt visibility preserved) ...
+    assert conv["total"] == 5
+    # ... but unread reflects only the two incoming messages, not the three
+    # outgoing replies the bot itself produced.
+    assert conv["unread"] == 2
+
+
+def test_check_reports_zero_unread_after_fully_read_chat(tmp_path: Path) -> None:
+    workdir = tmp_path / "agent"
+    _write_inbox_message(workdir, message_id=53, text="question 1")
+    _write_inbox_message(workdir, message_id=54, text="question 2")
+    _write_sent_message(workdir, message_id=9001, text="answer 1")
+
+    manager = _manager(workdir)
+    manager._read({"account": "main", "chat_id": 123, "limit": 10})
+
+    conv = _chat_by_id(manager._check({"account": "main"}), 123)
+    # A fully-handled chat drains to zero: the incoming messages were read and
+    # the bot's own reply is never counted.
+    assert conv["unread"] == 0
+    assert conv["total"] == 3
+
+
+def test_check_unread_drains_when_bot_replies_to_last_message(tmp_path: Path) -> None:
+    """Headline #715 scenario: bot replied last, yet unread stayed positive."""
+    workdir = tmp_path / "agent"
+    compound_id = _write_inbox_message(workdir, message_id=53, text="question")
+
+    manager = _manager(workdir)
+    result = manager._reply({"account": "main", "message_id": compound_id, "text": "answer"})
+    assert result["status"] == "sent"
+
+    check = manager._check({"account": "main"})
+    conv = _chat_by_id(check, 123)
+    # The chat shows the bot's own reply as the last message ...
+    assert conv["last_from"] == {"is_bot": True}
+    # ... yet the unread counter is zero: the answered incoming message was
+    # marked read and the outgoing reply is not counted.
+    assert conv["unread"] == 0
+    assert conv["total"] == 2

--- a/tests/test_wechat_reply_read_state.py
+++ b/tests/test_wechat_reply_read_state.py
@@ -1,0 +1,105 @@
+"""Regression tests: WeChat reply() drains the unread counter.
+
+Issue #715: replying to an incoming message never marked it read, so a chat
+where the bot answered directly (without an explicit read) kept a positive
+unread count forever. Replying handles the message and must mark it read,
+mirroring the Telegram addon's reply handler.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from lingtai.mcp_servers.wechat.manager import WechatManager
+
+
+def _manager(tmp_path: Path) -> WechatManager:
+    return WechatManager(
+        token="test-token",
+        user_id="test-bot",
+        working_dir=tmp_path,
+        on_inbound=lambda _event: None,
+    )
+
+
+def _write_inbox(
+    mgr: WechatManager, message_id: str, user_id: str = "human-1",
+) -> None:
+    msg_dir = mgr._inbox_dir / message_id
+    msg_dir.mkdir(parents=True, exist_ok=True)
+    (msg_dir / "message.json").write_text(
+        json.dumps(
+            {
+                "id": message_id,
+                "from_user_id": user_id,
+                "text": "hello",
+                "date": "2026-07-06T00:00:00Z",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _conversations(mgr: WechatManager) -> list[dict]:
+    return mgr._handle_check({})["conversations"]
+
+
+def _unread_for_human(mgr: WechatManager) -> int:
+    for conv in _conversations(mgr):
+        if conv["alias"] == "human-1":
+            return conv["unread"]
+    return -1
+
+
+def test_incoming_message_starts_unread(tmp_path: Path) -> None:
+    mgr = _manager(tmp_path)
+    _write_inbox(mgr, "msg-1")
+    assert _unread_for_human(mgr) == 1
+
+
+def test_reply_marks_original_message_read(tmp_path: Path, monkeypatch) -> None:
+    mgr = _manager(tmp_path)
+    _write_inbox(mgr, "msg-1")
+
+    monkeypatch.setattr(
+        mgr,
+        "_handle_send",
+        lambda args: {"status": "ok", "sent": ["text"], "message_id": "sent-1"},
+    )
+    result = mgr._handle_reply({"message_id": "msg-1", "text": "got it"})
+    assert result["status"] == "ok"
+
+    convs = _conversations(mgr)
+    assert convs[0]["unread"] == 0
+    assert convs[0]["total"] == 1
+
+
+def test_reply_read_state_persists_across_restart(tmp_path: Path, monkeypatch) -> None:
+    mgr = _manager(tmp_path)
+    _write_inbox(mgr, "msg-1")
+
+    monkeypatch.setattr(
+        mgr,
+        "_handle_send",
+        lambda args: {"status": "ok", "sent": ["text"], "message_id": "sent-1"},
+    )
+    mgr._handle_reply({"message_id": "msg-1", "text": "got it"})
+
+    # read.json is written: a fresh manager over the same dir still reports
+    # the answered message as read.
+    restarted = _manager(tmp_path)
+    assert _unread_for_human(restarted) == 0
+
+
+def test_failed_reply_does_not_mark_read(tmp_path: Path, monkeypatch) -> None:
+    mgr = _manager(tmp_path)
+    _write_inbox(mgr, "msg-1")
+
+    monkeypatch.setattr(
+        mgr,
+        "_handle_send",
+        lambda args: {"error": "send failed"},
+    )
+    result = mgr._handle_reply({"message_id": "msg-1", "text": "got it"})
+    assert "error" in result
+    assert _unread_for_human(mgr) == 1


### PR DESCRIPTION
Fixes #715

## Problem

The messaging addons' `unread` counter is monotonic and meaningless:

1. **Telegram counts the bot's own replies as unread.** `_check` merges inbox + sent history and increments `unread` for any message id not in `read_ids`. Sent records are persisted with ids and are never added to `read_ids`, so every reply the bot sends inflates its own unread count (observed at 310 / 1005 unread on chats where the bot spoke last).
2. **WeChat replies never drain the counter.** `_handle_reply` sent the answer but never marked the answered message read, so a chat answered directly (without an explicit `read`) stayed unread forever. The WeChat `_handle_check` already documents the intent — "Unread counts incoming messages only" — but its counter still never drained.

## Changes

- **`telegram/manager.py` — `_check`**: count `unread` for incoming messages only (records carrying a `to` field are the bot's own outgoing messages and are excluded), matching the WeChat addon's documented rule. `total` still merges inbox + sent so post-molt visibility is preserved.
- **`wechat/manager.py` — `_handle_reply`**: after a successful send, mark the answered incoming message id as read (persisted to `read.json`), mirroring the Telegram addon's reply handler. A failed send does not mark read.
- **`telegram/SKILL.md`**: document that `check` unread counts incoming messages only.

The per-chat last-read watermark and an explicit `mark_read` action suggested in #715 remain follow-up design items (data-model change touching both addons); this PR fixes the two observable counter defects.

## Tests

New regression tests (all passing):

- `tests/test_telegram_unread_count.py`
  - `test_check_counts_only_incoming_messages_as_unread` — 2 inbox + 3 sent → `total=5`, `unread=2`
  - `test_check_reports_zero_unread_after_fully_read_chat` — fully read chat drains to 0
  - `test_check_unread_drains_when_bot_replies_to_last_message` — headline scenario: bot replied last (`last_from.is_bot=true`), `unread=0`
- `tests/test_wechat_reply_read_state.py`
  - `test_reply_marks_original_message_read` — reply → `unread=0`
  - `test_reply_read_state_persists_across_restart` — read state survives `read.json` reload
  - `test_failed_reply_does_not_mark_read` — failed send leaves `unread=1`

```
$ python -m pytest tests/test_telegram_unread_count.py tests/test_wechat_reply_read_state.py
7 passed in 0.88s

$ python -m pytest tests/test_telegram_notification_read_state.py tests/test_telegram_lossless_envelope.py tests/test_telegram_task_card_toggle.py tests/test_wechat_inbound_replay.py tests/test_wechat_toolfamily_ltpv2.py tests/test_telegram_toolfamily_ltpv2.py tests/test_telegram_unread_count.py tests/test_wechat_reply_read_state.py
214 passed in 4.66s
```
