### PR TITLE
docs(system): improve log.sqlite query manual discoverability

### DIFF
--- a/src/lingtai/intrinsic_skills/system-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/SKILL.md
@@ -4,8 +4,8 @@ description: >
   Second-layer router for LingTai's progressive-disclosure operating manuals.
   Read this when resident substrate/procedures are too compact and you need the
   right lower reference; route from the table, then open that node.
-version: 1.11.0
-last_changed_at: "2026-08-07T00:00:00Z"
+version: 1.12.0
+last_changed_at: "2026-08-09T00:00:00Z"
 tags: [lingtai, agent, runtime, procedures, substrate, system, lifecycle, memory, communication, skills, molt, summarize, nudge, updates, runtime-checks, refresh, preset, llm, adapters, codex, websocket]
 related_files:
 - src/lingtai/prompts/substrate/substrate.md
@@ -55,7 +55,9 @@ The router table is the routing authority; this list is the inventory.
   description: |
     SQLite/`log.sqlite` runtime trace inspection: `lingtai-agent log
     doctor|query|rebuild`, JSONL source-of-truth rules, read-only SQL safety,
-    the events/chat_entries/token_entries schema, SQL recipes, and redaction.
+    the events/chat_entries/token_entries schema, quick-start snippets, SQL
+    recipes (`tool_call_id` lifecycle, tool result stats/percentiles, spilled
+    results), gotchas, and redaction.
 - name: trajectory-mining
   location: reference/trajectory-mining/SKILL.md
   description: |
@@ -112,7 +114,7 @@ The router table is the routing authority; this list is the inventory.
 | `init.json` composition/owner map; preset runtime model; raw vs resolved `system/manifest.resolved.json`; preset identity/path; TUI/library discovery vs `system(action="presets")` allowed-only catalog; main-agent swap/revert/refresh; daemon `tasks[].preset` explicit/omitted path; external CLI backend preset skip | `reference/substrate-manual/SKILL.md` §11 |
 | Expanded procedures; progressive disclosure; writing skills/knowledge; action discipline; responsiveness; skill routing; HTML deliverables; artifact sharing; issue reporting; when to read which manual | `reference/procedures-manual/SKILL.md` |
 | Tool-result summarization; large-result ranking via agent_meta; progressive disclosure of raw outputs; original-result recovery; summarize vs molt | `context-manual` → `reference/summarize-manual/SKILL.md` |
-| SQLite; `log.sqlite`; LingTai runtime logs; JSONL traces; `lingtai-agent log doctor`; `lingtai-agent log query`; `lingtai-agent log rebuild`; events/chat_entries schema; daemon/chat-history trace indexing; WAL/live-read caveats; SQL recipes | `reference/sqlite-log-query/SKILL.md` |
+| SQLite; `log.sqlite`; LingTai runtime logs; runtime trace inspection; JSONL traces; `lingtai-agent log doctor`; `lingtai-agent log query`; `lingtai-agent log rebuild`; events/chat_entries schema; daemon/chat-history trace indexing; WAL/live-read caveats; SQL recipes; `tool_call_id` lifecycle; tool result stats and percentiles; spilled/large tool results | `reference/sqlite-log-query/SKILL.md` |
 | Trajectory mining; trajectory/anomaly mining; improvement digests; finding schema and validation; cheap-model daemon strategy; mining prompt templates; periodic mining mode | `reference/trajectory-mining/SKILL.md` |
 | Notifications; direct `notification(action='manual', input={})`; check/dismiss_channel/dismiss_event/dismiss_ref/manual; `.notification/<channel>.json`; channel allowlist; the top-level `instructions` field in the `.notification/<channel>.json` envelope; protected channels; generic vs producer dismiss; stale-version/force; legacy `large_tool_result` dismiss | `notification-manual` |
 | About to call `system(action="refresh")`; preset swap/revert pre-flight; "will this refresh break something?"; refresh returned but MCP/tools/LLM look wrong; refresh failed | `reference/refresh-precheck/SKILL.md` |

--- a/src/lingtai/intrinsic_skills/system-manual/reference/sqlite-log-query/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/sqlite-log-query/SKILL.md
@@ -4,11 +4,13 @@ description: >
   Nested system-manual reference for the additive SQLite/`log.sqlite` sidecar
   over LingTai's JSONL runtime traces. Read it when you need
   `lingtai-agent log doctor|query|rebuild`, read-only SQL safety and WAL/rebuild
-  caveats, the events/chat_entries/token_entries schema, SQL recipes, or the
-  redaction rules. Trajectory mining is the sibling `trajectory-mining`.
-version: 1.3.0
+  caveats, the events/chat_entries/token_entries schema, quick-start snippets,
+  SQL recipes (`tool_call_id` lifecycle, tool result stats and percentiles,
+  spilled/large tool results), gotchas, or the redaction rules. Runtime trace
+  forensics start here; trajectory mining is the sibling `trajectory-mining`.
+version: 1.4.0
 tags: [lingtai, system-manual, sqlite, log.sqlite, runtime-logs, trace, jsonl, daemon, event-log, pitfalls, observability]
-last_changed_at: "2026-08-07T00:00:00Z"
+last_changed_at: "2026-08-09T00:00:00Z"
 related_files:
 - src/lingtai/intrinsic_skills/system-manual/SKILL.md
 - src/lingtai/intrinsic_skills/system-manual/reference/trajectory-mining/SKILL.md
@@ -25,6 +27,39 @@ sources of truth. Use it to answer questions that are painful with `grep`: which
 event types are hottest, what happened inside daemon runs, what chat-history
 turn surrounded a failure, whether notification/daemon/context events are
 storming, or how token usage is distributed across main/soul/daemon sources.
+
+## Start here for log.sqlite (quick start)
+
+First-use, copy-pasteable snippets. `log.sqlite` lives at `logs/log.sqlite`
+under the agent directory (`AGENT_DIR=/path/to/project/.lingtai/agent-name`).
+Open it read-only and run the three first checks:
+
+```bash
+sqlite3 -readonly logs/log.sqlite '.tables'
+sqlite3 -readonly logs/log.sqlite 'pragma table_info(events);'
+sqlite3 -readonly logs/log.sqlite \
+  "select type, count(*) as n from events group by type order by n desc limit 20;"
+```
+
+Plain `sqlite3 logs/log.sqlite` opens the file read-write; for inspection
+prefer `-readonly` (or the Python URI form below) so you never accidentally
+write the sidecar. Equivalent read-only Python:
+
+```python
+import sqlite3
+
+db_path = "/path/to/.lingtai/<agent>/logs/log.sqlite"
+conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+for row in conn.execute(
+    "select type, count(*) from events group by type order by count(*) desc limit 20;"
+):
+    print(row)
+```
+
+The five recipes in **Query recipes** below (event type counts, per-tool result
+length, percentiles, `tool_call_id` lifecycle, large/spilled results) are
+directly copy-pasteable. The **Safety contract** and **Gotchas** sections apply
+to every query.
 
 ## Safety contract
 
@@ -49,6 +84,21 @@ storming, or how token usage is distributed across main/soul/daemon sources.
 - **Never paste secrets.** Logs and chat history can contain URLs, tokens,
   prompts, and user data — including raw `fields_json`/`entry_json`. Apply the
   redaction rules below before sharing anything.
+
+## Gotchas
+
+- The event-kind column is **`type`**, not `event_type`.
+- The structured event payload lives in **`fields_json`** (chat rows in
+  `entry_json`); reach into it with `json_extract(fields_json, '$.key')`.
+- `log.sqlite` is **derived and rebuildable**; JSONL remains authoritative.
+  A missing sidecar is a rebuildable index gap, never lost facts.
+- Open the sidecar **read-only** for inspection: `sqlite3 -readonly`, the
+  `file:...?mode=ro` URI, or `lingtai-agent log query`. Never write to it
+  directly.
+- For exact forensic payloads, follow `source_file` / `source_offset` back to
+  the JSONL source.
+- `fields_json`/`entry_json` can carry URLs, tokens, prompts, and user data —
+  redact before sharing anything.
 
 ## Commands
 
@@ -180,6 +230,74 @@ FROM events
 GROUP BY source_kind, type
 ORDER BY n DESC
 LIMIT 50;
+```
+
+Per-tool result length aggregation (`$.result` holds the tool output text):
+
+```sql
+SELECT json_extract(fields_json, '$.tool_name') AS tool,
+       COUNT(*) AS n,
+       CAST(AVG(length(json_extract(fields_json, '$.result'))) AS INT) AS avg_result_len,
+       MAX(length(json_extract(fields_json, '$.result'))) AS max_result_len,
+       SUM(CASE WHEN length(json_extract(fields_json, '$.result')) > 5000 THEN 1 ELSE 0 END) AS over_5000
+FROM events
+WHERE type = 'tool_result'
+  AND json_extract(fields_json, '$.result') IS NOT NULL
+GROUP BY tool
+ORDER BY n DESC
+LIMIT 20;
+```
+
+Nearest-rank percentiles of tool result lengths (SQLite window functions):
+
+```sql
+WITH ranked AS (
+  SELECT length(json_extract(fields_json, '$.result')) AS result_len,
+         ROW_NUMBER() OVER (ORDER BY length(json_extract(fields_json, '$.result'))) AS rn,
+         COUNT(*) OVER () AS n
+  FROM events
+  WHERE type = 'tool_result'
+    AND json_extract(fields_json, '$.result') IS NOT NULL
+)
+SELECT MAX(CASE WHEN rn <= CAST(n * 0.50 + 0.5 AS INTEGER) THEN result_len END) AS p50,
+       MAX(CASE WHEN rn <= CAST(n * 0.90 + 0.5 AS INTEGER) THEN result_len END) AS p90,
+       MAX(CASE WHEN rn <= CAST(n * 0.95 + 0.5 AS INTEGER) THEN result_len END) AS p95,
+       MAX(CASE WHEN rn <= CAST(n * 0.99 + 0.5 AS INTEGER) THEN result_len END) AS p99,
+       MAX(result_len) AS max_len
+FROM ranked;
+```
+
+Trace one `tool_call_id` lifecycle. A full lifecycle typically spans
+`tool_call_received` -> `tool_reasoning` -> `tool_call_normalized` ->
+`tool_call_approved` -> `tool_call` -> `tool_call_dispatch_start` ->
+`tool_call_dispatch_done` -> `tool_result` -> `tool_result_durable_log_visible`
+-> `tool_result_model_visible` (daemon runs prefix some of these with
+`daemon_` and carry `run_id`):
+
+```sql
+SELECT ts, type, source_kind, run_id,
+       json_extract(fields_json, '$.tool_name') AS tool,
+       substr(fields_json, 1, 160) AS fields
+FROM events
+WHERE json_extract(fields_json, '$.tool_call_id') = 'call_00_XXXX'
+   OR json_extract(fields_json, '$.tool_trace_id') = 'call_00_XXXX'
+ORDER BY ts;
+```
+
+Find large/spilled tool results. `tool_result_spilled` rows keep the real size
+in `$.original_char_count` and point to `$.spill_path`:
+
+```sql
+SELECT id, ts, type,
+       json_extract(fields_json, '$.tool_name') AS tool,
+       COALESCE(json_extract(fields_json, '$.original_char_count'),
+                length(json_extract(fields_json, '$.result'))) AS result_len,
+       json_extract(fields_json, '$.spill_path') AS spill_path
+FROM events
+WHERE type IN ('tool_result', 'tool_result_spilled')
+  AND json_extract(fields_json, '$.result') IS NOT NULL
+ORDER BY result_len DESC
+LIMIT 20;
 ```
 
 Recent chat-history entries:


### PR DESCRIPTION
Fixes #344.

Docs-only change to the system-manual SQLite/log.sqlite query layer, per the issue acceptance criteria:

- **Router (`system-manual/SKILL.md`)** — added discoverability keywords to the sqlite-log-query router row (`runtime trace inspection`, `tool_call_id lifecycle`, `tool result stats and percentiles`, `spilled/large tool results`) and extended the nested-catalog description. Version 1.11.0 -> 1.12.0.
- **Nested manual (`reference/sqlite-log-query/SKILL.md`)** — added a copy-pasteable **Start here for log.sqlite (quick start)** section (`.tables`, `pragma table_info(events)`, event-type counts, Python `mode=ro` URI) before the safety theory; a prominent **Gotchas** section (`type` not `event_type`, `fields_json`, JSONL-authoritative/rebuildable, read-only connections, `source_file`/`source_offset` forensics, secrets); and the five required recipes: 1) event type counts, 2) per-tool result length aggregation, 3) nearest-rank percentiles (window functions), 4) one `tool_call_id` lifecycle trace, 5) large/spilled tool results. Version 1.3.0 -> 1.4.0.

**Test evidence** — all SQL blocks in the edited manual were run verbatim (read-only) against a real 1.78 GB `log.sqlite` (dev-2/mimo-1, HEAD df2b523): 25/27 OK; the 2 non-OK are pre-existing parameterized recipes that require `:start_ts`/`:end_ts`-style bindings. The five acceptance recipes produced real results (e.g. p50=1634/p90=13881/p95=20806/p99=50172 chars; lifecycle spans `tool_call_received` -> `tool_reasoning` -> `tool_call_normalized` -> `tool_call_approved` -> `tool_call` -> `tool_call_dispatch_start` -> `tool_call_dispatch_done` -> `tool_result` -> `tool_result_durable_log_visible` -> `tool_result_model_visible`; largest result 1.73M chars). Quick-start bash/Python snippets verified against the same DB.

Focused tests: `test_prompt.py` 15 passed. `test_skills.py::test_lingtai_owned_skill_frontmatter_has_last_changed_at` still fails on **pre-existing** `psyche-manual/SKILL.md` (missing `last_changed_at` on main; untouched by this PR).