### PR TITLE
fix(refresh): single-flight refresh so concurrent requests cannot spawn duplicate watchers

### DIFF
--- a/src/lingtai/kernel/base_agent/lifecycle.py
+++ b/src/lingtai/kernel/base_agent/lifecycle.py
@@ -716,6 +716,29 @@ def _perform_refresh(
     ``_shutdown`` / ``_cancel_event`` ourselves so the watcher's second
     phase can complete.
     """
+    # Single-flight guard (lingtai#624): refresh is terminal for this
+    # process — the watcher relaunches a NEW `lingtai run <dir>` child and
+    # we set `_shutdown` so `.agent.lock` releases — so at most ONE refresh
+    # operation may ever run per process lifetime. Two near-concurrent
+    # refresh requests (heartbeat-detected `.refresh` racing a
+    # `system(action='refresh')` tool call, or the AED preset-fallback
+    # racing either) must coalesce into one watcher; otherwise sibling
+    # watchers each launch a `lingtai run <dir>` child that the other
+    # rejects with "another lingtai agent is already running", and both
+    # retry loops exhaust MAX_ATTEMPTS, failing recovery permanently.
+    guard = getattr(agent, "_refresh_singleflight_lock", None)
+    if guard is None:
+        guard = threading.Lock()
+        agent._refresh_singleflight_lock = guard
+    with guard:
+        if getattr(agent, "_refresh_started", False):
+            agent._log("refresh_skipped", reason="refresh_already_in_progress")
+            return
+        # Claim the single-flight slot before any side effect (chat-history
+        # save, handshake rename, watcher spawn). Released on every failure
+        # exit below so a failed refresh never wedges a live agent.
+        agent._refresh_started = True
+
     # When the worker interface is poisoned, the in-memory ChatInterface may
     # still be mutated by a stuck worker thread — saving it would serialize
     # unsafe state. Fail closed: skip the save and rebuild from disk.
@@ -742,6 +765,8 @@ def _perform_refresh(
     cmd = agent._build_launch_cmd()
     if cmd is None:
         agent._log("refresh_no_launch_cmd")
+        with guard:
+            agent._refresh_started = False
         return
 
     # A real launch command means this refresh will actually spawn a watcher.
@@ -751,6 +776,8 @@ def _perform_refresh(
     # Port must never orphan an agent mid-handshake or leave it silently
     # unable to relaunch.
     if agent._refresh_watcher is None:
+        with guard:
+            agent._refresh_started = False
         raise RuntimeError(
             "_perform_refresh requires a RefreshWatcherPort to spawn the "
             "relaunch watcher, but this agent was constructed without one "
@@ -794,6 +821,8 @@ def _perform_refresh(
         # agent with no relaunch. If .refresh still exists, leave it for
         # the heartbeat path or a later retry rather than consuming it.
         agent._log("refresh_ack_failed", handshake=handshake_source)
+        with guard:
+            agent._refresh_started = False
         return
 
     # If both files happen to exist (heartbeat renamed but a later
@@ -829,7 +858,14 @@ def _perform_refresh(
         address=address,
         identity_fields_json=identity_fields_json,
     )
-    agent._refresh_watcher.spawn_detached(request)
+    try:
+        agent._refresh_watcher.spawn_detached(request)
+    except BaseException:
+        # Spawn failed: the agent stays alive and must be able to retry
+        # refresh later — release the single-flight slot.
+        with guard:
+            agent._refresh_started = False
+        raise
     agent._log("refresh_deferred_relaunch",
                cmd=cmd[0], handshake=handshake_source)
     # Lock-clear signaling — direct callers (intrinsic system tool call,

--- a/tests/test_perform_refresh_handshake.py
+++ b/tests/test_perform_refresh_handshake.py
@@ -1157,3 +1157,70 @@ def test_refresh_watcher_cleanup_then_success_does_not_write_failure_alert(tmp_p
     assert "refresh_watcher_stale_duplicate_terminate" in event_types
     assert "refresh_watcher_success" in event_types
     assert "refresh_failed_permanent" not in event_types
+
+
+# ---------------------------------------------------------------------------
+# Single-flight coalescing (Lingtai-AI/lingtai#624)
+# ---------------------------------------------------------------------------
+
+
+def test_two_refresh_requests_coalesce_to_one_watcher(tmp_path):
+    """Two near-concurrent refresh requests on the same agent must coalesce
+    into ONE watcher spawn (lingtai#624 regression).
+
+    Before the single-flight guard, a second ``_perform_refresh`` call while
+    the first refresh operation was pending saw ``.refresh.taken`` already on
+    disk and spawned its own watcher anyway. Sibling watchers then each
+    launched ``lingtai run <dir>`` children that mutually rejected one
+    another with "another lingtai agent is already running" until both
+    exhausted MAX_ATTEMPTS and recovery failed permanently. The second
+    request must instead be coalesced: logged ``refresh_skipped`` with
+    reason ``refresh_already_in_progress`` and no second watcher spawn.
+    """
+    agent = _make_agent_with_launch_cmd(tmp_path)
+    watcher = agent._refresh_watcher
+    log_events = []
+    agent._log = lambda event, **kw: log_events.append((event, kw))
+
+    agent._perform_refresh()
+    assert len(watcher.calls) == 1, "first refresh must spawn exactly one watcher"
+
+    agent._perform_refresh()  # second near-concurrent request
+
+    assert len(watcher.calls) == 1, \
+        "a second refresh while one is already in flight must not spawn another watcher"
+    assert any(
+        event == "refresh_skipped"
+        and kw.get("reason") == "refresh_already_in_progress"
+        for event, kw in log_events
+    ), "the second request must coalesce: log refresh_skipped(refresh_already_in_progress)"
+
+
+def test_concurrent_refresh_requests_spawn_exactly_one_watcher(tmp_path):
+    """Threaded variant with a start barrier: even when two refresh requests
+    arrive at the same instant from different threads (heartbeat thread vs
+    LLM worker thread), exactly one watcher is spawned and one refresh
+    operation wins the single-flight slot (lingtai#624)."""
+    import threading
+
+    agent = _make_agent_with_launch_cmd(tmp_path)
+    watcher = agent._refresh_watcher
+    barrier = threading.Barrier(2)
+    errors = []
+
+    def refresh():
+        try:
+            barrier.wait(timeout=5)
+            agent._perform_refresh()
+        except BaseException as exc:  # pragma: no cover - failure reporting
+            errors.append(exc)
+
+    threads = [threading.Thread(target=refresh) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=15)
+
+    assert not errors, f"refresh threads failed: {errors!r}"
+    assert len(watcher.calls) == 1, \
+        "concurrent refresh requests must spawn exactly one watcher"


### PR DESCRIPTION
## Summary

Fixes Lingtai-AI/lingtai#624 (blocking): concurrent refresh requests for the same agent directory spawn duplicate relaunch watchers that lock each other and exhaust recovery.

`_perform_refresh` (kernel lifecycle) had no per-agent single-flight guard: a second refresh request while one was pending saw `.refresh.taken` already on disk and spawned its own watcher anyway (e.g. a heartbeat-detected `.refresh` racing a `system(action='refresh')` tool call, or the AED preset-fallback racing either). Sibling watchers then each launched `lingtai run <dir>` children that mutually rejected one another with `error: another lingtai agent is already running`, exhausting both 12-attempt retry loops and publishing a permanent refresh failure; the agent stayed offline until an external restart.

## Fix

Make `_perform_refresh` single-flight per agent process:

- A per-agent `threading.Lock` + `_refresh_started` claim, taken at the very start of `_perform_refresh` before any side effect (chat-history save, handshake rename, watcher spawn).
- A second refresh while one is in flight is coalesced: logged `refresh_skipped` with `reason=refresh_already_in_progress` and **no second watcher is spawned**.
- The slot is released on every failure exit (no launch command, missing `RefreshWatcherPort`, ack-write failure, spawn exception) so a failed refresh never wedges a live agent.

Rationale: refresh is terminal for the current process — the watcher relaunches a NEW `lingtai run` child and `_shutdown` is set so `.agent.lock` releases — so at most one refresh operation may ever run per process lifetime. All refresh paths (heartbeat, intrinsic tool call, AED preset fallback, worker-recovery) funnel through `_perform_refresh`, so one guard covers them all.

## Tests

New regression tests in `tests/test_perform_refresh_handshake.py`:

- `test_two_refresh_requests_coalesce_to_one_watcher` — a second `_perform_refresh` on the same agent logs `refresh_skipped(refresh_already_in_progress)` and spawns no second watcher.
- `test_concurrent_refresh_requests_spawn_exactly_one_watcher` — barrier-driven two-thread variant (heartbeat thread vs LLM worker thread); exactly one watcher spawn.

Verified the new tests **FAIL on unpatched main** (`assert 2 == 1` — two watchers spawned, deterministically reproducing #624) and **PASS with the fix**.

Full local runs (Python 3.13):

- `tests/test_perform_refresh_handshake.py`: 44 passed
- `tests/test_refresh_watcher_process.py tests/test_deep_refresh.py tests/test_lifecycle_daemon_shutdown.py`: 87 passed
- `tests/test_cli_worker_poison_recovery.py tests/test_system.py`: 39 passed
- `tests/test_aed_recovery.py tests/test_base_agent.py tests/test_cli.py`: 62 passed

## Follow-ups (not in this PR)

- Stable operation ID / initiator attribution in refresh-watcher events (issue item 3).
- Typed `refresh_in_progress`/`agent_stopping` tool result instead of the unstructured `RuntimeError: MCP client has been closed` on dispatch after stop (issue item 4).
- Explicit cancel/transfer/handoff disposition for child-daemon records during refresh (issue item 7).