### PR TITLE
fix(aed): abort over-window retry on zero-progress compaction (#713)

### DIFF
--- a/src/lingtai/kernel/base_agent/turn.py
+++ b/src/lingtai/kernel/base_agent/turn.py
@@ -915,10 +915,48 @@ def _run_loop(agent) -> None:
                     # the already-shrunk wire.  Over-window errors get a
                     # distinct source tag so AED logs make the cause
                     # auditable.
-                    _compact_history_before_retry(
+                    compaction_stats = _compact_history_before_retry(
                         agent,
                         source="aed_over_window" if over_window else "aed_deterministic",
                     )
+
+                    # Issue #713: an over-window error means the wire itself
+                    # is too long, and retroactive compaction is the only
+                    # mechanism that can shrink it before the replay.  If the
+                    # pass freed nothing, the rebuilt wire is the same size
+                    # (the retry prompt only adds tokens), so every remaining
+                    # AED attempt is mathematically guaranteed to fail with
+                    # the same provider error.  Abort the wake immediately
+                    # instead of burning the rest of the AED budget (which
+                    # can be configured as high as 99 attempts) on a doomed
+                    # retry storm.  A ``None`` result (no live chat / helper
+                    # failure) is not proof of zero progress, so only a
+                    # positively-observed empty pass aborts.
+                    if (
+                        over_window
+                        and compaction_stats is not None
+                        and compaction_stats.compacted_blocks == 0
+                    ):
+                        agent._log(
+                            "aed_zero_progress_abort",
+                            attempt=aed_attempts,
+                            max_attempts=agent._config.max_aed_attempts,
+                            error=err_desc,
+                            scanned_blocks=compaction_stats.scanned_blocks,
+                        )
+                        _report_api_error_to_task_card(
+                            agent,
+                            _original_provider_exc,
+                            attempt=aed_attempts,
+                            max_attempts=agent._config.max_aed_attempts,
+                            terminal=True,
+                        )
+                        agent._log(
+                            "aed_exhausted", attempts=aed_attempts, error=err_desc
+                        )
+                        sleep_state = AgentState.ASLEEP
+                        agent._asleep.set()
+                        break
 
                     # Rebuild session with current config, preserving history
                     if agent._session.chat is not None:

--- a/tests/test_aed_recovery.py
+++ b/tests/test_aed_recovery.py
@@ -376,6 +376,117 @@ def test_structural_error_skips_transient_retry(tmp_path, monkeypatch):
     assert any(name == "aed_attempt" and fields["attempt"] == 1 for name, fields in agent._logs)
 
 
+def test_over_window_zero_progress_compaction_aborts_aed_retry_loop(tmp_path, monkeypatch):
+    """Issue #713: an over-window error followed by a zero-progress
+    retroactive compaction is a doomed retry — the rebuilt wire is the same
+    size (plus the retry prompt), so further AED attempts can never succeed.
+    The run loop must abort the wake after the first attempt instead of
+    burning the full AED budget (max_aed_attempts can be configured as high
+    as 99, which produced an 11-day zombie / 34.9M wasted input tokens)."""
+    from lingtai.kernel.tool_result_artifacts import CompactionStats
+
+    agent = _make_run_loop_agent(tmp_path)
+    agent._config.max_aed_attempts = 10
+    calls = {"n": 0}
+
+    def fake_handle(_agent, _msg):
+        calls["n"] += 1
+        raise RuntimeError("Your input exceeds the context window of this model.")
+
+    def fake_compact(_agent, *, source):
+        return CompactionStats(scanned_blocks=87, compacted_blocks=0)
+
+    monkeypatch.setattr(turn, "_handle_message", fake_handle)
+    monkeypatch.setattr(turn, "_compact_history_before_retry", fake_compact)
+
+    import lingtai.tools.soul.flow as soul_flow
+    monkeypatch.setattr(soul_flow, "_cancel_soul_timer", lambda _a: _a._shutdown.set())
+
+    turn._run_loop(agent)
+
+    assert calls["n"] == 1
+    assert getattr(agent, "rebuilds", 0) == 0
+    assert agent._asleep.is_set()
+    assert [name for name, _ in agent._logs].count("aed_attempt") == 1
+    assert any(
+        name == "aed_zero_progress_abort" and fields["scanned_blocks"] == 87
+        for name, fields in agent._logs
+    )
+    assert any(name == "aed_exhausted" for name, _ in agent._logs)
+
+
+def test_over_window_zero_progress_abort_reports_terminal_to_task_card(tmp_path, monkeypatch):
+    """Issue #713: the task-card error row must be flipped terminal when the
+    wake is aborted on zero-progress compaction — the turn is observably
+    done (the same wire will fail identically), not left as a retrying row."""
+    from lingtai.kernel.tool_result_artifacts import CompactionStats
+
+    agent = _make_run_loop_agent(tmp_path)
+    agent.reports = []
+    agent._report_task_card_api_error = (
+        lambda exc, **kw: agent.reports.append((exc, kw))
+    )
+
+    def fake_handle(_agent, _msg):
+        raise RuntimeError("prompt is too long: maximum context length exceeded")
+
+    def fake_compact(_agent, *, source):
+        return CompactionStats(scanned_blocks=1, compacted_blocks=0)
+
+    monkeypatch.setattr(turn, "_handle_message", fake_handle)
+    monkeypatch.setattr(turn, "_compact_history_before_retry", fake_compact)
+
+    import lingtai.tools.soul.flow as soul_flow
+    monkeypatch.setattr(soul_flow, "_cancel_soul_timer", lambda _a: _a._shutdown.set())
+
+    turn._run_loop(agent)
+
+    assert any(name == "aed_zero_progress_abort" for name, _ in agent._logs)
+    terminal_reports = [kw for _, kw in agent.reports if kw.get("terminal")]
+    assert terminal_reports
+    assert terminal_reports[-1]["attempt"] == 1
+    assert terminal_reports[-1]["max_attempts"] == 10
+
+
+def test_over_window_compaction_with_progress_keeps_aed_retry(tmp_path, monkeypatch):
+    """Issue #713 regression guard: when retroactive compaction actually frees
+    blocks, the AED retry must still proceed — the wire shrank, so the next
+    attempt has a real chance of succeeding."""
+    from lingtai.kernel.tool_result_artifacts import CompactionStats
+
+    agent = _make_run_loop_agent(tmp_path)
+    agent._config.max_aed_attempts = 10
+    calls = {"n": 0}
+
+    def fake_handle(_agent, _msg):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("Your input exceeds the context window of this model.")
+        _agent._shutdown.set()
+
+    def fake_compact(_agent, *, source):
+        return CompactionStats(
+            scanned_blocks=87,
+            compacted_blocks=3,
+            original_chars_total=15000,
+            replacement_chars_total=600,
+        )
+
+    monkeypatch.setattr(turn, "_handle_message", fake_handle)
+    monkeypatch.setattr(turn, "_compact_history_before_retry", fake_compact)
+
+    import lingtai.tools.soul.flow as soul_flow
+    monkeypatch.setattr(soul_flow, "_cancel_soul_timer", lambda _a: None)
+
+    turn._run_loop(agent)
+
+    assert calls["n"] == 2
+    assert getattr(agent, "rebuilds", 0) == 1
+    assert [name for name, _ in agent._logs].count("aed_attempt") == 1
+    assert not any(name == "aed_zero_progress_abort" for name, _ in agent._logs)
+    assert not agent._asleep.is_set()
+
+
 def test_empty_llm_response_is_classified_transient():
     err = turn.EmptyLLMResponseError(ledger_source="main", in_tool_loop=False)
     assert turn._is_transient_provider_error(err) is True


### PR DESCRIPTION
Fixes #713

## Problem

An agent configured with `max_aed_attempts: 99` burned the full AED budget on **every wake** for 11 days (1,458 `aed_over_window_detected` events, 1,489 zero-progress compaction events, ~34.9M input tokens). Each retry replayed an over-window wire that retroactive compaction could not shrink (`compacted_blocks: 0`), so every attempt was mathematically guaranteed to fail — the runtime never detected the non-progress and never escalated.

## Fix

In the main AED loop (`src/lingtai/kernel/base_agent/turn.py`), when an over-window provider error is followed by a retroactive compaction pass that positively freed nothing (`compacted_blocks == 0`), abort the wake immediately instead of retrying up to `max_aed_attempts`:

- the rebuilt wire is identical in size (the retry prompt only adds tokens), so remaining attempts cannot succeed;
- logs a new `aed_zero_progress_abort` event (attempt + scanned blocks) so operators can see exactly why the wake stopped;
- flips the Task Card error row terminal and takes the same ASLEEP path as `aed_exhausted`, keeping state observability consistent.

A `None` compaction result (no live chat / helper failure) is **not** treated as zero progress — only a positively observed empty pass aborts. The non-over-window (deterministic structural) AED branch is unchanged, since zero progress there does not prove the retry is doomed.

This implements **layer 1** of #713. Layers 2 (pre-flight molt trigger / token-accounting reconciliation) and 3 (wake-cycle circuit breaker) are larger design items and are left as follow-ups.

## Tests

- `tests/test_aed_recovery.py` — 3 new regression tests:
  - `test_over_window_zero_progress_compaction_aborts_aed_retry_loop`: with `max_aed_attempts=10` and a zero-progress compactor, exactly **1** attempt happens, `aed_zero_progress_abort` is logged, no session rebuild, agent sleeps;
  - `test_over_window_zero_progress_abort_reports_terminal_to_task_card`: the error row is reported terminal;
  - `test_over_window_compaction_with_progress_keeps_aed_retry`: a compaction that frees blocks still retries (rebuild + second attempt).
- Full suite: `python3 -m pytest tests/ -q --continue-on-collection-errors` → all collected tests pass (36 pre-existing collection errors from missing optional deps exist identically on main).
