### PR TITLE
fix(whatsapp): dedup inbound webhook replays by stable wamid (#733)

### DIFF
--- a/src/lingtai/mcp_servers/whatsapp/manager.py
+++ b/src/lingtai/mcp_servers/whatsapp/manager.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
+import tempfile
 import threading
 from datetime import datetime, timezone
 from importlib import resources
@@ -49,6 +51,12 @@ _CS_WINDOW_NOTE = (
 _CONVERSATION_CONTEXT_MESSAGES = 10
 _STRUCTURED_MESSAGE_TEXT_CAP = 500
 
+# Bounded FIFO window for the inbound replay guard (inbox_seen.json). Sized
+# well above a single Meta webhook retry horizon: Meta re-delivers the same
+# wamid with backoff, so a live retry never falls outside this window while it
+# could still be re-delivered. Bounds memory/disk for the persisted seen-set.
+SEEN_KEYS_MAX = 5000
+
 DESCRIPTION = "WhatsApp Cloud API client for LingTai. Official Meta API only; no WhatsApp Web bridge."
 
 # Public callers receive the strict LTP-v2 family schema. Manager dispatch
@@ -73,6 +81,15 @@ class WhatsAppManager:
         self.config_source = config_source
         self._last_verified_at = _utcnow()
         self._contacts_lock = threading.Lock()
+        # Inbound replay guard state (see _stable_key/_is_replay/_record_seen).
+        # Meta webhooks are at-least-once: on a slow or non-200 response the
+        # same payload (same wamid) is redelivered with backoff. Persisted to
+        # root/inbox_seen.json so the guard survives restarts; keys are
+        # namespaced by account alias, so one file covers all accounts.
+        self._seen_keys: dict[str, str] = {}
+        self._seen_order: list[str] = []
+        self._seen_lock = threading.Lock()
+        self._load_seen()
 
     def _account_alias(self, alias: str | None) -> str:
         if alias:
@@ -127,13 +144,19 @@ class WhatsAppManager:
             raise ValueError("message_id must be account:wa_id:wamid")
         return parts[0], parts[1], parts[2]
 
-    def _store_message(self, alias: str, folder: str, msg: dict[str, Any]) -> dict[str, Any]:
+    def _store_message(self, alias: str, folder: str, msg: dict[str, Any]) -> tuple[dict[str, Any], str]:
+        """Write ``msg`` to a fresh local inbox/sent directory.
+
+        Returns ``(stored_msg, local_id)`` where ``local_id`` is the local
+        directory name (the replay guard records it so a suppressed duplicate
+        can be traced to its original landing).
+        """
         d = self._account_dir(alias) / folder / str(uuid4())
         d.mkdir(parents=True, exist_ok=True)
         msg = dict(msg)
         msg.setdefault("stored_at", _utcnow())
         (d / "message.json").write_text(json.dumps(msg, ensure_ascii=False, indent=2), encoding="utf-8")
-        return msg
+        return msg, d.name
 
     def _iter_messages(self, alias: str, folder: str | None = None) -> list[dict[str, Any]]:
         base = self._account_dir(alias)
@@ -204,7 +227,7 @@ class WhatsAppManager:
         try:
             response = self._client(alias).post_message(payload)
             wamid = (((response.get("messages") or [{}])[0]).get("id") or f"local-{uuid4()}")
-            stored = self._store_message(alias, "sent", {"id": self._compound(alias, to, wamid), "wa_id": to, "message_id": wamid, "text": args.get("text"), "payload": payload, "response": response, "direction": "outgoing"})
+            stored, _ = self._store_message(alias, "sent", {"id": self._compound(alias, to, wamid), "wa_id": to, "message_id": wamid, "text": args.get("text"), "payload": payload, "response": response, "direction": "outgoing"})
             return {"status": "sent", "message_id": stored["id"], "response": response}
         except Exception as e:
             return {"status": "error", "error": str(e), "note": _CS_WINDOW_NOTE}
@@ -222,7 +245,7 @@ class WhatsAppManager:
         try:
             response = self._client(alias).post_message(payload)
             new_id = (((response.get("messages") or [{}])[0]).get("id") or f"local-{uuid4()}")
-            stored = self._store_message(alias, "sent", {"id": self._compound(alias, wa_id, new_id), "wa_id": wa_id, "message_id": new_id, "reply_to": wamid, "text": args.get("text"), "payload": payload, "response": response, "direction": "outgoing"})
+            stored, _ = self._store_message(alias, "sent", {"id": self._compound(alias, wa_id, new_id), "wa_id": wa_id, "message_id": new_id, "reply_to": wamid, "text": args.get("text"), "payload": payload, "response": response, "direction": "outgoing"})
             return {"status": "sent", "message_id": stored["id"], "response": response}
         except Exception as e:
             return {"status": "error", "error": str(e), "note": _CS_WINDOW_NOTE}
@@ -431,14 +454,117 @@ class WhatsAppManager:
         )
         return structured, latest_incoming
 
+    # ── Inbound replay / idempotency guard ──────────────────────────────────────────────────────
+
+    @staticmethod
+    def _stable_key(alias: str, ev: dict[str, Any]) -> str | None:
+        """Derive a stable, replay-resistant signature for an inbound event.
+
+        Meta assigns a globally stable wamid (``message_id``) to every message
+        and repeats it verbatim on redelivery, so it is the primary key. The
+        key is namespaced by account alias and sender so a collision across
+        accounts/senders cannot suppress a real message. Returns ``None`` when
+        the event carries no stable upstream id — the caller must land it
+        unconditionally rather than key on a local ``local-<uuid4>`` placeholder.
+        """
+        wamid = ev.get("message_id")
+        if wamid:
+            return f"{alias}|{ev.get('wa_id') or 'unknown'}|mid:{wamid}"
+        return None
+
+    def _is_replay(self, key: str) -> bool:
+        """True if this stable key was already landed (replay guard hit)."""
+        with self._seen_lock:
+            return key in self._seen_keys
+
+    def _record_seen(self, key: str, local_id: str) -> None:
+        """Persist that ``key`` was landed under ``local_id`` (atomic)."""
+        with self._seen_lock:
+            if key in self._seen_keys:
+                return
+            self._seen_keys[key] = local_id
+            self._seen_order.append(key)
+            # Evict oldest beyond the window to bound the state file.
+            while len(self._seen_order) > SEEN_KEYS_MAX:
+                evicted = self._seen_order.pop(0)
+                self._seen_keys.pop(evicted, None)
+        self._save_seen()
+
+    def _save_seen(self) -> None:
+        with self._seen_lock:
+            payload = {
+                "version": 1,
+                "order": list(self._seen_order),
+                "keys": dict(self._seen_keys),
+            }
+        self._atomic_write(
+            self.root / "inbox_seen.json",
+            json.dumps(payload, ensure_ascii=False),
+        )
+
+    def _load_seen(self) -> None:
+        """Load the persisted replay guard; corrupt/missing state degrades to empty."""
+        seen_file = self.root / "inbox_seen.json"
+        if not seen_file.is_file():
+            return
+        try:
+            seen = json.loads(seen_file.read_text(encoding="utf-8"))
+            self._seen_keys = dict(seen.get("keys", {}))
+            self._seen_order = [
+                k for k in seen.get("order", []) if k in self._seen_keys
+            ]
+        except (ValueError, AttributeError, OSError) as e:
+            # Corrupt index degrades to "no guard", never crashes boot.
+            log.warning("Failed to load inbox_seen.json (ignoring): %s", e)
+            self._seen_keys = {}
+            self._seen_order = []
+
+    @staticmethod
+    def _atomic_write(path: Path, content: str) -> None:
+        """Write content to path atomically via tempfile + os.replace."""
+        fd, tmp = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(content)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp, path)
+        except BaseException:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+
     def ingest_webhook(self, alias: str, payload: dict[str, Any]) -> list[dict[str, Any]]:
         events = extract_events(payload)
         for ev in events:
             if ev.get("kind") == "message":
+                # Replay guard. Meta's webhook delivery is at-least-once: when
+                # the receiver is slow, down, or answers non-200, Meta re-sends
+                # the same notification — with the same wamid — with backoff.
+                # Without a guard each redelivery would land a duplicate inbox
+                # entry under a fresh local UUID and wake the agent again.
+                # Detect redeliveries by their stable upstream signature and
+                # skip the second landing entirely — no new inbox entry, no
+                # LICC wake. Record the key only after the inbox write has
+                # succeeded, so a crash mid-write cannot mark a message seen
+                # without landing it (mirrors the WeChat manager).
+                stable_key = self._stable_key(alias, ev)
+                if stable_key is not None and self._is_replay(stable_key):
+                    log.info("WhatsApp inbound replay suppressed: %s", stable_key)
+                    continue
                 wa_id = ev.get("wa_id") or "unknown"
                 wamid = ev.get("message_id") or f"local-{uuid4()}"
                 msg = {"id": self._compound(alias, wa_id, wamid), "wa_id": wa_id, "message_id": wamid, "text": ev.get("text"), "type": ev.get("type"), "direction": "incoming", "metadata": ev.get("metadata"), "timestamp": ev.get("timestamp"), "stored_at": _utcnow()}
-                self._store_message(alias, "inbox", msg)
+                if stable_key is not None:
+                    # Provenance: the stable signature this message was first
+                    # landed under, so a suppressed duplicate can be traced to
+                    # its original (same convention as the WeChat manager).
+                    msg["stable_key"] = stable_key
+                _, local_id = self._store_message(alias, "inbox", msg)
+                if stable_key is not None:
+                    self._record_seen(stable_key, local_id)
                 if self.on_inbound:
                     header = _NOTIFICATION_HEADER_TEMPLATE.format(channel="WhatsApp").rstrip("\n")
                     message_body = ev.get("text") or f"[{ev.get('type')}]"

--- a/tests/test_whatsapp_inbound_replay.py
+++ b/tests/test_whatsapp_inbound_replay.py
@@ -1,0 +1,196 @@
+"""Regression tests for inbound WhatsApp webhook replay suppression.
+
+Meta's Cloud API webhook delivery is at-least-once: whenever the receiver does
+not answer with a timely HTTP 200, Meta re-delivers the same notification with
+the same stable messages[].id (wamid) with backoff for hours. Before the replay
+guard, every redelivery landed a duplicate inbox entry under a fresh local UUID
+and woke the agent again. These tests pin the idempotency guard (mirroring the
+WeChat manager's inbox_seen.json design) that suppresses such replays while
+preserving genuinely new messages.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from lingtai.mcp_servers.whatsapp.manager import WhatsAppManager
+
+ACCESS_TOKEN = "secret-access-token"
+APP_SECRET = "secret-app-secret"
+
+
+def _manager(tmp_path: Path, *, on_inbound=None) -> WhatsAppManager:
+    return WhatsAppManager(
+        accounts_config=[
+            {
+                "alias": "default",
+                "phone_number_id": "10001",
+                "access_token": ACCESS_TOKEN,
+                "app_secret": APP_SECRET,
+            }
+        ],
+        working_dir=tmp_path,
+        on_inbound=on_inbound,
+    )
+
+
+def _webhook_payload(*messages: dict) -> dict:
+    return {
+        "entry": [
+            {
+                "changes": [
+                    {
+                        "value": {
+                            "metadata": {"phone_number_id": "10001"},
+                            "messages": list(messages),
+                        }
+                    }
+                ]
+            }
+        ]
+    }
+
+
+def _text_message(wamid: str, body: str, *, wa_id: str = "15551234567") -> dict:
+    return {
+        "from": wa_id,
+        "id": wamid,
+        "timestamp": "1752000000",
+        "type": "text",
+        "text": {"body": body},
+    }
+
+
+def _inbox_entries(tmp_path: Path) -> list[Path]:
+    return sorted((tmp_path / "whatsapp" / "default" / "inbox").glob("*/message.json"))
+
+
+def test_duplicate_webhook_delivery_lands_once(tmp_path):
+    inbound: list[dict] = []
+    manager = _manager(tmp_path, on_inbound=inbound.append)
+    payload = _webhook_payload(_text_message("wamid.A", "hello"))
+
+    first = manager.ingest_webhook("default", payload)
+    second = manager.ingest_webhook("default", payload)
+
+    # One inbox landing, one wake; the return value is unchanged by the guard.
+    assert len(_inbox_entries(tmp_path)) == 1
+    assert len(inbound) == 1
+    assert first == second
+
+
+def test_distinct_wamids_both_land(tmp_path):
+    inbound: list[dict] = []
+    manager = _manager(tmp_path, on_inbound=inbound.append)
+
+    manager.ingest_webhook("default", _webhook_payload(_text_message("wamid.A", "hello")))
+    manager.ingest_webhook("default", _webhook_payload(_text_message("wamid.B", "hello")))
+
+    assert len(_inbox_entries(tmp_path)) == 2
+    assert len(inbound) == 2
+
+
+def test_same_text_different_message_ids_not_deduped(tmp_path):
+    manager = _manager(tmp_path)
+
+    manager.ingest_webhook("default", _webhook_payload(_text_message("wamid.A", "same text")))
+    manager.ingest_webhook("default", _webhook_payload(_text_message("wamid.B", "same text")))
+
+    # Identical content but distinct wamids are different messages: both land.
+    assert len(_inbox_entries(tmp_path)) == 2
+
+
+def test_seen_state_survives_restart(tmp_path):
+    inbound: list[dict] = []
+    manager = _manager(tmp_path, on_inbound=inbound.append)
+    payload = _webhook_payload(_text_message("wamid.A", "hello"))
+    manager.ingest_webhook("default", payload)
+    assert len(inbound) == 1
+
+    # New manager over the same working_dir reloads inbox_seen.json.
+    restarted = _manager(tmp_path, on_inbound=inbound.append)
+    restarted.ingest_webhook("default", payload)
+
+    assert len(_inbox_entries(tmp_path)) == 1
+    assert len(inbound) == 1
+
+
+def test_corrupt_seen_file_degrades_gracefully(tmp_path):
+    seen = tmp_path / "whatsapp" / "inbox_seen.json"
+    seen.parent.mkdir(parents=True, exist_ok=True)
+    seen.write_text("{not json", encoding="utf-8")
+
+    manager = _manager(tmp_path)
+    manager.ingest_webhook("default", _webhook_payload(_text_message("wamid.A", "hello")))
+
+    # Corrupt guard state must not crash boot and ingest still works.
+    assert len(_inbox_entries(tmp_path)) == 1
+
+
+def test_missing_message_id_never_suppressed(tmp_path):
+    manager = _manager(tmp_path)
+    payload = _webhook_payload(
+        {
+            "from": "15551234567",
+            "timestamp": "1752000000",
+            "type": "text",
+            "text": {"body": "no id"},
+        }
+    )
+
+    manager.ingest_webhook("default", payload)
+    manager.ingest_webhook("default", payload)
+
+    # No stable upstream id -> no dedup key: both deliveries land.
+    assert len(_inbox_entries(tmp_path)) == 2
+
+
+def test_seen_keys_fifo_eviction(tmp_path, monkeypatch):
+    from lingtai.mcp_servers.whatsapp import manager as whatsapp_manager_module
+
+    monkeypatch.setattr(whatsapp_manager_module, "SEEN_KEYS_MAX", 3)
+    manager = _manager(tmp_path)
+    payloads = [_webhook_payload(_text_message(f"wamid.{i}", f"msg {i}")) for i in range(4)]
+    for payload in payloads:
+        manager.ingest_webhook("default", payload)
+    assert len(_inbox_entries(tmp_path)) == 4
+
+    # Oldest key was evicted: replaying wamid.0 lands again.
+    manager.ingest_webhook("default", payloads[0])
+    # Newest key is still in the window: replaying wamid.3 is suppressed.
+    manager.ingest_webhook("default", payloads[3])
+
+    assert len(_inbox_entries(tmp_path)) == 5
+
+
+def test_record_after_store_ordering(tmp_path, monkeypatch):
+    manager = _manager(tmp_path)
+    real_store = WhatsAppManager._store_message
+    calls = {"n": 0}
+
+    def flaky_store(self, alias, folder, msg):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise OSError("disk full")
+        return real_store(self, alias, folder, msg)
+
+    monkeypatch.setattr(WhatsAppManager, "_store_message", flaky_store)
+    payload = _webhook_payload(_text_message("wamid.A", "hello"))
+
+    with pytest.raises(OSError):
+        manager.ingest_webhook("default", payload)
+    # The key must NOT have been recorded for the failed write: retrying the
+    # same payload lands the message instead of suppressing it.
+    manager.ingest_webhook("default", payload)
+
+    assert len(_inbox_entries(tmp_path)) == 1
+
+
+def test_stored_message_keeps_stable_key_provenance(tmp_path):
+    manager = _manager(tmp_path)
+    manager.ingest_webhook("default", _webhook_payload(_text_message("wamid.A", "hello")))
+
+    stored = json.loads(_inbox_entries(tmp_path)[0].read_text(encoding="utf-8"))
+    assert stored["stable_key"] == "default|15551234567|mid:wamid.A"


### PR DESCRIPTION
Fixes #733.

## Problem
Meta Cloud API webhook delivery is at-least-once. Whenever the receiver is slow, down, or answers non-200, Meta re-delivers the same notification - with the same stable `messages[].id` (wamid) - on backoff, potentially for hours. `WhatsAppManager.ingest_webhook` landed every delivery under a fresh local UUID and woke the agent each time, creating duplicate inbox entries and duplicate agent wakes (and a busy-host amplification loop). The WeChat manager already solves this with a persisted replay guard; WhatsApp had no equivalent and no replay test.

## Change
All in `src/lingtai/mcp_servers/whatsapp/manager.py`, mirroring the WeChat manager's `inbox_seen.json` idiom (one dedup pattern across channel addons):

- `SEEN_KEYS_MAX = 5000` bounded FIFO window constant.
- `_stable_key(alias, ev)` - stable key from the upstream wamid, namespaced by account alias and `wa_id`; returns `None` (no dedup) when the event carries no stable id, never keying on a local `local-<uuid4>` placeholder.
- Lock-protected `_is_replay` / `_record_seen` with FIFO eviction, `_save_seen` (atomic tempfile + `os.replace`) and `_load_seen` (missing/corrupt file degrades to an empty guard, never crashes boot).
- `ingest_webhook` checks the seen-set before storing/waking, skips replays entirely (no new inbox entry, no LICC wake), and records the key only after the inbox write succeeds - crash-safe ordering: a crash mid-write can never mark a message seen without landing it. Stored messages carry `stable_key` provenance for traceability.
- `_store_message` now returns `(msg, local_id)` so the guard records the local landing directory; `_send`/`_reply` unpack the tuple.

`status` events are not stored or woken today, so they stay out of the seen-set.

## Tests
New `tests/test_whatsapp_inbound_replay.py` (9 tests):

- duplicate webhook delivery lands once (1 inbox entry, 1 wake, return value unchanged)
- distinct wamids both land
- same text + different wamids are NOT deduped (no content-key false positives)
- seen state survives restart (inbox_seen.json reload)
- corrupt inbox_seen.json degrades gracefully
- missing message_id is never suppressed
- FIFO eviction at SEEN_KEYS_MAX
- store failure does NOT record the key (retry lands the message)
- stored message keeps stable_key provenance

Results:
- `pytest tests/test_whatsapp_inbound_replay.py` - 9 passed
- `pytest tests/test_whatsapp_notification_metadata.py tests/test_whatsapp_toolfamily_ltpv2.py tests/test_wechat_inbound_replay.py` - 55 passed
- `ruff check` on the new test file - clean (manager.py carries the same 12 pre-existing violations on base main; this PR adds none)

Note: this implements the check-then-record split from the issue's detailed plan (step 5), exactly mirroring the WeChat manager. The fused `_claim` alternative mentioned in the issue's risks section remains a possible follow-up; the split never drops a message, which is the crash-ordering invariant the issue prioritizes.
