### PR TITLE
fix: snapshot adapter cache scan in get_adapter fast path (#739)

### DIFF
--- a/src/lingtai/llm/service.py
+++ b/src/lingtai/llm/service.py
@@ -313,29 +313,36 @@ class LLMService(LLMServiceABC):
         with different base URLs (e.g. OpenRouter vs local vLLM) gets separate
         adapter instances.
 
+        When *base_url* is None and multiple adapters are cached for
+        *provider*, the returned adapter is chosen deterministically: the
+        ``(provider, None)`` entry wins, then the entry whose base_url matches
+        the provider's configured default, then the first match in sorted-key
+        order (see ``_find_provider_adapter``).
+
         Raises RuntimeError if the API key for *provider* is not configured.
         """
         provider = provider.lower()
         cache_key = (provider, base_url)
 
-        # Fast path — no lock needed for reads of an already-cached adapter
-        if cache_key in self._adapters:
-            return self._adapters[cache_key]
-        # When no base_url specified, find any cached adapter for this provider
+        # Fast path — atomic point read, then snapshot-based scan; no lock needed
+        adapter = self._adapters.get(cache_key)
+        if adapter is not None:
+            return adapter
         if base_url is None:
-            for (p, _url), adapter in self._adapters.items():
-                if p == provider:
-                    return adapter
+            adapter = self._find_provider_adapter(provider)
+            if adapter is not None:
+                return adapter
 
         # Slow path — lock to prevent duplicate adapter creation
         with self._adapter_lock:
             # Double-check after acquiring lock
-            if cache_key in self._adapters:
-                return self._adapters[cache_key]
+            adapter = self._adapters.get(cache_key)
+            if adapter is not None:
+                return adapter
             if base_url is None:
-                for (p, _url), adapter in self._adapters.items():
-                    if p == provider:
-                        return adapter
+                adapter = self._find_provider_adapter(provider)
+                if adapter is not None:
+                    return adapter
 
             # Need to create a new adapter — check API key first
             api_key = self._key_resolver(provider)
@@ -353,6 +360,28 @@ class LLMService(LLMServiceABC):
             adapter = self._create_adapter(provider, api_key, effective_base_url)
             self._adapters[cache_key] = adapter
             return adapter
+
+    def _find_provider_adapter(self, provider: str) -> LLMAdapter | None:
+        """Deterministically pick a cached adapter for *provider* (any base_url).
+
+        Preference order:
+        1. the (provider, None) entry,
+        2. the entry matching the provider's configured default base_url,
+        3. first match by sorted cache key (stable tie-break).
+
+        Snapshots the cache so it is safe to call without _adapter_lock.
+        """
+        items = list(self._adapters.items())  # atomic snapshot; safe vs concurrent insert
+        matches = {url: adapter for (p, url), adapter in items if p == provider}
+        if not matches:
+            return None
+        if None in matches:
+            return matches[None]
+        defaults = self._get_provider_defaults(provider)
+        default_url = defaults.get("base_url") if defaults else None
+        if default_url in matches:
+            return matches[default_url]
+        return matches[min(url for url in matches if url is not None)]
 
     def _get_provider_defaults(self, provider_name: str) -> dict | None:
         """Get defaults for a provider from the injected provider_defaults dict."""

--- a/tests/test_llm_service_adapter_cache.py
+++ b/tests/test_llm_service_adapter_cache.py
@@ -1,0 +1,216 @@
+"""Regression tests for LLMService.get_adapter adapter-cache concurrency.
+
+Issue lingtai-kernel#739: the lock-free fast-path scan of ``self._adapters``
+(``base_url=None``) raced with a concurrent insert from the locked slow path,
+raising ``RuntimeError: dictionary changed size during iteration``. The scan is
+now snapshot-based and follows a documented deterministic preference:
+
+1. the ``(provider, None)`` entry,
+2. the entry matching the provider's configured default base_url,
+3. first match by sorted cache key (stable tie-break).
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+
+from lingtai.llm.service import LLMService
+
+
+def _register_identity_adapter(provider: str) -> None:
+    """Register a hermetic factory returning a fresh opaque object per call."""
+    LLMService.register_adapter(provider, lambda **kwargs: object())
+
+
+def _make_service(
+    provider: str = "p",
+    *,
+    base_url: str | None = None,
+    defaults: dict | None = None,
+) -> LLMService:
+    """Build an LLMService whose adapter cache the test controls exactly.
+
+    The constructor seeds one ``(provider, base_url)`` entry; tests that need
+    a precise cache shape call :meth:`_make_service` and then replace
+    ``svc._adapters`` contents themselves.
+    """
+    _register_identity_adapter(provider)
+    svc = LLMService(
+        provider=provider,
+        model="m",
+        api_key="k",
+        base_url=base_url,
+        key_resolver=lambda p: "k",
+        provider_defaults=defaults or {},
+    )
+    svc._adapters.clear()
+    return svc
+
+
+# ---------------------------------------------------------------------------
+# Regression: lock-free fast-path scan vs concurrent insert (the #739 crash)
+# ---------------------------------------------------------------------------
+
+
+def test_get_adapter_scan_race_with_concurrent_insert():
+    """A base_url=None scan must never raise under a concurrent cache insert.
+
+    On the unfixed code this reproduces ``RuntimeError: dictionary changed
+    size during iteration``: the fast path iterates the live dict while the
+    slow path inserts a fresh ``(provider, base_url)`` key under the lock.
+    """
+    _register_identity_adapter("race-other")
+    _register_identity_adapter("race-b")
+    svc = LLMService(
+        provider="race-other",
+        model="m",
+        api_key="k",
+        key_resolver=lambda p: "k",
+    )
+    svc._adapters.clear()
+    # Every reader scan walks thousands of NON-matching entries before hitting
+    # the single match at the end, so each get_adapter("race-a") call does a
+    # long full-dict iteration (the unfixed fast-path scan is the race window).
+    for i in range(1500):
+        svc._adapters[("race-other", f"http://x/{i}")] = object()
+    svc._adapters[("race-a", "http://end")] = object()
+
+    errors: list[BaseException] = []
+    errors_lock = threading.Lock()
+    n_readers = 4
+    n_writers = 2
+    old_interval = sys.getswitchinterval()
+
+    def reader() -> None:
+        try:
+            for _ in range(1200):
+                svc.get_adapter("race-a")  # no base_url -> scans the cache
+        except BaseException as exc:  # pragma: no cover - failure path
+            with errors_lock:
+                errors.append(exc)
+
+    def writer() -> None:
+        try:
+            for i in range(200):
+                # Fresh key each time -> slow path creates + inserts concurrently.
+                svc.get_adapter("race-b", f"http://w/{i}")
+        except BaseException as exc:  # pragma: no cover - failure path
+            with errors_lock:
+                errors.append(exc)
+
+    barrier = threading.Barrier(n_readers + n_writers)
+    threads = []
+    try:
+        # Dense thread switches make the mid-scan insert window much likelier.
+        sys.setswitchinterval(1e-6)
+        for _ in range(n_readers):
+            threads.append(threading.Thread(target=lambda: (barrier.wait(), reader())))
+        for _ in range(n_writers):
+            threads.append(threading.Thread(target=lambda: (barrier.wait(), writer())))
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=60)
+    finally:
+        sys.setswitchinterval(old_interval)
+
+    assert not errors, f"get_adapter raced on concurrent insert: {errors!r}"
+
+
+def test_get_adapter_single_creation_under_contention():
+    """Double-checked locking still guarantees one adapter per cache key."""
+    _register_identity_adapter("p")
+    created: list[object] = []
+    created_lock = threading.Lock()
+
+    def counting_factory(**kwargs):
+        with created_lock:
+            created.append(object())
+            return created[-1]
+
+    LLMService.register_adapter("newprov", counting_factory)
+    svc = _make_service()
+    n = 8
+    results: list[object] = []
+    results_lock = threading.Lock()
+    barrier = threading.Barrier(n)
+
+    def worker() -> None:
+        barrier.wait()
+        adapter = svc.get_adapter("newprov")
+        with results_lock:
+            results.append(adapter)
+
+    threads = [threading.Thread(target=worker) for _ in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+
+    assert len(created) == 1, f"factory ran {len(created)} times instead of once"
+    assert all(r is created[0] for r in results)
+
+
+# ---------------------------------------------------------------------------
+# Deterministic preference for base_url=None lookups with multiple cached URLs
+# ---------------------------------------------------------------------------
+
+
+def test_get_adapter_prefers_none_key_entry():
+    """Rule 1: the (provider, None) entry wins over any URL entry."""
+    svc = _make_service()
+    none_adapter = object()
+    url_adapter = object()
+    for order in ("none_first", "url_first"):
+        svc._adapters.clear()
+        if order == "none_first":
+            svc._adapters[("p", None)] = none_adapter
+            svc._adapters[("p", "http://b")] = url_adapter
+        else:
+            svc._adapters[("p", "http://b")] = url_adapter
+            svc._adapters[("p", None)] = none_adapter
+        assert svc.get_adapter("p") is none_adapter, order
+
+
+def test_get_adapter_prefers_configured_default_base_url():
+    """Rule 2: the entry matching the provider's configured default wins."""
+    svc = _make_service(defaults={"p": {"base_url": "http://b"}})
+    a_adapter = object()
+    b_adapter = object()
+    for order in ("a_first", "b_first"):
+        svc._adapters.clear()
+        if order == "a_first":
+            svc._adapters[("p", "http://a")] = a_adapter
+            svc._adapters[("p", "http://b")] = b_adapter
+        else:
+            svc._adapters[("p", "http://b")] = b_adapter
+            svc._adapters[("p", "http://a")] = a_adapter
+        assert svc.get_adapter("p") is b_adapter, order
+
+
+def test_get_adapter_sorted_tiebreak_is_stable():
+    """Rule 3: with no None entry or default match, sorted-key order wins."""
+    svc = _make_service()  # no provider defaults -> no default base_url
+    z_adapter = object()
+    a_adapter = object()
+    for order in ("z_first", "a_first"):
+        svc._adapters.clear()
+        if order == "z_first":
+            svc._adapters[("p", "http://z")] = z_adapter
+            svc._adapters[("p", "http://a")] = a_adapter
+        else:
+            svc._adapters[("p", "http://a")] = a_adapter
+            svc._adapters[("p", "http://z")] = z_adapter
+        assert svc.get_adapter("p") is a_adapter, order
+
+
+def test_get_adapter_exact_key_still_wins():
+    """An explicit base_url lookup never falls back to the provider scan."""
+    svc = _make_service()
+    none_adapter = object()
+    a_adapter = object()
+    svc._adapters[("p", None)] = none_adapter
+    svc._adapters[("p", "http://a")] = a_adapter
+    assert svc.get_adapter("p", "http://a") is a_adapter
+    assert svc.get_adapter("p") is none_adapter


### PR DESCRIPTION
Fixes #739.

## Root cause

`LLMService.get_adapter` (`src/lingtai/llm/service.py`) had a lock-free fast path that, when the caller passes no `base_url`, scans the live `self._adapters` dict (`for ... in self._adapters.items()`). The slow path inserts `self._adapters[cache_key] = adapter` under `self._adapter_lock` from another thread; a concurrent insert landing mid-iteration raises `RuntimeError: dictionary changed size during iteration`, surfacing as a spurious LLM failure exactly when several threads race to warm the cache.

## Fix (smallest correct scope)

- Add `_find_provider_adapter`: one shared, snapshot-based provider scan (`list(self._adapters.items())` — a single C-level operation, safe against concurrent inserts) with a documented deterministic preference: (1) the `(provider, None)` entry, (2) the entry matching the provider's configured default base_url, (3) first match in sorted-key order. This also removes the insertion-order nondeterminism for `base_url=None` lookups when several base_urls are cached for one provider (the second defect in #739).
- Fast path and locked double-check in `get_adapter` now reuse that helper; point reads switched from `in` + `[]` to a single atomic `.get()`.
- No schema / signature / back-compat changes. Public behavior changes only in (a) never raising the spurious RuntimeError, and (b) a deterministic (previously unspecified) pick for `base_url=None` multi-entry lookups.

## Validation

Failing-first regression test (`tests/test_llm_service_adapter_cache.py`), run against the unfixed code — reproduces the exact crash from #739 (3/3 runs):

```
AssertionError: get_adapter raced on concurrent insert: [RuntimeError('dictionary changed size during iteration'), ...]
```

After the fix — all 6 new tests pass, race test stable across repeats, under 2s:

```
6 passed in 1.83s
race test: passed 3/3 repeat runs
```

Existing tests for the touched module — unaffected:

```
tests/test_llm_service.py -q          -> 15 passed
tests/test_services_integration.py -q -> 14 passed, 2 skipped (1 pre-existing env failure: test_duckduckgo, ModuleNotFoundError: ddgs)
```

Pre-existing, unrelated env failures in the test venv (also present on pristine main): `test_llm_identity_headers.py` (4, missing adapter deps) and `test_llm_adapter_timeouts.py` (collection, missing anthropic).

Note: an earlier attempt at this crash fix (#787, fable-5/issue-739) was closed unmerged; this PR implements the full #739 plan including the deterministic `_find_provider_adapter` rule and the complete test suite.
