### PR TITLE
fix(telegram): surface taskcard loaded-runtime drift hint before refresh

### DIFF
--- a/src/lingtai/mcp_servers/telegram/_runtime.py
+++ b/src/lingtai/mcp_servers/telegram/_runtime.py
@@ -1,0 +1,94 @@
+"""Telegram Task Card loaded-vs-installed runtime identity (issue #987).
+
+The non-deletable Task Card self-heal (PR #984) can only run after the live
+Telegram manager process has loaded the repair code. If the on-disk checkout
+is updated underneath a long-lived manager process, the installed source
+contains the repair while the loaded runtime predates it: the old card stays
+frozen, ``/taskcard`` still reports a healthy ``enabled`` setting, and nothing
+says that one refresh is required.
+
+This module captures the source identity of the Task Card runtime the current
+*process* imported (a non-secret SHA-256 prefix over the curated Task Card
+source files) and compares it with the same files as they exist on disk at
+query time. A deterministic ``refresh required`` hint is returned only when
+loaded != installed, so the plain settings response never implies resident
+health it cannot prove.
+"""
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+# Curated files whose loaded-vs-installed mismatch changes resident Task Card
+# lifecycle behavior (mirrors the kernel's ``_FP_KEY_FILES`` approach in
+# ``lingtai.kernel.base_agent.lifecycle``). The kernel fingerprint covers only
+# ``lingtai.kernel`` sources; the Telegram manager lives outside it, so the
+# exact #987 drift (``manager.py`` / ``task_card`` gaining the repair under a
+# live process) is invisible to that fingerprint and needs its own identity.
+_TASK_CARD_SOURCE_FILES: tuple[str, ...] = (
+    "manager.py",
+    "task_card/__init__.py",
+    "task_card/controller.py",
+    "task_card/interface.py",
+    "task_card/resident.py",
+)
+
+#: Bounded, actionable hint surfaced when the loaded runtime predates the
+#: installed checkout. One refresh is exactly the remediation the live manager
+#: needs; nothing here toggles Task Card or deletes/re-sends anything.
+DRIFT_HINT = (
+    "\u26a0\ufe0f Task Card runtime drift: this process predates the installed "
+    "checkout \u2014 one /refresh is required to apply the installed Task Card "
+    "self-heal."
+)
+
+
+def _task_card_source_dir() -> Path:
+    """The telegram package directory this module was imported from."""
+    return Path(__file__).resolve().parent
+
+
+def _digest_source_files(root: Path) -> str | None:
+    """SHA-256 prefix (12 hex) of the curated Task Card source files.
+
+    Returns ``None`` only when the source directory itself cannot be read, so
+    the caller stays silent rather than misreporting drift. Missing individual
+    files hash a ``\x00`` marker (kernel convention) so removals still change
+    the digest.
+    """
+    hasher = hashlib.sha256()
+    for rel in _TASK_CARD_SOURCE_FILES:
+        try:
+            hasher.update((root / rel).read_bytes())
+        except OSError:
+            hasher.update(b"\x00")
+    return hasher.hexdigest()[:12]
+
+
+# Loaded identity: computed once at import time by this process. If the disk is
+# updated underneath a running process, this constant still describes the code
+# that actually executed.
+LOADED_TASK_CARD_SOURCE_DIGEST: str | None = _digest_source_files(
+    _task_card_source_dir()
+)
+
+
+def installed_task_card_source_digest() -> str | None:
+    """Re-read the same curated files from disk now (the installed runtime)."""
+    return _digest_source_files(_task_card_source_dir())
+
+
+def task_card_drift_hint() -> str | None:
+    """Return :data:`DRIFT_HINT` when the loaded runtime predates installed source.
+
+    Returns ``None`` when the digests match or either side is unprovable, i.e.
+    absence of the hint means the loaded Task Card runtime matches the
+    installed checkout (the healthy state).
+    """
+    loaded = LOADED_TASK_CARD_SOURCE_DIGEST
+    installed = installed_task_card_source_digest()
+    if loaded is None or installed is None:
+        return None
+    if loaded == installed:
+        return None
+    return DRIFT_HINT

--- a/src/lingtai/mcp_servers/telegram/account.py
+++ b/src/lingtai/mcp_servers/telegram/account.py
@@ -23,6 +23,7 @@ from lingtai.mcp_servers.local_commands import (
     TaskCardSettingsPort,
 )
 
+from . import _runtime as tg_runtime
 from . import updates as tg_updates
 
 logger = logging.getLogger(__name__)
@@ -513,11 +514,14 @@ class TelegramAccount:
                 "automatic and programmable Task Cards are hidden for this agent; "
                 "internal mechanics still run."
             )
-        self.send_message(
-            chat_id,
+        payload = (
             f"📋 taskcard: {enabled} · normal rows: {normal_rows} — {description}\n"
-            "Usage: /taskcard on | /taskcard off | /taskcard N (1-10)",
+            "Usage: /taskcard on | /taskcard off | /taskcard N (1-10)"
         )
+        hint = tg_runtime.task_card_drift_hint()
+        if hint is not None:
+            payload += f"\n{hint}"
+        self.send_message(chat_id, payload)
 
     def _cmd_taskcard_menu(self, chat_id: int, message_id: int | None = None) -> None:
         """Show the interactive Task Card settings menu (kanban-style)."""
@@ -530,6 +534,9 @@ class TelegramAccount:
             f"👁️ Rows: {normal_rows} (latest API-call groups)\n\n"
             "Tap to change:"
         )
+        hint = tg_runtime.task_card_drift_hint()
+        if hint is not None:
+            menu_text += f"\n\n{hint}"
         keyboard = inline_keyboard_options(
             [
                 {"text": "◀️ Rows −", "data": "tc:rows_dec"},

--- a/tests/test_telegram_task_card_runtime_drift.py
+++ b/tests/test_telegram_task_card_runtime_drift.py
@@ -1,0 +1,117 @@
+"""Focused contract tests for the Task Card loaded-runtime drift diagnostic (issue #987).
+
+When the on-disk checkout gains the non-deletable Task Card self-heal under a
+long-lived manager process, the loaded runtime predates the installed source:
+``/taskcard`` must stop implying resident health and emit one bounded
+``/refresh``-required hint instead.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from lingtai.mcp_servers.telegram import _runtime as tg_runtime
+from tests.test_telegram_task_card_toggle import _service
+
+
+def _write_source_tree(root: Path) -> None:
+    for rel in tg_runtime._TASK_CARD_SOURCE_FILES:
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(rel, encoding="utf-8")
+
+
+# Pure runtime-identity helpers -------------------------------------------------
+
+
+def test_loaded_digest_is_deterministic_hex_prefix() -> None:
+    loaded = tg_runtime.LOADED_TASK_CARD_SOURCE_DIGEST
+    assert isinstance(loaded, str)
+    assert len(loaded) == 12
+    assert all(c in "0123456789abcdef" for c in loaded)
+
+
+def test_installed_digest_tracks_on_disk_changes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root = tmp_path / "pkg"
+    _write_source_tree(root)
+    monkeypatch.setattr(tg_runtime, "_task_card_source_dir", lambda: root)
+
+    first = tg_runtime.installed_task_card_source_digest()
+    assert first is not None
+    # The exact #987 drift: the on-disk manager gains the repair without the
+    # running process importing it again.
+    (root / "manager.py").write_text("repaired\n", encoding="utf-8")
+    second = tg_runtime.installed_task_card_source_digest()
+    assert second is not None
+    assert second != first
+
+
+def test_drift_hint_none_when_loaded_matches_installed(monkeypatch: pytest.MonkeyPatch) -> None:
+    loaded = tg_runtime.LOADED_TASK_CARD_SOURCE_DIGEST
+    monkeypatch.setattr(tg_runtime, "installed_task_card_source_digest", lambda: loaded)
+    assert tg_runtime.task_card_drift_hint() is None
+
+
+def test_drift_hint_returned_when_loaded_predates_installed(monkeypatch: pytest.MonkeyPatch) -> None:
+    loaded = tg_runtime.LOADED_TASK_CARD_SOURCE_DIGEST
+    monkeypatch.setattr(tg_runtime, "installed_task_card_source_digest", lambda: "0" * 12)
+    hint = tg_runtime.task_card_drift_hint()
+    assert hint is not None
+    assert "one /refresh is required" in hint
+    assert loaded != "0" * 12
+
+
+def test_drift_hint_silent_when_unprovable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(tg_runtime, "installed_task_card_source_digest", lambda: None)
+    assert tg_runtime.task_card_drift_hint() is None
+
+
+# /taskcard surfaces -----------------------------------------------------------
+
+
+def _account_and_replies(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    service = _service(tmp_path, "main", allowed_users=[7])
+    account = service.get_account("main")
+    replies: list[str] = []
+    monkeypatch.setattr(
+        account,
+        "send_message",
+        lambda _chat_id, text, **_kwargs: replies.append(text) or {"message_id": 1},
+    )
+    return account, replies
+
+
+def test_taskcard_settings_response_carries_drift_hint_only_when_drifting(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    account, replies = _account_and_replies(tmp_path, monkeypatch)
+
+    # Healthy state: loaded matches installed — plain settings response, no hint.
+    monkeypatch.setattr(tg_runtime, "task_card_drift_hint", lambda: None)
+    account._cmd_taskcard(123, "/taskcard on")
+    assert "taskcard: True" in replies[-1]
+    assert "one /refresh" not in replies[-1]
+
+    # Drift: loaded predates installed — one bounded, actionable hint appended.
+    monkeypatch.setattr(tg_runtime, "task_card_drift_hint", lambda: tg_runtime.DRIFT_HINT)
+    account._cmd_taskcard(123, "/taskcard on")
+    assert "taskcard: True" in replies[-1]
+    assert "one /refresh is required" in replies[-1]
+    assert "on | /taskcard off" in replies[-1]  # usage line still intact
+
+
+def test_taskcard_menu_carries_drift_hint_only_when_drifting(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    account, replies = _account_and_replies(tmp_path, monkeypatch)
+
+    monkeypatch.setattr(tg_runtime, "task_card_drift_hint", lambda: None)
+    account._cmd_taskcard_menu(123)
+    assert "Task Card — settings" in replies[-1]
+    assert "one /refresh" not in replies[-1]
+
+    monkeypatch.setattr(tg_runtime, "task_card_drift_hint", lambda: tg_runtime.DRIFT_HINT)
+    account._cmd_taskcard_menu(123)
+    assert "Task Card — settings" in replies[-1]
+    assert "one /refresh is required" in replies[-1]


### PR DESCRIPTION
Fixes #987.

## Problem

PR #984's non-deletable Task Card self-heal only runs after the live Telegram manager has loaded the repair code. When the on-disk checkout is updated underneath a long-lived manager process, the installed source contains the repair while the loaded runtime predates it: the old card stays frozen, `/taskcard` still reports a healthy `enabled` setting, and no diagnostic says that one refresh is required.

This PR does **not** touch the bounded one-replacement semantics from #984 and does not auto-toggle Task Card or delete/re-send anything. It adds the bootstrap/observability half: a deterministic loaded-runtime drift diagnostic on the `/taskcard` surfaces.

## Change

- New `src/lingtai/mcp_servers/telegram/_runtime.py`: captures a non-secret SHA-256 prefix (12 hex) of the curated Telegram Task Card source files (`manager.py` + `task_card/*.py`) **at import time** (the loaded identity), and re-reads the same files from disk at query time (the installed identity). The kernel's issue-#178 fingerprint covers only `lingtai.kernel` sources, so it cannot see the exact #987 drift; this is a telegram-scoped identity.
- `account.py` `_cmd_taskcard` and `_cmd_taskcard_menu`: when loaded != installed, append one bounded, actionable line: `⚠️ Task Card runtime drift: this process predates the installed checkout — one /refresh is required to apply the installed Task Card self-heal.` Absence of the hint means the loaded Task Card runtime matches the installed checkout (the healthy state). Unprovable digests stay silent rather than misreport.
- `tests/test_telegram_task_card_runtime_drift.py`: 7 focused tests (helper determinism, on-disk change detection, hint only when drifting, both `/taskcard` surfaces).

## Tests

- `PYTHONPATH=src python3 -m pytest tests/test_telegram_task_card_runtime_drift.py -q` → **7 passed**
- `python3 -m pytest tests/test_telegram_task_card_*.py -q` → **234 passed, 1 failed**; the single failure (`test_public_telegram_action_reaches_manager`) is **pre-existing on main** (verified by stashing this change and rerunning: it fails identically — the test's `FakeService` lacks `list_accounts`, unrelated to this PR).
- `python3 -m py_compile src/lingtai/mcp_servers/telegram/_runtime.py src/lingtai/mcp_servers/telegram/account.py tests/test_telegram_task_card_runtime_drift.py` → OK
- `git diff --check` → OK

## Scope

3 files, +221/−3. No change to resident lifecycle, controller, persistence, or the #984 replacement semantics.
