### PR TITLE
fix(kernel): wire setup_logging(log_dir) into agent boot; durable agent.log for daemon diagnostics

### DIFF
--- a/ENVIRONMENT_VARIABLES.md
+++ b/ENVIRONMENT_VARIABLES.md
@@ -4,7 +4,7 @@ description: >
   Canonical registry for environment variables consumed by LingTai source,
   bundled MCPs, adapters, daemon composition, and focused tests.
 version: 1.0.0
-last_changed_at: "2026-08-07"
+last_changed_at: "2026-08-09"
 related_files:
 - ANATOMY.md
 - CONTRACT.md
@@ -57,6 +57,7 @@ reports, prompts, or this registry.
 | `LINGTAI_REFRESH_ENV_OVERWRITE` | unset and off | `1` enables one refresh overwrite | One refresh handoff | Boot or refresh setup; consumed and removed after use | Other values are treated as off | `src/lingtai/cli.py`, `src/lingtai/agent.py` | Do not log inherited or env-file contents |
 | `LINGTAI_RUNTIME_PYTHON` | unset; caller uses `sys.executable` | Local executable path | Runtime self-check and host-tool routing | When the consumer is invoked; relaunch to change interpreter | Missing or invalid is a caller/configuration error | `src/lingtai/cli.py` and runtime checks | A path is not a credential or a trust decision |
 | `LINGTAI_RUNTIME_VENV` | unset | Local virtualenv directory path | Host-tool runtime hint | When a host tool is invoked; new process sees changes | Missing is tolerated when another interpreter is available | `src/lingtai/cli.py` | Do not infer package trust or freshness from an unrelated shell |
+| `LINGTAI_VERBOSE` | unset and off | `1` enables DEBUG console logging for `lingtai-agent run` | Agent boot file logging; the rotating `logs/agent.log` file handler is always DEBUG, the console handler is DEBUG only when set | Boot of `lingtai-agent run`; the `--verbose` flag is equivalent | Other values are treated as off | `src/lingtai/cli.py`, `src/lingtai/kernel/logging.py` | Console verbosity only; not an authorization boundary |
 | `LINGTAI_SHELL` | unset (platform default) | `posix`, `powershell`, `cmd`, `gitbash`, `wsl`; case-insensitive | Canonical shell tool dialect and spawn selection | Shell tool setup; restart to change | Unknown values fall back to the platform default | `src/lingtai/adapters/shell.py` | Only changes which shell program the model-driven shell tool spawns; it is not an authorization boundary |
 | `LINGTAI_AGENT_DIR` | unset; normally launcher-injected | Existing local directory | Out-of-process MCP and client workdir | MCP/client process start; restart after change | Invalid path fails the MCP or client operation | `src/lingtai/mcp_servers/_config.py` | Keep private workdir contents out of model-facing output |
 | `LINGTAI_MCP_NAME` | unset | Registered MCP name | One MCP process identity | MCP process start; restart after change | Missing or unknown name fails closed | `src/lingtai/mcp_servers/_config.py` | Prevents arbitrary server selection; it is not a secret |

--- a/src/lingtai/cli.py
+++ b/src/lingtai/cli.py
@@ -246,6 +246,18 @@ def run(working_dir: Path) -> None:
     """Boot agent into ASLEEP — wakes on external messages (mail/imap/telegram)."""
     _check_duplicate_process(working_dir)
     _clean_signal_files(working_dir)
+    # Durable file logging for daemonized agents: stderr alone is DEVNULL for
+    # avatars and truncated per-spawn in logs/spawn.stderr, so logger warnings
+    # (mail claim failures, adapter retries, restore diagnostics) would
+    # otherwise be lost. Do this before load_init() so boot/migration warnings
+    # are captured too. Short-lived inspector subcommands (log, check-caps,
+    # maintenance) deliberately never reach this path.
+    from lingtai.kernel.logging import setup_logging
+
+    setup_logging(
+        verbose=os.environ.get("LINGTAI_VERBOSE") == "1",
+        log_dir=working_dir / "logs",
+    )
     data = load_init(working_dir)
 
     # Resolve venv and store on agent for CPR/avatar to use
@@ -449,6 +461,11 @@ def main() -> None:
 
     run_parser = sub.add_parser("run", help="Boot agent into sleep — wakes on external messages")
     run_parser.add_argument("working_dir", type=Path, help="Agent working directory containing init.json")
+    run_parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="DEBUG-level console logging (equivalent to LINGTAI_VERBOSE=1)",
+    )
 
     sub.add_parser("check-caps", help="Output capability provider metadata as JSON")
 
@@ -506,6 +523,8 @@ def main() -> None:
         if not working_dir.is_dir():
             print(f"error: {working_dir} is not a directory", file=sys.stderr)
             sys.exit(1)
+        if getattr(args, "verbose", False):
+            os.environ["LINGTAI_VERBOSE"] = "1"
         run(working_dir)
     elif args.command == "check-caps":
         from lingtai.tools.registry import get_all_providers

--- a/src/lingtai/kernel/logging.py
+++ b/src/lingtai/kernel/logging.py
@@ -1,17 +1,37 @@
-"""Package-internal logging for lingtai."""
+"""Package-internal logging for lingtai.
+
+One process, one agent: ``setup_logging`` configures the process-global
+``"lingtai"`` logger (see the workdir lease / ``_check_duplicate_process``
+exclusion in ``lingtai.cli``). Every module binds the *same* logger object via
+``get_logger()``, so handlers added here are visible to all call sites
+regardless of import order.
+"""
 from __future__ import annotations
 
 import logging
+from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
 _logger: logging.Logger | None = None
+
+_CONSOLE_FMT = logging.Formatter(
+    "%(asctime)s %(levelname)s %(name)s: %(message)s",
+    datefmt="%H:%M:%S",
+)
+_FILE_FMT = logging.Formatter(
+    "%(asctime)s %(levelname)s %(name)s %(module)s: %(message)s"
+)
+# Rotation keeps a long-lived daemon from growing agent.log unboundedly.
+_FILE_MAX_BYTES = 5 * 1024 * 1024
+_FILE_BACKUP_COUNT = 3
+
 
 def setup_logging(
     verbose: bool = False,
     log_dir: Path | str | None = None,
     logger_name: str = "lingtai",
 ) -> logging.Logger:
-    """Initialize the package logger.
+    """Initialize the package logger. Idempotent; safe to re-invoke.
 
     Args:
         verbose: If True, set console to DEBUG; otherwise INFO.
@@ -22,25 +42,60 @@ def setup_logging(
     logger = logging.getLogger(logger_name)
     logger.setLevel(logging.DEBUG)
 
-    if not logger.handlers:
-        ch = logging.StreamHandler()
-        ch.setLevel(logging.DEBUG if verbose else logging.INFO)
-        fmt = logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s",
-                                datefmt="%H:%M:%S")
-        ch.setFormatter(fmt)
-        logger.addHandler(ch)
+    # Reuse the existing console handler (if any) instead of stacking a new
+    # one on every call, and honor a re-invocation with verbose=True.
+    console = next(
+        (
+            h
+            for h in logger.handlers
+            if isinstance(h, logging.StreamHandler)
+            and not isinstance(h, logging.FileHandler)
+        ),
+        None,
+    )
+    if console is None:
+        console = logging.StreamHandler()
+        console.setFormatter(_CONSOLE_FMT)
+        logger.addHandler(console)
+    console.setLevel(logging.DEBUG if verbose else logging.INFO)
 
     if log_dir is not None:
-        log_path = Path(log_dir)
-        log_path.mkdir(parents=True, exist_ok=True)
-        fh = logging.FileHandler(log_path / "agent.log")
-        fh.setLevel(logging.DEBUG)
-        fmt = logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
-        fh.setFormatter(fmt)
-        logger.addHandler(fh)
+        target = Path(log_dir).resolve() / "agent.log"
+        # Guard against duplicate FileHandlers when setup_logging() is invoked
+        # more than once with the same log_dir (tests, refresh boots in
+        # process, future callers).
+        if not any(
+            isinstance(h, logging.FileHandler)
+            and Path(getattr(h, "baseFilename", "")).resolve() == target
+            for h in logger.handlers
+        ):
+            target.parent.mkdir(parents=True, exist_ok=True)
+            fh = RotatingFileHandler(
+                target,
+                maxBytes=_FILE_MAX_BYTES,
+                backupCount=_FILE_BACKUP_COUNT,
+            )
+            fh.setLevel(logging.DEBUG)
+            fh.setFormatter(_FILE_FMT)
+            logger.addHandler(fh)
 
     _logger = logger
     return logger
+
+
+def reset_logging() -> None:
+    """Detach and close all handlers from the package logger.
+
+    Intended for tests and teardown so handler state cannot leak across test
+    cases or processes. ``get_logger()`` lazily recreates the default setup
+    afterwards.
+    """
+    global _logger
+    if _logger is not None:
+        for handler in list(_logger.handlers):
+            handler.close()
+            _logger.removeHandler(handler)
+        _logger = None
 
 
 def get_logger() -> logging.Logger:

--- a/src/lingtai/tools/avatar/CONTRACT.md
+++ b/src/lingtai/tools/avatar/CONTRACT.md
@@ -220,6 +220,7 @@ the network root (`<parent>/..`):
   .prompt                         # first-turn brief (parent identity + reasoning), consumed once
   .rules                          # distributed rules signal
   logs/spawn.stderr               # captured child stderr for boot diagnosis
+  logs/agent.log                  # rotating stdlib logging (boot + runtime warnings)
   system/ knowledge/ exports/ combo.json   # deep mode only
 ```
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,3 +42,19 @@ def _isolate_notification_dismiss_guards():
     yield
     _GENERIC_DISMISS_GUARDED.clear()
     _GENERIC_DISMISS_GUARDED.update(snapshot)
+
+
+@pytest.fixture(autouse=True)
+def _reset_package_logging():
+    """Keep stdlib-logging handler state from leaking across tests.
+
+    ``setup_logging``/``get_logger`` configure a process-global "lingtai"
+    logger; without a reset, a FileHandler attached by one test would stay
+    attached for every subsequent test in the run (writing to a stale path).
+    """
+
+    from lingtai.kernel.logging import reset_logging
+
+    reset_logging()
+    yield
+    reset_logging()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -683,3 +683,88 @@ def test_windows_venv_launcher_stub_is_not_a_duplicate(tmp_path, monkeypatch):
     monkeypatch.setattr(win_module.subprocess, "check_output", lambda *a, **k: payload)
     # Must NOT raise: every match belongs to this process's own launch chain.
     _check_duplicate_process(working_dir)
+
+
+def test_run_wires_file_logging(monkeypatch, tmp_path):
+    """run() must wire setup_logging(log_dir=working_dir/logs) into boot.
+
+    Guards the regression where file logging was dead code: the only sink was
+    the stderr console handler, and daemonized agents (stdout=DEVNULL,
+    stderr truncated per spawn in logs/spawn.stderr) lost all diagnostics.
+    """
+    from lingtai import cli
+    from lingtai.kernel.logging import get_logger, reset_logging
+
+    reset_logging()
+
+    class _Flag:
+        def __init__(self):
+            self.was_set = False
+
+        def set(self):
+            self.was_set = True
+
+    class _Shutdown:
+        def wait(self):
+            return None
+
+    class _FakeAgent:
+        def __init__(self):
+            self._asleep = _Flag()
+            self._shutdown = _Shutdown()
+            self._state = None
+            self._venv_path = None
+            self.started = False
+            self.stopped = False
+
+        def start(self):
+            self.started = True
+
+        def stop(self, timeout=10.0):
+            self.stopped = True
+
+    monkeypatch.setattr(cli, "_check_duplicate_process", lambda working_dir: None)
+    monkeypatch.setattr(cli, "_clean_signal_files", lambda working_dir: None)
+    monkeypatch.setattr(cli, "_install_signal_handlers", lambda working_dir, agent: None)
+    monkeypatch.setattr(cli, "load_init", lambda working_dir: {})
+    monkeypatch.setattr(cli, "build_agent", lambda data, working_dir: _FakeAgent())
+
+    import lingtai.venv_resolve as venv_resolve
+
+    monkeypatch.setattr(venv_resolve, "resolve_venv", lambda data: tmp_path / "runtime-venv")
+
+    cli.run(tmp_path)
+
+    log_file = tmp_path / "logs" / "agent.log"
+    assert log_file.is_file()
+
+    # The package logger now routes into the file: a warning emitted through
+    # any module's get_logger() binding lands in logs/agent.log.
+    get_logger().warning("boot wiring marker")
+    assert "boot wiring marker" in log_file.read_text(encoding="utf-8")
+
+    reset_logging()
+
+
+def test_log_doctor_does_not_create_agent_log(monkeypatch, tmp_path):
+    """Inspector subcommands must stay write-free w.r.t. agent.log.
+
+    Only run() (the daemon boot path) calls setup_logging(log_dir=...); short-
+    lived inspectors like `lingtai-agent log doctor` must not create or touch
+    logs/agent.log.
+    """
+    from lingtai import cli
+    from lingtai.kernel.logging import reset_logging
+
+    reset_logging()
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+
+    class _Args:
+        agent_dir = tmp_path
+        log_command = "doctor"
+
+    cli._handle_log_command(_Args())
+
+    assert not (logs_dir / "agent.log").exists()
+    reset_logging()

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -1,0 +1,95 @@
+"""Tests for lingtai.kernel.logging: file logging, idempotency, rotation."""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from lingtai.kernel import logging as kernel_logging
+from lingtai.kernel.logging import (
+    get_logger,
+    reset_logging,
+    setup_logging,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_logger_state():
+    reset_logging()
+    yield
+    reset_logging()
+
+
+def test_setup_logging_creates_agent_log(tmp_path):
+    setup_logging(log_dir=tmp_path)
+    get_logger().warning("hello from the kernel")
+
+    log_file = tmp_path / "agent.log"
+    assert log_file.is_file()
+    assert "hello from the kernel" in log_file.read_text(encoding="utf-8")
+
+
+def test_setup_logging_idempotent_no_duplicate_file_handler(tmp_path):
+    setup_logging(log_dir=tmp_path)
+    setup_logging(log_dir=tmp_path)  # second call must not stack a second FileHandler
+
+    get_logger().warning("only once")
+    text = (tmp_path / "agent.log").read_text(encoding="utf-8")
+    assert text.count("only once") == 1
+
+    file_handlers = [
+        h for h in logging.getLogger("lingtai").handlers
+        if isinstance(h, logging.FileHandler)
+    ]
+    assert len(file_handlers) == 1
+
+
+def test_verbose_reconfigures_console_level():
+    setup_logging()  # default INFO console
+    setup_logging(verbose=True)  # must raise the console handler to DEBUG
+
+    logger = logging.getLogger("lingtai")
+    console = next(
+        h for h in logger.handlers
+        if isinstance(h, logging.StreamHandler)
+        and not isinstance(h, logging.FileHandler)
+    )
+    assert console.level == logging.DEBUG
+
+
+def test_exc_info_traceback_lands_in_file(tmp_path):
+    setup_logging(log_dir=tmp_path)
+    try:
+        raise RuntimeError("claim failure diagnostic")
+    except RuntimeError:
+        get_logger().warning("failed to write claimed message", exc_info=True)
+
+    text = (tmp_path / "agent.log").read_text(encoding="utf-8")
+    assert "failed to write claimed message" in text
+    assert "RuntimeError: claim failure diagnostic" in text
+    assert "Traceback (most recent call last)" in text
+
+
+def test_rotation_caps_file_size(tmp_path, monkeypatch):
+    monkeypatch.setattr(kernel_logging, "_FILE_MAX_BYTES", 512)
+    monkeypatch.setattr(kernel_logging, "_FILE_BACKUP_COUNT", 2)
+    setup_logging(log_dir=tmp_path)
+
+    logger = get_logger()
+    for i in range(200):
+        logger.warning("rotating payload %s %s", i, "x" * 64)
+
+    assert (tmp_path / "agent.log").is_file()
+    assert (tmp_path / "agent.log.1").is_file()  # a rotated backup exists
+
+
+def test_reset_logging_detaches_handlers(tmp_path):
+    setup_logging(log_dir=tmp_path)
+    logger = logging.getLogger("lingtai")
+    assert len(logger.handlers) == 2  # console + file
+
+    reset_logging()
+    assert len(logger.handlers) == 0
+
+    # get_logger() lazily recreates the default (console-only) setup.
+    assert len(get_logger().handlers) == 1


### PR DESCRIPTION
Fixes #765.

## Problem

`lingtai.kernel.logging.setup_logging(verbose=..., log_dir=...)` shipped a file-logging path (`logs/agent.log`) that no caller ever invoked: every module binds `get_logger()`, which falls back to `setup_logging()` with defaults — an INFO stderr console handler and **no file handler**. Agents run as detached daemons (avatar spawn uses `stdout=DEVNULL` and opens `logs/spawn.stderr` in `"wb"` mode, truncated per respawn), so `logger.warning(..., exc_info=True)` diagnostics (mail-claim failures in `services/mail.py`, adapter retries, lifecycle restore warnings) were lost or clobbered. The `log_dir`/`verbose` parameters were dead code, and the file-handler block was unguarded (duplicate handlers on a second in-process call).

## Fix

- `src/lingtai/kernel/logging.py`: make `setup_logging` idempotent and rotation-safe
  - `RotatingFileHandler` (`maxBytes=5MB`, `backupCount=3`) so long-lived daemons cannot grow `agent.log` unboundedly
  - reuse the existing console handler and honor `verbose` re-invocations (reconfigure the level instead of no-op)
  - dedupe file handlers by resolved `baseFilename`
  - add `reset_logging()` for tests/teardown
  - file formatter carries full date + module; console keeps the terse `%H:%M:%S` format
- `src/lingtai/cli.py`: `run()` now calls `setup_logging(log_dir=working_dir/"logs")` right after `_clean_signal_files()` and before `load_init()` (so boot/migration warnings are captured too), honoring `LINGTAI_VERBOSE=1`; `lingtai-agent run --verbose` flag added as the equivalent. Inspector subcommands (`log`, `check-caps`, `maintenance`) stay write-free.
- Docs: `LINGTAI_VERBOSE` registered in `ENVIRONMENT_VARIABLES.md`; avatar layout doc lists `logs/agent.log`.
- Tests: `tests/test_logging_setup.py` (6 unit tests), wiring tests in `tests/test_cli.py`, autouse `reset_logging()` fixture in `tests/conftest.py`.

Because every module binds the same `logging.getLogger("lingtai")` object at import time, no call-site changes are needed — all ~23 `get_logger()` users pick up the file handler automatically.

## Tests (all run locally, Python 3.14 venv, `PYTHONPATH` cleared to isolate this checkout)

- `tests/test_logging_setup.py`: **6 passed** — creates `agent.log`, idempotent/no duplicate handler, `verbose` reconfigures console level, `exc_info` traceback lands in file, rotation caps file size, `reset_logging` detaches handlers
- `tests/test_cli.py`: **33 passed** — incl. new `test_run_wires_file_logging` (boot creates `working_dir/logs/agent.log`) and `test_log_doctor_does_not_create_agent_log` (inspector stays write-free)
- `tests/test_cli_runtime_env.py`, `tests/test_services_logging.py`, `tests/test_cli_worker_poison_recovery.py`, `tests/test_avatar_launcher.py`, `tests/test_daemon_windows_lock.py`: passed (11 passed, 2 skipped)
- `tests/test_environment_variable_catalogue.py`: 3/4 pass. `test_literal_environment_names_are_registered_and_owning_anatomies_are_linked` fails on clean `origin/main` too — pre-existing registry staleness for `LINGTAI_TASKCARD_POLL_INTERVAL`, `LINGTAI_INJECT_REASONING_FALLBACK`, `LINGTAI_RUN_LIVE_KIMI_CODE` from recently merged PRs (verified on an `origin/main` worktree; unrelated to this change). `LINGTAI_VERBOSE` is fully registered.

## Back-compat

No schema or data migration. `logs/` already exists per working dir (avatar `_launch` pre-creates it); existing deployments simply gain a new rotating file. Refresh relaunches re-enter `run()` in a fresh process, so the in-process idempotency guard matters mainly for tests and future callers; rotation handles append-across-restarts.