### PR TITLE
fix(kernel): harden load_env_file/resolve_env (export prefix, quote stripping, api_key_env miss diagnostics)

### DIFF
--- a/src/lingtai/agent.py
+++ b/src/lingtai/agent.py
@@ -1673,7 +1673,7 @@ class Agent(BaseAgent):
 
         from lingtai.kernel.config_resolve import (
             load_env_file,
-            resolve_env,
+            resolve_env_checked,
             resolve_file,
             _resolve_capabilities,
         )
@@ -1751,7 +1751,16 @@ class Agent(BaseAgent):
 
         # Reconstruct LLM service if changed
         llm = m["llm"]
-        api_key = resolve_env(llm.get("api_key"), llm.get("api_key_env"))
+        # Warn (not raise) on refresh: a live agent should not be killed by a
+        # hot-edited env_file that transiently loses the api_key variable. The
+        # diagnostic lands in the agent log so the cause is findable instead of
+        # surfacing as an opaque provider auth error on the next turn.
+        api_key = resolve_env_checked(
+            llm.get("api_key"),
+            llm.get("api_key_env"),
+            context="manifest.llm.api_key_env",
+            warn=lambda m: self._log("env_resolve_warning", message=m),
+        )
         new_provider = llm["provider"]
         new_model = llm["model"]
         new_base_url = llm.get("base_url")

--- a/src/lingtai/cli.py
+++ b/src/lingtai/cli.py
@@ -17,8 +17,8 @@ from lingtai.adapters.lifecycle_clock import SystemLifecycleClockAdapter
 from lingtai.adapters.refresh_watcher import select_refresh_watcher
 from lingtai.adapters.workdir_lease import select_workdir_lease
 from lingtai.kernel.config_resolve import (
-    resolve_env,
     load_env_file,
+    resolve_env_checked,
 )
 from lingtai.init_reader import InitReadStatus, read_init, reader_callbacks
 from lingtai.llm.service import (
@@ -62,6 +62,19 @@ def load_init(working_dir: Path) -> dict:
     return outcome.data
 
 
+def _raise_env_miss(message: str, env_file: str | None) -> None:
+    """Boot-time hard failure when ``manifest.llm.api_key_env`` cannot resolve.
+
+    A fresh agent with no API key can never make an LLM call, so failing fast
+    at boot with a message naming the variable is strictly better than an
+    opaque provider auth error on the first turn.
+    """
+    raise ValueError(
+        f"{message}; the agent cannot boot without it "
+        f"(env_file: {env_file!r})"
+    )
+
+
 def build_agent(data: dict, working_dir: Path) -> Agent:
     """Construct Agent from validated init data.
 
@@ -83,7 +96,12 @@ def build_agent(data: dict, working_dir: Path) -> Agent:
     m = data["manifest"]
     llm = m["llm"]
 
-    api_key = resolve_env(llm.get("api_key"), llm.get("api_key_env"))
+    api_key = resolve_env_checked(
+        llm.get("api_key"),
+        llm.get("api_key_env"),
+        context="manifest.llm.api_key_env",
+        warn=lambda m: _raise_env_miss(m, env_file),
+    )
 
     # Default 60 matches AgentConfig.max_rpm — agents whose init.json
     # predates this field cooperatively share the network-wide 60 RPM cap

--- a/src/lingtai/kernel/config_resolve.py
+++ b/src/lingtai/kernel/config_resolve.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import sys
 from pathlib import Path
 
 
@@ -75,6 +76,45 @@ def resolve_env(value: str | None, env_name: str | None) -> str | None:
     return value
 
 
+def resolve_env_checked(
+    value: str | None,
+    env_name: str | None,
+    *,
+    context: str = "",
+    warn=None,
+) -> str | None:
+    """``resolve_env`` plus a diagnostic when *env_name* is named but misses.
+
+    ``resolve_env`` itself stays silent because the generic ``*_env`` paths
+    (capability kwargs via ``_resolve_env_fields``, preset resolution) treat an
+    absent variable as routine. Callers where a miss is always a
+    misconfiguration (the LLM api-key path at boot/refresh) pass a ``warn``
+    callback; the default prints a warning to stderr.
+
+    ``warn`` receives one message argument. Returns the same value as
+    ``resolve_env`` (possibly ``None``).
+    """
+    resolved = resolve_env(value, env_name)
+    if env_name and resolved is None:
+        msg = (
+            f"{context}: environment variable {env_name!r} is unset or empty "
+            "and no fallback value is configured"
+        )
+        (warn or (lambda m: print(f"warning: {m}", file=sys.stderr)))(msg)
+    return resolved
+
+
+def _strip_matched_quotes(val: str) -> str:
+    """Strip exactly one layer of symmetric matching quotes (dotenv semantics).
+
+    ``'"v"'`` keeps its inner double quotes (``"v"``) rather than collapsing
+    both layers; an unmatched leading or trailing quote is preserved verbatim.
+    """
+    if len(val) >= 2 and val[0] == val[-1] and val[0] in ("'", '"'):
+        return val[1:-1]
+    return val
+
+
 def load_env_file(path: str | Path, *, overwrite: bool = False) -> None:
     """Load a .env file into os.environ.
 
@@ -91,11 +131,20 @@ def load_env_file(path: str | Path, *, overwrite: bool = False) -> None:
         line = line.strip()
         if not line or line.startswith("#"):
             continue
-        key, _, val = line.partition("=")
-        if not _:
+        # Copy-pasted shell lines (`export KEY=val`) are the most common way
+        # env files are produced; every mainstream dotenv implementation
+        # accepts the `export ` prefix.
+        if line.startswith("export ") or line.startswith("export\t"):
+            line = line[len("export"):].lstrip()
+        key, sep, val = line.partition("=")
+        if not sep:
             continue
         key = key.strip()
-        val = val.strip().strip("'\"")
+        # A malformed key would otherwise write a bogus name (e.g. the old
+        # `export KEY` behavior) that no lookup can ever find.
+        if not key or " " in key:
+            continue
+        val = _strip_matched_quotes(val.strip())
         if overwrite or key not in os.environ:
             os.environ[key] = val
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -158,7 +158,7 @@ def test_load_env_file_missing():
 
 
 def test_resolve_env_prefers_env_var():
-    from lingtai.cli import resolve_env
+    from lingtai.kernel.config_resolve import resolve_env
     os.environ["TEST_RESOLVE_KEY"] = "from-env"
     try:
         assert resolve_env("raw-value", "TEST_RESOLVE_KEY") == "from-env"
@@ -167,15 +167,145 @@ def test_resolve_env_prefers_env_var():
 
 
 def test_resolve_env_falls_back_to_raw():
-    from lingtai.cli import resolve_env
+    from lingtai.kernel.config_resolve import resolve_env
     os.environ.pop("NONEXISTENT_KEY_12345", None)
     assert resolve_env("raw-value", "NONEXISTENT_KEY_12345") == "raw-value"
 
 
 def test_resolve_env_no_env_name():
-    from lingtai.cli import resolve_env
+    from lingtai.kernel.config_resolve import resolve_env
     assert resolve_env("raw-value", None) == "raw-value"
     assert resolve_env(None, None) is None
+
+
+def test_load_env_file_export_prefix(tmp_path):
+    """`export KEY=val` lines set KEY, never a bogus `export KEY` name."""
+    from lingtai.cli import load_env_file
+    env_path = tmp_path / ".env"
+    env_path.write_text("export TEST_EXPORT_KEY=bar\n")
+    try:
+        load_env_file(env_path)
+        assert os.environ.get("TEST_EXPORT_KEY") == "bar"
+        assert not any(k.startswith("export ") for k in os.environ)
+    finally:
+        os.environ.pop("TEST_EXPORT_KEY", None)
+
+
+def test_load_env_file_export_tab_prefix(tmp_path):
+    """`export\tKEY=val` (tab separator) also parses."""
+    from lingtai.cli import load_env_file
+    env_path = tmp_path / ".env"
+    env_path.write_text("export\tTEST_TAB_KEY=baz\n")
+    try:
+        load_env_file(env_path)
+        assert os.environ.get("TEST_TAB_KEY") == "baz"
+    finally:
+        os.environ.pop("TEST_TAB_KEY", None)
+
+
+def test_load_env_file_matched_quotes_single_layer(tmp_path):
+    """Exactly one layer of symmetric quotes is stripped (dotenv semantics)."""
+    from lingtai.cli import load_env_file
+    env_path = tmp_path / ".env"
+    env_path.write_text('A="v"\nB=\'v\'\nC=\'"v"\'\n')
+    for k in ("A", "B", "C"):
+        os.environ.pop(k, None)
+    try:
+        load_env_file(env_path)
+        assert os.environ["A"] == "v"
+        assert os.environ["B"] == "v"
+        # Inner double quotes survive: one layer only.
+        assert os.environ["C"] == '"v"'
+    finally:
+        for k in ("A", "B", "C"):
+            os.environ.pop(k, None)
+
+
+def test_load_env_file_unmatched_quote_preserved(tmp_path):
+    """Values ending/starting in a lone quote round-trip untouched."""
+    from lingtai.cli import load_env_file
+    env_path = tmp_path / ".env"
+    env_path.write_text('A=abc"\nB="abc\n')
+    for k in ("A", "B"):
+        os.environ.pop(k, None)
+    try:
+        load_env_file(env_path)
+        assert os.environ["A"] == 'abc"'
+        assert os.environ["B"] == '"abc'
+    finally:
+        for k in ("A", "B"):
+            os.environ.pop(k, None)
+
+
+def test_load_env_file_malformed_key_skipped(tmp_path):
+    """A key with an internal space never becomes an env var name."""
+    from lingtai.cli import load_env_file
+    env_path = tmp_path / ".env"
+    env_path.write_text("some words=x\n")
+    before = set(os.environ)
+    load_env_file(env_path)
+    assert set(os.environ) == before
+
+
+def test_resolve_env_checked_warns_on_miss():
+    """A named but unresolvable variable triggers the warn callback."""
+    from lingtai.kernel.config_resolve import resolve_env_checked
+    os.environ.pop("MISSING_VAR_759", None)
+    captured = []
+    result = resolve_env_checked(
+        None, "MISSING_VAR_759", context="t", warn=captured.append
+    )
+    assert result is None
+    assert captured and "MISSING_VAR_759" in captured[0]
+
+
+def test_resolve_env_checked_silent_on_hit_and_fallback():
+    """No diagnostic when the variable resolves or a fallback value exists."""
+    from lingtai.kernel.config_resolve import resolve_env_checked
+    os.environ["HIT_VAR_759"] = "yes"
+    captured = []
+    try:
+        assert (
+            resolve_env_checked(None, "HIT_VAR_759", context="t", warn=captured.append)
+            == "yes"
+        )
+        assert (
+            resolve_env_checked(None, None, context="t", warn=captured.append) is None
+        )
+        assert (
+            resolve_env_checked(
+                "fallback", "MISSING_VAR_759", context="t", warn=captured.append
+            )
+            == "fallback"
+        )
+    finally:
+        os.environ.pop("HIT_VAR_759", None)
+    assert captured == []
+
+
+@patch("lingtai.cli.LLMService")
+@patch("lingtai.cli.Agent")
+@patch("lingtai.cli.PosixFilesystemMailAdapter")
+def test_build_agent_raises_on_unresolvable_api_key_env(
+    mock_mail, mock_agent, mock_llm, tmp_path
+):
+    """A named api_key_env that resolves to nothing fails fast at boot."""
+    from lingtai.cli import load_init, build_agent
+
+    env_file = tmp_path / ".env"
+    env_file.write_text("UNRELATED_KEY=value\n")
+    _write_init(tmp_path)
+    data = load_init(tmp_path)
+    data["manifest"]["llm"]["api_key"] = None
+    data["manifest"]["llm"]["api_key_env"] = "TEST_LLM_KEY_MISSING"
+    data["env_file"] = str(env_file)
+
+    os.environ.pop("TEST_LLM_KEY_MISSING", None)
+    try:
+        with pytest.raises(ValueError, match="TEST_LLM_KEY_MISSING"):
+            build_agent(data, tmp_path)
+    finally:
+        os.environ.pop("TEST_LLM_KEY_MISSING", None)
 
 
 @patch("lingtai.cli.LLMService")

--- a/tests/test_deep_refresh.py
+++ b/tests/test_deep_refresh.py
@@ -348,6 +348,36 @@ def test_deep_refresh_reseals(tmp_path):
     assert agent._sealed is True
 
 
+@patch("lingtai.agent.LLMService")
+def test_refresh_logs_env_resolve_warning(mock_llm_service, tmp_path, monkeypatch):
+    """A refresh whose api_key_env no longer resolves warns instead of dying.
+
+    A live agent must not be killed by a hot-edited env_file that transiently
+    loses the named variable; the diagnostic lands in the agent log.
+    """
+    init = _make_init()
+    init["manifest"]["llm"]["api_key"] = None
+    init["manifest"]["llm"]["api_key_env"] = "TEST_REFRESH_MISSING_KEY"
+    env_file = tmp_path / ".env"
+    env_file.write_text("UNRELATED=1\n")
+    init["env_file"] = str(env_file)
+    agent = _make_agent(tmp_path, init)
+
+    logged = []
+    monkeypatch.setattr(
+        agent, "_log", lambda *args, **kwargs: logged.append((args, kwargs))
+    )
+    monkeypatch.delenv("TEST_REFRESH_MISSING_KEY", raising=False)
+
+    agent._setup_from_init()
+
+    assert any(
+        args and args[0] == "env_resolve_warning"
+        and "TEST_REFRESH_MISSING_KEY" in str(kwargs.get("message", ""))
+        for args, kwargs in logged
+    )
+
+
 def test_live_refresh_rebuilds_service_for_effective_context_window(tmp_path, monkeypatch):
     from lingtai.llm.service import CONSERVATIVE_CONTEXT_WINDOW
 


### PR DESCRIPTION
## Summary

Fixes #759. Hardens the kernel's hand-rolled dotenv loader and the LLM api-key resolution path:

1. **`load_env_file` export-prefix support** (`src/lingtai/kernel/config_resolve.py`): lines like `export KEY=val` (space or tab after `export`) now set `KEY` instead of writing a bogus `export KEY` env name that no lookup can find. This is the most common copy-paste path from shell rc files / provider docs, and matches python-dotenv / docker compose / direnv behavior.
2. **Matched-quote stripping**: replaced `val.strip().strip("'\"")` (which stripped arbitrary runs of mixed quotes from both ends, corrupting values like `'"v"'` or `abc"`) with `_strip_matched_quotes`, which removes exactly one layer of symmetric matching quotes. Unmatched quotes round-trip untouched.
3. **Malformed-key guard**: keys with internal spaces (e.g. a line `some words=x`) are skipped instead of polluting `os.environ` with an unreachable name.
4. **Silent `api_key_env` misses now diagnosed** via a new `resolve_env_checked` helper:
   - Boot (`cli.build_agent`): raises `ValueError` naming the missing variable and the env_file — a fresh agent with no key can never make an LLM call, so failing fast beats an opaque provider auth error on the first turn.
   - Refresh (`Agent._setup_from_init`): warns and logs `env_resolve_warning` (warn-not-raise so a live agent is not killed by a hot-edited env_file).
   - `resolve_env` itself is untouched, so the generic `*_env` paths (capability kwargs, preset resolution) that legitimately tolerate misses keep their silent behavior.

Providers that intentionally ship no `api_key_env` (e.g. `claude_code`) are naturally unaffected — the guard is keyed on `api_key_env` being set.

## Tests

Added 8 tests in `tests/test_cli.py` (export prefix space/tab, single-layer matched quotes, unmatched-quote preservation, malformed-key skip, `resolve_env_checked` warn/silent behavior, boot raise on unresolvable `api_key_env`) and 1 in `tests/test_deep_refresh.py` (`test_refresh_logs_env_resolve_warning`).

Results (venv pinned to current main `df2b523d`):

- `tests/test_cli.py tests/test_deep_refresh.py`: **74 passed**
- `tests/test_preset_materialization.py tests/test_resolved_manifest_artifact.py tests/test_agent_preset_manifest.py`: **57 passed**, 1 pre-existing failure (see below)
- `tests/test_cli_integration.py tests/test_inherit_fallback.py tests/test_unified_web_capability.py`: **36 passed**
- `tests/test_init_schema.py tests/test_init_schema_procedures.py`: **134 passed**
- `tests/test_process_scan.py tests/test_process_match.py tests/test_event_journal.py`: **53 passed**

### Pre-existing failures on current main (verified by stash-run, unrelated to this PR)

- `tests/test_resolved_manifest_artifact.py::test_artifact_redacts_api_key_like_secrets` — fails on pristine `main` at `df2b523d` (uses the deepseek provider removed by #1249).
- `tests/test_preset_runtime_model_docs.py::test_system_manual_routes_preset_runtime_model_to_substrate_reference` and `test_wrapper_anatomy_cites_current_symbol_lines` — doc-drift tests failing on pristine `main`.

## Notes

- The optional init_schema on-disk env_file warning from the issue's plan (step 5) is intentionally left out to keep this change minimal; the existing structural rule already requires `env_file` to be present when `api_key_env` is set without `api_key`.
- No migration needed: the parser changes only alter behavior for inputs that were broken before (bogus `export KEY` names, mixed-quote corruption).
