### PR TITLE
fix(daemon): preserve nested provider_defaults in detached child reconstruction (lingtai#750)

### DIFF
--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -1258,6 +1258,17 @@ def _parse_tool_calls(raw_tool_calls) -> list[ToolCall]:
 
 def _parse_response(raw) -> LLMResponse:
     """Parse a raw OpenAI ChatCompletion into a provider-agnostic LLMResponse."""
+    if not hasattr(raw, "choices"):
+        # Defense-in-depth: a non-conforming gateway (e.g. an OpenAI-compatible
+        # endpoint that returns a scalar string) must surface a typed protocol
+        # error instead of failing through a bare attribute dereference. This
+        # is deliberately a TypeError, not a ValueError: the response object
+        # has the wrong type, not merely an empty payload.
+        raise TypeError(
+            "OpenAI-compatible endpoint returned a non-ChatCompletion response "
+            "(expected an object with a `choices` list); check the provider's "
+            "wire_api/endpoint compatibility"
+        )
     if not raw.choices:
         return LLMResponse(raw=raw)
 

--- a/src/lingtai/tools/daemon/__init__.py
+++ b/src/lingtai/tools/daemon/__init__.py
@@ -2848,6 +2848,21 @@ class DaemonManager:
             base_defaults = effective_preset_llm["_provider_defaults"]
         else:
             base_defaults = self._llm_defaults_from_manifest(effective_preset_llm)
+            # A detached child receives the provider bucket under the public
+            # ``provider_defaults`` key (the private ``_provider_defaults`` alias
+            # never crosses the process boundary). Merge the nested bucket so
+            # provider-specific fields such as ``wire_api`` / ``api_compat`` /
+            # ``max_rpm`` survive the reconstruction; without this a Responses
+            # provider degrades to ``auto`` and is misrouted to Chat Completions.
+            public_defaults = effective_preset_llm.get("provider_defaults")
+            if isinstance(public_defaults, dict):
+                nested = public_defaults.get(provider)
+                if not isinstance(nested, dict):
+                    nested = public_defaults.get(str(provider).lower())
+                if isinstance(nested, dict) and nested:
+                    merged = dict(base_defaults)
+                    merged.update(nested)
+                    base_defaults = merged
         from lingtai.llm.service import CONSERVATIVE_CONTEXT_WINDOW
 
         context_window = effective_preset_llm.get("context_limit")

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -4371,6 +4371,90 @@ def test_run_emanation_no_preset_preserves_parent_provider_defaults(
     }
 
 
+def test_run_emanation_detached_child_merges_public_provider_defaults(
+    tmp_path, monkeypatch
+):
+    """Detached-child reconstruction must merge the public ``provider_defaults`` map.
+
+    The parent serializes the effective provider bucket into the manifest under
+    the public ``provider_defaults`` key; the private ``_provider_defaults``
+    alias never crosses the process boundary. The child's ``_run_emanation``
+    receives ``preset_llm`` carrying that public map and must merge the nested
+    ``provider_defaults[provider]`` bucket — otherwise fields like
+    ``wire_api: responses`` are dropped, the wire degrades to ``auto``, and a
+    Responses provider is misrouted to Chat Completions.
+    """
+    agent = _make_agent(tmp_path, ["file", "daemon"])
+    agent.service.provider = "custom"
+    agent.service.model = "glm-5.1"
+    agent.service._base_url = "https://proxy.example/v1"
+    agent.service._context_window = 200000
+    agent.service._key_resolver = lambda provider: "token"
+    agent.service._api_key = "sk-effective"
+    agent.service.api_key = "sk-effective"
+    agent.service._provider_defaults = {
+        "custom": {
+            "api_compat": "openai",
+            "wire_api": "responses",
+            "max_rpm": 9,
+            "default_headers": {"x-test": "1"},
+        }
+    }
+
+    captured = {}
+    import lingtai.llm.service as service_mod
+    monkeypatch.setattr(service_mod, "LLMService", _capturing_fake_service(captured))
+
+    mgr = agent.get_capability("daemon")
+    cancel = threading.Event()
+    em_id = "em-detached-defaults"
+    schemas, dispatch = mgr._build_tool_surface(["file"])
+    run_dir = _make_run_dir(agent, em_id=em_id)
+    mgr._emanations[em_id] = {
+        "followup_buffer": "",
+        "followup_lock": threading.Lock(),
+        "run_dir": run_dir,
+    }
+
+    # Exactly what a detached child receives: a manifest ``llm``/``preset_llm``
+    # block whose provider bucket lives under the PUBLIC ``provider_defaults``
+    # key (no ``_provider_defaults`` alias survives serialization).
+    child_preset_llm = {
+        "provider": "custom",
+        "model": "glm-5.1",
+        "api_key": "sk-effective",
+        "base_url": "https://proxy.example/v1",
+        "context_window": 200000,
+        "provider_defaults": {
+            "custom": {
+                "api_compat": "openai",
+                "wire_api": "responses",
+                "max_rpm": 9,
+                "default_headers": {"x-test": "1"},
+            }
+        },
+    }
+
+    result = mgr._run_emanation(
+        em_id, run_dir, schemas, dispatch, "x", cancel, preset_llm=child_preset_llm
+    )
+
+    assert result == "daemon done"
+    # The nested wire_api=responses bucket survives the child reconstruction and
+    # reaches LLMService (merged over the top-level manifest-derived keys, e.g.
+    # base_url), so the adapter selects OpenAIResponsesSession instead of
+    # degrading to auto/Chat Completions.
+    assert captured["init"]["provider_defaults"] == {
+        "custom": {
+            "api_compat": "openai",
+            "base_url": "https://proxy.example/v1",
+            "wire_api": "responses",
+            "max_rpm": 9,
+            "default_headers": {"x-test": "1"},
+        }
+    }
+
+
 def test_implicit_parent_preset_llm_does_not_resolve_primary_key(tmp_path):
     """``_implicit_parent_preset_llm`` reads the parent's effective key directly.
 

--- a/tests/test_wire_api.py
+++ b/tests/test_wire_api.py
@@ -627,3 +627,21 @@ def test_daemon_llm_defaults_from_manifest_retains_wire_api():
     }
     defaults = DaemonManager._llm_defaults_from_manifest(llm)
     assert defaults["wire_api"] == "responses"
+
+
+def test_parse_chat_completion_rejects_non_object_response():
+    """A scalar string from a non-conforming gateway yields a typed error.
+
+    Regression for the detached-daemon misroute: when a provider configured
+    with ``wire_api: responses`` was reconstructed as ``auto`` and routed to
+    ``/chat/completions``, a scalar-string response crashed with
+    ``AttributeError: 'str' object has no attribute 'choices'``. The adapter
+    must reject the wrong-typed payload with a clear TypeError instead of
+    dereferencing ``.choices`` on it.
+    """
+    import pytest
+
+    from lingtai.llm.openai.adapter import _parse_response
+
+    with pytest.raises(TypeError, match="non-ChatCompletion"):
+        _parse_response("{\"error\": \"not a chat completion\"}")


### PR DESCRIPTION
Fixes Lingtai-AI/lingtai#750 (cross-repo reference; the issue was filed on `Lingtai-AI/lingtai` but the affected kernel code lives in this repo).

## Problem

Detached LingTai daemon execution drops provider-specific values stored under the public nested `provider_defaults.<provider>` configuration. A custom OpenAI-compatible provider configured with `wire_api: responses` is reconstructed as `wire_api: auto` inside the daemon child, which switches the selected session from the Responses API to Chat Completions. The daemon then calls `/chat/completions`; when the compatibility layer returns a scalar string rather than a `ChatCompletion`, LingTai dereferences `.choices` and fails at turn 0 with `AttributeError: 'str' object has no attribute 'choices'`.

Root cause: the parent serializes the effective provider bucket into the run manifest under the **public** `provider_defaults` key, while the private `_provider_defaults` alias never crosses the process boundary. The child's `_run_emanation` only read `_provider_defaults` (absent in the child) and fell back to `_llm_defaults_from_manifest`, which reads top-level manifest `llm` keys only — so the nested bucket (with `wire_api`, `api_compat`, `max_rpm`, …) was dropped.

Reproduced on current main with a focused test: the reconstructed `provider_defaults` contained only `base_url`; `wire_api` was lost (matches the issue's probe: `reconstructed provider config: base_url only; resolved wire_api: auto`).

## Fix

1. `src/lingtai/tools/daemon/__init__.py` — in `DaemonManager._run_emanation`, when the private `_provider_defaults` alias is absent, merge the nested public `provider_defaults[provider]` bucket over the manifest-derived defaults so provider-specific fields survive the detached-child reconstruction (nested bucket wins on key overlap).
2. `src/lingtai/llm/openai/adapter.py` — defense-in-depth: `_parse_response` now raises a typed `TypeError` for a non-`ChatCompletion` response (e.g. a scalar string) instead of failing through the bare `raw.choices` attribute dereference.

## Tests

- `tests/test_daemon.py::test_run_emanation_detached_child_merges_public_provider_defaults` (new) — simulates the detached child receiving the public `provider_defaults` map and asserts `wire_api: responses` (plus `api_compat`, `max_rpm`, `default_headers`) reaches `LLMService`. Failed on unpatched main (`wire_api` dropped), passes with the fix.
- `tests/test_wire_api.py::test_parse_chat_completion_rejects_non_object_response` (new) — a scalar-string response raises `TypeError` with a clear message.

Evidence:

```
$ pytest tests/test_wire_api.py tests/test_daemon.py::test_run_emanation_detached_child_merges_public_provider_defaults -q
48 passed

$ pytest tests/test_daemon.py tests/test_daemon_backend_options.py tests/test_daemon_detached_supervisor.py -q
226 passed

$ pytest tests/test_openai_responses_streaming.py tests/test_custom_responses_stateless.py tests/test_openai_overflow_recovery.py tests/test_openai_compact_threshold.py -q
107 passed, 2 failed  # the 2 failures are pre-existing on clean main (verified via git stash)
```

## Notes

Branch name deviates from the shared template (`fix/issue-750-dev4-20260809` was already taken by a sibling lane's PR for a different issue, kernel#750); this branch is `fix/lingtai-issue-750-provider-defaults-dev4-20260809`.