### PR TITLE
fix(mail): skip corrupt UTF-8 message files in poll loop instead of crashing (#1063)

### DIFF
--- a/src/lingtai/adapters/posix/mail.py
+++ b/src/lingtai/adapters/posix/mail.py
@@ -306,7 +306,7 @@ class PosixFilesystemMailAdapter(MailTransportPort):
                         payload = json.loads(msg_file.read_text(encoding="utf-8"))
                         on_message(payload)
                         dispatched += 1
-                    except (json.JSONDecodeError, OSError):
+                    except (json.JSONDecodeError, UnicodeDecodeError, OSError):
                         pass
                     self._seen.add(entry.name)
 
@@ -392,7 +392,7 @@ class PosixFilesystemMailAdapter(MailTransportPort):
                 continue
             try:
                 payload = json.loads(msg_file.read_text(encoding="utf-8"))
-            except (json.JSONDecodeError, OSError):
+            except (json.JSONDecodeError, UnicodeDecodeError, OSError):
                 continue
 
             # Normalize `to` to a list of strings.

--- a/tests/test_filesystem_mail.py
+++ b/tests/test_filesystem_mail.py
@@ -967,3 +967,82 @@ def test_mail_poll_slow_phase_telemetry_is_body_free(tmp_path, caplog):
     assert "phase=own_inbox_slice" in caplog.text
     assert "agent=agent01" in caplog.text
     assert "do-not-log-body" not in caplog.text
+
+
+def test_pseudo_outbox_corrupt_utf8_skipped_does_not_crash(tmp_path):
+    """A pseudo-outbox message.json with invalid UTF-8 must be skipped, not
+    crash the poll loop.
+
+    Regression for #1063: ``read_text(encoding="utf-8")`` raises
+    ``UnicodeDecodeError`` (a ``ValueError``), which the old
+    ``except (json.JSONDecodeError, OSError)`` guard did not catch — a single
+    corrupt file escaped ``_poll_pseudo_outboxes`` and killed the whole
+    mail-delivery thread.
+    """
+    from lingtai.adapters.posix.mail import PosixFilesystemMailAdapter
+
+    base = tmp_path
+    pseudo_dir = base / "human"
+    agent_dir = base / "agent01"
+    pseudo_dir.mkdir()
+    agent_dir.mkdir()
+    (agent_dir / "mailbox" / "inbox").mkdir(parents=True)
+
+    outbox_dir = pseudo_dir / "mailbox" / "outbox"
+    corrupt_dir = outbox_dir / "corrupt-msg"
+    corrupt_dir.mkdir(parents=True)
+    # 0xff is never a valid UTF-8 byte.
+    (corrupt_dir / "message.json").write_bytes(b'{"message": "\xff", "to": ["agent01"]}')
+
+    good_dir = outbox_dir / "good-msg"
+    good_dir.mkdir()
+    (good_dir / "message.json").write_text(
+        json.dumps({"message": "valid", "to": ["agent01"]}),
+        encoding="utf-8",
+    )
+
+    svc = PosixFilesystemMailAdapter(
+        working_dir=agent_dir,
+        pseudo_agent_subscriptions=["../human"],
+    )
+    received: list[dict] = []
+    # Must not raise: the corrupt entry is skipped and the valid one is
+    # still claimed and dispatched in the same pass.
+    svc._poll_pseudo_outboxes(received.append)
+
+    assert received == [{"message": "valid", "to": ["agent01"]}]
+    assert not good_dir.exists()  # valid message claimed into pseudo sent/
+    assert corrupt_dir.exists()  # corrupt entry left in place for inspection
+
+
+def test_own_inbox_corrupt_utf8_skipped_does_not_crash(tmp_path):
+    """A corrupt message.json in the own inbox must be skipped by the poll
+    slice, not crash the poll loop.
+
+    Regression for #1063: ``UnicodeDecodeError`` escaped the slice's read
+    guard and killed the mail-delivery thread.
+    """
+    from lingtai.adapters.posix.mail import PosixFilesystemMailAdapter
+
+    agent_dir = _make_agent_dir(tmp_path, "agent01")
+    inbox = agent_dir / "mailbox" / "inbox"
+    inbox.mkdir(parents=True, exist_ok=True)
+
+    corrupt_entry = inbox / "corrupt-msg"
+    corrupt_entry.mkdir()
+    (corrupt_entry / "message.json").write_bytes(b'{"message": "\xff"}')
+
+    good_entry = inbox / "good-msg"
+    good_entry.mkdir()
+    (good_entry / "message.json").write_text(
+        json.dumps({"message": "ok"}),
+        encoding="utf-8",
+    )
+
+    svc = PosixFilesystemMailAdapter(agent_dir, mailbox_rel="mailbox")
+    # Deterministic entry order: corrupt first, valid second.
+    svc._own_inbox_iter = iter([corrupt_entry, good_entry])
+    received: list[dict] = []
+    assert svc._poll_own_inbox_slice(received.append) is True
+
+    assert received == [{"message": "ok"}]


### PR DESCRIPTION
Fixes #1063 (Bug 1 only: outbox corrupt file crashes poll loop).

## Problem

A message file in `human/mailbox/outbox/` with invalid UTF-8 bytes makes
`msg_file.read_text(encoding="utf-8")` raise `UnicodeDecodeError`, which is a
`ValueError` subclass and was **not** caught by the existing
`except (json.JSONDecodeError, OSError)` guards in `_poll_pseudo_outbox` and
`_poll_own_inbox_slice`. The exception escaped `_poll_pseudo_outboxes`
(which only catches `OSError`) and killed the whole mail-delivery poll thread
— one corrupt file stops the agent from receiving any further messages.

Verified reproducible on current `main` (df2b523d): a corrupt `message.json`
crashed `_poll_pseudo_outboxes` with `UnicodeDecodeError`.

## Fix

Add `UnicodeDecodeError` to the read guards at both poll-loop read sites in
`src/lingtai/adapters/posix/mail.py`:

- `_poll_own_inbox_slice` (own-inbox scan)
- `_poll_pseudo_outbox` (subscribed pseudo-agent outbox claim)

A corrupt entry is now skipped (left in place for inspection) and the poll
loop continues; valid messages in the same pass are still delivered. This
matches the issue's suggested fix ("Add `try/except UnicodeDecodeError` around
message file reads in the poll loop").

Note: the issue's Bug 2 (persistence restore auto-sleep) is not changed here —
on current main that behavior is already governed by the notification-sync
wake mechanism (`_sync_notifications` ASLEEP -> IDLE + MSG_TC_WAKE on
notification fingerprint change, covered by
`tests/test_notification_sync.py::test_sync_asleep_wakes_on_change`), and
boot-into-ASLEEP is the documented `lingtai-agent run` contract
("wakes on external messages"). See the issue thread for details.

## Tests

- `tests/test_filesystem_mail.py`: added two regression tests
  (`test_pseudo_outbox_corrupt_utf8_skipped_does_not_crash`,
  `test_own_inbox_corrupt_utf8_skipped_does_not_crash`) that plant a corrupt
  `message.json` (invalid `0xff` byte) next to a valid message and assert the
  poll skips the corrupt entry, does not raise, and still delivers the valid
  message.
- Full file: `pytest tests/test_filesystem_mail.py -q` -> **29 passed**
  (27 pre-existing + 2 new).
- Adjacent suites: `pytest tests/test_layers_email.py
  tests/test_email_abs_reply_route.py -q` -> **74 passed**.
- Manual repro against main before fix: `UnicodeDecodeError` escaped the poll
  loop; after fix: no exception, corrupt entry skipped, valid entry delivered.
