### PR TITLE
fix(mail): stop silently dropping unreadable inbox messages (#732)

### DIFF
--- a/src/lingtai/adapters/posix/mail.py
+++ b/src/lingtai/adapters/posix/mail.py
@@ -34,6 +34,14 @@ from lingtai.kernel.services.mail import _new_mailbox_id
 
 logger = logging.getLogger(__name__)
 
+# A ``message.json`` that fails to read (transient OSError: permissions blip,
+# network-filesystem hiccup) is retried for this many poll cycles before being
+# dead-lettered. At the 0.5 s poll cadence this is ~5 s of retries.
+_MAX_READ_RETRIES = 10
+# Dead-letter store for permanently bad inbox entries, mirroring the MCP inbox
+# poller's ``.dead/`` convention.
+_DEAD_DIRNAME = ".dead"
+
 
 def _presence_store_for(recipient_dir: Path):
     """Build a target-bound POSIX presence adapter for a recipient directory."""
@@ -78,6 +86,9 @@ class PosixFilesystemMailAdapter(MailTransportPort):
         self._poll_thread: threading.Thread | None = None
         self._poll_stop = threading.Event()
         self._seen: set[str] = set()
+        # Consecutive read-failure counts per inbox entry name, for bounded
+        # retry of transiently unreadable ``message.json`` files.
+        self._read_failures: dict[str, int] = {}
         # Own-inbox scans can be expensive on large/slow external-volume
         # mailboxes. Keep iterator progress across poll ticks so Phase 2 can
         # be sliced instead of restarting from the first historical entry.
@@ -198,10 +209,12 @@ class PosixFilesystemMailAdapter(MailTransportPort):
         re-delivered.  New directories that appear with a ``message.json``
         trigger *on_message*.
         """
-        # Snapshot existing inbox entries so we don't re-notify
+        # Snapshot existing inbox entries so we don't re-notify. Dotted
+        # directories (e.g. the ``.dead/`` dead-letter store) are not inbox
+        # entries and are excluded from the snapshot.
         if self._inbox_dir.is_dir():
             for entry in self._inbox_dir.iterdir():
-                if entry.is_dir():
+                if entry.is_dir() and not entry.name.startswith("."):
                     self._seen.add(entry.name)
 
         self._poll_stop.clear()
@@ -294,21 +307,59 @@ class PosixFilesystemMailAdapter(MailTransportPort):
 
                 visited += 1
                 # _seen only holds handled directory names or pseudo-claim
-                # UUIDs, so skip before the stat.
+                # UUIDs, so skip before the stat. Dotted directories (e.g. the
+                # ``.dead/`` dead-letter store) are never inbox entries.
                 if entry.name in self._seen:
                     skipped_seen += 1
                     continue
-                if not entry.is_dir():
+                if not entry.is_dir() or entry.name.startswith("."):
                     continue
                 msg_file = entry / "message.json"
                 if msg_file.is_file():
+                    # Transient read failures are retried (NOT marked seen),
+                    # so a one-cycle OSError on a network filesystem cannot
+                    # permanently drop an intact message. Permanent failures
+                    # are dead-lettered with a logged error report.
                     try:
-                        payload = json.loads(msg_file.read_text(encoding="utf-8"))
+                        raw = msg_file.read_text(encoding="utf-8")
+                    except OSError as e:
+                        n = self._read_failures.get(entry.name, 0) + 1
+                        self._read_failures[entry.name] = n
+                        if n >= _MAX_READ_RETRIES:
+                            self._dead_letter_inbox_entry(
+                                entry, f"read failed after {n} attempts: {e}"
+                            )
+                        else:
+                            logger.warning(
+                                "mail inbox: transient read failure on %s (attempt %d/%d): %s",
+                                entry.name,
+                                n,
+                                _MAX_READ_RETRIES,
+                                e,
+                            )
+                        continue
+
+                    try:
+                        payload = json.loads(raw)
+                    except json.JSONDecodeError as e:
+                        # `send()` writes message.json atomically (tmp -> rename),
+                        # so a parse error means genuinely malformed content;
+                        # dead-letter immediately.
+                        self._dead_letter_inbox_entry(entry, f"invalid JSON: {e}")
+                        continue
+
+                    self._read_failures.pop(entry.name, None)
+                    # Mark seen BEFORE dispatch: a consumer error must not
+                    # redeliver (at-most-once), and must not be misdiagnosed
+                    # as a transport failure.
+                    self._seen.add(entry.name)
+                    try:
                         on_message(payload)
                         dispatched += 1
-                    except (json.JSONDecodeError, OSError):
-                        pass
-                    self._seen.add(entry.name)
+                    except Exception:
+                        logger.exception(
+                            "mail inbox: on_message handler failed for %s", entry.name
+                        )
 
         except OSError:
             self._reset_own_inbox_iter()
@@ -324,6 +375,44 @@ class PosixFilesystemMailAdapter(MailTransportPort):
             )
 
         return visited > 0
+
+    def _dead_letter_inbox_entry(self, entry: Path, error: str) -> None:
+        """Move a bad inbox entry directory into ``inbox/.dead/`` with a report.
+
+        Mail inbox entries are directories (``<uuid>/message.json`` plus
+        optional ``attachments/``), so unlike the single-file MCP inbox
+        dead-letter path the whole entry directory is moved. An ``error.json``
+        report and a warning log line are left behind for operators.
+        """
+        from datetime import datetime, timezone
+
+        dead_dir = self._inbox_dir / _DEAD_DIRNAME
+        try:
+            dead_dir.mkdir(parents=True, exist_ok=True)
+            target = dead_dir / entry.name
+            shutil.move(str(entry), str(target))
+            (target / "error.json").write_text(
+                json.dumps(
+                    {
+                        "error": error,
+                        "timestamp": datetime.now(timezone.utc).isoformat(),
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                ),
+                encoding="utf-8",
+            )
+            logger.warning("mail inbox: dead-lettered %s: %s", target, error)
+        except OSError as e:
+            logger.error(
+                "mail inbox: failed to dead-letter %s: %s (original error: %s)",
+                entry,
+                e,
+                error,
+            )
+        # Either way, stop re-processing this entry.
+        self._seen.add(entry.name)
+        self._read_failures.pop(entry.name, None)
 
     def _reset_own_inbox_iter(self) -> None:
         iterator = self._own_inbox_iter

--- a/tests/test_filesystem_mail.py
+++ b/tests/test_filesystem_mail.py
@@ -967,3 +967,222 @@ def test_mail_poll_slow_phase_telemetry_is_body_free(tmp_path, caplog):
     assert "phase=own_inbox_slice" in caplog.text
     assert "agent=agent01" in caplog.text
     assert "do-not-log-body" not in caplog.text
+
+
+def _write_message(msg_dir, payload):
+    """Write an inbox message atomically (tmp -> os.replace), exactly like
+    ``PosixFilesystemMailAdapter.send()`` does, so tests never expose a
+    half-written ``message.json`` to the poller."""
+    import os
+
+    msg_dir.mkdir(parents=True, exist_ok=True)
+    tmp = msg_dir / "message.json.tmp"
+    tmp.write_text(json.dumps(payload), encoding="utf-8")
+    os.replace(str(tmp), str(msg_dir / "message.json"))
+
+
+def test_listen_retries_transient_read_error_then_delivers(
+    tmp_path, monkeypatch, caplog
+):
+    """A transient OSError reading message.json must be retried, not dropped.
+
+    Regression for #732: the old poller swallowed the error with ``pass`` and
+    marked the entry seen, permanently losing an intact message.
+    """
+    import pathlib
+
+    from lingtai.adapters.posix.mail import PosixFilesystemMailAdapter
+
+    agent_dir = _make_agent_dir(tmp_path, "agent01")
+    inbox = agent_dir / "mailbox" / "inbox"
+    inbox.mkdir(parents=True)
+
+    payload = {"from": "/tmp/other", "message": "hi"}
+    real_read_text = pathlib.Path.read_text
+    failures = {"count": 0}
+
+    def flaky_read_text(self, *args, **kwargs):
+        if self.name == "message.json" and failures["count"] < 2:
+            failures["count"] += 1
+            raise OSError("transient EIO")
+        return real_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "read_text", flaky_read_text)
+
+    received = []
+    received_event = threading.Event()
+    svc = PosixFilesystemMailAdapter(agent_dir, mailbox_rel="mailbox")
+    svc.listen(on_message=lambda p: (received.append(p), received_event.set()))
+
+    # Deliver AFTER listen() so the startup snapshot does not mark it seen.
+    _write_message(inbox / "uuid-1", payload)
+
+    try:
+        assert received_event.wait(timeout=6.0)
+    finally:
+        svc.stop()
+
+    assert failures["count"] >= 2
+    assert len(received) == 1
+    assert received[0]["message"] == "hi"
+    # The intact message must NOT have been dead-lettered.
+    assert not (inbox / ".dead").exists()
+    assert "transient read failure" in caplog.text
+
+
+def test_listen_dead_letters_after_max_read_retries(tmp_path, monkeypatch, caplog):
+    """A persistently unreadable entry is dead-lettered, not retried forever."""
+    import pathlib
+
+    from lingtai.adapters.posix.mail import PosixFilesystemMailAdapter
+
+    agent_dir = _make_agent_dir(tmp_path, "agent01")
+    inbox = agent_dir / "mailbox" / "inbox"
+    inbox.mkdir(parents=True)
+
+    # Bound the retry window so the test runs in seconds, not minutes.
+    monkeypatch.setattr("lingtai.adapters.posix.mail._MAX_READ_RETRIES", 3)
+
+    real_read_text = pathlib.Path.read_text
+
+    def always_fail_read_text(self, *args, **kwargs):
+        if self.name == "message.json":
+            raise OSError("EACCES persistent")
+        return real_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "read_text", always_fail_read_text)
+
+    received = []
+    svc = PosixFilesystemMailAdapter(agent_dir, mailbox_rel="mailbox")
+    svc.listen(on_message=lambda p: received.append(p))
+
+    _write_message(inbox / "uuid-1", {"message": "hi"})
+
+    dead_dir = inbox / ".dead"
+    try:
+        deadline = time.time() + 8.0
+        while time.time() < deadline:
+            if (dead_dir / "uuid-1" / "error.json").is_file():
+                break
+            time.sleep(0.1)
+        svc.stop()
+    finally:
+        svc.stop()
+
+    assert not (inbox / "uuid-1").exists()
+    error_report = json.loads((dead_dir / "uuid-1" / "error.json").read_text())
+    assert "read failed after 3 attempts" in error_report["error"]
+    assert len(received) == 0
+    assert "dead-lettered" in caplog.text
+
+
+def test_listen_dead_letters_malformed_json_immediately(tmp_path, caplog):
+    """Malformed JSON is dead-lettered on the first cycle with a report."""
+    from lingtai.adapters.posix.mail import PosixFilesystemMailAdapter
+
+    agent_dir = _make_agent_dir(tmp_path, "agent01")
+    inbox = agent_dir / "mailbox" / "inbox"
+    inbox.mkdir(parents=True)
+
+    received = []
+    svc = PosixFilesystemMailAdapter(agent_dir, mailbox_rel="mailbox")
+    svc.listen(on_message=lambda p: received.append(p))
+
+    # Genuinely malformed content (cannot happen from send(), which writes
+    # atomically, but can arrive from hand-edited or corrupted files).
+    msg_dir = inbox / "uuid-1"
+    msg_dir.mkdir()
+    (msg_dir / "message.json").write_text("{not json", encoding="utf-8")
+
+    dead_dir = inbox / ".dead"
+    try:
+        deadline = time.time() + 5.0
+        while time.time() < deadline:
+            if (dead_dir / "uuid-1" / "error.json").is_file():
+                break
+            time.sleep(0.1)
+        svc.stop()
+    finally:
+        svc.stop()
+
+    assert not (inbox / "uuid-1").exists()
+    error_report = json.loads((dead_dir / "uuid-1" / "error.json").read_text())
+    assert "invalid JSON" in error_report["error"]
+    assert len(received) == 0
+    assert "dead-lettered" in caplog.text
+
+
+def test_listen_on_message_exception_is_logged_not_silent(tmp_path, caplog):
+    """A consumer exception is logged; the poll thread survives and no
+    redelivery occurs (at-most-once preserved)."""
+    from lingtai.adapters.posix.mail import PosixFilesystemMailAdapter
+
+    agent_dir = _make_agent_dir(tmp_path, "agent01")
+    inbox = agent_dir / "mailbox" / "inbox"
+    inbox.mkdir(parents=True)
+
+    received = []
+    received_event = threading.Event()
+    calls = {"n": 0}
+
+    def on_message(payload):
+        calls["n"] += 1
+        if payload["message"] == "boom":
+            raise RuntimeError("consumer bug")
+        received.append(payload)
+        received_event.set()
+
+    svc = PosixFilesystemMailAdapter(agent_dir, mailbox_rel="mailbox")
+    svc.listen(on_message=on_message)
+
+    # First message: the handler raises; must be logged and marked seen.
+    _write_message(inbox / "bad-1", {"message": "boom"})
+    # Second message: must still be delivered (poll thread stayed alive).
+    _write_message(inbox / "good-1", {"message": "fine"})
+
+    try:
+        assert received_event.wait(timeout=6.0)
+        # Let several cycles pass: the failing entry must not redeliver.
+        time.sleep(1.5)
+        svc.stop()
+    finally:
+        svc.stop()
+
+    assert received == [{"message": "fine"}]
+    # bad-1 dispatched exactly once (marked seen before dispatch), good-1 once.
+    assert calls["n"] == 2
+    assert "on_message handler failed for bad-1" in caplog.text
+
+
+def test_listen_skips_dead_dir(tmp_path):
+    """The .dead/ store is never treated as inbox content, and dotted
+    directories are excluded from the _seen snapshot."""
+    from lingtai.adapters.posix.mail import PosixFilesystemMailAdapter
+
+    agent_dir = _make_agent_dir(tmp_path, "agent01")
+    inbox = agent_dir / "mailbox" / "inbox"
+    inbox.mkdir(parents=True)
+
+    # Pre-existing dead-letter store (as produced by dead-lettering before a
+    # restart): must be skipped by both the snapshot and the poll loop.
+    _write_message(inbox / ".dead" / "stuck-1", {"message": "dead"})
+
+    received = []
+    svc = PosixFilesystemMailAdapter(agent_dir, mailbox_rel="mailbox")
+    svc.listen(on_message=lambda p: received.append(p))
+
+    # A live message proves the poller still works.
+    _write_message(inbox / "live-1", {"message": "live"})
+
+    try:
+        deadline = time.time() + 5.0
+        while time.time() < deadline:
+            if len(received) >= 1:
+                break
+            time.sleep(0.1)
+        svc.stop()
+    finally:
+        svc.stop()
+
+    assert received == [{"message": "live"}]
+    assert ".dead" not in svc._seen


### PR DESCRIPTION
Fixes #732

## Root cause

`PosixFilesystemMailAdapter._poll_own_inbox_slice()` (the Phase 1 own-inbox
poller, formerly `FilesystemMailService.listen()` in
`src/lingtai_kernel/services/mail.py`, moved to the adapter layer by the
Ports & Adapters refactor) collapsed three distinct failure classes into one
silent drop:

```python
if msg_file.is_file():
    try:
        payload = json.loads(msg_file.read_text(encoding="utf-8"))
        on_message(payload)
    except (json.JSONDecodeError, OSError):
        pass
    self._seen.add(entry.name)
```

- A transient `OSError` (permissions blip, network-filesystem hiccup on one
  0.5 s cycle) dropped a perfectly intact message **forever** — the entry was
  marked seen with no retry and no log line.
- A genuinely malformed `message.json` vanished into `_seen` with no
  dead-letter artifact and no log line.
- `on_message()` ran inside the same `try`: a consumer `OSError` was
  misdiagnosed as a transport failure, and any other handler exception
  escaped into the loop's `except OSError` and **killed the poll thread**.

This mirrors the bug report exactly; the defect is still reproducible on
current main (verified at HEAD `df2b523d`). The earlier attempt, PR #786
(`fix(mail): stop silently dropping unreadable inbox messages`), was closed
unmerged and predates the adapter-layer move.

## Fix (all in `src/lingtai/adapters/posix/mail.py`)

Follows the mature dead-letter pattern the MCP inbox poller already uses
(`src/lingtai/core/mcp/inbox.py`), applied to directory-based inbox entries:

- **Transient `OSError` on read** → log a warning and skip **without** marking
  `_seen`, so the next 0.5 s cycle retries the still-intact file. A bounded
  retry counter (`_MAX_READ_RETRIES = 10`, ~5 s) dead-letters a persistently
  unreadable entry instead of retrying forever.
- **`JSONDecodeError`** → dead-letter the whole entry directory into
  `inbox/.dead/<uuid>/` with an `error.json` report and a logged warning.
  Safe to treat as permanent because `send()` writes `message.json`
  atomically via `tmp → os.replace`.
- **`on_message` dispatch** moved out of the read `try` and wrapped
  separately: the entry is marked seen **before** dispatch (at-most-once
  preserved), and a handler exception is logged via `logger.exception`
  instead of dropping the message or killing the poll thread.
- **Dotted directories** (the new `.dead/` store) are skipped in both the
  startup snapshot and the poll loop, so dead-lettered entries are never
  re-dispatched.

## Validation

New regression tests in `tests/test_filesystem_mail.py`:
`test_listen_retries_transient_read_error_then_delivers`,
`test_listen_dead_letters_after_max_read_retries`,
`test_listen_dead_letters_malformed_json_immediately`,
`test_listen_on_message_exception_is_logged_not_silent`, and
`test_listen_skips_dead_dir`.

Failing-first run (new tests against the pre-fix `mail.py`):

```
$ pytest tests/test_filesystem_mail.py -q -k "transient or dead_letters or on_message_exception or skips_dead"
5 failed, 27 deselected in 21.17s
```

After the fix:

```
$ pytest tests/test_filesystem_mail.py -q -k "transient or dead_letters or on_message_exception or skips_dead"
5 passed, 27 deselected in 5.91s
```

Full touched-module suites:

```
$ pytest tests/test_filesystem_mail.py -q
32 passed in 17.31s
$ pytest tests/test_filesystem_mail.py tests/test_services_mail.py tests/test_mail_transport.py -q
56 passed in 18.48s
```

`tests/test_three_agent_email.py` shows 5 pre-existing collection errors in
this minimal venv (missing third-party deps in the agent boot path); they are
identical on pristine `main` and unrelated to this change.

`git diff --check` is clean.
