### PR TITLE
fix(init-schema): reject bool for any int-accepting field in _check_type (#737)

### DIFF
--- a/src/lingtai/init_schema.py
+++ b/src/lingtai/init_schema.py
@@ -106,8 +106,9 @@ MANIFEST_OPTIONAL: dict[str, type | tuple[type, ...]] = {
     "aed_timeout": (int, float),
     # Soft per-molt/session cache-miss token budget. Positive int; default
     # 1_000_000 lives in AgentConfig.cache_miss_budget. The range check
-    # (reject bool and <= 0) is enforced explicitly in validate_init below —
-    # the (int) type here only rejects non-int types like str/float/None.
+    # (<= 0) is enforced explicitly in validate_init below; the (int) type
+    # here rejects non-int types like str/float/None (bool is rejected by
+    # _check_type's general rule, since bool subclasses int).
     "cache_miss_budget": int,
     "admin": dict,
     "streaming": bool,
@@ -365,10 +366,6 @@ def validate_init(data: dict) -> list[str]:
 
     if "summarize_notification_threshold" in manifest:
         summarize_threshold = manifest["summarize_notification_threshold"]
-        if isinstance(summarize_threshold, bool):
-            raise ValueError(
-                "manifest.summarize_notification_threshold: expected non-negative int, got bool"
-            )
         if summarize_threshold < 0:
             raise ValueError(
                 "manifest.summarize_notification_threshold: expected non-negative int"
@@ -376,12 +373,6 @@ def validate_init(data: dict) -> list[str]:
 
     if "cache_miss_budget" in manifest:
         cache_miss_budget = manifest["cache_miss_budget"]
-        # bool is an int subclass — reject it explicitly, then require > 0.
-        # (_optional_keys already rejected non-int types like str/float/None.)
-        if isinstance(cache_miss_budget, bool):
-            raise ValueError(
-                "manifest.cache_miss_budget: expected positive int, got bool"
-            )
         if cache_miss_budget <= 0:
             raise ValueError(
                 "manifest.cache_miss_budget: expected positive int (> 0)"
@@ -399,8 +390,6 @@ def validate_init(data: dict) -> list[str]:
     _optional_keys(llm, LLM_OPTIONAL, prefix="manifest.llm")
     if "compact_threshold" in llm:
         compact_threshold = llm["compact_threshold"]
-        if isinstance(compact_threshold, bool):
-            raise ValueError("manifest.llm.compact_threshold: expected int | null, got bool")
         if isinstance(compact_threshold, int) and compact_threshold <= 0:
             raise ValueError(
                 "manifest.llm.compact_threshold: expected positive int or null"
@@ -541,8 +530,10 @@ def _check_type(
     path: str,
 ) -> None:
     """Validate a single value's type."""
+    expected = expected_type if isinstance(expected_type, tuple) else (expected_type,)
     # bool is a subclass of int in Python — reject bools for numeric fields
-    if isinstance(value, bool) and expected_type in (int, (int, float)):
+    # unless bool is explicitly one of the accepted types.
+    if isinstance(value, bool) and int in expected and bool not in expected:
         raise ValueError(f"{path}: expected number, got bool")
 
     if not isinstance(value, expected_type):

--- a/tests/test_init_schema.py
+++ b/tests/test_init_schema.py
@@ -1,6 +1,6 @@
 import json
 import pytest
-from lingtai.init_schema import validate_init
+from lingtai.init_schema import _check_type, validate_init
 
 
 def _valid_init() -> dict:
@@ -96,7 +96,7 @@ def test_summarize_notification_threshold_rejects_negative():
 def test_summarize_notification_threshold_rejects_bool():
     data = _valid_init()
     data["manifest"]["summarize_notification_threshold"] = True
-    with pytest.raises(ValueError, match="summarize_notification_threshold"):
+    with pytest.raises(ValueError, match="summarize_notification_threshold.*bool"):
         validate_init(data)
 
 
@@ -128,10 +128,39 @@ def test_cache_miss_budget_rejects_negative():
 
 def test_cache_miss_budget_rejects_bool():
     data = _valid_init()
-    # bool is an int subclass in Python — must be rejected explicitly.
+    # bool is an int subclass in Python — rejected by _check_type's general
+    # rule for any int-accepting field (issue #737).
     data["manifest"]["cache_miss_budget"] = True
-    with pytest.raises(ValueError, match="manifest.cache_miss_budget"):
+    with pytest.raises(ValueError, match="manifest.cache_miss_budget.*bool"):
         validate_init(data)
+
+
+@pytest.mark.parametrize("bad_value", [True, False])
+def test_context_limit_rejects_bool(bad_value):
+    data = _valid_init()
+    data["manifest"]["context_limit"] = bad_value
+    with pytest.raises(ValueError, match=r"manifest\.context_limit.*bool"):
+        validate_init(data)
+
+
+@pytest.mark.parametrize("good_value", [200_000, None])
+def test_context_limit_accepts_int_and_null(good_value):
+    data = _valid_init()
+    data["manifest"]["context_limit"] = good_value
+    assert validate_init(data) == []
+
+
+def test_compact_threshold_rejects_bool_via_check_type():
+    data = _valid_init()
+    data["manifest"]["llm"]["compact_threshold"] = True
+    with pytest.raises(ValueError, match=r"manifest\.llm\.compact_threshold.*bool"):
+        validate_init(data)
+
+
+def test_check_type_bool_allowed_when_listed():
+    # Escape hatch: a field that explicitly accepts bool | int is not rejected.
+    _check_type(True, (int, bool), "x")  # should not raise
+    _check_type(3, (int, bool), "x")  # should not raise
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Fix `_check_type` in `src/lingtai/init_schema.py` to reject a `bool` whenever `int` is among the accepted types (unless `bool` is explicitly listed), instead of enumerating only the exact specs `int` and `(int, float)`.
- Delete the three now-redundant hand-rolled per-field bool guards in `validate_init`: `summarize_notification_threshold` and `cache_miss_budget` (both plain `int` — their guards were already dead code, `_check_type` rejected the bool first) and `compact_threshold` (`(int, None)` — its guard was live and is now covered by the general rule). The `< 0` / `<= 0` range checks are kept.
- Add regression tests for `manifest.context_limit`, `manifest.llm.compact_threshold`, and the `_check_type` general rule + escape hatch.
- Update the stale `cache_miss_budget` schema comment that claimed bool rejection happened "explicitly in validate_init below".

### Root cause

`bool` subclasses `int` in Python, so `isinstance(True, int)` is `True`. The guard rejected bools only for `expected_type in (int, (int, float))`. `manifest.context_limit` is typed `(int, type(None))` (`init_schema.py:89`), which was not in that enumeration, so `context_limit: true` passed `validate_init` with zero warnings, hydrated verbatim into `AgentConfig.context_limit`, and made `ctx_window = self._config.context_limit or ...` (`session.py:421`) evaluate to `True` — a 1-token context window. Context-usage percentages then ran astronomically over 100% with nothing pointing back at the one-character init.json mistake. Asking the general question "is `int` accepted?" closes the whole class of bug (the same gap had already produced two dead guards and one missed field).

### Non-goals

- `src/lingtai/kernel/presets.py` (`isinstance(ctx_limit, int)` at ~:356) has the same class of gap on the preset path. It is a separate module/consumer and the issue explicitly flagged it as optional follow-up; left out to keep this PR one concern.

### Back-compat

An existing init.json carrying `context_limit: true/false` was already misbehaving at runtime (1-token window, or silently null for `false`). It now fails validation loudly with `manifest.context_limit: expected number, got bool` — an invisible runtime pathology becomes a clear config error. No migration needed; operators set an integer or `null`.

## Validation

Failing-first run (fix reverted via `git stash push src/lingtai/init_schema.py`, new tests run against pre-fix code):

```
FAILED tests/test_init_schema.py::test_context_limit_rejects_bool[True]
FAILED tests/test_init_schema.py::test_context_limit_rejects_bool[False]
E   Failed: DID NOT RAISE ValueError
```

Post-fix, full module suite:

```
$ python -m pytest tests/test_init_schema.py -q
125 passed in 0.15s
```

Broader affected modules (schema, hydration, presets, agent config):

```
$ python -m pytest tests/ -q -k "hydrat or build_agent_config or preset or init_schema or agent_config"
496 passed, 4 failed (the 4 failures are pre-existing on pristine main in this env: test_daemon_preset_capabilities, test_feishu_automatic_task_cards, test_preset_runtime_model_docs x2)
```

Whitespace:

```
$ git diff --check
(no output)
```

Fixes #737
