### PR TITLE
fix(mcp): suppress httpx request logging and redact Telegram bot credentials

### DIFF
--- a/src/lingtai/mcp_servers/_entrypoint.py
+++ b/src/lingtai/mcp_servers/_entrypoint.py
@@ -4,23 +4,93 @@ Every bundled MCP server's ``__main__.py`` ran the same three steps: configure
 INFO logging to **stderr** (so logs never corrupt the JSON-RPC stdout channel),
 ``asyncio.run(serve())``, and swallow ``KeyboardInterrupt`` on Ctrl-C. This is
 the single copy.
+
+Since #812, the stderr logging setup also applies defense in depth against
+credential leakage:
+
+1. ``httpx``/``httpcore`` are pinned to WARNING so the INFO ``HTTP Request:``
+   lines (whose URL embeds provider credentials such as the Telegram bot token
+   in the request path) never reach stderr.
+2. A redaction filter is attached to the root logger so any record that still
+   contains a Telegram bot token or a ``api.telegram.org/bot<TOKEN>/...`` URL
+   is rewritten to a fixed placeholder before any handler renders it.
 """
 from __future__ import annotations
 
 import asyncio
 import logging
+import re
 import sys
 from collections.abc import Awaitable, Callable
 
+# HTTP clients log one INFO ``HTTP Request: <METHOD> <url> ...`` line per
+# request. Providers such as Telegram embed the live credential in the URL
+# path (``https://api.telegram.org/bot<TOKEN>/<method>``), so at INFO level
+# that line would copy the token to stderr — and from there into
+# refresh-watcher diagnostics. Keep these clients quiet by default for every
+# curated MCP server.
+_QUIET_CLIENT_LOGGERS = ("httpx", "httpcore")
 
-def run_stdio_server_main(serve: Callable[[], Awaitable[None]]) -> None:
-    """Configure stderr logging and run ``serve()`` until interrupted."""
-    # Logs to stderr so they don't pollute the MCP stdio channel.
+# Telegram bot tokens look like ``<bot_id>:<secret>`` with a 6-12 digit bot
+# id and a long base64url-ish secret, e.g. ``123456789:AAH...``. The Bot API
+# embeds the token in the request path.
+_TELEGRAM_BOT_URL_RE = re.compile(
+    r"(https://api\.telegram\.org/(?:file/)?bot)\d{6,12}:[A-Za-z0-9_-]{30,}"
+)
+_TELEGRAM_TOKEN_RE = re.compile(r"\b\d{6,12}:[A-Za-z0-9_-]{30,}\b")
+
+_REDACTED = "[REDACTED]"
+
+
+class _RedactTelegramCredentials(logging.Filter):
+    """Replace Telegram bot credentials before any handler renders them."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        try:
+            rendered = record.getMessage()
+        except Exception:
+            return True
+        redacted = _TELEGRAM_BOT_URL_RE.sub(r"\1" + _REDACTED, rendered)
+        redacted = _TELEGRAM_TOKEN_RE.sub(_REDACTED, redacted)
+        if redacted != rendered:
+            record.msg = redacted
+            record.args = ()
+        return True
+
+
+_telegram_credential_filter = _RedactTelegramCredentials()
+
+
+def configure_stdio_logging() -> None:
+    """Configure INFO stderr logging for a curated MCP stdio server.
+
+    Logs go to stderr so they don't pollute the MCP stdio channel. HTTP client
+    request logging is suppressed and Telegram-shaped credentials are redacted
+    before the stderr handler renders them (defense in depth, issue #812).
+    """
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s %(levelname)s %(name)s %(message)s",
         stream=sys.stderr,
     )
+    for name in _QUIET_CLIENT_LOGGERS:
+        logging.getLogger(name).setLevel(logging.WARNING)
+    root_logger = logging.getLogger()
+    if _telegram_credential_filter not in root_logger.filters:
+        root_logger.addFilter(_telegram_credential_filter)
+    # Filters on ancestor loggers are not consulted for records emitted by
+    # descendant loggers (only the emitting logger's and each handler's filters
+    # run), so the redaction filter must also sit on every root handler — the
+    # layer every propagated record passes through before it reaches stderr.
+    # Same pattern as the feishu addon's credential filter.
+    for handler in root_logger.handlers:
+        if _telegram_credential_filter not in handler.filters:
+            handler.addFilter(_telegram_credential_filter)
+
+
+def run_stdio_server_main(serve: Callable[[], Awaitable[None]]) -> None:
+    """Configure stderr logging and run ``serve()`` until interrupted."""
+    configure_stdio_logging()
     try:
         asyncio.run(serve())
     except KeyboardInterrupt:

--- a/tests/test_mcp_server_credential_logging.py
+++ b/tests/test_mcp_server_credential_logging.py
@@ -1,0 +1,158 @@
+"""Regression tests for #812: curated MCP stderr must not leak Telegram bot credentials.
+
+The shared ``lingtai.mcp_servers._entrypoint`` logging setup is the single
+place every curated MCP server configures stderr logging. These tests pin:
+
+- ``httpx``/``httpcore`` INFO request lines (whose URL embeds the Bot API token
+  in the request path) are suppressed by default;
+- records that still contain a Telegram bot token or a
+  ``api.telegram.org/bot<TOKEN>/...`` URL are redacted before any handler
+  renders them;
+- ordinary non-secret Telegram/MCP diagnostics remain visible.
+"""
+from __future__ import annotations
+
+import io
+import logging
+
+import pytest
+
+from lingtai.mcp_servers import _entrypoint
+
+# Deliberately fake: never use a real token in tests or logs.
+_FAKE_TOKEN = "123456789:AAH3fakefakefakefakefakefakefakefakefakefake"
+_FAKE_URL = f"https://api.telegram.org/bot{_FAKE_TOKEN}/getMe"
+
+
+def _attach_capture_handler() -> tuple[io.StringIO, logging.Handler]:
+    """Attach a DEBUG StringIO handler to root; returns (stream, handler).
+
+    Must run before ``configure_stdio_logging()`` so the redaction filter is
+    installed on this handler too — the same way the real stderr handler gets
+    it — and records emitted by descendant loggers are rendered through it.
+    """
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setLevel(logging.DEBUG)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    logging.getLogger().addHandler(handler)
+    return stream, handler
+
+
+class _LoggingState:
+    """Save/restore the root logger and HTTP-client logger state."""
+
+    def __init__(self) -> None:
+        root = logging.getLogger()
+        self._root_handlers = root.handlers[:]
+        self._root_level = root.level
+        self._root_filters = root.filters[:]
+        self._httpx_level = logging.getLogger("httpx").level
+        self._httpcore_level = logging.getLogger("httpcore").level
+
+    def restore(self) -> None:
+        root = logging.getLogger()
+        root.handlers[:] = self._root_handlers
+        root.setLevel(self._root_level)
+        root.filters[:] = self._root_filters
+        logging.getLogger("httpx").setLevel(self._httpx_level)
+        logging.getLogger("httpcore").setLevel(self._httpcore_level)
+
+
+@pytest.fixture
+def saved_logging_state():
+    state = _LoggingState()
+    yield state
+    state.restore()
+
+
+def _record(msg: str) -> logging.LogRecord:
+    return logging.LogRecord(
+        name="lingtai.mcp_servers.telegram",
+        level=logging.ERROR,
+        pathname=__file__,
+        lineno=1,
+        msg=msg,
+        args=(),
+        exc_info=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Filter unit behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_filter_redacts_bot_api_url():
+    rec = _record(f"startup failed: {_FAKE_URL}")
+    assert _entrypoint._telegram_credential_filter.filter(rec) is True
+    assert _FAKE_TOKEN not in rec.getMessage()
+    assert "[REDACTED]" in rec.getMessage()
+    # Non-secret host/prefix survives so diagnostics stay useful.
+    assert "api.telegram.org/bot" in rec.getMessage()
+
+
+def test_filter_redacts_bare_token():
+    rec = _record(f"token {_FAKE_TOKEN} rotated")
+    assert _entrypoint._telegram_credential_filter.filter(rec) is True
+    assert _FAKE_TOKEN not in rec.getMessage()
+    assert "[REDACTED]" in rec.getMessage()
+    assert "rotated" in rec.getMessage()
+
+
+def test_filter_keeps_ordinary_diagnostics():
+    rec = _record("Telegram account 'myagent' started (@test_bot)")
+    assert _entrypoint._telegram_credential_filter.filter(rec) is True
+    assert rec.getMessage() == "Telegram account 'myagent' started (@test_bot)"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: stderr output of a configured stdio server
+# ---------------------------------------------------------------------------
+
+
+def test_httpx_info_request_lines_are_suppressed(saved_logging_state):
+    stream, handler = _attach_capture_handler()
+    try:
+        _entrypoint.configure_stdio_logging()
+        httpx_logger = logging.getLogger("httpx")
+        # The INFO request line is dropped at the logger level, so it must not
+        # reach any handler at all.
+        assert httpx_logger.getEffectiveLevel() >= logging.WARNING
+        httpx_logger.info('HTTP Request: POST %s "HTTP/1.1 200 OK"', _FAKE_URL)
+        # A WARNING that still carries the URL is redacted before rendering.
+        httpx_logger.warning('HTTP Request: POST %s "HTTP/1.1 200 OK"', _FAKE_URL)
+    finally:
+        logging.getLogger().removeHandler(handler)
+    captured = stream.getvalue()
+    assert _FAKE_TOKEN not in captured
+    assert _FAKE_URL not in captured
+    assert captured.count("HTTP Request") == 1  # only the WARNING line
+
+
+def test_stderr_never_contains_token(saved_logging_state):
+    stream, handler = _attach_capture_handler()
+    try:
+        _entrypoint.configure_stdio_logging()
+        logger = logging.getLogger("lingtai.mcp_servers.telegram")
+        logger.error("startup failed: %s", _FAKE_URL)
+        logger.error("token %s rotated", _FAKE_TOKEN)
+        logger.info("Telegram account 'myagent' started (@test_bot)")
+    finally:
+        logging.getLogger().removeHandler(handler)
+    captured = stream.getvalue()
+    assert _FAKE_TOKEN not in captured
+    assert _FAKE_URL not in captured
+    assert "[REDACTED]" in captured
+    # Ordinary non-secret diagnostics remain visible.
+    assert "Telegram account 'myagent' started (@test_bot)" in captured
+
+
+def test_configure_stdio_logging_attaches_filter_once(saved_logging_state):
+    _entrypoint.configure_stdio_logging()
+    _entrypoint.configure_stdio_logging()
+    root = logging.getLogger()
+    assert root.filters.count(_entrypoint._telegram_credential_filter) == 1
+    assert root.handlers  # basicConfig created the stderr handler
+    for handler in root.handlers:
+        assert handler.filters.count(_entrypoint._telegram_credential_filter) == 1


### PR DESCRIPTION
Fixes https://github.com/Lingtai-AI/lingtai/issues/812

## Problem

The curated MCP stdio entrypoint (`lingtai/mcp_servers/_entrypoint.py`) configures root logging at INFO. HTTP clients (`httpx`/`httpcore`) emit one INFO `HTTP Request: <METHOD> <url> ...` line per request. Providers such as Telegram embed the live bot token in the URL path (`https://api.telegram.org/bot<TOKEN>/<method>`), so at startup (e.g. `getMe`) the live token is written to the MCP process stderr and can be persisted into refresh-watcher event stderr tails — a credential exposure, not just noise.

## Fix (defense in depth at the shared stderr boundary)

1. **Suppress sensitive client request logging.** `httpx` and `httpcore` loggers are pinned to WARNING in `run_stdio_server_main()` so token-bearing INFO request lines never reach stderr. This protects every curated MCP server, not just Telegram.
2. **Redact before stderr.** A Telegram-credential redaction `logging.Filter` is attached to the root logger and every root handler (same pattern as the feishu addon's `_lark_credential_filter`), rewriting `https://api.telegram.org/bot<TOKEN>/...` URLs and bare Telegram-token-shaped strings to `[REDACTED]` before any handler renders them. Handler-level filters are required because ancestor logger filters are not consulted for records emitted by descendant loggers.

`configure_stdio_logging()` was extracted from `run_stdio_server_main()` so the setup is directly testable.

## Tests

- **New `tests/test_mcp_server_credential_logging.py` (6 tests, all pass):** filter redacts Bot API URLs and bare tokens; httpx INFO request lines are suppressed while WARNING lines are redacted; ordinary non-secret Telegram/MCP diagnostics stay visible; filter is attached exactly once (idempotent).
- **Real-httpx reproduction** (validated locally with a fake token): with pre-fix root INFO + httpx INFO, `httpx.get(.../bot<FAKE>/getMe)` writes the token-bearing URL to stderr; after `configure_stdio_logging()` the same call emits no token and no INFO request line.
- `tests/test_telegram_rate_limit.py`, `tests/test_telegram_slash_commands.py`: 24 passed.
- `tests/test_mcp_server_scaffold.py`, `tests/test_feishu_stdio_logging.py`, `tests/test_services_logging.py`: identical pass/fail set before and after this change (remaining failures are pre-existing environment issues — missing optional dep `msal` for the imap import and 2 fallback event-id cases that fail identically on pristine main).

## Notes / follow-ups

- Persistence-layer sanitization of captured stderr tails inside the refresh watchers (issue suggestion #3) is intentionally **not** included: it is a larger cross-cutting change with many capture sites. Fixing the child-process stderr at the source removes the credential from what the watcher can capture.
- Users of affected versions should still rotate any token that may have been logged and follow the incident-response guidance in the issue.
