### PR TITLE
fix: stage-then-rename mail delivery to prevent orphaned inbox dirs (#731)

### DIFF
--- a/src/lingtai/adapters/posix/ANATOMY.md
+++ b/src/lingtai/adapters/posix/ANATOMY.md
@@ -88,11 +88,14 @@ co-located owning ANATOMY.md files.
 - `PosixFilesystemMailAdapter` implements `MailTransportPort` by delivering
   messages as files into a recipient's inbox and polling its own inbox plus
   subscribed pseudo-agent outboxes (`src/lingtai/adapters/posix/mail.py:34-69`).
-- `send()` handshakes, injects mailbox metadata, copies attachments, and writes
-  `message.json` atomically via `os.replace`
-  (`send()`, `src/lingtai/adapters/posix/mail.py:102`; atomic write at :184);
+- `send()` handshakes, injects mailbox metadata, validates every attachment
+  path up front, stages the full message (attachments + `message.json`) in a
+  hidden `.<id>.staging` dir under the inbox, and publishes it with a single
+  atomic `os.replace` — the recipient never observes a partial entry and any
+  failure removes the sender-owned staging dir
+  (`send()`, `src/lingtai/adapters/posix/mail.py:102`; publish at :199);
   `listen()`/`stop()` own the 0.5-second daemon poll loop with pseudo-outbox
-  priority and per-phase `OSError` isolation.
+  priority, dot-prefixed staging skips, and per-phase `OSError` isolation.
 - `PosixWorkdirLeaseAdapter` implements `WorkdirLeasePort` by holding an exclusive
   non-blocking `fcntl.flock` on `<workdir>/.agent.lock`
   (`src/lingtai/adapters/posix/workdir_lease.py:27-95`); `acquire()` polls at

--- a/src/lingtai/adapters/posix/mail.py
+++ b/src/lingtai/adapters/posix/mail.py
@@ -112,8 +112,12 @@ class PosixFilesystemMailAdapter(MailTransportPort):
         1. ``{address}/.agent.json`` must exist.
         2. ``{address}/.agent.heartbeat`` must be fresh (< 2 s).
 
-        Then write ``message.json`` atomically into the recipient's inbox
-        and copy any attachment files.
+        Then stage the whole message (attachments + ``message.json``) in a
+        hidden ``.<id>.staging`` directory inside the recipient's inbox and
+        publish it with a single atomic ``os.replace``, so the recipient can
+        never observe a partial inbox entry. Every failure path removes the
+        sender-owned staging directory and leaves the recipient's inbox
+        untouched.
 
         Modes:
         - peer: resolve bare name against parent dir (default — sibling agents in same .lingtai/)
@@ -155,34 +159,47 @@ class PosixFilesystemMailAdapter(MailTransportPort):
             ),
         }
 
-        # Handle attachments
+        # Validate every attachment path up front: a missing file is a
+        # zero-side-effect early return instead of a partial inbox entry.
         attachment_paths = message.get("attachments")
+        srcs: list[Path] = []
         if attachment_paths:
-            att_dir = msg_dir / "attachments"
-            att_dir.mkdir(parents=True, exist_ok=True)
-            local_copies: list[str] = []
             for fpath in attachment_paths:
                 src = Path(fpath)
                 if not src.is_file():
                     return f"Attachment not found: {fpath}"
-                dst = att_dir / src.name
-                shutil.copy2(src, dst)
-                local_copies.append(str(dst))
-            # Replace original paths with recipient-local paths
-            message = {**message, "attachments": local_copies}
-        else:
-            msg_dir.mkdir(parents=True, exist_ok=True)
+                srcs.append(src)
 
-        # Atomic write: tmp → rename
-        tmp_path = msg_dir / "message.json.tmp"
-        final_path = msg_dir / "message.json"
+        # Assemble the whole message (attachments + ``message.json``) in a
+        # hidden staging dir inside the recipient's inbox, then publish with a
+        # single atomic ``os.replace``. Staging under the inbox (not the system
+        # temp dir) keeps the final rename on one filesystem, and the
+        # dot-prefixed name keeps the listener from ever dispatching a partial
+        # entry. Every failure path removes the sender-owned staging dir, so a
+        # failed send never leaves an orphan in another agent's mailbox.
+        inbox_dir.mkdir(parents=True, exist_ok=True)
+        staging_dir = inbox_dir / f".{msg_id}.staging"
         try:
-            tmp_path.write_text(
+            staging_dir.mkdir(parents=True, exist_ok=True)
+            if srcs:
+                staging_att_dir = staging_dir / "attachments"
+                staging_att_dir.mkdir(parents=True, exist_ok=True)
+                # Recipient-local paths recorded in the payload must point at
+                # the final location (``msg_dir``), not the staging path.
+                local_copies = [
+                    str(msg_dir / "attachments" / src.name) for src in srcs
+                ]
+                for src in srcs:
+                    shutil.copy2(src, staging_att_dir / src.name)
+                message = {**message, "attachments": local_copies}
+
+            (staging_dir / "message.json").write_text(
                 json.dumps(message, indent=2, ensure_ascii=False, default=str),
                 encoding="utf-8",
             )
-            os.replace(str(tmp_path), str(final_path))
+            os.replace(str(staging_dir), str(msg_dir))
         except OSError as e:
+            _remove_tree_retry(staging_dir)
             return f"Failed to write message: {e}"
 
         return None
@@ -201,6 +218,10 @@ class PosixFilesystemMailAdapter(MailTransportPort):
         # Snapshot existing inbox entries so we don't re-notify
         if self._inbox_dir.is_dir():
             for entry in self._inbox_dir.iterdir():
+                if entry.name.startswith("."):
+                    # Sender-owned staging dirs (``.{id}.staging``) are
+                    # invisible to delivery; skip them here and in the scan.
+                    continue
                 if entry.is_dir():
                     self._seen.add(entry.name)
 
@@ -293,6 +314,12 @@ class PosixFilesystemMailAdapter(MailTransportPort):
                     return visited > 0
 
                 visited += 1
+                # Sender-owned staging dirs (``.{id}.staging``) contain a
+                # ``message.json`` while the message is being assembled; only
+                # the final atomic publish is deliverable, so never dispatch or
+                # record dot-prefixed entries.
+                if entry.name.startswith("."):
+                    continue
                 # _seen only holds handled directory names or pseudo-claim
                 # UUIDs, so skip before the stat.
                 if entry.name in self._seen:

--- a/src/lingtai/kernel/mail_transport/CONTRACT.md
+++ b/src/lingtai/kernel/mail_transport/CONTRACT.md
@@ -40,7 +40,8 @@ polling, or concurrency mechanisms.
 Agents and coding agents MUST preserve the current observable semantics:
 fire-and-forget `send` (no request/response coupling), background non-blocking
 `listen`, explicit idempotent `stop`, handshake-before-delivery, mailbox metadata
-injection, attachment copy, atomic `message.json` write, pseudo-outbox priority
+injection, attachment copy, atomic stage-then-rename delivery (a partial inbox
+entry is never observable), pseudo-outbox priority
 over the own-inbox scan, optimistic claim/rollback for subscribed outboxes,
 0.5-second polling, and the current string error / `None` success result of
 `send`. They MUST NOT let concrete-transport identities (POSIX vs Windows,
@@ -77,7 +78,8 @@ pseudo-agent subscriptions, `Path`). Those are adapter construction concerns.
 into the recipient's inbox and polls its own inbox plus subscribed pseudo-agent
 outboxes. It owns peer/abs address resolution, the
 `mailbox/{inbox,outbox,sent}/<id>/message.json` layout and `attachments/`,
-handshake liveness checks, atomic tmp→rename writes, the optimistic
+handshake liveness checks, atomic stage-then-rename delivery (a partial inbox
+entry is never observable), the optimistic
 outbox→claim→sent rename protocol with rollback, 0.5-second polling with
 per-phase `OSError` isolation, and the runtime-probe ack. A test-only in-memory
 fake in `tests/test_mail_transport.py` implements the same Port to prove
@@ -87,13 +89,19 @@ substitutability. IMAP/SMTP/network transports are explicitly out of scope.
 
 1. `send` is fire-and-forget and returns `None` on success. The POSIX adapter
    returns the current exact error strings for no agent, failed liveness,
-   missing attachment, and final `message.json` write failure. Other filesystem
+   missing attachment, and delivery write failure. Failed sends leave no
+   partial entry in the recipient's inbox: attachments are validated up front
+   and the message is published by a single atomic rename, so an error path
+   only removes the sender-owned staging directory. Other filesystem
    exceptions retain existing behavior and may propagate; the Port does not
    upgrade them into a blanket no-raise guarantee.
 2. Delivery is gated by the handshake (recipient is an agent and is alive) before
    any inbox write, except human pseudo-agents which skip the liveness check.
 3. Payloads delivered through `send` carry injected `_mailbox_id` and
-   `received_at`; `message.json` is written atomically (tmp → rename).
+   `received_at`; the adapter assembles the whole message (attachments +
+   `message.json`) in a hidden `.<id>.staging` dir under the recipient's inbox
+   and publishes it with one atomic `os.replace`, so a partial inbox entry is
+   never observable (the listener skips dot-prefixed entries).
    Pseudo-outbox pickup preserves the already-authored payload rather than
    reinjecting those fields.
 4. `listen` is non-blocking. Within one active listener, each newly observed

--- a/tests/test_services_mail.py
+++ b/tests/test_services_mail.py
@@ -228,6 +228,10 @@ class TestMailAttachments:
             )
             assert isinstance(result, str)
             assert "Attachment not found" in result
+            # A failed send must not leave an orphaned partial message
+            # directory in the recipient's inbox.
+            inbox = receiver_dir / "mailbox" / "inbox"
+            assert not inbox.is_dir() or not list(inbox.iterdir())
         finally:
             stop.set()
 
@@ -299,6 +303,155 @@ class TestMailAttachments:
             msg_dirs = list(mailbox.iterdir())
             assert len(msg_dirs) == 1
             assert (msg_dirs[0] / "message.json").is_file()
+        finally:
+            listener.stop()
+            stop.set()
+
+    def test_attachment_not_found_leaves_no_inbox_orphan(self, tmp_path):
+        """A missing attachment must not leave an orphaned inbox directory."""
+        sender_dir = _setup_agent_dir(tmp_path / "sender")
+        receiver_dir = _setup_agent_dir(tmp_path / "receiver")
+        stop = threading.Event()
+        _keep_heartbeat_alive(receiver_dir, stop)
+
+        try:
+            sender = PosixFilesystemMailAdapter(working_dir=sender_dir)
+            result = sender.send(
+                str(receiver_dir),
+                {"message": "hi", "attachments": ["/nonexistent/file.png"]},
+            )
+            assert isinstance(result, str)
+            assert "Attachment not found" in result
+            inbox = receiver_dir / "mailbox" / "inbox"
+            assert not inbox.is_dir() or not list(inbox.iterdir())
+        finally:
+            stop.set()
+
+    def test_partial_attachment_failure_leaves_no_inbox_orphan(self, tmp_path):
+        """When the second of two attachments is missing, nothing remains."""
+        sender_dir = _setup_agent_dir(tmp_path / "sender")
+        receiver_dir = _setup_agent_dir(tmp_path / "receiver")
+        stop = threading.Event()
+        _keep_heartbeat_alive(receiver_dir, stop)
+
+        good = sender_dir / "good.txt"
+        good.write_text("hello")
+
+        try:
+            sender = PosixFilesystemMailAdapter(working_dir=sender_dir)
+            result = sender.send(
+                str(receiver_dir),
+                {"message": "hi", "attachments": [str(good), "/nonexistent/bad.txt"]},
+            )
+            assert isinstance(result, str)
+            assert "Attachment not found" in result
+            # No partial copy of the first attachment may exist anywhere
+            # under the recipient's mailbox.
+            assert not list((receiver_dir / "mailbox").rglob("good.txt"))
+            inbox = receiver_dir / "mailbox" / "inbox"
+            assert not inbox.is_dir() or not list(inbox.iterdir())
+        finally:
+            stop.set()
+
+    def test_attachment_copy_error_returns_error_not_raise(self, tmp_path, monkeypatch):
+        """A copy2 OSError returns an error string and leaves the inbox clean."""
+        sender_dir = _setup_agent_dir(tmp_path / "sender")
+        receiver_dir = _setup_agent_dir(tmp_path / "receiver")
+        stop = threading.Event()
+        _keep_heartbeat_alive(receiver_dir, stop)
+
+        attachment = sender_dir / "a.txt"
+        attachment.write_text("data")
+
+        def _boom(src, dst):
+            raise OSError("disk full")
+
+        monkeypatch.setattr("lingtai.adapters.posix.mail.shutil.copy2", _boom)
+
+        try:
+            sender = PosixFilesystemMailAdapter(working_dir=sender_dir)
+            result = sender.send(
+                str(receiver_dir),
+                {"message": "hi", "attachments": [str(attachment)]},
+            )
+            assert isinstance(result, str)
+            assert "Failed to write message" in result
+            inbox = receiver_dir / "mailbox" / "inbox"
+            assert not inbox.is_dir() or not list(inbox.iterdir())
+        finally:
+            stop.set()
+
+    def test_delivered_attachment_paths_point_at_final_location(self, tmp_path):
+        """Delivered message.json attachment paths must be final inbox paths."""
+        sender_dir = _setup_agent_dir(tmp_path / "sender")
+        receiver_dir = _setup_agent_dir(tmp_path / "receiver")
+        stop = threading.Event()
+        _keep_heartbeat_alive(receiver_dir, stop)
+
+        attachment = sender_dir / "a.txt"
+        attachment.write_text("data")
+
+        try:
+            sender = PosixFilesystemMailAdapter(working_dir=sender_dir)
+            result = sender.send(
+                str(receiver_dir),
+                {"message": "hi", "attachments": [str(attachment)]},
+            )
+            assert result is None
+
+            inbox = receiver_dir / "mailbox" / "inbox"
+            msg_dirs = list(inbox.iterdir())
+            assert len(msg_dirs) == 1
+            msg_dir = msg_dirs[0]
+            payload = json.loads((msg_dir / "message.json").read_text(encoding="utf-8"))
+            delivered = [Path(p) for p in payload["attachments"]]
+            assert len(delivered) == 1
+            final_path = msg_dir / "attachments" / "a.txt"
+            assert delivered[0] == final_path
+            assert delivered[0].is_file()
+            assert delivered[0].read_text(encoding="utf-8") == "data"
+            # No sender-owned staging leftovers.
+            assert not any(e.name.startswith(".") for e in inbox.iterdir())
+        finally:
+            stop.set()
+
+    def test_listener_never_dispatches_partial_message(self, tmp_path):
+        """A failing send followed by a successful send dispatches exactly once."""
+        sender_dir = _setup_agent_dir(tmp_path / "sender")
+        receiver_dir = _setup_agent_dir(tmp_path / "receiver")
+
+        received = []
+        event = threading.Event()
+        stop = threading.Event()
+        _keep_heartbeat_alive(receiver_dir, stop)
+
+        def on_message(msg):
+            received.append(msg)
+            event.set()
+
+        listener = PosixFilesystemMailAdapter(working_dir=receiver_dir)
+        listener.listen(on_message)
+
+        try:
+            sender = PosixFilesystemMailAdapter(working_dir=sender_dir)
+            result = sender.send(
+                str(receiver_dir),
+                {"message": "bad", "attachments": ["/nonexistent/bad.png"]},
+            )
+            assert isinstance(result, str)
+            result = sender.send(str(receiver_dir), {"message": "good"})
+            assert result is None
+
+            assert event.wait(timeout=5.0), "Successful message not received"
+            time.sleep(1.0)  # give any wrong extra dispatch time to surface
+            assert len(received) == 1
+            assert received[0]["message"] == "good"
+
+            # The failed send left nothing behind: exactly one delivered
+            # message directory and no staging leftovers.
+            inbox = receiver_dir / "mailbox" / "inbox"
+            assert not any(e.name.startswith(".") for e in inbox.iterdir())
+            assert len(list(inbox.iterdir())) == 1
         finally:
             listener.stop()
             stop.set()


### PR DESCRIPTION
Fixes #731.

## Summary

`PosixFilesystemMailAdapter.send()` (`src/lingtai/adapters/posix/mail.py`) created the message directory and copied attachments directly into the recipient's inbox **before** validating that every attachment path existed. Two failure modes left permanent orphans in another agent's mailbox:

- A missing attachment (`is_file()` false — a stale/moved file, a cleaned-up temp file, or a hallucinated path) returned `"Attachment not found: ..."` *after* `att_dir.mkdir(...)` had created `inbox/<id>/attachments/` and any earlier attachments were copied. No cleanup ran.
- `shutil.copy2` was uncaught, so a copy error (permission, disk full, TOCTOU delete) **raised** `OSError` out of the transport, again leaving the partial directory behind.

Also, a failure writing `message.json` returned an error string without removing `msg_dir` or the copied attachments. The recipient's poll loop only dispatches inbox dirs containing `message.json`, so these orphans are never delivered, never cleaned up, and accumulate on every failed send.

**Root cause:** the pre-`message.json` attachment phase was non-transactional while the final JSON write was already atomic. The fix stays at the owning layer (`send()`) and reuses the module's own claim/publish idiom from `_poll_pseudo_outbox()`:

1. Validate all attachment paths up front → the common bad-path case is a zero-side-effect early return.
2. Stage the whole message (attachments + `message.json`) in a hidden `.<id>.staging` sibling of the inbox (same filesystem → `os.replace` is atomic; dot prefix keeps it out of the listener scans).
3. Wrap all staging I/O so a `copy2` failure returns an error string instead of raising.
4. Publish with a single atomic `os.replace`; on any failure clean up the sender-owned staging dir via the existing `_remove_tree_retry`.
5. Belt-and-braces: the listener's Phase-1 snapshot and Phase-2 own-inbox scan skip dot-prefixed entries, so even a crashed sender's leftover staging dir is never dispatched and is identifiable for future sweeping.

Recipient-local attachment paths recorded in the payload point at the **final** location (`inbox/<id>/attachments/<name>`), not the staging path. Published entries are byte-identical to today's successful sends — no schema/format change, no migration, no new config flag. Docs updated: `send()` docstring, `src/lingtai/adapters/posix/ANATOMY.md`, and `src/lingtai/kernel/mail_transport/CONTRACT.md` (failed sends leave no partial entry in the recipient's inbox).

## Validation

Failing-first (against unmodified `send()`), the bug-exposing tests fail:

```
$ PYTHONPATH=$PWD/src python -m pytest tests/test_services_mail.py -q -k "orphan or copy_error or final_location or partial_message or attachment_file_not_found"
FAILED tests/test_services_mail.py::TestMailAttachments::test_attachment_file_not_found
FAILED tests/test_services_mail.py::TestMailAttachments::test_attachment_not_found_leaves_no_inbox_orphan
FAILED tests/test_services_mail.py::TestMailAttachments::test_partial_attachment_failure_leaves_no_inbox_orphan
FAILED tests/test_services_mail.py::TestMailAttachments::test_attachment_copy_error_returns_error_not_raise
FAILED tests/test_services_mail.py::TestMailAttachments::test_listener_never_dispatches_partial_message
5 failed, 1 passed, 10 deselected
```
(`test_attachment_copy_error_...` failed by *raising* the uncaught `OSError`; the rest failed on orphaned inbox dirs / stray copies.)

After the fix, the full module passes:

```
$ python -m pytest tests/test_services_mail.py -q
16 passed in 6.86s
```

Targeted existing mail/email suites for the touched transport (identical pass/fail to baseline on unmodified main — no regressions):

```
$ python -m pytest tests/test_filesystem_mail.py tests/test_mail_transport.py \
    tests/test_email_abs_reply_route.py tests/test_three_agent_email.py \
    tests/test_layers_email.py tests/test_email_identity.py \
    tests/test_time_awareness_mail.py tests/test_time_awareness_email.py -q
141 passed in 51.23s
```

```
$ git diff --check   # (no output — clean)
```
