### PR TITLE
fix(kernel): serialize _sync_notifications against run-loop/heartbeat double-inject (#659)

### DIFF
--- a/src/lingtai/kernel/base_agent/__init__.py
+++ b/src/lingtai/kernel/base_agent/__init__.py
@@ -615,6 +615,14 @@ class BaseAgent:
         #   skeletonized in-place, not deleted).
         # See notifications.py and notification-filesystem-redesign.md.
         self._notification_fp: tuple = ()
+        # Serializes ``_sync_notifications()`` check-then-act between the
+        # run-loop IDLE boundary and the heartbeat thread (issue #659).
+        # The store's flock guards on-disk mutations only; it does NOT
+        # serialize this in-memory fingerprint check + wire append, so
+        # without this lock both callers can pass the fp check and
+        # double-inject notification pairs.  RLock so hook/synthesize
+        # paths that transitively re-enter sync cannot self-deadlock.
+        self._notification_sync_lock: threading.RLock = threading.RLock()
         # System-channel RMW serialization is owned by the injected
         # NotificationStorePort through compare_update_channel.
         # Last ACTIVE-state notification fingerprint that has already emitted
@@ -1273,6 +1281,22 @@ class BaseAgent:
     # ------------------------------------------------------------------
 
     def _sync_notifications(self) -> None:
+        """Sync `.notification/` state into the wire.
+
+        Serialized under ``_notification_sync_lock``: the run-loop IDLE
+        boundary (turn.py) and the heartbeat thread (lifecycle.py) call
+        this concurrently, and without the lock their check-then-act on
+        ``_notification_fp`` can both observe the same stale fingerprint
+        and inject duplicate notification pairs (issue #659).
+        """
+        lock = getattr(self, "_notification_sync_lock", None)
+        if lock is None:
+            # Partial test doubles bypass __init__; give them a real lock.
+            lock = self._notification_sync_lock = threading.RLock()
+        with lock:
+            self._sync_notifications_locked()
+
+    def _sync_notifications_locked(self) -> None:
         """Sync `.notification/` state into the wire.
 
         Computes the current fingerprint; if unchanged, no-op.  On change:

--- a/tests/test_notification_sync.py
+++ b/tests/test_notification_sync.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import json
 import threading
+import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -1345,6 +1346,7 @@ def test_sync_noninjecting_state_commits_observed_store_version(
 
     class _Agent:
         _sync_notifications = BaseAgent._sync_notifications
+        _sync_notifications_locked = BaseAgent._sync_notifications_locked
 
         def __init__(self):
             self._notification_store = store
@@ -2744,3 +2746,99 @@ def test_heal_pending_tool_calls_logs_pending_tail_diagnostics(tmp_path: Path) -
     assert fields["pending_tail_block_types"] == [["text"], ["text"], ["tool_call", "tool_call"]]
     assert "SECRET" not in str(fields)
     assert saves == ["heal"]
+
+
+def test_sync_notifications_serialized_across_runloop_and_heartbeat(tmp_path: Path) -> None:
+    """Regression for #659: two concurrent ``_sync_notifications`` calls
+    (the run-loop IDLE boundary and the heartbeat thread) must not both
+    pass the fingerprint check-then-act and double-inject a pair.
+
+    Pre-fix the second caller observes the still-uncommitted fingerprint,
+    injects a duplicate pair, and posts a second MSG_TC_WAKE.  Post-fix
+    the second caller blocks on ``_notification_sync_lock``, re-reads the
+    fingerprint after the first caller commits, and no-ops.
+    """
+    from lingtai.kernel.base_agent import BaseAgent
+    from lingtai.kernel.state import AgentState
+
+    chat = _make_chat_stub()
+
+    class _Agent(BaseAgent):
+        def __init__(self, workdir):
+            self._working_dir = workdir
+            self._notification_store = notification_store_for(workdir)
+            self._state = AgentState.IDLE
+            self._notification_fp = ()
+            self._notification_deferred_log_fp = ()
+            self._notification_block_id = None
+            self._chat_stub = chat
+            self._logs = []
+            self.agent_name = "stub"
+            import queue
+            self.inbox = queue.Queue()
+
+        @property
+        def _chat(self):
+            return self._chat_stub
+
+        def _save_chat_history(self, *, ledger_source="main"):
+            pass
+
+        def _log(self, evt, **fields):
+            self._logs.append((evt, fields))
+
+        def _wake_nap(self, *_a, **_kw):
+            pass
+
+        def _set_state(self, *_a, **_kw):
+            pass
+
+        def _reset_uptime(self):
+            pass
+
+    agent = _Agent(tmp_path)
+    publish_test_payload(tmp_path, "email", {"count": 1, "data": {"count": 1}})
+
+    release = threading.Event()
+    injected_threads: list[str] = []
+    orig_inject = agent._inject_notification_pair
+
+    def slow_inject(notifications):
+        injected_threads.append(threading.current_thread().name)
+        release.wait(timeout=10)
+        return orig_inject(notifications)
+
+    agent._inject_notification_pair = slow_inject
+
+    runloop = threading.Thread(
+        target=agent._sync_notifications, name="runloop"
+    )
+    heartbeat = threading.Thread(
+        target=agent._sync_notifications, name="heartbeat"
+    )
+    runloop.start()
+    deadline = time.monotonic() + 10
+    while not injected_threads and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert injected_threads, "first sync call never entered injection"
+    heartbeat.start()
+    time.sleep(0.5)  # pre-fix: the second caller passes the fp check here
+    release.set()
+    runloop.join(15)
+    heartbeat.join(15)
+    assert not runloop.is_alive() and not heartbeat.is_alive()
+
+    # Exactly one injection for the single fingerprint change: the losing
+    # caller must observe the committed fingerprint and no-op.
+    assert len(injected_threads) == 1, (
+        f"double injection: both callers passed the fp check "
+        f"({sorted(injected_threads)})"
+    )
+    # And only one synthesized pair on the wire + one wake message.
+    entries = agent._chat_stub.interface.entries
+    assert len(entries) == 2, "wire must carry exactly one (call, result) pair"
+    wake = 0
+    while not agent.inbox.empty():
+        agent.inbox.get_nowait()
+        wake += 1
+    assert wake == 1, "exactly one MSG_TC_WAKE per fingerprint change"


### PR DESCRIPTION
Fixes #659.

## Problem

`_sync_notifications()` performs a check-then-act on `self._notification_fp`:
both the run-loop IDLE boundary (`turn.py`) and the heartbeat thread
(`lifecycle.py`) call it concurrently, and nothing serializes the in-memory
fingerprint check + wire append. The notification store's flock guards
on-disk mutations only; it does not serialize the sync check-then-act.
Two concurrent callers can both observe the same stale fingerprint and
double-inject a synthesized notification pair: duplicate history blocks,
duplicate `MSG_TC_WAKE` messages, and wasted LLM tokens.

Reproduced on current main (HEAD `df2b523d`) with a two-thread harness:
both the "runloop" and "heartbeat" threads passed the fp check, producing
4 wire entries (double-injected pair) and 2 wake messages for one
fingerprint change.

## Fix

- Add `self._notification_sync_lock` (`threading.RLock`) per agent.
- `_sync_notifications()` now acquires it around the whole check-then-act
  (thin wrapper delegating to `_sync_notifications_locked`). The losing
  caller re-reads the fingerprint after the winner commits and no-ops.
- RLock (not plain Lock) so hook/synthesize paths that transitively
  re-enter sync cannot self-deadlock. Lazy `getattr` init keeps partial
  test doubles that bypass `__init__` working.

## Tests

- New regression test `test_sync_notifications_serialized_across_runloop_and_heartbeat`
  in `tests/test_notification_sync.py`:
  - pre-fix: **FAILS** with `double injection: both callers passed the fp
    check (['heartbeat', 'runloop'])`;
  - post-fix: **passes** (one injection, one pair on the wire, one wake).
- `pytest tests/test_notification_sync.py tests/test_turn_boundary_housekeeping.py tests/test_system_dismiss.py`
  → 109 passed; the only failures (3 in `test_system_dismiss.py`) are
  order-dependent flakes that pass individually and reproduce identically
  on pristine main with this change stashed (verified).
- Notification-family suites (`test_notification_store`, `test_tc_inbox*`,
  `test_system_notifications`, `test_molt_notification_persistence`,
  `test_post_molt_notification`, `test_goal_notification`,
  `test_messaging_notification_format`, `test_notification_tool`,
  `test_large_result_no_notification`) → **173 passed**.
- Run-loop/heartbeat suites (`test_base_agent`, `test_heartbeat`,
  `test_lifecycle_stop_wake`, `test_runtime_block_turn_integration`) → **38 passed**.
- `git diff --check` → clean.
