### PR TITLE
fix(kernel): migrate remaining fixed-temp-name atomic writers to _fsutil (resolved manifest, soul init.json, mail)

### DIFF
--- a/docs/plans/2026-06-25-fsutil-migration.md
+++ b/docs/plans/2026-06-25-fsutil-migration.md
@@ -60,7 +60,8 @@ These are migration *candidates*, not a commitment to change every one.
 ### Stage 1 — riskiest crash-sensitive / model-visible state (do first)
 - [x] `workdir.py::WorkingDir.write_manifest` (`.agent.json`) — **migrated here**
 - [x] `base_agent/__init__.py::_write_status_snapshot` (`.status.json`) — migrated with byte-parity coverage and opt-in existing-mode retention
-- [ ] `workdir.py::write_resolved_manifest` (`manifest.resolved.json`, trailing newline → pass explicit newline or keep inline)
+- [x] `workdir.py::write_resolved_manifest` (`manifest.resolved.json`, trailing newline kept via `atomic_write_text(json.dumps(...) + "\n")`; unique sibling temp removes the fixed-`.tmp` race) — migrated in the #756 PR
+- [x] `adapters/posix/mail.py` `message.json` writes (`PosixFilesystemMailAdapter` `send`, pseudo-agent claim delivery, runtime-probe ack) — migrated to `atomic_write_json` in the #756 PR
 - [x] notification files (`.notification/*.json`) — migrated to `atomic_write_json` (`adapters/posix/notification_store.py`)
 - [ ] `tools/email/primitives.py` message/`message.json` writes (currently direct `write_text`; some non-contact paths can escape non-ASCII)
 - [ ] `tools/email/manager.py` contact persistence (already atomic via `mkstemp`+`os.replace`; migrate for consistency)
@@ -73,7 +74,8 @@ These are migration *candidates*, not a commitment to change every one.
 
 ### Stage 3 — broader writes + retire local helpers
 - [ ] `migrate/*.py` write/replace sites
-- [ ] `tools/soul/config.py`, psyche snapshot/molt/archive writers
+- [x] `tools/soul/config.py` init.json persistence (`_atomic_write_init` → `atomic_write_text(fsync=True)`) — migrated in the #756 PR
+- [ ] psyche snapshot/molt/archive writers
 - [ ] remaining `read_json(default=...)`-style local readers → `_fsutil.read_json`
 
 Each checkbox above should land as (or within) its own PR with format-parity

--- a/src/lingtai/adapters/posix/mail.py
+++ b/src/lingtai/adapters/posix/mail.py
@@ -24,6 +24,7 @@ import uuid
 from pathlib import Path
 from typing import Callable, Iterator
 
+from lingtai.kernel._fsutil import atomic_write_json
 from lingtai.kernel.agent_presence import (
     is_agent as _presence_is_agent,
     observe_alive as _presence_observe_alive,
@@ -173,15 +174,12 @@ class PosixFilesystemMailAdapter(MailTransportPort):
         else:
             msg_dir.mkdir(parents=True, exist_ok=True)
 
-        # Atomic write: tmp → rename
-        tmp_path = msg_dir / "message.json.tmp"
+        # Atomic write: unique sibling temp → os.replace (via _fsutil).
         final_path = msg_dir / "message.json"
         try:
-            tmp_path.write_text(
-                json.dumps(message, indent=2, ensure_ascii=False, default=str),
-                encoding="utf-8",
+            atomic_write_json(
+                final_path, message, indent=2, ensure_ascii=False, default=str
             )
-            os.replace(str(tmp_path), str(final_path))
         except OSError as e:
             return f"Failed to write message: {e}"
 
@@ -410,7 +408,6 @@ class PosixFilesystemMailAdapter(MailTransportPort):
             uuid_name = entry.name
             own_inbox_dir = self._inbox_dir / uuid_name
             own_msg_file = own_inbox_dir / "message.json"
-            own_tmp_file = own_inbox_dir / "message.json.tmp"
             claim_dir = sent_parent / f".{uuid_name}.claim-{uuid.uuid4()}"
             sent_dir = sent_parent / uuid_name
 
@@ -424,14 +421,12 @@ class PosixFilesystemMailAdapter(MailTransportPort):
             # Removed on rollback.
             self._seen.add(uuid_name)
 
-            # Step 1: write the payload to own inbox (tmp -> rename).
+            # Step 1: write the payload to own inbox (unique sibling temp -> rename).
             try:
                 own_inbox_dir.mkdir(parents=True, exist_ok=True)
-                own_tmp_file.write_text(
-                    json.dumps(payload, indent=2, ensure_ascii=False, default=str),
-                    encoding="utf-8",
+                atomic_write_json(
+                    own_msg_file, payload, indent=2, ensure_ascii=False, default=str
                 )
-                os.replace(str(own_tmp_file), str(own_msg_file))
             except OSError:
                 logger.warning(
                     "failed to write claimed pseudo-agent message %s to own inbox",
@@ -535,15 +530,12 @@ class PosixFilesystemMailAdapter(MailTransportPort):
         }
 
         inbox_dir = pseudo_dir / self._mailbox_rel / "inbox" / ack_id
-        tmp_file = inbox_dir / "message.json.tmp"
         final_file = inbox_dir / "message.json"
         try:
             inbox_dir.mkdir(parents=True, exist_ok=True)
-            tmp_file.write_text(
-                json.dumps(ack, indent=2, ensure_ascii=False, default=str),
-                encoding="utf-8",
+            atomic_write_json(
+                final_file, ack, indent=2, ensure_ascii=False, default=str
             )
-            os.replace(str(tmp_file), str(final_file))
         except OSError:
             logger.exception(
                 "failed to write runtime probe ack %s to %s",

--- a/src/lingtai/kernel/workdir.py
+++ b/src/lingtai/kernel/workdir.py
@@ -8,7 +8,6 @@ Core-owned ``lingtai.kernel.workdir_lease.WorkdirLeasePort`` and its production
 from __future__ import annotations
 
 import json
-import os
 import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -105,10 +104,6 @@ class WorkdirLayout:
     def resolved_manifest(self) -> Path:
         return self.system_dir / _RESOLVED_MANIFEST_FILE
 
-    @property
-    def resolved_manifest_tmp(self) -> Path:
-        return self.system_dir / (_RESOLVED_MANIFEST_FILE + ".tmp")
-
     def notification_file(self, channel: str) -> Path:
         """Path to a ``.notification/<channel>.json`` file (no validation)."""
         return self.notification_dir / f"{channel}.json"
@@ -189,10 +184,12 @@ def write_resolved_manifest(working_dir: Path | str, data: dict) -> Path | None:
     (issue #259).
 
     Secrets (api_key/password/token-like fields) are removed recursively.
-    The write is atomic (``.tmp`` → ``os.replace``) and best-effort: returns
-    the artifact path on success, None when *data* has no manifest or the
-    write failed.
+    The write is atomic (unique sibling temp → ``os.replace`` via
+    ``_fsutil.atomic_write_text``) and best-effort: returns the artifact path
+    on success, None when *data* has no manifest or the write failed.
     """
+    from ._fsutil import atomic_write_text
+
     manifest = data.get("manifest") if isinstance(data, dict) else None
     if not isinstance(manifest, dict):
         return None
@@ -210,14 +207,11 @@ def write_resolved_manifest(working_dir: Path | str, data: dict) -> Path | None:
 
     try:
         layout = workdir_layout(working_dir)
-        layout.system_dir.mkdir(parents=True, exist_ok=True)
         target = layout.resolved_manifest
-        tmp = layout.resolved_manifest_tmp
-        tmp.write_text(
+        atomic_write_text(
+            target,
             json.dumps(artifact, indent=2, ensure_ascii=False) + "\n",
-            encoding="utf-8",
         )
-        os.replace(str(tmp), str(target))
         return target
     except (OSError, TypeError, ValueError):
         return None

--- a/src/lingtai/tools/soul/config.py
+++ b/src/lingtai/tools/soul/config.py
@@ -322,31 +322,24 @@ def _persist_soul_voice(agent, *, voice: str, voice_prompt: str) -> str | None:
 
 
 def _atomic_write_init(init_path, data) -> str | None:
-    """Write ``data`` to ``init_path`` via temp-file-then-rename.
+    """Write ``data`` to ``init_path`` atomically (unique sibling temp
+    via ``_fsutil.atomic_write_text``).
 
     Used by both _persist_soul_config and _persist_soul_voice. Returns
     ``None`` on success or a short error string on failure.
     """
     import json
-    import os
 
-    tmp_path = init_path.with_suffix(init_path.suffix + ".tmp")
+    from lingtai.kernel._fsutil import atomic_write_text
+
     try:
-        with tmp_path.open("w", encoding="utf-8") as f:
-            json.dump(data, f, ensure_ascii=False, indent=2)
-            f.write("\n")
-            f.flush()
-            try:
-                os.fsync(f.fileno())
-            except OSError:
-                pass
-        os.replace(tmp_path, init_path)
+        atomic_write_text(
+            init_path,
+            json.dumps(data, ensure_ascii=False, indent=2) + "\n",
+            fsync=True,
+        )
         return None
     except Exception as e:
-        try:
-            tmp_path.unlink(missing_ok=True)
-        except Exception:
-            pass
         return f"failed to write init.json: {e!s}"[:200]
 
 

--- a/tests/test_resolved_manifest_artifact.py
+++ b/tests/test_resolved_manifest_artifact.py
@@ -291,3 +291,102 @@ def test_refresh_rewrites_artifact_after_preset_change(tmp_path, monkeypatch):
     assert artifact["manifest"]["llm"]["model"] == "gemini-2.5-pro"
     assert artifact["preset"]["active"] == smart
     assert artifact["manifest"]["capabilities"]["skills"]["paths"] == ["~/s"]
+
+
+# ---------------------------------------------------------------------------
+# write_resolved_manifest — _fsutil migration golden + concurrency coverage
+# ---------------------------------------------------------------------------
+
+def test_write_resolved_manifest_byte_identical_to_legacy_format(tmp_path, monkeypatch):
+    """Golden-bytes: the _fsutil-migrated write keeps the legacy format
+    exactly (indent=2, ensure_ascii=False, trailing newline), redacts
+    secrets, and leaves no fixed ``*.tmp`` sibling behind."""
+    import datetime as _dt
+
+    from lingtai.kernel import workdir as _workdir
+
+    class _FakeDatetime:
+        @classmethod
+        def now(cls, tz=None):
+            return _dt.datetime(2026, 7, 6, 12, 0, 0, tzinfo=_dt.timezone.utc)
+
+    monkeypatch.setattr(_workdir, "datetime", _FakeDatetime)
+
+    wd = tmp_path / "agent"
+    data = {
+        "manifest": {
+            "agent_name": "内省",
+            "llm": {"provider": "deepseek", "model": "deepseek-v4-flash"},
+            "soul": {"voice": "inner", "delay": 120},
+        },
+        "principle": "p",
+    }
+    target = _workdir.write_resolved_manifest(wd, data)
+    assert target is not None
+
+    # The legacy implementation serialized exactly this dict with
+    # json.dumps(indent=2, ensure_ascii=False) plus a trailing newline.
+    expected_artifact = {
+        "schema": "lingtai.manifest.resolved/v1",
+        "schema_version": 1,
+        "generated_at": "2026-07-06T12:00:00Z",
+        "source": "kernel",
+        "manifest": data["manifest"],
+    }
+    expected = json.dumps(expected_artifact, indent=2, ensure_ascii=False) + "\n"
+    assert target.read_text(encoding="utf-8") == expected
+    # ensure_ascii=False really round-trips non-ASCII bytes
+    assert "内省" in target.read_text(encoding="utf-8")
+    # no transient temp siblings remain (fixed or unique)
+    assert not (wd / "system" / "manifest.resolved.json.tmp").exists()
+    assert not list((wd / "system").glob("*.tmp"))
+
+
+def test_write_resolved_manifest_concurrent_writers(tmp_path):
+    """Concurrent same-workdir writers must all succeed (no silent None), the
+    final artifact must parse as valid JSON with the expected schema, and no
+    ``*.tmp`` litter may remain — the fixed-temp-name race this migration
+    removes."""
+    import threading
+
+    from lingtai.kernel.workdir import write_resolved_manifest
+
+    wd = tmp_path / "agent"
+    errors: list[str] = []
+    barrier = threading.Barrier(8)
+
+    def worker(idx: int) -> None:
+        try:
+            barrier.wait(timeout=10)
+        except threading.BrokenBarrierError:  # pragma: no cover
+            errors.append(f"worker {idx}: barrier broken")
+            return
+        for i in range(20):
+            payload = {
+                "manifest": {
+                    "agent_name": f"alice-{idx}",
+                    "soul": {"delay": 120 + i},
+                }
+            }
+            try:
+                result = write_resolved_manifest(wd, payload)
+            except Exception as e:  # pragma: no cover
+                errors.append(f"worker {idx} iter {i}: raised {e!r}")
+                return
+            if result is None:
+                errors.append(f"worker {idx} iter {i}: returned None")
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=60)
+
+    assert not errors, errors[:5]
+    artifact = json.loads(
+        (wd / "system" / "manifest.resolved.json").read_text(encoding="utf-8")
+    )
+    assert artifact["schema"] == "lingtai.manifest.resolved/v1"
+    assert artifact["schema_version"] == 1
+    assert artifact["manifest"]["agent_name"].startswith("alice-")
+    assert not list((wd / "system").glob("*.tmp"))

--- a/tests/test_services_mail.py
+++ b/tests/test_services_mail.py
@@ -302,3 +302,26 @@ class TestMailAttachments:
         finally:
             listener.stop()
             stop.set()
+
+
+def test_send_writes_utf8_message_json(tmp_path):
+    """CJK subject/body survive send() as raw UTF-8 (ensure_ascii=False) and
+    no fixed ``message.json.tmp`` sibling is left behind."""
+    sender_dir = _setup_agent_dir(tmp_path / "sender")
+    receiver_dir = _setup_agent_dir(tmp_path / "receiver")
+    (receiver_dir / "mailbox" / "inbox").mkdir(parents=True)
+
+    svc = PosixFilesystemMailAdapter(sender_dir, mailbox_rel="mailbox")
+    result = svc.send(
+        str(receiver_dir),
+        {"subject": "测试主题", "message": "你好，世界"},
+    )
+    assert result is None
+
+    inbox = receiver_dir / "mailbox" / "inbox"
+    msg_dir = list(inbox.iterdir())[0]
+    raw = (msg_dir / "message.json").read_bytes()
+    text = raw.decode("utf-8")
+    assert "测试主题" in text
+    assert "你好，世界" in text
+    assert not (msg_dir / "message.json.tmp").exists()

--- a/tests/test_soul.py
+++ b/tests/test_soul.py
@@ -665,3 +665,48 @@ def test_consultation_fire_discards_late_result_after_state_change(monkeypatch):
     # consultation_discarded_state event.
     agent._tc_inbox.enqueue.assert_not_called()
     assert any(name == "consultation_fire" for name, _ in agent._logs)
+
+
+# ---------------------------------------------------------------------------
+# _atomic_write_init — _fsutil migration format parity + error contract
+# ---------------------------------------------------------------------------
+
+def test_atomic_write_init_format_parity(tmp_path):
+    """The _fsutil-migrated init.json write is byte-identical to the legacy
+    format (indent=2, ensure_ascii=False, trailing newline) and leaves no
+    temp file beside init.json."""
+    import json as _json
+
+    from lingtai.tools.soul.config import _atomic_write_init
+
+    init_path = tmp_path / "init.json"
+    data = {
+        "manifest": {"soul": {"voice": "内省", "delay": 120}},
+        "principle": "p",
+    }
+    err = _atomic_write_init(init_path, data)
+    assert err is None
+
+    expected = _json.dumps(data, ensure_ascii=False, indent=2) + "\n"
+    assert init_path.read_text(encoding="utf-8") == expected
+    # ensure_ascii=False really round-trips non-ASCII bytes
+    assert "内省" in init_path.read_text(encoding="utf-8")
+    assert _json.loads(init_path.read_text(encoding="utf-8")) == data
+    assert not list(tmp_path.glob("*.tmp"))
+
+
+def test_atomic_write_init_error_string_on_failure(tmp_path):
+    """An unwritable target returns the truncated error-string contract (no
+    exception escapes) and leaves no temp litter behind."""
+    from lingtai.tools.soul.config import _atomic_write_init
+
+    ro_dir = tmp_path / "ro"
+    ro_dir.mkdir()
+    ro_dir.chmod(0o500)
+    try:
+        err = _atomic_write_init(ro_dir / "init.json", {"manifest": {}})
+        assert err is not None
+        assert err.startswith("failed to write init.json:")
+    finally:
+        ro_dir.chmod(0o700)
+    assert not list(ro_dir.glob("*.tmp"))

--- a/tests/test_workdir.py
+++ b/tests/test_workdir.py
@@ -49,7 +49,6 @@ class TestWorkdirLayout:
         layout = workdir_layout(tmp_path)
         assert layout.chat_history == tmp_path / "history" / "chat_history.jsonl"
         assert layout.resolved_manifest == tmp_path / "system" / "manifest.resolved.json"
-        assert layout.resolved_manifest_tmp == tmp_path / "system" / "manifest.resolved.json.tmp"
 
     def test_notification_file(self, tmp_path):
         layout = workdir_layout(tmp_path)


### PR DESCRIPTION
Fixes #756.

## Summary

Migrates the last three fixed-temp-name atomic writers to the shared `_fsutil` helpers (issue #510 plan, `docs/plans/2026-06-25-fsutil-migration.md`), removing the same-target concurrent-writer race on a shared temp path and deleting ~40 lines of duplicated atomic-write boilerplate:

1. **`workdir.py::write_resolved_manifest`** (`system/manifest.resolved.json`) — replaced the fixed sibling temp `WorkdirLayout.resolved_manifest_tmp` + `os.replace` with `_fsutil.atomic_write_text(target, json.dumps(..., indent=2, ensure_ascii=False) + "\n")`. The trailing-newline format is preserved exactly (plan rule 3); serialization stays at the call site so `TypeError`/`ValueError` remain inside the existing best-effort `except (OSError, TypeError, ValueError)` envelope. Removed the now-unused `resolved_manifest_tmp` layout property and its test assertion. On-disk format: byte-identical.
2. **`tools/soul/config.py::_atomic_write_init`** (user-owned `init.json`) — replaced the fixed `init.json.tmp` + `os.replace` + hand-rolled fsync with `_fsutil.atomic_write_text(init_path, json.dumps(data, ensure_ascii=False, indent=2) + "\n", fsync=True)`, keeping the `str | None` error-string contract both callers depend on. Intentional behavior delta (flagged in #756): an `os.fsync` failure now surfaces as the error string instead of being silently swallowed — strictly safer for user-owned input; callers already log the returned string. Format: byte-identical.
3. **`adapters/posix/mail.py`** — all three `message.json.tmp` → `os.replace` sites (`send`, pseudo-agent claim delivery, runtime-probe ack) now use `_fsutil.atomic_write_json(final, msg, indent=2, ensure_ascii=False, default=str)`, which produces byte-identical output (no trailing newline, `ensure_ascii=False`, `default=str`) and always writes UTF-8. The `os.replace` calls that move *directories* (claim/sent renames) are unchanged. The old code's missing `encoding=` was already fixed repo-wide by #1123; this PR consolidates the three drifted copies into one helper.

`docs/plans/2026-06-25-fsutil-migration.md` checklist updated: Stage 1 `write_resolved_manifest` ticked, `adapters/posix/mail.py` added to Stage 1 and ticked, Stage 3 `tools/soul/config.py` split out and ticked (psyche writers remain unchecked). Note: the mail service moved to `lingtai.adapters.posix.mail` during the Ports & Adapters refactor, so the issue's `services/mail.py` sites now live there. No ANATOMY entries referenced these writes.

No schema/data-structure/on-disk-format changes; unique dot-prefixed temp names (`_unique_tmp`, pid + uuid4, `"x"` exclusive create) make concurrent same-target writes collision-free and are invisible to the mail poll loops (they filter on directories / `message.json` presence).

## Validation

- `git diff --check` — clean.
- New golden/parity + concurrency coverage:
  - `tests/test_resolved_manifest_artifact.py::test_write_resolved_manifest_byte_identical_to_legacy_format` (frozen `generated_at`; byte-exact vs. legacy format incl. trailing newline and unescaped CJK)
  - `tests/test_resolved_manifest_artifact.py::test_write_resolved_manifest_concurrent_writers` (8 threads × 20 writes to one workdir: no silent `None`, valid artifact, no `*.tmp` litter)
  - `tests/test_soul.py::test_atomic_write_init_format_parity` (byte-exact legacy format, no temp sibling)
  - `tests/test_soul.py::test_atomic_write_init_error_string_on_failure` (read-only dir → error string, no exception escapes, no litter)
  - `tests/test_services_mail.py::test_send_writes_utf8_message_json` (CJK subject/body survive as raw UTF-8; no `message.json.tmp` sibling)
- Focused suites (`test_workdir.py`, `test_fsutil.py`, `test_services_mail.py`, `test_filesystem_mail.py`, `test_resolved_manifest_artifact.py`, `test_soul.py`, `test_tool_family_soul_migration.py`): **186 passed**, 2 failed — one is a pre-existing main failure (`test_artifact_redacts_api_key_like_secrets`, KeyError in the `_read_init` read path, identical on the base commit before this change, unrelated to the write mechanics) and one is a timing-sensitive listen test that passes in isolation and on repeated reruns.
- Broader mail/email/workdir regression net (`test_three_agent_email.py`, `test_mail_transport.py`, `test_layers_email.py`, `test_email_abs_reply_route.py`, `test_time_awareness_mail.py`, `test_tool_family_email_migration.py`, `test_workdir_lease.py`): **167 passed, 9 skipped**, 1 timing-sensitive flake that passes in isolation and 3/3 reruns.
- Environment: Python 3.14 venv with the package installed editable (`LINGTAI_SKIP_RUST_BUILD=1`); all changed files `py_compile` clean.

## Notes

- `tools/email/primitives.py` / `tools/email/manager.py` remain on the Stage 1 backlog (separate plan items, out of this issue's scope).
- `src/lingtai/agent.py::_activate_preset` still writes `init.json` via a fixed `init.json.tmp`; it is not one of the three writers listed in #756 and is left for a follow-up.
