### PR TITLE
fix(mcp): contain outbound attachments/media to the agent workdir

### DIFF
--- a/src/lingtai/mcp_servers/_outbound_files.py
+++ b/src/lingtai/mcp_servers/_outbound_files.py
@@ -1,0 +1,41 @@
+"""Shared outbound-file containment policy for MCP send tools.
+
+The IMAP ``attachments``, Telegram ``media.path`` and WeChat ``media_path``
+tool fields accept agent-supplied local file paths that are then read and
+uploaded/sent to an external service.  Without containment, a
+prompt-injection or an over-broad tool call can exfiltrate arbitrary local
+files (``~/.ssh/id_rsa``, agent ``.secrets/*``, ...) to an outside
+recipient/chat.
+
+This module is the single enforcement point: relative paths resolve against
+the agent working directory, and anything that, after symlink/``..``
+resolution, lies outside the working directory is rejected.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+class OutboundFileError(ValueError):
+    """Raised when a tool-supplied path is not allowed as an outbound file."""
+
+
+def resolve_outbound_file(raw: str | Path, working_dir: Path) -> Path:
+    """Resolve ``raw`` against ``working_dir`` and enforce containment.
+
+    - Relative paths resolve against ``working_dir``.
+    - The result is fully resolved (``..`` and symlinks followed) and must be
+      inside ``working_dir``; otherwise :class:`OutboundFileError` is raised.
+
+    The caller is still responsible for checking ``is_file()`` before use.
+    """
+    wd = working_dir.resolve()
+    p = Path(raw)
+    if not p.is_absolute():
+        p = wd / p
+    p = p.resolve()
+    if not p.is_relative_to(wd):
+        raise OutboundFileError(
+            f"refusing outbound file outside working directory: {raw}"
+        )
+    return p

--- a/src/lingtai/mcp_servers/imap/SKILL.md
+++ b/src/lingtai/mcp_servers/imap/SKILL.md
@@ -69,9 +69,10 @@ a list of ids.
 
 - You are encouraged to `read` multiple relevant — or even all unread — emails
   and think before acting.
-- `attachments` is a list of file paths (absolute or relative to the working
-  dir) for `send`/`reply`. Attach generated artifacts (charts, reports, CSVs,
-  PDFs) as files rather than pasting a path into the body.
+- `attachments` is a list of file paths for `send`/`reply`. Relative paths
+  resolve against the working dir; absolute paths must be inside it. Attach
+  generated artifacts (charts, reports, CSVs, PDFs) as files rather than
+  pasting a path into the body.
 
 ## SIDE EFFECTS & SAFETY
 

--- a/src/lingtai/mcp_servers/imap/manager.py
+++ b/src/lingtai/mcp_servers/imap/manager.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Callable
 
 from .. import _skill
+from .._outbound_files import OutboundFileError, resolve_outbound_file
 from . import _family
 
 if TYPE_CHECKING:
@@ -203,7 +204,10 @@ SCHEMA = {
         "attachments": {
             "type": "array",
             "items": {"type": "string"},
-            "description": "List of file paths to attach (absolute or relative to working dir).",
+            "description": (
+                "List of file paths to attach. Relative paths resolve against "
+                "the agent working dir; absolute paths must be inside it."
+            ),
         },
     },
     "required": ["action"],
@@ -478,7 +482,12 @@ class IMAPMailManager:
     # ------------------------------------------------------------------
 
     def _resolve_attachment_paths(self, raw_attachments: object) -> list[str]:
-        """Resolve tool-supplied attachment paths relative to the agent workdir."""
+        """Resolve tool-supplied attachment paths relative to the agent workdir.
+
+        Enforces the shared outbound-file containment policy: absolute paths
+        outside the working directory (including ``..`` and symlink escapes)
+        raise :class:`OutboundFileError`.
+        """
         if not raw_attachments:
             return []
         if isinstance(raw_attachments, (str, Path)):
@@ -486,13 +495,10 @@ class IMAPMailManager:
         else:
             raw_items = list(raw_attachments)
 
-        attachments: list[str] = []
-        for item in raw_items:
-            path = Path(item)
-            if not path.is_absolute():
-                path = self._working_dir / path
-            attachments.append(str(path))
-        return attachments
+        return [
+            str(resolve_outbound_file(item, self._working_dir))
+            for item in raw_items
+        ]
 
     def _send(self, args: dict, account: "IMAPAccount") -> dict:
         to_list = self._normalize_addresses(args.get("address"))
@@ -500,7 +506,10 @@ class IMAPMailManager:
         message_text = args.get("message", "")
         cc = self._normalize_addresses(args.get("cc"))
         bcc = self._normalize_addresses(args.get("bcc"))
-        attachments = self._resolve_attachment_paths(args.get("attachments", []))
+        try:
+            attachments = self._resolve_attachment_paths(args.get("attachments", []))
+        except OutboundFileError as e:
+            return {"error": str(e)}
 
         if not to_list:
             return {"error": "address is required"}
@@ -657,7 +666,10 @@ class IMAPMailManager:
 
         # CC and attachments
         cc = self._normalize_addresses(args.get("cc"))
-        attachments = self._resolve_attachment_paths(args.get("attachments", []))
+        try:
+            attachments = self._resolve_attachment_paths(args.get("attachments", []))
+        except OutboundFileError as e:
+            return {"error": str(e)}
 
         # Reply to sender
         reply_to = original.get("from_address") or original.get("from", "")

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -41,6 +41,7 @@ from lingtai.mcp_servers.task_card import (
 )
 
 from .. import _skill
+from .._outbound_files import OutboundFileError, resolve_outbound_file
 from . import _family
 from . import updates as tg_updates
 from .account import TelegramRateLimitError
@@ -448,6 +449,8 @@ SCHEMA = {
             },
             "description": (
                 "Media attachment: {type: 'photo'|'document', path: '/path/to/file'}. "
+                "The path must be inside the agent working directory; relative "
+                "paths resolve against it. "
                 "For charts, HTML/SVG/PNG reports, CSVs, PDFs, and other generated artifacts that should arrive as an intact file, use type='document'. "
                 "Use type='photo' only for native inline photo previews; Telegram photo delivery can crop, compress, thumbnail, or otherwise display text-heavy charts poorly. "
                 "Do not paste local file paths in message text as a substitute for attaching the file."
@@ -3762,6 +3765,12 @@ class TelegramManager:
         if media:
             media_type = media.get("type")
             media_path = media.get("path", "")
+            try:
+                media_path = str(
+                    resolve_outbound_file(media_path, self._working_dir)
+                )
+            except OutboundFileError as e:
+                return {"error": str(e)}
             media_file = Path(media_path)
             if not media_file.is_file() or media_file.stat().st_size == 0:
                 return {

--- a/src/lingtai/mcp_servers/wechat/SKILL.md
+++ b/src/lingtai/mcp_servers/wechat/SKILL.md
@@ -63,7 +63,8 @@ ATTACHMENTS below), not a mutually exclusive choice.
 
 ## MEDIA / ATTACHMENTS
 
-- `send` with `media_path` (absolute path) attaches a file. Type is detected from
+- `send` with `media_path` attaches a file (absolute or relative to the agent
+  working directory; paths outside it are rejected). Type is detected from
   the extension: `.jpg`/`.png` → image, `.mp4` → video, `.wav`/`.mp3` → voice,
   anything else → file.
 - For charts, reports, and other artifacts the user should open intact, send them

--- a/src/lingtai/mcp_servers/wechat/manager.py
+++ b/src/lingtai/mcp_servers/wechat/manager.py
@@ -25,6 +25,7 @@ from . import _family
 from . import media as media_mod
 from .lockfile import AccountLock, PollerLockBusy
 from .. import _identity, _skill
+from .._outbound_files import OutboundFileError, resolve_outbound_file
 
 if TYPE_CHECKING:
     pass
@@ -537,9 +538,18 @@ class WechatManager:
         if not text and not media_path:
             return {"error": "text or media_path is required"}
 
-        # Validate media_path before sending text to avoid partial sends
-        if media_path and not Path(media_path).is_file():
-            return {"error": f"File not found: {media_path}"}
+        # Validate media_path before sending text to avoid partial sends.
+        # Enforce the shared outbound-file containment policy first so a
+        # prompt-injected path cannot exfiltrate files outside the workdir.
+        if media_path:
+            try:
+                media_path = str(
+                    resolve_outbound_file(media_path, self._working_dir)
+                )
+            except OutboundFileError as e:
+                return {"error": str(e)}
+            if not Path(media_path).is_file():
+                return {"error": f"File not found: {media_path}"}
 
         results = []
 

--- a/tests/test_imap_reply_attachments.py
+++ b/tests/test_imap_reply_attachments.py
@@ -51,12 +51,13 @@ def _manager(account: FakeAccount) -> IMAPMailManager:
 
 def test_reply_forwards_resolved_attachments_to_send_email():
     account = FakeAccount()
+    wd = Path("/tmp/imap-agent-workdir")
 
     result = _manager(account).handle({
         "action": "reply",
         "email_id": "me@example.com:INBOX:42",
         "message": "Here is the file.",
-        "attachments": ["relative.txt", "/abs/file.pdf"],
+        "attachments": ["relative.txt", str(wd / "abs-file.pdf")],
     })
 
     assert result["status"] == "delivered"
@@ -65,12 +66,27 @@ def test_reply_forwards_resolved_attachments_to_send_email():
     assert account.sent_kwargs["subject"] == "Re: Question"
     assert account.sent_kwargs["body"] == "Here is the file."
     assert account.sent_kwargs["attachments"] == [
-        "/tmp/imap-agent-workdir/relative.txt",
-        "/abs/file.pdf",
+        str((wd / "relative.txt").resolve()),
+        str((wd / "abs-file.pdf").resolve()),
     ]
     assert account.sent_kwargs["in_reply_to"] == "<orig@example.com>"
     assert account.sent_kwargs["references"] == "<parent@example.com> <orig@example.com>"
     assert account.stored_flags == [("INBOX", "42", ["\\Answered"])]
+
+
+def test_reply_rejects_absolute_attachment_outside_workdir():
+    account = FakeAccount()
+
+    result = _manager(account).handle({
+        "action": "reply",
+        "email_id": "me@example.com:INBOX:42",
+        "message": "Here is the file.",
+        "attachments": ["/etc/passwd"],
+    })
+
+    assert "error" in result
+    assert "outside working directory" in result["error"]
+    assert account.sent_kwargs is None
 
 
 def test_reply_keeps_attachments_none_when_absent():

--- a/tests/test_outbound_file_containment.py
+++ b/tests/test_outbound_file_containment.py
@@ -1,0 +1,320 @@
+"""Outbound-file containment tests for MCP send surfaces (issue #631).
+
+A prompt-injection or over-broad tool call must not be able to exfiltrate
+arbitrary local files through IMAP ``attachments``, Telegram ``media.path``
+or WeChat ``media_path``.  These tests pin the shared policy in
+``lingtai.mcp_servers._outbound_files`` and its enforcement at each manager
+boundary: absolute paths outside the agent working directory, ``..`` escapes
+and symlink escapes are rejected before any bytes are read or sent.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from lingtai.mcp_servers import _outbound_files
+from lingtai.mcp_servers._outbound_files import (
+    OutboundFileError,
+    resolve_outbound_file,
+)
+from lingtai.mcp_servers.imap.manager import IMAPMailManager
+from lingtai.mcp_servers.telegram.manager import TelegramManager
+from lingtai.mcp_servers.wechat import api as wx_api
+from lingtai.mcp_servers.wechat import media as wx_media
+from lingtai.mcp_servers.wechat.manager import WechatManager
+from tests._notification_store_helpers import FakeNotificationStore
+
+# ---------------------------------------------------------------------------
+# Shared policy helper
+# ---------------------------------------------------------------------------
+
+class TestResolveOutboundFile:
+    def test_relative_path_resolves_against_workdir(self, tmp_path):
+        assert resolve_outbound_file("report.pdf", tmp_path) == (
+            tmp_path / "report.pdf"
+        ).resolve()
+
+    def test_absolute_path_inside_workdir_allowed(self, tmp_path):
+        inside = tmp_path / "sub" / "file.txt"
+        assert resolve_outbound_file(str(inside), tmp_path) == inside.resolve()
+
+    def test_absolute_path_outside_workdir_rejected(self, tmp_path):
+        outside = tmp_path.parent / "secret.txt"
+        with pytest.raises(OutboundFileError):
+            resolve_outbound_file(str(outside), tmp_path)
+
+    def test_dotdot_escape_rejected(self, tmp_path):
+        with pytest.raises(OutboundFileError):
+            resolve_outbound_file("../secret.txt", tmp_path)
+
+    def test_symlink_escape_rejected(self, tmp_path):
+        secret = tmp_path.parent / "secret.txt"
+        secret.write_text("top secret", encoding="utf-8")
+        link = tmp_path / "link.txt"
+        link.symlink_to(secret)
+        with pytest.raises(OutboundFileError):
+            resolve_outbound_file("link.txt", tmp_path)
+
+    def test_missing_file_inside_workdir_still_resolves(self, tmp_path):
+        # resolve() does not require existence; a not-yet-created artifact
+        # path inside the workdir is allowed (the caller checks is_file()).
+        assert resolve_outbound_file("pending.txt", tmp_path) == (
+            tmp_path / "pending.txt"
+        ).resolve()
+
+    def test_module_reexports_helpers(self):
+        assert _outbound_files.resolve_outbound_file is resolve_outbound_file
+        assert _outbound_files.OutboundFileError is OutboundFileError
+
+
+# ---------------------------------------------------------------------------
+# IMAP manager (attachments)
+# ---------------------------------------------------------------------------
+
+class FakeImapAccount:
+    address = "me@example.com"
+
+    def __init__(self) -> None:
+        self.sent: list[dict] = []
+        self.stored_flags: list[tuple] = []
+
+    def fetch_full(self, folder: str, uid: str) -> dict:
+        return {
+            "from": "Sender <sender@example.com>",
+            "from_address": "sender@example.com",
+            "subject": "Question",
+            "message_id": "<orig@example.com>",
+            "references": "<parent@example.com>",
+        }
+
+    def send_email(self, **kwargs):
+        self.sent.append(kwargs)
+
+    def store_flags(self, folder: str, uid: str, flags: list[str]) -> bool:
+        self.stored_flags.append((folder, uid, flags))
+        return True
+
+
+class FakeImapService:
+    def __init__(self, account: FakeImapAccount) -> None:
+        self.default_account = account
+        self._map = {account.address: account}
+
+    def get_account(self, address: str | None):
+        if address is None:
+            return self.default_account
+        return self._map.get(address)
+
+
+def _imap_manager(tmp_path: Path, account: FakeImapAccount) -> IMAPMailManager:
+    return IMAPMailManager(
+        FakeImapService(account),
+        working_dir=tmp_path,
+        tcp_alias="/tmp/imap-bridge",
+        on_inbound=lambda payload: None,
+    )
+
+
+def test_imap_send_rejects_attachment_outside_workdir(tmp_path):
+    account = FakeImapAccount()
+    manager = _imap_manager(tmp_path, account)
+
+    result = manager._send({
+        "address": "victim@example.com",
+        "message": "leak",
+        "attachments": [str(tmp_path.parent / "id_rsa")],
+    }, account)
+
+    assert "error" in result
+    assert "outside working directory" in result["error"]
+    assert account.sent == []
+
+
+def test_imap_send_accepts_relative_attachment_inside_workdir(tmp_path):
+    account = FakeImapAccount()
+    manager = _imap_manager(tmp_path, account)
+    (tmp_path / "report.pdf").write_text("x", encoding="utf-8")
+
+    result = manager._send({
+        "address": "a@example.com",
+        "message": "hi",
+        "attachments": ["report.pdf"],
+    }, account)
+
+    assert result["status"] == "delivered"
+    assert account.sent[0]["attachments"] == [
+        str((tmp_path / "report.pdf").resolve())
+    ]
+
+
+def test_imap_reply_rejects_attachment_outside_workdir(tmp_path):
+    account = FakeImapAccount()
+    manager = _imap_manager(tmp_path, account)
+
+    result = manager._reply({
+        "email_id": "me@example.com:INBOX:42",
+        "message": "re",
+        "attachments": ["/etc/passwd"],
+    }, account)
+
+    assert "error" in result
+    assert "outside working directory" in result["error"]
+    assert account.sent == []
+
+
+# ---------------------------------------------------------------------------
+# Telegram manager (media.path)
+# ---------------------------------------------------------------------------
+
+class FakeTgAccount:
+    alias = "mybot"
+
+    def __init__(self) -> None:
+        self.calls: list = []
+
+    def send_message(self, *args, **kwargs):
+        self.calls.append(("send_message", args, kwargs))
+        return {"message_id": 1}
+
+    def send_photo(self, *args, **kwargs):
+        self.calls.append(("send_photo", args, kwargs))
+        return {"message_id": 2}
+
+    def send_document(self, *args, **kwargs):
+        self.calls.append(("send_document", args, kwargs))
+        return {"message_id": 3}
+
+    def set_message_reaction(self, *args, **kwargs):
+        return True
+
+
+class FakeTgService:
+    def __init__(self) -> None:
+        self.default_account = FakeTgAccount()
+
+    def get_account(self, alias):
+        return self.default_account
+
+    def list_accounts(self):
+        return ["mybot"]
+
+
+def _tg_manager(tmp_path: Path) -> tuple[TelegramManager, FakeTgAccount]:
+    service = FakeTgService()
+    manager = TelegramManager(
+        service,
+        working_dir=tmp_path,
+        on_inbound=lambda _: None,
+        notification_store=FakeNotificationStore(),
+    )
+    return manager, service.default_account
+
+
+def test_telegram_send_rejects_media_path_outside_workdir(tmp_path):
+    manager, account = _tg_manager(tmp_path)
+
+    result = manager._send({
+        "account": "mybot",
+        "chat_id": 123,
+        "media": {"type": "document", "path": "/etc/passwd"},
+    })
+
+    assert "error" in result
+    assert "outside working directory" in result["error"]
+    assert account.calls == []
+
+
+def test_telegram_send_accepts_media_path_inside_workdir(tmp_path):
+    manager, account = _tg_manager(tmp_path)
+    media_path = tmp_path / "demo.txt"
+    media_path.write_text("demo", encoding="utf-8")
+
+    result = manager._send({
+        "account": "mybot",
+        "chat_id": 123,
+        "text": "demo",
+        "media": {"type": "document", "path": str(media_path)},
+    })
+
+    assert "error" not in result
+    assert account.calls[0][0] == "send_document"
+    assert account.calls[0][1][1] == str(media_path.resolve())
+
+
+def test_telegram_send_rejects_dotdot_media_path(tmp_path):
+    manager, account = _tg_manager(tmp_path)
+
+    result = manager._send({
+        "account": "mybot",
+        "chat_id": 123,
+        "media": {"type": "photo", "path": "../secret.png"},
+    })
+
+    assert "error" in result
+    assert "outside working directory" in result["error"]
+    assert account.calls == []
+
+
+# ---------------------------------------------------------------------------
+# WeChat manager (media_path)
+# ---------------------------------------------------------------------------
+
+def _wx_manager(tmp_path: Path) -> WechatManager:
+    return WechatManager(
+        token="test-token",
+        user_id="test-bot",
+        working_dir=tmp_path,
+        on_inbound=lambda event: None,
+    )
+
+
+def test_wechat_send_rejects_media_path_outside_workdir(tmp_path, monkeypatch):
+    manager = _wx_manager(tmp_path)
+    uploads: list = []
+
+    async def _fake_upload(path, base_url, token, user_id):
+        uploads.append(str(path))
+        raise AssertionError("upload_media must not run for an outside path")
+
+    monkeypatch.setattr(wx_media, "upload_media", _fake_upload)
+
+    result = manager._handle_send({
+        "user_id": "wxid@im.wechat",
+        "media_path": "/etc/passwd",
+    })
+
+    assert "error" in result
+    assert "outside working directory" in result["error"]
+    assert uploads == []
+
+
+def test_wechat_send_accepts_media_path_inside_workdir(tmp_path, monkeypatch):
+    manager = _wx_manager(tmp_path)
+    media_path = tmp_path / "pic.png"
+    media_path.write_bytes(b"PNG")
+    seen: dict = {}
+
+    async def _fake_upload(path, base_url, token, user_id):
+        seen["upload_path"] = str(path)
+        return {"media_id": "m1", "media_type": "image"}
+
+    async def _fake_send_message(*args, **kwargs):
+        seen["sent"] = True
+
+    monkeypatch.setattr(wx_media, "upload_media", _fake_upload)
+    monkeypatch.setattr(
+        wx_media, "make_media_item", lambda info, path: object()
+    )
+    monkeypatch.setattr(wx_api, "send_message", _fake_send_message)
+    monkeypatch.setattr(manager, "_run_async", asyncio.run)
+
+    result = manager._handle_send({
+        "user_id": "wxid@im.wechat",
+        "media_path": str(media_path),
+    })
+
+    assert result["status"] == "ok"
+    assert seen["upload_path"] == str(media_path.resolve())
+    assert seen["sent"] is True


### PR DESCRIPTION
Fixes #631.

## Problem
IMAP `attachments`, Telegram `media.path` and WeChat `media_path` accept agent-supplied local file paths that are read and uploaded/sent to an external service. A prompt-injection or an over-broad tool call can exfiltrate arbitrary local files (`~/.ssh/id_rsa`, agent `.secrets/*`, ...) to an outside recipient/chat after only a `Path(...).is_file()` validation.

## Fix
Add a shared outbound-file containment policy (`lingtai.mcp_servers._outbound_files.resolve_outbound_file`): relative paths resolve against the agent working dir, and the fully resolved path (symlinks and `..` followed) must stay inside it. Enforced at all three send boundaries:

- IMAP `attachments` (`_resolve_attachment_paths`, used by `send`/`reply`) — outside-workdir absolute paths are rejected with an error before `send_email` is reached.
- Telegram `media.path` (`_send`) — rejected before `send_photo`/`send_document`.
- WeChat `media_path` (`_handle_send`) — rejected before `upload_media`.

Schema/SKILL docs updated to describe the containment rule.

## Tests
- New `tests/test_outbound_file_containment.py` (15 tests): helper unit tests (relative, absolute-inside, absolute-outside, `..` escape, symlink escape, missing-inside), IMAP `_send`/`_reply` rejection + relative acceptance, Telegram `_send` rejection (absolute + `..`) + inside acceptance, WeChat `_handle_send` rejection + inside acceptance (upload_media receives the resolved in-workdir path).
- Updated `tests/test_imap_reply_attachments.py`: the old test pinned the vulnerable behavior (passing `/abs/file.pdf` through); it now uses an inside-workdir absolute path and asserts resolved forwarding, plus a new rejection test.
- Results: `pytest tests/test_imap*.py tests/test_wechat*.py` → 183 passed; `pytest tests/test_telegram*.py` → 432 passed, 1 failed (`test_telegram_task_card_transport.py::test_public_telegram_action_reaches_manager` — pre-existing on pristine main, its `_FakeService` lacks `list_accounts`; unrelated to this change).