### PR TITLE
fix: make JSONC trailing-comma stripping string-aware

### DIFF
--- a/src/lingtai/kernel/config_resolve.py
+++ b/src/lingtai/kernel/config_resolve.py
@@ -7,17 +7,17 @@ import re
 from pathlib import Path
 
 
-def parse_jsonc(text: str) -> dict:
-    """Parse JSON or JSONC text (strips // comments and trailing commas).
+_TRAILING_COMMA_RE = re.compile(r',\s*([}\]])')
 
-    Pure text→object transform with no I/O, so callers holding raw text (e.g.
-    migration transforms) use it directly. Comment stripping is string-aware: //
-    inside a quoted string is never a comment (URLs like "https://host/..." survive).
+
+def _strip_comments(text: str) -> str:
+    """Strip ``//`` comments while preserving string literals verbatim.
+
+    Implemented as a small state machine rather than splitting around string
+    literals: JSONC comments may themselves contain quoted examples (for
+    example ``// copy as "init.json"``); those quotes must not become JSON data
+    or hide the real delimiters on the following lines.
     """
-    # Strip comments with a small state machine rather than splitting around
-    # string literals. JSONC comments may themselves contain quoted examples
-    # (for example `// copy as "init.json"`); those quotes must not become JSON
-    # data or hide the real delimiters on the following lines.
     parts: list[str] = []
     in_string = False
     escaped = False
@@ -52,8 +52,59 @@ def parse_jsonc(text: str) -> dict:
             continue
         parts.append(ch)
         i += 1
-    text = "".join(parts)
-    text = re.sub(r',\s*([}\]])', r'\1', text)
+    return "".join(parts)
+
+
+def _strip_trailing_commas(text: str) -> str:
+    """Remove trailing commas without touching string literals.
+
+    Equivalent to applying ``re.sub(r',\\s*([}\\]]])', r'\\1', text)`` only to the
+    non-string spans of *text*, so a string value containing `, ]` or `, }`
+    (or `,]` / `,}`) survives byte-for-byte instead of being silently
+    rewritten. Genuine trailing commas always sit in the same non-string span
+    as their closing bracket, so this is semantically identical to the old
+    whole-text pass for every parseable input.
+    """
+    out: list[str] = []
+    pos = 0
+    in_string = False
+    escaped = False
+    i = 0
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if in_string:
+            out.append(ch)  # copy the string literal verbatim
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == '"':
+                in_string = False
+                pos = i + 1
+            i += 1
+            continue
+        if ch == '"':
+            out.append(_TRAILING_COMMA_RE.sub(r"\1", text[pos:i]))
+            out.append(ch)  # opening quote starts the string literal
+            in_string = True
+            i += 1
+            continue
+        i += 1
+    out.append(_TRAILING_COMMA_RE.sub(r"\1", text[pos:]))
+    return "".join(out)
+
+
+def parse_jsonc(text: str) -> dict:
+    """Parse JSON or JSONC text (strips // comments and trailing commas).
+
+    Pure text→object transform with no I/O, so callers holding raw text (e.g.
+    migration transforms) use it directly. Both normalisations are string-aware:
+    // inside a quoted string is never a comment (URLs like "https://host/..."
+    survive), and a string value containing `, ]` or `, }` is left intact.
+    """
+    text = _strip_comments(text)
+    text = _strip_trailing_commas(text)
     return json.loads(text)
 
 

--- a/tests/test_config_resolve_jsonc.py
+++ b/tests/test_config_resolve_jsonc.py
@@ -1,0 +1,92 @@
+"""Direct unit coverage for the string-aware JSONC reader.
+
+``parse_jsonc`` / ``load_jsonc`` are the kernel's single entry point for
+reading preset manifests, init config, and migration inputs. These tests lock
+in the string-aware handling of both JSONC normalisations (``//`` comments and
+trailing commas): string values must survive byte-for-byte, even when they
+contain text that looks like a comment marker or a trailing-comma pattern.
+
+Regression: lingtai-kernel#725 — the whole-text trailing-comma regex used to
+corrupt string values containing `, ]` / `, }` (or `,]` / `,}`).
+"""
+
+import json
+
+import pytest
+
+from lingtai.kernel.config_resolve import (
+    _strip_trailing_commas,
+    load_jsonc,
+    parse_jsonc,
+)
+
+
+def test_load_jsonc_preserves_comma_bracket_inside_strings(tmp_path):
+    """String values containing `, ]` / `, }` are not rewritten (#725)."""
+    p = tmp_path / "carriers.jsonc"
+    p.write_text('{"pattern": "a, ]b", "cmd": "x, }y"}', encoding="utf-8")
+    assert load_jsonc(p) == {"pattern": "a, ]b", "cmd": "x, }y"}
+
+
+def test_load_jsonc_preserves_multi_space_bracket_inside_strings(tmp_path):
+    """Multiple spaces between comma and bracket inside a string survive."""
+    p = tmp_path / "ws.jsonc"
+    p.write_text('{"pattern": "a,   ]b", "cmd": "x,    }y"}', encoding="utf-8")
+    assert load_jsonc(p) == {"pattern": "a,   ]b", "cmd": "x,    }y"}
+
+
+def test_parse_jsonc_string_aware_across_real_whitespace():
+    """The comma pass never rewrites string content, even when the span
+    would cover real control whitespace (newline or tab).
+
+    Real control characters inside a string are invalid JSON, so those inputs
+    now raise ``JSONDecodeError`` instead of being silently "fixed" by eating
+    the comma+bracket like the old whole-text regex did.
+    """
+    assert _strip_trailing_commas('{"a": "x,\n ]y"}') == '{"a": "x,\n ]y"}'
+    assert _strip_trailing_commas('{"a": "x,\t]y"}') == '{"a": "x,\t]y"}'
+    for malformed in ('{"a": "x,\n]y"}', '{"a": "x,\t]y"}'):
+        with pytest.raises(json.JSONDecodeError):
+            parse_jsonc(malformed)
+
+
+def test_parse_jsonc_still_strips_trailing_commas():
+    """Genuine JSONC trailing commas still collapse to strict JSON."""
+    assert parse_jsonc('{"a": [1, 2, ], "b": {"c": 1, }, }') == {
+        "a": [1, 2],
+        "b": {"c": 1},
+    }
+
+
+def test_parse_jsonc_trailing_comma_before_comment():
+    """A trailing comma before a `//` comment still collapses (comment
+    stripping runs before comma stripping within each pass)."""
+    assert parse_jsonc('{"a": 1,  // note\n}') == {"a": 1}
+
+
+def test_parse_jsonc_features_compose_with_strings():
+    """URLs, `, ]`-bearing strings, comments (incl. quoted examples) and
+    trailing commas all behave at once."""
+    body = """{
+      // copy as "init.json" -- a quote inside a comment must stay inert
+      "url": "https://example.test/path?from=kernel",
+      "desc": "options: a, } or b, ]",
+      "arr": [1, 2, ],
+    }"""
+    assert parse_jsonc(body) == {
+        "url": "https://example.test/path?from=kernel",
+        "desc": "options: a, } or b, ]",
+        "arr": [1, 2],
+    }
+
+
+def test_parse_jsonc_preserves_escaped_quote_before_pattern():
+    """An escaped quote immediately before `, ]` inside a string survives."""
+    assert parse_jsonc('{"re": "end \\", ]"}') == {"re": 'end ", ]'}
+
+
+def test_parse_jsonc_preserves_double_slash_inside_strings():
+    """`//` inside a string value is never treated as a comment."""
+    assert parse_jsonc('{"docs": "https://example.test/docs//nested"}') == {
+        "docs": "https://example.test/docs//nested"
+    }


### PR DESCRIPTION
Fixes #725

## What

`parse_jsonc()` (used by `load_jsonc()` — the kernel's single entry point for reading preset manifests, `init.jsonc`, and migration inputs) applies the trailing-comma regex `re.sub(r',\s*([}\]])', ...)` to the **fully reassembled text**, string literals included. Any string value containing `, ]` or `, }` (or `,]` / `,}` with any whitespace between) is silently rewritten before parsing:

```python
>>> parse_jsonc('{"pattern": "a, ]b", "cmd": "x, }y"}')
{'pattern': 'a]b', 'cmd': 'x}y'}   # old — silent corruption, no error
```

## Fix

Move trailing-comma removal into a string-aware pass that only touches the non-string spans of the text, mirroring the existing string-aware comment stripping:

- `_strip_comments(text)` — the existing comment-stripping state machine, extracted as a helper.
- `_strip_trailing_commas(text)` — walks the text, applies `,\s*([}\]]) -> \1` only to non-string spans, and copies string literals byte-for-byte.
- `parse_jsonc()` = `_strip_comments` → `_strip_trailing_commas` → `json.loads`.

Genuine trailing commas always sit in the same non-string span as their closing bracket, so the pass is semantically identical to the old whole-text regex for every parseable input (including `,  // comment
}` — comment stripping still runs first). No schema, signature, or call-site changes.

## Tests

New `tests/test_config_resolve_jsonc.py` (direct unit coverage of `parse_jsonc`/`load_jsonc`, which previously only had indirect coverage):

- `test_load_jsonc_preserves_comma_bracket_inside_strings` — the #725 repro now round-trips exactly (fails on old code).
- `test_load_jsonc_preserves_multi_space_bracket_inside_strings` — `,   ]` / `,    }` inside strings survive.
- `test_parse_jsonc_string_aware_across_real_whitespace` — the comma pass never rewrites string content even when the span would cover newline/tab; malformed inputs now raise `JSONDecodeError` instead of being silently patched.
- `test_parse_jsonc_still_strips_trailing_commas` / `test_parse_jsonc_trailing_comma_before_comment` — legitimate JSONC behavior unchanged.
- `test_parse_jsonc_features_compose_with_strings` — URLs, `, ]`-bearing strings, comments (incl. quoted examples) and trailing commas compose.
- `test_parse_jsonc_preserves_escaped_quote_before_pattern` / `test_parse_jsonc_preserves_double_slash_inside_strings` — escape handling and URL preservation lock-ins.

### Evidence

```
$ PYTHONPATH=src python3 -m pytest tests/test_config_resolve_jsonc.py tests/test_presets.py tests/test_kernel_migrate.py tests/test_init_reader.py tests/test_inherit_fallback.py -q
160 passed in 0.80s

$ PYTHONPATH=src python3 -m pytest tests/test_agent_preset_manifest.py tests/test_preset_materialization.py tests/test_agent_config_hydration.py tests/test_preset_context_guard.py -q
86 passed in 4.88s
```

(Note: `tests/test_wechat_config_resolution.py` cannot be collected in this environment due to a pre-existing `mcp` SDK version mismatch — `ServerRequestContext` import error — unrelated to this change.)