### PR TITLE
fix(nudge): run kernel_version remote probe off the heartbeat thread (#730)

### DIFF
--- a/src/lingtai/kernel/base_agent/lifecycle.py
+++ b/src/lingtai/kernel/base_agent/lifecycle.py
@@ -532,9 +532,11 @@ def _heartbeat_loop(agent) -> None:
         # Per-agent periodic checks that publish to `.notification/nudge.json`
         # when something needs the agent's attention (e.g. a newer lingtai
         # wheel is installed on disk than the version this process imported).
-        # Each check throttles itself; the dispatcher wraps individual calls
-        # so a misbehaving check cannot block the heartbeat loop. See
-        # `nudge/ANATOMY.md`.
+        # Each check throttles itself; the dispatcher only guards against
+        # checks that *raise* -- latency inside a check is latency between
+        # heartbeat writes. Invariant: checks must never block on the network;
+        # long work is handed to a background thread (see
+        # `nudge/kernel_version.py`). See `nudge/ANATOMY.md`.
         try:
             from ..nudge import run_checks as _run_nudge_checks
             _run_nudge_checks(agent)

--- a/src/lingtai/kernel/nudge/ANATOMY.md
+++ b/src/lingtai/kernel/nudge/ANATOMY.md
@@ -67,7 +67,10 @@ the ordinary Notification Store channel; it does not create a second transport.
   `LINGTAI_NUDGE_FOLDER_SIZE_GB` (default `5` decimal GB) (`src/lingtai/kernel/nudge/folder_size.py:1-182`).
 - `kernel_version.py` — read-only installed/running observation plus bounded
   GitHub/Gitee release-manifest comparison; it does not own a product repeat
-  cadence (`src/lingtai/kernel/nudge/kernel_version.py:91-229`).
+  cadence (`src/lingtai/kernel/nudge/kernel_version.py:91-229`). Its remote
+  probe runs on a daemon worker thread and is consumed on a later probe, so
+  the 1s heartbeat tick never blocks on the network; the nudge surfaces up to
+  one probe (~60s) after the fetch completes.
 - `source_drift.py` — read-only runtime/source comparison in a separate
   integrity/diagnostic channel; it remains active for editable/source/dev
   runtimes (`src/lingtai/kernel/nudge/source_drift.py:21-111`).
@@ -81,7 +84,9 @@ the ordinary Notification Store channel; it does not create a second transport.
 
 ## Connections
 
-`base_agent/lifecycle.py:_heartbeat_loop` calls `run_checks` once per heartbeat;
+`base_agent/lifecycle.py:_heartbeat_loop` calls `run_checks` once per heartbeat
+(checks must never block on the network — long work goes to a background
+thread, see `kernel_version.py`);
 protected goal reminders are dispatched separately by
 `run_system_notifications`. Producer checks call `upsert`/`remove`; the shared
 `NotificationStorePort` persists `nudge.json`. `notification(action="dismiss_channel", input={"channel": "nudge", ...},

--- a/src/lingtai/kernel/nudge/kernel_version.py
+++ b/src/lingtai/kernel/nudge/kernel_version.py
@@ -4,15 +4,21 @@ This check is deliberately read-only. It surfaces the observed running and
 installed versions, plus the latest release-manifest facts published on the
 official GitHub/Gitee mirrors, through the shared ``nudge`` notification
 channel. It never mutates an installation.
+
+Cadence note: the remote probe runs on a daemon worker thread and is consumed
+on a later probe, so the nudge surfaces up to one probe (~60s) after the
+fetch completes. This is intentional: the check runs on the 1s heartbeat
+thread, which must never block on the network (#730).
 """
 
 from __future__ import annotations
 
 import hashlib
 import json
+import threading
 import time
 import urllib.request
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Mapping
@@ -27,6 +33,10 @@ from .prompts import (
 
 _FAST_INTERVAL_SECONDS = 60.0
 _REMOTE_TIMEOUT_SECONDS = 3.0
+# Hard ceiling for one background probe. Longer than the worst-case sequential
+# mirror fetch (4 bounded requests x 3.0s); a worker still running after this
+# (e.g. a stalled DNS lookup) is abandoned so the slot never pins forever.
+_FETCH_DEADLINE_SECONDS = 30.0
 _MAX_REMOTE_BYTES = 256 * 1024
 _MANIFEST_ASSET_NAME = "lingtai-kernel-release-manifest.json"
 _GITHUB_LATEST_RELEASE_URL = (
@@ -78,6 +88,63 @@ class _MirrorMismatchError(RuntimeError):
             for source, manifest in sorted(self.manifests.items())
         )
         super().__init__(f"release-manifest mirrors disagree: {versions}")
+
+
+@dataclass
+class _PendingFetch:
+    """Process-local slot for one in-flight remote probe.
+
+    ``result``/``error`` are written only by the daemon worker thread and read
+    by the heartbeat thread after ``done`` is set; ``done`` is the publication
+    barrier. The worker never touches ``.nudge_state.json`` or the
+    notification store, preserving the heartbeat thread's single-writer
+    property over persistent state.
+    """
+
+    thread: threading.Thread | None
+    started_ts: float
+    result: Any = None
+    error: BaseException | None = None
+    done: threading.Event = field(default_factory=threading.Event)
+
+
+def _fetch_slot(agent) -> _PendingFetch | None:
+    """Return the in-flight fetch slot for ``agent``, if any."""
+    return getattr(agent, "_nudge_kernel_fetch", None)
+
+
+def _start_fetch(agent) -> None:
+    """Start the remote probe on a daemon worker and return immediately.
+
+    The heartbeat tick must never block on the network (#730): a slow or
+    stalled fetch would hold the 1s tick past the 2s ``is_alive`` threshold
+    and make a live agent look dead. Single-flight is guaranteed because a
+    slot exists from spawn until consume/abandon, and ``check`` is gated by
+    the 60s fast interval.
+    """
+    pending = _PendingFetch(thread=None, started_ts=time.time())
+
+    def _worker() -> None:
+        try:
+            pending.result = _fetch_latest_version()
+        except Exception as exc:  # keep the slot consumable on any failure
+            pending.error = exc
+        finally:
+            pending.done.set()
+
+    try:
+        worker = threading.Thread(
+            target=_worker,
+            daemon=True,
+            name="nudge-kernel-version-fetch",
+        )
+    except Exception:
+        # Cannot even spawn the worker; stay inert and let the next probe
+        # re-arm the remote check.
+        return
+    pending.thread = worker
+    agent._nudge_kernel_fetch = pending
+    worker.start()
 
 
 def check(agent) -> None:
@@ -158,41 +225,79 @@ def check(agent) -> None:
     # The 60-second probe is only a bounded observation cost. Product repeat
     # behavior belongs to the shared global Nudge policy, not this producer.
 
-    try:
-        observation = _coerce_observation(_fetch_latest_version())
-    except _MirrorMismatchError as e:
-        mismatch = _mirror_mismatch_payload(e.manifests)
+    # The remote probe must never run on the heartbeat thread (#730): a slow
+    # or stalled fetch would hold the 1s tick past the 2s is_alive threshold
+    # and make a live agent look dead. The fetch runs on a daemon worker;
+    # each tick either starts one or consumes a finished one.
+    pending = _fetch_slot(agent)
+    if pending is None:
+        _start_fetch(agent)
+        return
+    if not pending.done.is_set():
+        if time.time() - pending.started_ts > _FETCH_DEADLINE_SECONDS:
+            # Abandon a wedged worker (e.g. a stalled DNS lookup); the
+            # orphaned daemon thread dies on its own. Record the failure so
+            # the day is not retried in a tight loop.
+            kernel_state.update(
+                {
+                    "last_remote_check_date": today,
+                    "checked_installed_version": info.installed_version,
+                    "last_error": "fetch timed out",
+                }
+            )
+            _save_persistent_state(agent, persistent)
+            _log(agent, "kernel_version_update_check_error", error="fetch timed out")
+            agent._nudge_kernel_fetch = None
+        return
+    agent._nudge_kernel_fetch = None
+    if pending.error is not None:
+        error = pending.error
+        if isinstance(error, _MirrorMismatchError):
+            mismatch = _mirror_mismatch_payload(error.manifests)
+            kernel_state.update(
+                {
+                    "last_remote_check_date": today,
+                    "checked_installed_version": info.installed_version,
+                    "latest_seen": None,
+                    "latest_source": None,
+                    "mirror_mismatch": mismatch,
+                    "last_error": None,
+                }
+            )
+            _save_persistent_state(agent, persistent)
+            upsert(
+                agent,
+                _KIND,
+                render_nudge_payload(
+                    NudgeSituation.MIRROR_MISMATCH,
+                    NudgeFacts(
+                        running=info.running_version,
+                        installed=info.installed_version,
+                        checked_at_date=today,
+                        mirror_mismatch=mismatch,
+                    ),
+                ),
+            )
+            _log(
+                agent,
+                "kernel_version_mirror_mismatch",
+                kind=_KIND,
+                sources=sorted(error.manifests),
+            )
+            return
         kernel_state.update(
             {
                 "last_remote_check_date": today,
                 "checked_installed_version": info.installed_version,
-                "latest_seen": None,
-                "latest_source": None,
-                "mirror_mismatch": mismatch,
-                "last_error": None,
+                "last_error": str(error)[:200],
             }
         )
         _save_persistent_state(agent, persistent)
-        upsert(
-            agent,
-            _KIND,
-            render_nudge_payload(
-                NudgeSituation.MIRROR_MISMATCH,
-                NudgeFacts(
-                    running=info.running_version,
-                    installed=info.installed_version,
-                    checked_at_date=today,
-                    mirror_mismatch=mismatch,
-                ),
-            ),
-        )
-        _log(
-            agent,
-            "kernel_version_mirror_mismatch",
-            kind=_KIND,
-            sources=sorted(e.manifests),
-        )
+        _log(agent, "kernel_version_update_check_error", error=str(error)[:200])
         return
+
+    try:
+        observation = _coerce_observation(pending.result)
     except Exception as e:
         kernel_state.update(
             {

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -296,3 +296,55 @@ class TestSelfSleep:
         assert agent._state == AgentState.ASLEEP
         assert agent._asleep.is_set()
         assert not agent._shutdown.is_set()
+
+
+class TestHeartbeatNeverBlocksOnNetwork:
+
+    def test_slow_kernel_version_fetch_does_not_stall_heartbeat(self, tmp_path, monkeypatch):
+        """#730 regression: the kernel_version remote probe runs off the
+        heartbeat thread, so a fetch slower than the 2s is_alive threshold
+        never makes a live agent look dead."""
+        import time
+        from lingtai.kernel import BaseAgent
+        from lingtai.kernel.nudge import kernel_version as kv
+        agent = BaseAgent(
+            intrinsics=_TEST_INTRINSICS,
+            service=make_mock_service(),
+            agent_name="test",
+            working_dir=tmp_path / "test_agent", workdir_lease=make_test_lease(),
+        agent_presence=PosixAgentPresenceStoreAdapter(tmp_path / "test_agent"), snapshot_port=make_test_snapshot_port(), lifecycle_clock=SystemLifecycleClockAdapter(), source_revision_port=make_test_source_revision_port(), notification_store=notification_store_for(tmp_path / "test_agent"),
+        )
+        # Force the nudge remote path: non-dev runtime with installed == running.
+        monkeypatch.setattr(
+            kv,
+            "_runtime_info",
+            lambda: kv._RuntimeInfo("0.17.0", "0.17.0", None),
+        )
+        # A fetch slower than the 2s is_alive threshold.
+        monkeypatch.setattr(
+            kv,
+            "_fetch_latest_version",
+            lambda: (time.sleep(3.0), "0.17.0")[1],
+        )
+
+        hb_file = agent._working_dir / ".agent.heartbeat"
+        agent._start_heartbeat()
+
+        samples = []
+        deadline = time.monotonic() + 4.5
+        while time.monotonic() < deadline:
+            if hb_file.exists():
+                try:
+                    samples.append((time.time(), float(hb_file.read_text())))
+                except ValueError:
+                    pass
+            time.sleep(0.2)
+
+        pending = kv._fetch_slot(agent)
+        if pending is not None:
+            pending.thread.join()
+        agent._stop_heartbeat()
+
+        assert len(samples) >= 3
+        stale = [(wall, ts) for wall, ts in samples if wall - ts >= 2.0]
+        assert not stale, f"heartbeat went stale during the slow fetch (#730): {stale[:3]}"

--- a/tests/test_kernel_version_nudge.py
+++ b/tests/test_kernel_version_nudge.py
@@ -30,6 +30,18 @@ def _reset_fast_gate(agent):
     agent._nudge_kernel_version_state["last_probe_ts"] = 0.0
 
 
+def _probe_and_consume(agent):
+    """Start the async fetch, wait for the worker, then consume its result
+    with a second check() -- mirroring the old synchronous contract for tests
+    that assert post-fetch state."""
+    kv.check(agent)
+    pending = kv._fetch_slot(agent)
+    assert pending is not None, "expected the async fetch to start"
+    pending.thread.join()
+    _reset_fast_gate(agent)
+    kv.check(agent)
+
+
 def test_installed_runtime_refresh_nudge_does_not_hit_remote(tmp_path, monkeypatch):
     agent = _Agent(tmp_path)
     monkeypatch.setattr(
@@ -97,11 +109,15 @@ def test_runtime_version_direction_is_fail_safe_and_equal_pairs_probe_remote(
             "_fetch_latest_version",
             lambda: (_ for _ in ()).throw(AssertionError("remote should not be queried")),
         )
-    kv.check(agent)
     if source is None:
+        kv.check(agent)
+        pending = kv._fetch_slot(agent)
+        assert pending is not None
+        pending.thread.join()
         assert calls == [True]
         assert _entries(tmp_path) == []
     else:
+        kv.check(agent)
         entry = _entries(tmp_path)[0]
         assert entry["source"] == source
         assert entry["suggested_action"] == action
@@ -202,7 +218,7 @@ def test_local_refresh_match_clears_mismatch_tracking_and_stale_nudge(tmp_path, 
     )
     monkeypatch.setattr(kv, "_fetch_latest_version", lambda: "0.14.2")
     _reset_fast_gate(agent)
-    kv.check(agent)
+    _probe_and_consume(agent)
     assert _entries(tmp_path) == []
 
     state = json.loads((tmp_path / ".notification" / ".nudge_state.json").read_text())
@@ -250,7 +266,7 @@ def test_match_after_refresh_clears_local_nudge_during_remote_outage(tmp_path, m
         lambda: (_ for _ in ()).throw(RuntimeError("both official mirrors unavailable")),
     )
 
-    kv.check(agent)
+    _probe_and_consume(agent)
 
     assert _entries(tmp_path) == []
     state = json.loads((tmp_path / ".notification" / ".nudge_state.json").read_text())
@@ -302,7 +318,7 @@ def test_remote_update_check_uses_bounded_probe_not_daily_product_cadence(tmp_pa
 
     monkeypatch.setattr(kv, "_fetch_latest_version", latest)
 
-    kv.check(agent)
+    _probe_and_consume(agent)
 
     entries = _entries(tmp_path)
     assert len(entries) == 1
@@ -321,9 +337,12 @@ def test_remote_update_check_uses_bounded_probe_not_daily_product_cadence(tmp_pa
     assert state["kernel_version"]["checked_installed_version"] == "0.14.1"
     assert state["kernel_version"]["latest_seen"] == "0.14.2"
 
+    # A later probe starts a fresh fetch (the single-flight slot was consumed).
     _reset_fast_gate(agent)
-    monkeypatch.setattr(kv, "_fetch_latest_version", latest)
     kv.check(agent)
+    pending = kv._fetch_slot(agent)
+    assert pending is not None
+    pending.thread.join()
     assert calls["n"] == 2
     assert _entries(tmp_path)[0]["latest"] == "0.14.2"
 
@@ -383,7 +402,7 @@ def test_current_remote_version_clears_existing_kernel_nudge(tmp_path, monkeypat
     monkeypatch.setattr(kv, "_today_utc", lambda: "2026-06-24")
     monkeypatch.setattr(kv, "_fetch_latest_version", lambda: "0.14.1")
 
-    kv.check(agent)
+    _probe_and_consume(agent)
 
     assert "nudge" not in snapshot_notifications(tmp_path)
     state = json.loads((tmp_path / ".notification" / ".nudge_state.json").read_text())
@@ -621,7 +640,7 @@ def test_mirror_mismatch_is_reported_without_selecting_a_version(tmp_path, monke
         ),
     )
 
-    kv.check(agent)
+    _probe_and_consume(agent)
 
     entry = _entries(tmp_path)[0]
     assert entry["source"] == "release-manifest-mirror-mismatch"
@@ -843,3 +862,146 @@ def test_release_manifest_same_version_content_or_hash_mismatch_is_not_accepted(
 
     with pytest.raises(kv._MirrorMismatchError):
         kv._fetch_latest_version()
+
+
+def test_check_does_not_block_on_slow_fetch(tmp_path, monkeypatch):
+    """#730: a slow remote probe must not hold the 1s heartbeat tick."""
+    import threading as _threading
+    import time as _time
+
+    agent = _Agent(tmp_path)
+    monkeypatch.setattr(
+        kv,
+        "_runtime_info",
+        lambda: kv._RuntimeInfo("0.17.0", "0.17.0", None),
+    )
+    release = _threading.Event()
+
+    def slow_fetch():
+        release.wait(5.0)  # a slow-but-successful probe
+        return "0.17.0"
+
+    monkeypatch.setattr(kv, "_fetch_latest_version", slow_fetch)
+
+    started = _time.monotonic()
+    kv.check(agent)
+    elapsed = _time.monotonic() - started
+
+    assert elapsed < 0.5, f"check() blocked the heartbeat for {elapsed:.2f}s (#730)"
+    assert _entries(tmp_path) == []
+    assert kv._fetch_slot(agent) is not None
+    # Cleanup: let the worker finish so no daemon thread outlives the test.
+    release.set()
+    kv._fetch_slot(agent).thread.join()
+
+
+def test_fetch_result_consumed_on_later_probe(tmp_path, monkeypatch):
+    agent = _Agent(tmp_path)
+    monkeypatch.setattr(
+        kv,
+        "_runtime_info",
+        lambda: kv._RuntimeInfo("0.14.1", "0.14.1", None),
+    )
+    monkeypatch.setattr(kv, "_today_utc", lambda: "2026-07-17")
+    monkeypatch.setattr(kv, "_fetch_latest_version", lambda: "0.14.2")
+
+    kv.check(agent)  # starts the async fetch; the tick returns immediately
+    pending = kv._fetch_slot(agent)
+    assert pending is not None
+    pending.thread.join()
+    _reset_fast_gate(agent)
+    kv.check(agent)  # a later probe consumes the finished fetch
+
+    entries = _entries(tmp_path)
+    assert len(entries) == 1
+    assert entries[0]["latest"] == "0.14.2"
+    state = json.loads((tmp_path / ".notification" / ".nudge_state.json").read_text())
+    assert state["kernel_version"]["latest_seen"] == "0.14.2"
+    assert state["kernel_version"]["last_remote_check_date"] == "2026-07-17"
+    assert kv._fetch_slot(agent) is None
+
+
+def test_fetch_error_recorded_asynchronously(tmp_path, monkeypatch):
+    agent = _Agent(tmp_path)
+    monkeypatch.setattr(
+        kv,
+        "_runtime_info",
+        lambda: kv._RuntimeInfo("0.17.0", "0.17.0", None),
+    )
+    monkeypatch.setattr(
+        kv,
+        "_fetch_latest_version",
+        lambda: (_ for _ in ()).throw(RuntimeError("both official mirrors unavailable")),
+    )
+
+    kv.check(agent)
+    pending = kv._fetch_slot(agent)
+    assert pending is not None
+    pending.thread.join()
+    _reset_fast_gate(agent)
+    kv.check(agent)
+
+    state = json.loads((tmp_path / ".notification" / ".nudge_state.json").read_text())
+    assert "unavailable" in state["kernel_version"]["last_error"]
+    assert state["kernel_version"]["last_remote_check_date"] == kv._today_utc()
+    assert kv._fetch_slot(agent) is None
+
+
+def test_single_flight(tmp_path, monkeypatch):
+    import threading as _threading
+
+    agent = _Agent(tmp_path)
+    monkeypatch.setattr(
+        kv,
+        "_runtime_info",
+        lambda: kv._RuntimeInfo("0.17.0", "0.17.0", None),
+    )
+    starts = []
+    original_start = kv._start_fetch
+
+    def counting_start(a):
+        starts.append(a)
+        return original_start(a)
+
+    monkeypatch.setattr(kv, "_start_fetch", counting_start)
+    release = _threading.Event()
+
+    def slow_fetch():
+        release.wait(5.0)
+        return "0.17.0"
+
+    monkeypatch.setattr(kv, "_fetch_latest_version", slow_fetch)
+
+    kv.check(agent)
+    _reset_fast_gate(agent)
+    kv.check(agent)
+    _reset_fast_gate(agent)
+    kv.check(agent)
+
+    assert len(starts) == 1  # repeated due probes never spawn a second worker
+    release.set()
+    kv._fetch_slot(agent).thread.join()
+
+
+def test_fetch_deadline_abandons_stuck_worker(tmp_path, monkeypatch):
+    import time as _time
+
+    agent = _Agent(tmp_path)
+    monkeypatch.setattr(
+        kv,
+        "_runtime_info",
+        lambda: kv._RuntimeInfo("0.17.0", "0.17.0", None),
+    )
+    # Simulate a worker started past the deadline whose ``done`` never fires
+    # (e.g. a wedged DNS lookup).
+    agent._nudge_kernel_fetch = kv._PendingFetch(
+        thread=None,
+        started_ts=_time.time() - kv._FETCH_DEADLINE_SECONDS - 1.0,
+    )
+
+    kv.check(agent)
+
+    assert kv._fetch_slot(agent) is None
+    state = json.loads((tmp_path / ".notification" / ".nudge_state.json").read_text())
+    assert state["kernel_version"]["last_error"] == "fetch timed out"
+    assert state["kernel_version"]["last_remote_check_date"] == kv._today_utc()


### PR DESCRIPTION
## Summary

**Root cause.** `_heartbeat_loop` (`base_agent/lifecycle.py`) is the sole writer of the liveness heartbeat, and `agent_presence.is_alive` treats a tick older than the default `threshold=2.0`s as *dead* — a verdict that gates mail delivery and karma sleep/suspend/cpr decisions. That same loop runs nudge checks inline, and `kernel_version.check()` called `_fetch_latest_version()` **synchronously**: a blocking `urllib` GET chain against the GitHub/Gitee release manifests (up to 4 bounded requests × 3.0s socket timeout, DNS not reliably bounded). The dispatcher's `try/except` (`nudge/__init__.py:_run_one`) only guards a check that *raises*, never one that is *slow* — so a slow-but-successful fetch stalled the heartbeat tick past the 2.0s threshold and a healthy idle agent briefly read as dead.

Note: since the issue was filed, the remote probe moved from the once-per-UTC-day PyPI JSON fetch to a GitHub/Gitee release-manifest comparison that runs on **every 60s probe** (`_remote_check_due` is now dead code that always returns `True`), so the blocking window is more frequent than the issue describes — the fix addresses the current code.

**Fix, at the owning layer.** A network probe has no business on the single-writer heartbeat thread. Rather than weaken the network-wide liveness threshold (which would still lose to DNS stalls), the fix makes the fetch asynchronous inside the nudge that owns the I/O (`src/lingtai/kernel/nudge/kernel_version.py`):

- The due `check()` spawns a short-lived daemon worker (`_start_fetch`) that writes only into a process-local `_PendingFetch` slot and returns immediately — the heartbeat tick completes at once (measured: 2.7ms instead of ≥3s).
- A later probe (past the existing 60s fast gate) consumes the result **on the heartbeat thread** and emits/clears the nudge exactly as the synchronous path did, including the mirror-mismatch and error branches.
- **Single-flight:** no second worker spawns while a slot exists; a wedged worker (e.g. hung `getaddrinfo`) is abandoned after `_FETCH_DEADLINE_SECONDS = 30.0` with a recorded `"fetch timed out"`.
- All `.nudge_state.json` writes stay on the heartbeat thread, preserving the single-writer property; the worker only produces a value.

**Trade-off / non-goal.** The advisory nudge now surfaces up to one probe (~60s) after the fetch completes rather than in the same tick — acceptable for an at-most-every-60s advisory, documented in the module docstring and `nudge/ANATOMY.md`. Moving *all* post-tick housekeeping off the heartbeat thread (Alternative B in #730) is a larger structural change with its own races and remains a deliberate non-goal.

The previously-incorrect lifecycle comment ("a misbehaving check cannot block the loop") and `nudge/ANATOMY.md` now state the real invariant: **checks must never block on the network; long work goes to a background thread.**

## Validation

Failing-first — the new regression tests fail on unmodified `kernel_version.py`:

```
$ python -m pytest tests/test_kernel_version_nudge.py::test_check_does_not_block_on_slow_fetch tests/test_heartbeat.py::TestHeartbeatNeverBlocksOnNetwork -q
2 failed in 9.80s   # check() blocked past the threshold; heartbeat went stale
```

After the fix:

```
$ python -m pytest tests/test_kernel_version_nudge.py tests/test_heartbeat.py -q
49 passed in 25.50s

$ python -m pytest tests/test_base_agent.py tests/test_nudge_inline_cap.py tests/test_nudge_policy.py \
    tests/test_nudge_prompts.py tests/test_agent_presence.py tests/test_anatomy_drift_checker.py -q
91 passed, 1 failed in 0.67s   # the 1 failure is pre-existing on main, unrelated

$ python -m pytest tests/test_agent_presence.py tests/test_anatomy_drift_checker.py tests/test_nudge_policy.py -q
55 passed in 0.27s
```

(The `test_nudge_inline_cap.py::test_dismissal_round_trip_for_capped_finding` failure reproduces identically with `src` restored to HEAD — pre-existing baseline drift, not introduced here.)

- Direct repro before fix: `check()` blocked the heartbeat thread for 3.00s with a 3s fetch (is_alive threshold 2.0s → dead-flicker). After fix: 2.7ms.
- End-to-end: real `_heartbeat_loop` with a 3s fetch — `.agent.heartbeat` stays fresh throughout (test run 3×, stable).
- `python -m compileall -q src/lingtai/kernel/nudge src/lingtai/kernel/base_agent` — ok.
- `git diff --check` — clean.
- Anatomy drift checker: same 3 pre-existing items as baseline, none introduced by this change.

Fixes #730
