### PR TITLE
fix(tools): relocate action-schema root field into input instead of rejecting whole call (#1251)

### DIFF
--- a/src/lingtai/tools/tool_family/CONTRACT.md
+++ b/src/lingtai/tools/tool_family/CONTRACT.md
@@ -1,6 +1,6 @@
 ---
 name: tool-family
-contract_version: 1
+contract_version: 2
 root_contract: CONTRACT.md
 related_files:
   - src/lingtai/tools/tool_family/ANATOMY.md
@@ -116,7 +116,8 @@ model-visible `summarize` control that the kernel silently ignores —
 joining it is part of a migration, not something this package does on a
 family's behalf. Calling
 `handle()` is optional: it validates the envelope (unknown `action`,
-non-boolean `summarize`, unknown root fields, `input` keys outside the
+non-boolean `summarize`, unknown root fields — with one narrow relocation
+exception, see "Contract rules" below — `input` keys outside the
 selected child's own declared schema) before invoking exactly that child's
 handler with only its own `input` mapping. A family MAY skip `handle()`
 entirely and dispatch by hand — `web` uses it internally but still owns its
@@ -384,12 +385,27 @@ its own scoped migration.
   the schema level without adding a fifth public root field or duplicating
   `action` inside `input`.
 - `handle()`, when used, MUST validate `action` against the registry, type-
-  check and strip root `summarize` before any child handler runs, reject
-  unknown root fields, and reject `input` keys outside the selected child's
-  own declared schema `properties` — schema conformance alone is not the
-  sole enforcement boundary; dispatch remains always-authoritative and
-  fail-closed regardless of whether a given provider validates the root
-  `allOf`/`if`/`then` schema-side (`../CONTRACT.md` "Dispatch and actions").
+  check and strip root `summarize` before any child handler runs, and reject
+  `input` keys outside the selected child's own declared schema `properties`
+  — schema conformance alone is not the sole enforcement boundary; dispatch
+  remains always-authoritative and fail-closed regardless of whether a given
+  provider validates the root `allOf`/`if`/`then` schema-side
+  (`../CONTRACT.md` "Dispatch and actions").
+- `handle()` MUST reject an unknown root field UNLESS it is both (a) a
+  property declared in the *selected* action's own `input_schema` and (b)
+  entirely absent from `input` — in which case `handle()` MUST relocate it
+  into `input` (add it as that key) rather than reject the call, and MUST
+  continue validating exactly as if the caller had nested it correctly. A
+  root field whose name duplicates a key already present in `input` — even
+  with an identical value — MUST still be rejected; the relocation exception
+  exists only for a genuinely misplaced-and-otherwise-absent field (observed
+  cause: a calling model's own native flat tool shape, e.g. an
+  `Edit(file_path, old_string, new_string, replace_all)`-style tool, leaking
+  `replace_all` to root instead of nesting it under `input` for the `file`
+  family's `edit` action), not for tolerating a redundant or conflicting
+  duplicate. This exception applies per-family, automatically, to every
+  family built on this dispatcher — it is not something an individual family
+  opts into or configures.
 - `handle()` MUST treat an unhashable `action` (e.g. `[]` or `{}`, reachable
   when invalid JSON survives to dispatch — the issue #513 blocker class) as
   simply matching no child, rendering the stable typed `ACTION_REQUIRED`

--- a/src/lingtai/tools/tool_family/__init__.py
+++ b/src/lingtai/tools/tool_family/__init__.py
@@ -258,6 +258,28 @@ class ToolFamily:
         matches no child and renders the stable typed envelope failure below,
         exactly as ``kernel/tool_dispatch.py`` does, rather than raising
         ``TypeError`` out of the dispatcher.
+
+        A root-level key that is neither an envelope field nor a declared
+        property of the *selected* action's own input schema is rejected as
+        before — including a root-level key that duplicates a name already
+        present in ``input``, which stays a hygiene violation exactly as
+        before (two conflicting or redundant places for the same value is a
+        client bug worth surfacing, not something to silently prefer one
+        side of).
+
+        The one narrower case this now rescues instead of rejecting: a
+        root-level key that IS a declared property of the selected action
+        AND is entirely absent from ``input`` (e.g. ``replace_all`` sent as
+        a sibling of ``action``/``input`` instead of nested inside ``input``,
+        with no ``replace_all`` in ``input`` at all). That specific shape is
+        relocated into ``input`` rather than failing the whole call —
+        calling models with strong priors from their own native flat tool
+        shapes (e.g. a model's built-in ``Edit(file_path, old_string,
+        new_string, replace_all)`` tool) occasionally emit exactly this,
+        otherwise-harmless, misplacement. This never widens what ends up in
+        ``input`` beyond a key the schema already declares for this action,
+        and the existing ``input``-keys check below still runs unchanged
+        afterward.
         """
         raw = dict(args or {})
         action = raw.get("action")
@@ -274,14 +296,22 @@ class ToolFamily:
             summarize = raw.pop("summarize")
             if not isinstance(summarize, bool):
                 return self._envelope_error("INVALID_ARGUMENT", "summarize must be a boolean")
+        child = self._children[action]
+        allowed = self._allowed_input_keys(child)
         unknown = set(raw) - _ROOT_FIELDS
         if unknown:
-            return self._envelope_error("INVALID_ARGUMENT", f"unsupported {self.name} argument")
+            action_input_probe = raw.get("input")
+            already_in_input = (
+                set(action_input_probe) if isinstance(action_input_probe, Mapping) else set()
+            )
+            relocatable = (unknown & allowed) - already_in_input
+            if (unknown - relocatable) or not isinstance(action_input_probe, Mapping):
+                return self._envelope_error("INVALID_ARGUMENT", f"unsupported {self.name} argument")
+            for key in relocatable:
+                action_input_probe[key] = raw.pop(key)
         action_input = raw.get("input")
         if not isinstance(action_input, Mapping):
             return self._envelope_error("INVALID_ARGUMENT", "input must be an object")
-        child = self._children[action]
-        allowed = self._allowed_input_keys(child)
         if set(action_input) - allowed:
             return self._envelope_error(
                 "INVALID_ARGUMENT", f"unsupported {self.name} input field"

--- a/tests/test_browser_capability.py
+++ b/tests/test_browser_capability.py
@@ -203,8 +203,13 @@ def test_web_action_input_search_to_link_ref_browse(tmp_path):
         })
         assert browsed["status"] == "ok"
         assert browsed["requested_url"] == "https://public.example/page"
+        # A root-level key that IS a declared property of the selected
+        # action's schema and is entirely absent from ``input`` is relocated
+        # into ``input`` rather than rejected (issue #1251) — the search must
+        # run with the relocated query.
         flat = handler({"action": "search", "input": {}, "query": "legacy flat"})
-        assert flat["error_code"] == "INVALID_ARGUMENT"
+        assert flat["status"] == "ok"
+        assert search.queries == ["mission interval", "legacy flat"]
         engine = handler({"action": "manual", "input": {"engine": "duckduckgo"}})
         assert engine["error_code"] == "INVALID_ARGUMENT"
         for legacy_key in ("parameters", "parameter"):

--- a/tests/test_tool_family_generic.py
+++ b/tests/test_tool_family_generic.py
@@ -170,6 +170,47 @@ def test_dispatch_unknown_root_field_fails_with_invalid_argument():
     assert result["error_code"] == "INVALID_ARGUMENT"
 
 
+def test_dispatch_relocates_root_field_that_matches_selected_actions_own_schema_when_absent_from_input():
+    """A root-level key that IS a declared property of the selected action,
+    and is entirely absent from ``input``, is relocated into ``input``
+    rather than rejected — the fix for a calling model leaking its own
+    native flat tool shape (e.g. ``Edit(..., replace_all)``) into an
+    enveloped family's root instead of nesting it under ``input``."""
+    calls: list[dict] = []
+    fam = _widget_family(calls)
+    result = fam.handle({"action": "spin", "input": {}, "speed": 7})
+    assert result["status"] == "ok"
+    assert result["speed"] == 7
+    assert calls == [{"speed": 7}]
+
+
+def test_dispatch_rejects_duplicate_root_field_matching_key_already_in_input():
+    """The relocation exception does NOT cover a root-level key that
+    duplicates a name already present in ``input`` — even with an identical
+    value. Two conflicting-or-redundant places for the same value stays a
+    rejected hygiene violation, unchanged from before."""
+    fam = _widget_family()
+    result = fam.handle({"action": "spin", "input": {"speed": 1}, "speed": 1})
+    assert result["status"] == "failed"
+    assert result["error_code"] == "INVALID_ARGUMENT"
+
+
+def test_dispatch_still_rejects_root_field_belonging_to_a_different_actions_schema():
+    """A root-level key that matches some OTHER child's input property (not
+    the selected action's) is not relocated — the exception is scoped to the
+    selected action's own schema only, so cross-branch keys are still
+    rejected exactly as before."""
+    fam = _widget_family()
+    # "manual_path" belongs to no widget action's input schema at all, and
+    # even a name matching another action's own declared property (there is
+    # none to collide with here, since `manual`'s input schema is empty)
+    # would not be relocated for `spin`'s dispatch — this proves the plain
+    # not-in-any-schema case remains rejected under the new code path too.
+    result = fam.handle({"action": "spin", "input": {"speed": 1}, "manual_path": "/x"})
+    assert result["status"] == "failed"
+    assert result["error_code"] == "INVALID_ARGUMENT"
+
+
 def test_dispatch_rejects_reasoning_or_summarize_leaking_into_input():
     fam = _widget_family()
     result = fam.handle({"action": "spin", "input": {"speed": 1, "summarize": True}})


### PR DESCRIPTION
Fixes #1251

## Problem

`ToolFamily.handle()` validates root fields against the fixed `_ROOT_FIELDS` allowlist (`action`/`input`/`reasoning`/`_reasoning`/`summarize`) and rejects the **entire call** when the calling model places an action-specific optional field at the envelope root instead of nesting it inside `input`. Observed in production as `file(action="edit", input={...}, replace_all=false)` failing 100% with `INVALID_ARGUMENT: unsupported file argument` — but the dispatcher bug is family-agnostic: every family built on `ToolFamily.handle()` (`web`, `mcp`, `knowledge`, `file`, `vision`, `avatar`, `soul`, `shell`, `skills`, `notification`, `system`, `daemon`) shares it for any of their own optional action fields.

## Fix (smallest correct change)

When a root-level key is unknown to the envelope, `handle()` now relocates it into `input` **only if** it is (a) a property declared in the *selected* action's own `input_schema` and (b) entirely absent from `input`. Everything else is rejected exactly as before:

- a root field duplicating a key already present in `input` (even with an identical value) stays rejected — hygiene violation preserved;
- a root field belonging to a *different* action's schema (or to no schema) stays rejected;
- non-object `input` stays rejected with the same message.

The existing `input`-keys validation runs unchanged afterward, so nothing not already declared for this action can reach the child handler. `CONTRACT.md` updated (`contract_version` 1 → 2) since this changes a normatively-documented MUST-level behavior of `handle()`.

## Verification

- Reproduced pre-fix on current `main` (`df2b523d`): `handle({"action": "spin", "input": {}, "speed": 7})` → `failed / INVALID_ARGUMENT / unsupported widget argument` (using the repo's fake `widget` family harness). Post-fix: same payload → `ok`, handler receives `{"speed": 7}`.
- 3 new regression tests in `tests/test_tool_family_generic.py`: relocation-when-absent succeeds; duplicate-with-input-present still rejected; field-not-in-this-action's-schema still rejected.
- Existing strict migration tests (`test_shell_tool_family_migration.py::test_unknown_root_field_and_non_object_input_are_rejected`, same in daemon migration) still pass — their root field duplicates an `input` key and must stay rejected.
- Focused `tool_family`/`file`/`shell` suites: **264 passed** (`test_tool_family_generic.py`, `test_tool_family_generic_summarize_executor.py`, `test_file_tool_family.py`, `test_file_io_sidecar.py`, `test_layers_file.py`, `test_services_file_io.py`, `test_shell_tool_family_migration.py`, `test_tool_family_daemon_migration.py`).
- All remaining `tool_family_*` test files: **380 passed, 3 failed** — the 3 failures are the pre-existing stale-manual-pointer docstring assertions in `test_tool_family_vision_migration.py`, confirmed present on the unmodified baseline (full-suite baseline comparison in progress).

## Notes

No unrelated changes. Single commit `a50a97a4`.
