### PR TITLE
fix(llm): notify agent when overflow recovery terminates after trimming entries

### DIFF
--- a/src/lingtai/kernel/llm/base.py
+++ b/src/lingtai/kernel/llm/base.py
@@ -517,6 +517,40 @@ class ChatSession(ABC):
         )
         self._interface._append("user", [TextBlock(text=notice)])
 
+    def _inject_overflow_notice_after_error(self, exc: Exception) -> None:
+        """Surface the trim on the terminal-failure path, mirroring the notice.
+
+        ``_run_with_overflow_recovery`` attaches ``_overflow_trim_stats`` to
+        the re-raised provider exception when retry rounds were exhausted (or
+        trimming stalled) after entries had already been deleted. Adapters
+        call this from their ``except`` block **after** the ``drop_trailing``
+        revert — the revert would otherwise strip the just-injected
+        user-role notice. No-op when the exception carries no stats, i.e.
+        nothing was trimmed to report.
+        """
+        stats = getattr(exc, "_overflow_trim_stats", None)
+        if not stats:
+            return
+        total_dropped, rounds = stats
+        if total_dropped > 0:
+            self._inject_overflow_notice(total_dropped=total_dropped, rounds=rounds)
+
+    @staticmethod
+    def _attach_overflow_trim_stats(
+        exc: Exception, total_dropped: int, rounds: int,
+    ) -> None:
+        """Best-effort: record trim stats on a re-raised overflow error.
+
+        Provider exception objects normally accept attribute assignment;
+        tolerate anything that does not so recovery behavior is unchanged.
+        """
+        if total_dropped <= 0:
+            return
+        try:
+            exc._overflow_trim_stats = (total_dropped, rounds)
+        except Exception:
+            pass
+
     def _run_with_overflow_recovery(self, do_call):
         """Run an API call with context-overflow auto-recovery.
 
@@ -545,6 +579,10 @@ class ChatSession(ABC):
                         "(dropped %d entries total) — re-raising provider error.",
                         rounds, total_dropped,
                     )
+                    # Entries trimmed in earlier rounds are already deleted;
+                    # record the loss on the exception so adapters can surface
+                    # it after their error-revert step (issue #653).
+                    self._attach_overflow_trim_stats(exc, total_dropped, rounds)
                     raise
                 dropped = self._trim_context_one_round()
                 if dropped == 0:
@@ -553,6 +591,7 @@ class ChatSession(ABC):
                         "(dropped %d entries across %d rounds) — re-raising.",
                         total_dropped, rounds,
                     )
+                    self._attach_overflow_trim_stats(exc, total_dropped, rounds)
                     raise
                 total_dropped += dropped
                 rounds += 1

--- a/src/lingtai/llm/anthropic/adapter.py
+++ b/src/lingtai/llm/anthropic/adapter.py
@@ -395,13 +395,17 @@ class AnthropicChatSession(ChatSession):
 
         try:
             raw, total_dropped, rounds = self._run_with_overflow_recovery(_do_call)
-        except Exception:
+        except Exception as exc:
             # Revert the interface on error - drop the last user entry,
             # but only when this call appended one.  ``message is None``
             # means the caller pre-staged the wire and we must not
             # corrupt it on failure.
             if message is not None:
                 self._interface.drop_trailing(lambda e: e.role == "user")
+            # Terminal overflow failure may already have trimmed entries;
+            # surface the loss after the revert (the revert would strip a
+            # just-injected user-role notice) — issue #653.
+            self._inject_overflow_notice_after_error(exc)
             raise
 
         # If recovery fired (entries were dropped), inject the molt notice.
@@ -515,11 +519,14 @@ class AnthropicChatSession(ChatSession):
 
         try:
             raw_result, total_dropped, rounds = self._run_with_overflow_recovery(_do_stream)
-        except Exception:
+        except Exception as exc:
             # Revert the interface on error — drop the last user entry
             # only if this call appended one.
             if message is not None:
                 self._interface.drop_trailing(lambda e: e.role == "user")
+            # Terminal overflow failure may already have trimmed entries;
+            # surface the loss after the revert (see issue #653).
+            self._inject_overflow_notice_after_error(exc)
             raise
 
         # If recovery fired (entries were dropped), inject the molt notice.

--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -1907,9 +1907,13 @@ class OpenAIChatSession(ChatSession):
 
         try:
             raw, total_dropped, rounds = self._run_with_overflow_recovery(_do_call)
-        except Exception:
+        except Exception as exc:
             if message is not None:
                 self._interface.drop_trailing(lambda e: e.role == "user")
+            # Terminal overflow failure may already have trimmed entries;
+            # surface the loss after the revert (the revert would strip a
+            # just-injected user-role notice).
+            self._inject_overflow_notice_after_error(exc)
             raise
 
         # 3b. If recovery fired (entries were dropped), inject the molt notice.
@@ -2152,9 +2156,12 @@ class OpenAIChatSession(ChatSession):
                             name=(tc.function.name if tc.function else None),
                             args_delta=(tc.function.arguments if tc.function else None),
                         )
-        except Exception:
+        except Exception as exc:
             if message is not None:
                 self._interface.drop_trailing(lambda e: e.role == "user")
+            # Terminal overflow failure may already have trimmed entries;
+            # surface the loss after the revert (see issue #653).
+            self._inject_overflow_notice_after_error(exc)
             raise
 
         # 4. Finalize

--- a/tests/test_openai_overflow_recovery.py
+++ b/tests/test_openai_overflow_recovery.py
@@ -11,6 +11,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import openai
+import pytest
 
 from lingtai.llm.openai.adapter import OpenAIChatSession
 from lingtai.kernel.llm.interface import (
@@ -276,12 +277,51 @@ def test_recovery_gives_up_after_max_rounds():
     def do_call():
         raise _make_overflow_error()
 
+    pre = len(iface._entries)
     try:
         session._run_with_overflow_recovery(do_call)
-    except openai.BadRequestError:
-        pass
+    except openai.BadRequestError as exc:
+        # Earlier-round trims are NOT rolled back on the failure path
+        # (issue #653): history is shorter, and the loss is recorded on
+        # the exception so adapters can surface a notice after their
+        # error-revert step.
+        assert len(iface._entries) < pre
+        total_dropped, rounds = exc._overflow_trim_stats
+        assert rounds == session._OVERFLOW_MAX_ROUNDS
+        assert total_dropped >= rounds  # at least one entry dropped per round
     else:
         raise AssertionError("expected BadRequestError after max rounds")
+
+
+def test_recovery_attaches_trim_stats_when_trim_stalls():
+    """The 'cannot trim further' terminal path also records earlier trims."""
+    iface = ChatInterface()
+    iface.add_system("sys")
+    _seed_history(iface, n_pairs=3)  # few entries: trimming stalls quickly
+    session = _make_session(client=MagicMock(), interface=iface)
+
+    def do_call():
+        raise _make_overflow_error()
+
+    with pytest.raises(openai.BadRequestError) as ei:
+        session._run_with_overflow_recovery(do_call)
+    total_dropped, rounds = ei.value._overflow_trim_stats
+    assert total_dropped > 0
+    assert rounds < session._OVERFLOW_MAX_ROUNDS  # stalled, not max rounds
+
+
+def test_recovery_attaches_no_stats_when_nothing_trimmed():
+    """Untrimmable overflow (system only) records no stats -> no notice."""
+    iface = ChatInterface()
+    iface.add_system("sys")
+    session = _make_session(client=MagicMock(), interface=iface)
+
+    def do_call():
+        raise _make_overflow_error()
+
+    with pytest.raises(openai.BadRequestError) as ei:
+        session._run_with_overflow_recovery(do_call)
+    assert getattr(ei.value, "_overflow_trim_stats", None) is None
 
 
 def test_recovery_reraises_non_overflow_400():
@@ -362,3 +402,95 @@ def test_send_passes_through_when_no_overflow():
                 raise AssertionError("unexpected [kernel] notice in interface")
     # User message was added, assistant reply was recorded — net +2.
     assert len(iface._entries) == pre_len + 2
+
+
+def _always_overflow(**kw):
+    """Side-effect for a client whose every call overflows the context."""
+    raise _make_overflow_error()
+
+
+def _kernel_notices(iface: ChatInterface) -> list[str]:
+    return [
+        b.text
+        for e in iface._entries
+        for b in e.content
+        if isinstance(b, TextBlock) and b.text.startswith("[kernel]")
+    ]
+
+
+def test_send_terminal_overflow_injects_notice_and_persists_trim():
+    """Terminal overflow failure (issue #653): the trimmed entries stay gone,
+    but the agent now learns about the loss via a [kernel] notice instead of
+    a silent re-raise."""
+    iface = ChatInterface()
+    iface.add_system("sys")
+    _seed_history(iface, n_pairs=50)
+
+    client = MagicMock()
+    client.chat.completions.create.side_effect = _always_overflow
+    session = _make_session(client=client, interface=iface)
+
+    pre = len(iface._entries)
+    with pytest.raises(openai.BadRequestError):
+        session.send("brand new question")
+
+    # The pending user message was reverted by the adapter's drop_trailing.
+    texts = [
+        b.text for e in iface._entries for b in e.content
+        if isinstance(b, TextBlock)
+    ]
+    assert "brand new question" not in texts
+    # The recovery trims persist (history is shorter than before the send).
+    assert len(iface._entries) < pre
+    # Exactly one notice about the dropped entries was injected after the
+    # revert (a pre-revert injection would have been stripped).
+    notices = _kernel_notices(iface)
+    assert len(notices) == 1
+    assert "dropped" in notices[0].lower()
+    assert "molt" in notices[0].lower()
+
+
+def test_send_stream_terminal_overflow_injects_notice_and_persists_trim():
+    """Same guarantee on the streaming path."""
+    iface = ChatInterface()
+    iface.add_system("sys")
+    _seed_history(iface, n_pairs=50)
+
+    client = MagicMock()
+    client.chat.completions.create.side_effect = _always_overflow
+    session = _make_session(client=client, interface=iface)
+
+    pre = len(iface._entries)
+    with pytest.raises(openai.BadRequestError):
+        session.send_stream("brand new streamed question")
+
+    texts = [
+        b.text for e in iface._entries for b in e.content
+        if isinstance(b, TextBlock)
+    ]
+    assert "brand new streamed question" not in texts
+    assert len(iface._entries) < pre
+    notices = _kernel_notices(iface)
+    assert len(notices) == 1
+    assert "dropped" in notices[0].lower()
+    assert "molt" in notices[0].lower()
+
+
+def test_send_terminal_overflow_untrimmable_no_notice():
+    """System-only history: nothing can be trimmed, so no loss occurred and
+    no notice is injected — the provider error is re-raised as before."""
+    iface = ChatInterface()
+    iface.add_system("sys")
+
+    client = MagicMock()
+    client.chat.completions.create.side_effect = _always_overflow
+    session = _make_session(client=client, interface=iface)
+
+    with pytest.raises(openai.BadRequestError):
+        session.send("q")
+
+    assert _kernel_notices(iface) == []
+    # System entry only: the pending user message was reverted and nothing
+    # else was touched.
+    assert len(iface._entries) == 1
+    assert iface._entries[0].role == "system"


### PR DESCRIPTION
Fixes #653

## Problem

When context-overflow recovery terminates (all `_OVERFLOW_MAX_ROUNDS` retry rounds exhausted, or `_trim_context_one_round` can no longer drop anything), entries deleted during earlier successful trim rounds stay deleted forever — and the agent never learns that history was trimmed. The `[kernel]` notice (`_inject_overflow_notice`) was only injected on the **success** path; the failure path just re-raised the provider error over a silently shortened history.

## Fix (Option A from the issue)

- `base.py` (`ChatSession._run_with_overflow_recovery`): on terminal failure, best-effort attach `_overflow_trim_stats = (total_dropped, rounds)` to the re-raised provider exception (only when `total_dropped > 0`, nothing to report otherwise).
- New `ChatSession._inject_overflow_notice_after_error(exc)`: reads the attached stats and injects the same `[kernel]` molt-recommendation notice the success path uses. No-op when the exception carries no stats.
- `openai` and `anthropic` adapters (`send` + `send_stream`): call `_inject_overflow_notice_after_error(exc)` in their `except` block **after** the `drop_trailing(lambda e: e.role == "user")` revert — the revert would strip a user-role notice injected before it (the naive fix the issue correctly rejects).

Not touched: `claude_code` / `kimi_code` already roll the canonical history back on failure via `_snapshot_interface()` + `restore()` (their `except` blocks restore the pre-trim entries), so no loss occurs there and no notice is needed.

Behavior after this PR on terminal overflow failure (e.g. system prompt itself exceeds the limit):

1. The provider error is still re-raised (unchanged).
2. The pending user message is still reverted (unchanged).
3. The agent now receives a `[kernel]` notice stating how many oldest entries were dropped and strongly recommending a molt — no more silent history loss.

## Tests

All in `tests/test_openai_overflow_recovery.py` (23 passed, was 18):

- `test_recovery_gives_up_after_max_rounds` — strengthened: asserts history is shorter after terminal failure and the exception carries `_overflow_trim_stats` with `rounds == _OVERFLOW_MAX_ROUNDS` and `total_dropped >= rounds`.
- `test_recovery_attaches_trim_stats_when_trim_stalls` — the "cannot trim further" terminal path also records earlier trims.
- `test_recovery_attaches_no_stats_when_nothing_trimmed` — system-only history: no stats, nothing to report.
- `test_send_terminal_overflow_injects_notice_and_persists_trim` — end-to-end `send()`: error re-raised, pending user message reverted, trims persist, exactly one `[kernel]` notice (with "dropped" and "molt").
- `test_send_stream_terminal_overflow_injects_notice_and_persists_trim` — same guarantee on the streaming path.
- `test_send_terminal_overflow_untrimmable_no_notice` — system-only history: no loss, no notice.

Full suite: `pytest tests/` → 7994 passed, 31 skipped. The 41 failed / 14 error cases are pre-existing environment failures (wheel builds, Windows shims, `claude_code` CLI transport, docs governance) — identical failure set on the pristine baseline (`git stash` comparison: same 5 failures in `test_openai_responses_streaming` / `llm_conversation_input` contracts before and after).

Also manually verified both Anthropic `send` and `send_stream` failure paths: error re-raised with `_overflow_trim_stats=(50, 10)`, exactly one `[kernel]` notice injected, pending message reverted.

## Notes / remaining scope

- The trimmed entries themselves are still not restored on the failure path (that is Option B, snapshot+restore, which the issue flags as needing careful revert semantics; `claude_code`/`kimi_code` already do it). The notice makes the loss non-silent, which is the issue's recommended Option A.
