### PR TITLE
fix(base_agent): isolate post-turn save/inquiry errors in AED loop

### DIFF
--- a/src/lingtai/kernel/base_agent/turn.py
+++ b/src/lingtai/kernel/base_agent/turn.py
@@ -965,24 +965,41 @@ def _run_loop(agent) -> None:
                 except Exception as notif_err:
                     agent._log("idle_notification_check_error",
                                error=str(notif_err))
-            if skip_post_turn_save:
-                agent._log(
-                    "chat_history_save_skipped",
-                    reason="worker_still_running_interface_unsafe",
-                )
-            else:
-                agent._save_chat_history()
-
-            # Auto-insight: fire after N turns
-            if not skip_post_turn_save and agent._config.insights_interval > 0:
-                agent._insight_turn_counter += 1
-                if agent._insight_turn_counter >= agent._config.insights_interval:
-                    agent._insight_turn_counter = 0
-                    from ..i18n import t as _ti
-                    agent._run_inquiry(
-                        _ti(agent._config.language, "insight.auto_question"),
-                        source="auto",
+            # Issue #655: the post-turn section (chat-history save and
+            # auto-insight) sits outside the AED try/except above, so an
+            # exception here (e.g. OSError from a full disk during save) would
+            # propagate out of _run_loop and silently kill the daemon run-loop
+            # thread, leaving the agent unresponsive while status still shows
+            # ACTIVE/IDLE. Log and continue — the next turn retries the save.
+            try:
+                if skip_post_turn_save:
+                    agent._log(
+                        "chat_history_save_skipped",
+                        reason="worker_still_running_interface_unsafe",
                     )
+                else:
+                    agent._save_chat_history()
+
+                # Auto-insight: fire after N turns
+                if not skip_post_turn_save and agent._config.insights_interval > 0:
+                    agent._insight_turn_counter += 1
+                    if agent._insight_turn_counter >= agent._config.insights_interval:
+                        agent._insight_turn_counter = 0
+                        from ..i18n import t as _ti
+                        agent._run_inquiry(
+                            _ti(agent._config.language, "insight.auto_question"),
+                            source="auto",
+                        )
+            except Exception as e:  # noqa: BLE001 — post-turn must never kill the loop
+                agent._log(
+                    "post_turn_error",
+                    exception=type(e).__name__,
+                    error=str(e)[:300],
+                )
+                logger.warning(
+                    f"[{agent.agent_name}] post-turn error "
+                    f"({type(e).__name__}): {str(e)[:300]}",
+                )
 
         break
 

--- a/tests/test_aed_recovery.py
+++ b/tests/test_aed_recovery.py
@@ -527,3 +527,90 @@ def test_tc_wake_error_logs_empty_response_diagnostics(tmp_path):
     assert fields["response_model"] == "gpt-test"
     assert fields["finish_reason"] == "stop"
     assert fields["api_call_id"] == "api_tc"
+
+
+# ---------------------------------------------------------------------------
+# Issue #655: post-turn _save_chat_history / _run_inquiry must never kill the
+# run loop (they sit outside the AED try/except; an uncaught exception there
+# would propagate out of _run_loop and silently kill the daemon thread).
+# ---------------------------------------------------------------------------
+
+
+def _run_loop_with_post_turn_error(tmp_path, monkeypatch, *, save_error=None,
+                                   inquiry_error=None):
+    """Drive one full message turn through _run_loop with an optional
+    post-turn save/inquiry failure, then a second turn that succeeds and
+    sets _shutdown so the loop exits."""
+    agent = _make_run_loop_agent(tmp_path)
+    agent.saves = 0
+    agent.handle_calls = 0
+
+    def fake_handle(_agent, _msg):
+        _agent.handle_calls += 1
+        if _agent.handle_calls == 1:
+            # Queue the second turn from inside the first _handle_message
+            # (a pre-queued MSG_REQUEST would be merged by
+            # _concat_queued_messages instead of becoming its own turn).
+            _agent.inbox.put(_make_message(MSG_REQUEST, "human", "second"))
+        else:
+            _agent._shutdown.set()
+
+    def fake_save(*a, **kw):
+        agent.saves += 1
+        if save_error is not None and agent.saves == 1:
+            raise save_error
+
+    def fake_inquiry(*a, **kw):
+        if inquiry_error is not None:
+            raise inquiry_error
+
+    monkeypatch.setattr(turn, "_handle_message", fake_handle)
+    agent._save_chat_history = fake_save
+    if inquiry_error is not None:
+        agent._config.insights_interval = 1
+        agent._insight_turn_counter = 0
+        agent._run_inquiry = fake_inquiry
+
+    import lingtai.tools.soul.flow as soul_flow
+    monkeypatch.setattr(soul_flow, "_cancel_soul_timer", lambda _a: None)
+
+    turn._run_loop(agent)
+    return agent
+
+
+def test_run_loop_save_error_logged_not_propagated(tmp_path, monkeypatch):
+    """An OSError raised by post-turn _save_chat_history is logged as
+    post_turn_error and must NOT propagate out of _run_loop (which would
+    silently kill the daemon run-loop thread)."""
+    agent = _run_loop_with_post_turn_error(
+        tmp_path, monkeypatch, save_error=OSError("disk full")
+    )
+
+    assert agent.handle_calls == 2  # second message still processed
+    assert agent.saves == 2  # save retried on the next turn
+    assert any(name == "post_turn_error" for name, _ in agent._logs)
+    error_log = next(
+        (fields for name, fields in agent._logs if name == "post_turn_error"),
+        None,
+    )
+    assert error_log is not None
+    assert error_log["exception"] == "OSError"
+    assert "disk full" in error_log["error"]
+
+
+def test_run_loop_inquiry_error_logged_not_propagated(tmp_path, monkeypatch):
+    """An exception raised by post-turn _run_inquiry (auto-insight) is logged
+    as post_turn_error and must NOT propagate out of _run_loop either."""
+    agent = _run_loop_with_post_turn_error(
+        tmp_path, monkeypatch, inquiry_error=RuntimeError("provider down")
+    )
+
+    assert agent.handle_calls == 2
+    assert any(name == "post_turn_error" for name, _ in agent._logs)
+    error_log = next(
+        (fields for name, fields in agent._logs if name == "post_turn_error"),
+        None,
+    )
+    assert error_log is not None
+    assert error_log["exception"] == "RuntimeError"
+    assert "provider down" in error_log["error"]


### PR DESCRIPTION
Fixes #655.

## Problem
After a turn completes, the post-turn section in `_run_loop` (`_save_chat_history()` + auto-insight `_run_inquiry()`) sits at indent 12 inside the AED `while True:` loop but OUTSIDE the AED `try/except Exception` block (indent 16). Any exception there (e.g. `OSError` from a full disk during save) propagates out of `_run_loop` unhandled. The run-loop thread runs with `daemon=True` (lifecycle.py), so it dies silently and the agent becomes permanently unresponsive while status still shows ACTIVE/IDLE.

## Fix
Wrap the post-turn section in its own try/except that logs `post_turn_error` (exception type + truncated message) and continues, so the run loop survives and the next turn retries the save. Preserves the existing `skip_post_turn_save` (worker-still-running) semantics.

## Tests
- `tests/test_aed_recovery.py` -> 15 passed (13 pre-existing + 2 new: `test_run_loop_save_error_logged_not_propagated`, `test_run_loop_inquiry_error_logged_not_propagated`)
- `tests/test_aed_tool_pairing.py tests/test_loop_guard.py tests/test_turn_boundary_housekeeping.py tests/test_cli_worker_poison_recovery.py` -> 16 passed
- `tests/test_tc_inbox_mid_turn_drain.py tests/test_runtime_block_turn_integration.py` -> 19 passed
- Regression validity: with only `turn.py` reverted to main, the 2 new tests fail (injected `OSError`/`RuntimeError` propagate out of `_run_loop`); with the fix they pass and the loop processes the next turn.