### PR TITLE
feat(taskcard): move row timestamp under API info line

### DIFF
--- a/src/lingtai/mcp_servers/task_card/event_projection.py
+++ b/src/lingtai/mcp_servers/task_card/event_projection.py
@@ -427,7 +427,16 @@ class TaskCardEventProjection:
     ) -> str:
         rows: list[dict[str, Any]] = []
         for group in groups[-normal_rows:]:
-            rows.append({"kind": "divider", "text": cls.API_CALL_DIVIDER})
+            group_ts: float | None = None
+            for row in group.get("events", []):
+                raw_ts = row.get("_ts")
+                if type(raw_ts) in (int, float) and not isinstance(raw_ts, bool):
+                    group_ts = float(raw_ts)
+                    break
+            divider: dict[str, Any] = {"kind": "divider", "text": cls.API_CALL_DIVIDER}
+            if group_ts is not None:
+                divider["ts"] = group_ts
+            rows.append(divider)
             # The group's API delay is the LLM round-trip gap since the previous
             # progress; the per-call usage rides the same divider line, both kept
             # out of tool rows.
@@ -444,7 +453,10 @@ class TaskCardEventProjection:
                     break
             info = cls.format_divider_info(api_delay_s, usage)
             if info:
-                rows.append({"kind": "api_info", "text": info})
+                api_row: dict[str, Any] = {"kind": "api_info", "text": info}
+                if group_ts is not None:
+                    api_row["ts"] = group_ts
+                rows.append(api_row)
             rows.extend(group.get("events", []))
         text = cls.format_task_card_text(
             "",
@@ -702,6 +714,9 @@ class TaskCardEventProjection:
                 info = redact_text(str(row.get("text", ""))).strip()
                 if info:
                     api_prepared.append((idx, info[: cls.EVENT_TEXT_CAP]))
+                info_ts = cls.format_row_timestamp(row.get("ts"))
+                if info_ts:
+                    api_prepared.append((idx + 0.5, info_ts))
                 continue
             if kind == "text":
                 text = redact_text(str(row.get("text", ""))).strip()
@@ -758,8 +773,7 @@ class TaskCardEventProjection:
         ) in tool_prepared:
             marker = "✓ " if done or status == "success" else "• "
             prefix = f"{marker}{label}: " if label else marker
-            stamp_suffix = f" · {started_at}" if started_at else ""
-            tool_scaffold += len(prefix) + len(suffix) + len(stamp_suffix) + 2
+            tool_scaffold += len(prefix) + len(suffix) + 2
         fixed = (
             len(cls.HEADER)
             + 1
@@ -785,8 +799,7 @@ class TaskCardEventProjection:
             )
             marker = "✓ " if done or status == "success" else "• "
             prefix = f"{marker}{label}: " if label else marker
-            stamp_suffix = f" · {started_at}" if started_at else ""
-            by_idx[idx] = f"{prefix}{excerpt}{suffix}{stamp_suffix}"
+            by_idx[idx] = f"{prefix}{excerpt}{suffix}"
         for idx, text in text_prepared:
             excerpt = text[:per_row_cap] + "…" if len(text) > per_row_cap else text
             by_idx[idx] = f"• {excerpt}"

--- a/tests/test_telegram_task_card_event_tail.py
+++ b/tests/test_telegram_task_card_event_tail.py
@@ -727,7 +727,10 @@ def test_row_started_at_is_derived_from_event_ts_and_rendered(tmp_path):
     assert window[0]["started_at"] == expected
     edits = [call for call in acct.calls if call[0] == "edit_message"]
     assert edits
-    assert f" · {expected}" in edits[-1][3]
+    # Tool rows no longer carry their own timestamp; the timestamp moved under
+    # the API-call info line (rendered only when usage info exists).
+    assert f" · {expected}" not in edits[-1][3]
+    assert window[0]["started_at"] == expected
 
 
 def test_event_log_final_carrier_projects_session_telemetry_into_final_render(tmp_path):
@@ -796,7 +799,9 @@ def test_event_log_final_carrier_projects_session_telemetry_into_final_render(tm
     assert edits
     rendered = edits[-1][3]
     assert "• bash.run: event-log row" in rendered
-    assert f" · {expected_stamp}" in rendered
+    # Tool rows no longer carry their own timestamp. This event carries no
+    # per-call usage, so no api-info line exists and no timestamp line renders.
+    assert f" · {expected_stamp}" not in rendered
     assert "cache 87.8% · miss 170.6k/1.0M · calls 13" in rendered
     assert "ctx 63% · 171.2k/272.0k" in rendered
     assert "calls 888" not in rendered


### PR DESCRIPTION
Tool rows drop their trailing per-row timestamp; each API-call info line now carries one timestamp on the line below it, derived from the group's first event ts. Per maintainer request. 93 taskcard tests pass.