### PR TITLE
fix(telegram): redact Bot API token from HTTP request URL logs

### DIFF
--- a/src/lingtai/kernel/trace_redaction.py
+++ b/src/lingtai/kernel/trace_redaction.py
@@ -22,6 +22,13 @@ _SECRET_PLACEHOLDER = "<REDACTED:secret>"
 # redacted mechanically before trajectory writes.
 _TOKEN_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     (re.compile(r"\b\d{6,12}:[A-Za-z0-9_-]{30,}\b"), "<REDACTED:telegram_bot_token>"),
+    # Telegram Bot API URLs embed the token in the request path itself
+    # (https://api.telegram.org/bot<id>:<secret>/<method> and the
+    # /file/bot<id>:<secret>/... download form). The generic pattern above
+    # cannot match there: the digit run directly follows "/bot", so the leading
+    # word boundary is missing. Match the URL form explicitly and keep the
+    # "/bot" prefix so the redaction is recognizable in context.
+    (re.compile(r"(/bot)\d{6,12}:[A-Za-z0-9_-]{30,}(?![A-Za-z0-9_-])"), r"\1<REDACTED:telegram_bot_token>"),
     (re.compile(r"\bsk-proj-[A-Za-z0-9_-]{40,}\b"), "<REDACTED:openai_project_key>"),
     (re.compile(r"\bsk-[A-Za-z0-9_-]{20,}\b"), "<REDACTED:api_key>"),
     (re.compile(r"\bghp_[A-Za-z0-9]{30,}\b"), "<REDACTED:github_token>"),

--- a/src/lingtai/mcp_servers/_entrypoint.py
+++ b/src/lingtai/mcp_servers/_entrypoint.py
@@ -4,13 +4,50 @@ Every bundled MCP server's ``__main__.py`` ran the same three steps: configure
 INFO logging to **stderr** (so logs never corrupt the JSON-RPC stdout channel),
 ``asyncio.run(serve())``, and swallow ``KeyboardInterrupt`` on Ctrl-C. This is
 the single copy.
+
+Since INFO logging is enabled for the whole addon process, HTTP client
+libraries (``httpx``/``httpcore``) would otherwise persist full request URLs at
+INFO level. Credential-bearing URL path segments (Telegram Bot API embeds the
+bot token as ``/bot<id>:<secret>/...``) are redacted by a logging filter before
+any handler persists the record.
 """
 from __future__ import annotations
 
 import asyncio
 import logging
+import re
 import sys
 from collections.abc import Awaitable, Callable
+
+
+# Matches the Telegram Bot API URL path segment that embeds the bot token
+# (https://api.telegram.org/bot<id>:<secret>/<method> and the
+# /file/bot<id>:<secret>/... download form). Keeps the "/bot" prefix visible so
+# the redacted record remains recognizable. Mirrors the trajectory redactor in
+# ``lingtai.kernel.trace_redaction``.
+_TELEGRAM_BOT_URL_RE = re.compile(r"(/bot)\d{6,12}:[A-Za-z0-9_-]{30,}(?![A-Za-z0-9_-])")
+_TELEGRAM_BOT_URL_REDACTED = r"\1<REDACTED:telegram_bot_token>"
+
+
+class _HttpUrlCredentialFilter(logging.Filter):
+    """Redact credential-bearing URL path segments from HTTP client logs."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        try:
+            message = record.getMessage()
+        except Exception:
+            return True  # malformed record: leave it to the normal formatter
+        redacted = _TELEGRAM_BOT_URL_RE.sub(_TELEGRAM_BOT_URL_REDACTED, message)
+        if redacted != message:
+            record.msg = redacted
+            record.args = ()
+        return True
+
+
+def _protect_http_loggers() -> None:
+    """Attach the credential-redacting filter to HTTP client loggers."""
+    for name in ("httpx", "httpcore"):
+        logging.getLogger(name).addFilter(_HttpUrlCredentialFilter())
 
 
 def run_stdio_server_main(serve: Callable[[], Awaitable[None]]) -> None:
@@ -21,6 +58,7 @@ def run_stdio_server_main(serve: Callable[[], Awaitable[None]]) -> None:
         format="%(asctime)s %(levelname)s %(name)s %(message)s",
         stream=sys.stderr,
     )
+    _protect_http_loggers()
     try:
         asyncio.run(serve())
     except KeyboardInterrupt:

--- a/tests/test_mcp_server_scaffold.py
+++ b/tests/test_mcp_server_scaffold.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import importlib
 import json
+import logging
 from pathlib import Path
 
 import pytest
@@ -46,6 +47,64 @@ def test_run_stdio_server_main_swallows_keyboard_interrupt(monkeypatch):
     monkeypatch.setattr(_entrypoint.asyncio, "run", boom)
     # Must not propagate — Ctrl-C is a clean shutdown.
     assert _entrypoint.run_stdio_server_main(lambda: None) is None
+
+
+# ---------------------------------------------------------------------------
+# HTTP client credential logging (issue Lingtai-AI/lingtai#680)
+# ---------------------------------------------------------------------------
+
+def test_http_url_credential_filter_redacts_telegram_token():
+    token = "1234567890:" + "A" * 35
+    record = logging.LogRecord(
+        name="httpx",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg=f"HTTP Request: GET https://api.telegram.org/bot{token}/getUpdates",
+        args=(),
+        exc_info=None,
+    )
+    assert _entrypoint._HttpUrlCredentialFilter().filter(record) is True
+    assert token not in record.getMessage()
+    assert "/bot<REDACTED:telegram_bot_token>/getUpdates" in record.getMessage()
+
+
+def test_http_url_credential_filter_passes_ordinary_records(caplog):
+    filt = _entrypoint._HttpUrlCredentialFilter()
+    record = logging.LogRecord(
+        name="httpx",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="HTTP Request: GET https://api.example.com/ping",
+        args=(),
+        exc_info=None,
+    )
+    assert filt.filter(record) is True
+    assert record.getMessage() == "HTTP Request: GET https://api.example.com/ping"
+
+
+def test_run_stdio_server_main_attaches_http_credential_filter():
+    # The entrypoint must attach the filter to httpx/httpcore loggers so HTTP
+    # client INFO lines never reach stderr with a token-bearing URL.
+    _entrypoint._protect_http_loggers()
+    for name in ("httpx", "httpcore"):
+        logger = logging.getLogger(name)
+        assert any(
+            isinstance(f, _entrypoint._HttpUrlCredentialFilter)
+            for f in logger.filters
+        ), name
+
+
+def test_run_stdio_server_main_logs_redact_telegram_urls(caplog):
+    _entrypoint._protect_http_loggers()
+    token = "987654321:" + "B" * 40
+    with caplog.at_level(logging.INFO, logger="httpx"):
+        logging.getLogger("httpx").info(
+            "HTTP Request: GET https://api.telegram.org/bot%s/getUpdates", token
+        )
+    assert token not in caplog.text
+    assert "<REDACTED:telegram_bot_token>" in caplog.text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_trace_redaction.py
+++ b/tests/test_trace_redaction.py
@@ -124,6 +124,58 @@ def test_credential_key_near_words_are_not_redacted():
     assert redact_for_trajectory(event)["tool_args"]["client_id"] == "public-client-identifier"
 
 
+def test_redact_text_telegram_bot_url_forms():
+    # Telegram Bot API embeds the token in the request path itself, so the
+    # generic \b\d{6,12}:... pattern cannot match (no leading word boundary
+    # after "/bot"). The URL form must be redacted explicitly.
+    token = "1234567890:" + "A" * 35
+    api_url = f"https://api.telegram.org/bot{token}/getUpdates"
+    file_url = f"https://api.telegram.org/file/bot{token}/photos/file_1.jpg"
+    for url in (api_url, file_url):
+        redacted = redact_text(url)
+        assert token not in redacted, url
+        assert "/bot<REDACTED:telegram_bot_token>" in redacted, url
+        # The rest of the URL survives so operators can still identify the call.
+        assert redacted.startswith("https://api.telegram.org"), redacted
+
+
+def test_redact_text_telegram_bot_url_form_inside_log_line():
+    token = "987654321:" + "B" * 40
+    line = (
+        '2026-07-18 10:00:00 INFO httpx HTTP Request: '
+        f'GET https://api.telegram.org/bot{token}/getUpdates "HTTP/1.1 200 OK"'
+    )
+    redacted = redact_text(line)
+    assert token not in redacted
+    assert "/bot<REDACTED:telegram_bot_token>/getUpdates" in redacted
+
+
+def test_redact_for_trajectory_telegram_bot_url_in_tool_result():
+    token = "112233445566:" + "C" * 30
+    event = {
+        "type": "tool_result",
+        "result": (
+            "2026-07-18 10:00:00 INFO httpx HTTP Request: "
+            f"POST https://api.telegram.org/bot{token}/setMyCommands"
+        ),
+    }
+    redacted = redact_for_trajectory(event)
+    assert token not in json.dumps(redacted)
+    assert "<REDACTED:telegram_bot_token>" in redacted["result"]
+
+
+def test_redact_text_does_not_mangle_ordinary_urls_or_prose():
+    # Ordinary URLs and prose without token shapes must pass through untouched.
+    ordinary = (
+        "GET https://api.telegram.org/botFather/getMe "
+        "the botched request was dropped"
+    )
+    assert redact_text(ordinary) == ordinary
+    # A short secret below the 30-char confidence floor is left alone.
+    short = "https://api.telegram.org/bot1234567890:short/getUpdates"
+    assert redact_text(short) == short
+
+
 def test_save_chat_history_redacts_persisted_copy_without_mutation(tmp_path):
     svc = MagicMock()
     svc.get_adapter.return_value = MagicMock()


### PR DESCRIPTION
Fixes Lingtai-AI/lingtai#680.

httpx/httpcore emit INFO records carrying the full request URL, and the Telegram Bot API authenticates via a token embedded in the URL path (/bot<id>:<secret>/...). The bundled Telegram addon therefore wrote unredacted bot tokens to the agent log on every ordinary request (getMe, setMyCommands, getUpdates), and the trajectory redactor did not recognize the URL form either, so tool/event logs persisted a second copy.

Changes:
- src/lingtai/mcp_servers/_entrypoint.py: attach a redacting logging filter to the httpx and httpcore loggers in the shared curated-MCP entrypoint, so token-bearing URLs are redacted before any handler persists the record (benefits every bundled addon, not just telegram).
- src/lingtai/kernel/trace_redaction.py: teach the trajectory redactor the Telegram Bot API URL form (/bot<id>:<secret>/... and /file/bot<id>:<secret>/...) so durable tool/event logs never persist the token.
- Tests with synthetic tokens: agent-log records and trajectory redaction both keep the /bot prefix visible while removing the secret; ordinary URLs and short secrets are untouched.

Validation:
- python -m pytest tests/test_trace_redaction.py tests/test_mcp_server_scaffold.py -> 51 passed
- Live httpx reproduction (httpx 0.28.1): INFO line before fix carried the full token URL; after fix it logs https://api.telegram.org/bot<REDACTED:telegram_bot_token>/getUpdates
- Full suite: no new failures vs clean main (2 flaky timing-sensitive tests fail identically on clean main; claude_code adapter env failure pre-existing)