### PR TITLE
fix(kernel): 429 rate-limit retries honor Retry-After/backoff; 4xx client errors fail fast

### DIFF
--- a/src/lingtai/kernel/base_agent/turn.py
+++ b/src/lingtai/kernel/base_agent/turn.py
@@ -115,6 +115,41 @@ _TRANSIENT_MSG_FRAGMENTS = (
     "gateway timeout",
 )
 
+# Issue #593: 429 / quota / rate-limit errors are transient along the *time*
+# axis — the same wire succeeds once the limit resets — so they must be
+# retried with backoff (ideally honoring the ``Retry-After`` header) instead of
+# being funneled through the generic AED path, which retries with no delay and
+# compacts history that has nothing to do with the rate limit.
+_RATE_LIMIT_RETRY_LIMIT = 3
+_RATE_LIMIT_BACKOFF_START_S = 5.0
+_RATE_LIMIT_BACKOFF_MAX_S = 60.0
+_RATE_LIMIT_MSG_FRAGMENTS = (
+    "rate limit",
+    "rate_limit",
+    "rate-limit",
+    "too many requests",
+    "quota",
+    "usage limit",
+    "usage_limit",
+    "usage_limit_reached",
+    "resets_in_seconds",
+    "throttl",
+    "429",
+)
+
+# Deterministic 4xx client errors (excluding 429, which is handled above).
+# A 400/401/403/404-style error means the request itself is wrong on our side:
+# retrying the identical wire is guaranteed to fail again, so the AED branch
+# must only retry when retroactive compaction actually changes the wire.
+_CLIENT_ERROR_MSG_FRAGMENTS = (
+    "bad request",
+    "400 bad request",
+    "messages_parameter_illegal",
+    "invalid request",
+    "invalid parameter",
+    "malformed request",
+)
+
 
 def _exception_status_code(exc: Exception) -> int | None:
     """Best-effort HTTP-ish status extraction across SDK exception shapes."""
@@ -166,7 +201,10 @@ def _is_transient_provider_error(exc: Exception) -> bool:
     The adapter zoo wraps HTTP failures through different SDK exception
     classes.  Prefer explicit status-code handling when present; otherwise
     fall back to stable class names and conservative message fragments.
-    4xx errors (including quota/rate limit) are not treated as transient here.
+    4xx errors (including quota/rate limit) are not treated as transient here:
+    429/rate-limit errors get their own backoff branch (``_is_rate_limit_error``)
+    and deterministic 4xx client errors fail fast in the AED branch
+    (``_is_client_error``) instead of burning retries on an unchanged wire.
     """
     if isinstance(exc, EmptyLLMResponseError):
         return True
@@ -188,6 +226,104 @@ def _is_transient_provider_error(exc: Exception) -> bool:
 
     msg = (str(exc) or "").lower()
     return any(fragment in msg for fragment in _TRANSIENT_MSG_FRAGMENTS)
+
+
+def _is_rate_limit_error(exc: Exception) -> bool:
+    """Return True for provider 429 / quota / rate-limit errors.
+
+    429 is transient along the *time* axis (the same wire succeeds after the
+    limit resets) but must not ride the generic transient branch: it needs
+    backoff (ideally ``Retry-After`` aware) and must never burn AED attempts
+    or compaction on an unchanged wire.  ``_is_transient_provider_error``
+    intentionally excludes all 4xx, so rate limits get their own branch here.
+    """
+    status_code = _exception_status_code(exc)
+    if status_code is not None:
+        return status_code == 429
+    msg = (str(exc) or "").lower()
+    return any(fragment in msg for fragment in _RATE_LIMIT_MSG_FRAGMENTS)
+
+
+def _is_client_error(exc: Exception) -> bool:
+    """Return True for deterministic 4xx client errors (excluding 429).
+
+    400/401/403/404-style errors mean the request itself is wrong on our side.
+    Retrying the identical wire is guaranteed to fail again; the only
+    wire-changing recovery is retroactive compaction, so the AED branch fails
+    fast when compaction has nothing to rewrite.
+    """
+    status_code = _exception_status_code(exc)
+    if status_code is not None:
+        return 400 <= status_code < 500 and status_code != 429
+    msg = (str(exc) or "").lower()
+    return any(fragment in msg for fragment in _CLIENT_ERROR_MSG_FRAGMENTS)
+
+
+def _parse_retry_after(value: object) -> float | None:
+    """Parse a ``Retry-After`` value: delta-seconds or HTTP-date (RFC 7231)."""
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    text = str(value).strip()
+    if not text:
+        return None
+    if text.isdigit():
+        return float(text)
+    try:
+        from datetime import datetime, timezone
+        from email.utils import parsedate_to_datetime
+
+        parsed = parsedate_to_datetime(text)
+        if parsed is not None:
+            delta = (parsed - datetime.now(timezone.utc)).total_seconds()
+            return max(delta, 0.0)
+    except Exception:  # noqa: BLE001 — best-effort parsing, never raise
+        pass
+    return None
+
+
+def _rate_limit_retry_after_seconds(exc: Exception) -> float | None:
+    """Best-effort ``Retry-After`` / ``resets_in_seconds`` extraction.
+
+    The adapter zoo wraps rate-limit failures differently: some SDKs put the
+    header on ``exc.response.headers``, some on ``exc.headers``, OpenAI-style
+    errors carry ``exc.body`` as a dict, and zhipu reports ``resets_in_seconds``
+    in the error payload/string.  All shapes are probed defensively; returns
+    ``None`` when nothing usable is found so the caller falls back to
+    exponential backoff.
+    """
+    for attr in ("retry_after", "retry_after_seconds"):
+        parsed = _parse_retry_after(getattr(exc, attr, None))
+        if parsed is not None:
+            return parsed
+    response = getattr(exc, "response", None)
+    if response is not None:
+        headers = getattr(response, "headers", None)
+        getter = getattr(headers, "get", None)
+        if getter is not None:
+            for key in ("Retry-After", "retry-after", "retry_after"):
+                try:
+                    parsed = _parse_retry_after(getter(key))
+                except Exception:  # noqa: BLE001
+                    parsed = None
+                if parsed is not None:
+                    return parsed
+        body = getattr(exc, "body", None)
+        if isinstance(body, dict):
+            for key in ("retry_after", "retry-after", "Retry-After", "resets_in_seconds"):
+                parsed = _parse_retry_after(body.get(key))
+                if parsed is not None:
+                    return parsed
+    import re
+
+    for key in ("resets_in_seconds", "retry_after", "retry-after"):
+        match = re.search(
+            rf"{re.escape(key)}[\"'=:\s]+(\d+)", str(exc) or "", re.IGNORECASE
+        )
+        if match:
+            return float(match.group(1))
+    return None
 
 
 def _tool_call_summary(tool_calls) -> dict:
@@ -654,6 +790,7 @@ def _run_loop(agent) -> None:
             sleep_state = AgentState.IDLE
             aed_attempts = 0
             transient_attempts = 0
+            rate_limit_attempts = 0
             skip_post_turn_save = False
             while True:
                 try:
@@ -682,9 +819,10 @@ def _run_loop(agent) -> None:
                     # If a prior provider API error was surfaced to the Task Card
                     # this turn, mark it recovered (observe-only/fail-open); a
                     # clean first-attempt turn reported nothing, so this no-ops.
-                    if aed_attempts or transient_attempts:
+                    if aed_attempts or transient_attempts or rate_limit_attempts:
                         _recover_api_error_on_task_card(agent)
                     transient_attempts = 0
+                    rate_limit_attempts = 0
                     break  # success (chat saved after each session.send inside)
                 except Exception as e:
                     from ..llm_utils import WorkerStillRunningError
@@ -788,6 +926,66 @@ def _run_loop(agent) -> None:
                             error=err_desc[:300],
                             exception=type(e).__name__,
                         )
+
+                    # Issue #593: 429 / quota / rate-limit errors are transient
+                    # along the time axis — the same wire succeeds after the
+                    # limit resets.  They must NOT spend AED attempts or
+                    # compaction (which would permanently discard history for
+                    # zero benefit): wait out Retry-After when the provider
+                    # sends it, otherwise exponential backoff, then resend.
+                    if not over_window and _is_rate_limit_error(e):
+                        if rate_limit_attempts < _RATE_LIMIT_RETRY_LIMIT:
+                            rate_limit_attempts += 1
+                            retry_after_s = _rate_limit_retry_after_seconds(e)
+                            if retry_after_s is not None:
+                                backoff_s = min(
+                                    max(retry_after_s, 1.0),
+                                    _RATE_LIMIT_BACKOFF_MAX_S,
+                                )
+                            else:
+                                backoff_s = min(
+                                    _RATE_LIMIT_BACKOFF_START_S
+                                    * (2.0 ** (rate_limit_attempts - 1)),
+                                    _RATE_LIMIT_BACKOFF_MAX_S,
+                                )
+                            if agent._session.chat is not None:
+                                agent._session.chat.interface.close_pending_tool_calls(
+                                    reason=f"rate_limit_retry: {err_desc[:200]}",
+                                    tool_completed=True,
+                                )
+                            agent._log(
+                                "aed_rate_limit_retry",
+                                attempt=rate_limit_attempts,
+                                max_attempts=_RATE_LIMIT_RETRY_LIMIT,
+                                backoff_s=backoff_s,
+                                retry_after_s=retry_after_s,
+                                error=err_desc[:300],
+                            )
+                            logger.warning(
+                                f"[{agent.agent_name}] AED rate-limit retry "
+                                f"{rate_limit_attempts}/{_RATE_LIMIT_RETRY_LIMIT}: {err_desc}",
+                            )
+                            _report_api_error_to_task_card(
+                                agent, e,
+                                attempt=rate_limit_attempts,
+                                max_attempts=_RATE_LIMIT_RETRY_LIMIT,
+                                terminal=False,
+                            )
+                            time.sleep(backoff_s)
+                            msg = _prepare_aed_retry_message(agent, err_desc)
+                            continue
+
+                        # Budget exhausted: the limit has not reset yet.  Retrying
+                        # (or compacting) now would burn quota and destroy history
+                        # for zero benefit — go ASLEEP and wait for refresh/human.
+                        agent._log(
+                            "aed_rate_limit_exhausted",
+                            attempts=rate_limit_attempts,
+                            error=err_desc[:300],
+                        )
+                        sleep_state = AgentState.ASLEEP
+                        agent._asleep.set()
+                        break
 
                     if not over_window and _is_transient_provider_error(e):
                         if transient_attempts < _TRANSIENT_AED_RETRY_LIMIT:
@@ -915,10 +1113,45 @@ def _run_loop(agent) -> None:
                     # the already-shrunk wire.  Over-window errors get a
                     # distinct source tag so AED logs make the cause
                     # auditable.
-                    _compact_history_before_retry(
+                    _compact_stats = _compact_history_before_retry(
                         agent,
                         source="aed_over_window" if over_window else "aed_deterministic",
                     )
+
+                    # Issue #593: a deterministic 4xx client error only becomes
+                    # retryable if the wire actually changes.  When retroactive
+                    # compaction spilled nothing, the rebuilt session ships the
+                    # same bytes and fails the same way — fail fast instead of
+                    # burning the remaining AED budget on guaranteed-to-fail
+                    # retries.  (429 and over-window errors are routed elsewhere.)
+                    if (
+                        not over_window
+                        and _is_client_error(e)
+                        and (
+                            _compact_stats is None
+                            or _compact_stats.compacted_blocks == 0
+                        )
+                    ):
+                        agent._log(
+                            "aed_client_error_noop",
+                            attempts=aed_attempts,
+                            error=err_desc[:300],
+                        )
+                        logger.warning(
+                            f"[{agent.agent_name}] AED client error with no wire "
+                            f"change ({type(e).__name__}); skipping further retries: "
+                            f"{err_desc}",
+                        )
+                        _report_api_error_to_task_card(
+                            agent,
+                            _original_provider_exc,
+                            attempt=aed_attempts,
+                            max_attempts=agent._config.max_aed_attempts,
+                            terminal=True,
+                        )
+                        sleep_state = AgentState.ASLEEP
+                        agent._asleep.set()
+                        break
 
                     # Rebuild session with current config, preserving history
                     if agent._session.chat is not None:

--- a/tests/test_aed_recovery.py
+++ b/tests/test_aed_recovery.py
@@ -527,3 +527,194 @@ def test_tc_wake_error_logs_empty_response_diagnostics(tmp_path):
     assert fields["response_model"] == "gpt-test"
     assert fields["finish_reason"] == "stop"
     assert fields["api_call_id"] == "api_tc"
+
+
+# ---------------------------------------------------------------------------
+# Issue #593: 429 rate-limit backoff (Retry-After aware) and 4xx fail-fast
+# ---------------------------------------------------------------------------
+
+
+class _StatusError(Exception):
+    """Minimal provider-shaped error exposing status_code + optional headers/body."""
+
+    def __init__(self, status_code: int, *, headers=None, body=None, message=None):
+        super().__init__(message or f"HTTP {status_code}")
+        self.status_code = status_code
+        self.response = SimpleNamespace(
+            headers=headers or {},
+            status_code=status_code,
+        )
+        if body is not None:
+            self.body = body
+
+
+def test_rate_limit_classifier():
+    assert turn._is_rate_limit_error(_StatusError(429)) is True
+    assert turn._is_rate_limit_error(_StatusError(400)) is False
+    assert turn._is_rate_limit_error(_StatusError(503)) is False
+    assert turn._is_rate_limit_error(RuntimeError("usage_limit_reached")) is True
+    assert turn._is_rate_limit_error(RuntimeError("rate limit exceeded")) is True
+    assert turn._is_rate_limit_error(RuntimeError("boom")) is False
+
+
+def test_client_error_classifier():
+    assert turn._is_client_error(_StatusError(400)) is True
+    assert turn._is_client_error(_StatusError(401)) is True
+    assert turn._is_client_error(_StatusError(429)) is False
+    assert turn._is_client_error(_StatusError(503)) is False
+    assert turn._is_client_error(RuntimeError("400 bad request")) is True
+    assert turn._is_client_error(RuntimeError("messages_parameter_illegal")) is True
+    assert turn._is_client_error(RuntimeError("boom")) is False
+
+
+def test_retry_after_extraction_shapes():
+    assert turn._rate_limit_retry_after_seconds(
+        _StatusError(429, headers={"Retry-After": "42"})
+    ) == 42.0
+    assert turn._rate_limit_retry_after_seconds(
+        _StatusError(429, headers={"retry-after": "120"})
+    ) == 120.0
+    assert turn._rate_limit_retry_after_seconds(
+        _StatusError(429, body={"resets_in_seconds": 24896})
+    ) == 24896.0
+    err = RuntimeError("usage limit reached; resets_in_seconds: 15")
+    assert turn._rate_limit_retry_after_seconds(err) == 15.0
+    assert turn._rate_limit_retry_after_seconds(_StatusError(429)) is None
+    assert turn._rate_limit_retry_after_seconds(
+        _StatusError(429, headers={"X-Other": "1"})
+    ) is None
+
+
+def test_retry_after_http_date_parsing():
+    from datetime import datetime, timedelta, timezone
+
+    future = datetime.now(timezone.utc) + timedelta(seconds=90)
+    http_date = future.strftime("%a, %d %b %Y %H:%M:%S GMT")
+    parsed = turn._rate_limit_retry_after_seconds(
+        _StatusError(429, headers={"Retry-After": http_date})
+    )
+    assert parsed is not None and 80 <= parsed <= 100
+
+
+def test_rate_limit_error_retries_honoring_retry_after(tmp_path, monkeypatch):
+    agent = _make_run_loop_agent(tmp_path)
+    calls = {"n": 0}
+    sleeps: list[float] = []
+
+    def fake_handle(_agent, _msg):
+        calls["n"] += 1
+        if calls["n"] <= 2:
+            raise _StatusError(429, headers={"Retry-After": "3"})
+        _agent._shutdown.set()
+
+    monkeypatch.setattr(turn, "_handle_message", fake_handle)
+    monkeypatch.setattr(turn.time, "sleep", lambda s: sleeps.append(s))
+
+    import lingtai.tools.soul.flow as soul_flow
+    monkeypatch.setattr(soul_flow, "_cancel_soul_timer", lambda _a: None)
+
+    turn._run_loop(agent)
+
+    assert calls["n"] == 3
+    rate_logs = [f for name, f in agent._logs if name == "aed_rate_limit_retry"]
+    assert len(rate_logs) == 2
+    assert all(f["retry_after_s"] == 3.0 for f in rate_logs)
+    assert all(f["backoff_s"] == 3.0 for f in rate_logs)
+    assert sleeps == [3.0, 3.0]
+    assert not any(name == "aed_attempt" for name, _ in agent._logs)
+    # Rate-limit recovery must not compact history (quota is the problem,
+    # not the wire) and must not consume the transient backoff budget.
+    assert not any(name == "aed_history_compacted" for name, _ in agent._logs)
+    assert not any(name == "aed_transient_retry" for name, _ in agent._logs)
+
+
+def test_rate_limit_error_without_retry_after_uses_exponential_backoff(tmp_path, monkeypatch):
+    agent = _make_run_loop_agent(tmp_path)
+    calls = {"n": 0}
+    sleeps: list[float] = []
+
+    def fake_handle(_agent, _msg):
+        calls["n"] += 1
+        raise _StatusError(429)
+
+    monkeypatch.setattr(turn, "_handle_message", fake_handle)
+    monkeypatch.setattr(turn.time, "sleep", lambda s: sleeps.append(s))
+
+    import lingtai.tools.soul.flow as soul_flow
+    monkeypatch.setattr(soul_flow, "_cancel_soul_timer", lambda _a: _a._shutdown.set())
+
+    turn._run_loop(agent)
+
+    assert calls["n"] == turn._RATE_LIMIT_RETRY_LIMIT + 1
+    rate_logs = [f for name, f in agent._logs if name == "aed_rate_limit_retry"]
+    assert len(rate_logs) == turn._RATE_LIMIT_RETRY_LIMIT
+    assert [f["backoff_s"] for f in rate_logs] == [5.0, 10.0, 20.0]
+    assert [f["retry_after_s"] for f in rate_logs] == [None, None, None]
+    assert sleeps == [5.0, 10.0, 20.0]
+    assert any(name == "aed_rate_limit_exhausted" for name, _ in agent._logs)
+    assert agent._asleep.is_set()
+    assert not any(name == "aed_history_compacted" for name, _ in agent._logs)
+    assert not any(name == "aed_attempt" for name, _ in agent._logs)
+
+
+def test_client_error_fails_fast_when_compaction_cannot_change_wire(tmp_path, monkeypatch):
+    from lingtai.kernel.tool_result_artifacts import CompactionStats
+
+    agent = _make_run_loop_agent(tmp_path)
+    agent._config.max_aed_attempts = 3
+    calls = {"n": 0}
+
+    def fake_handle(_agent, _msg):
+        calls["n"] += 1
+        raise _StatusError(400, message="messages_parameter_illegal")
+
+    monkeypatch.setattr(turn, "_handle_message", fake_handle)
+    monkeypatch.setattr(
+        turn,
+        "_compact_history_before_retry",
+        lambda _agent, *, source: CompactionStats(compacted_blocks=0),
+    )
+
+    import lingtai.tools.soul.flow as soul_flow
+    monkeypatch.setattr(soul_flow, "_cancel_soul_timer", lambda _a: _a._shutdown.set())
+
+    turn._run_loop(agent)
+
+    # One API attempt only: compaction changed nothing, so the remaining AED
+    # budget is not burned on an identical failing wire.
+    assert calls["n"] == 1
+    assert any(name == "aed_client_error_noop" for name, _ in agent._logs)
+    assert any(name == "aed_attempt" and f["attempt"] == 1 for name, f in agent._logs)
+    assert not any(name == "aed_attempt" and f["attempt"] == 2 for name, f in agent._logs)
+    assert agent._asleep.is_set()
+    assert getattr(agent, "rebuilds", 0) == 0
+
+
+def test_client_error_retries_when_compaction_changed_wire(tmp_path, monkeypatch):
+    from lingtai.kernel.tool_result_artifacts import CompactionStats
+
+    agent = _make_run_loop_agent(tmp_path)
+    agent._config.max_aed_attempts = 3
+    calls = {"n": 0}
+
+    def fake_handle(_agent, _msg):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise _StatusError(400, message="messages_parameter_illegal")
+        _agent._shutdown.set()
+
+    monkeypatch.setattr(turn, "_handle_message", fake_handle)
+    monkeypatch.setattr(
+        turn,
+        "_compact_history_before_retry",
+        lambda _agent, *, source: CompactionStats(compacted_blocks=2),
+    )
+
+    import lingtai.tools.soul.flow as soul_flow
+    monkeypatch.setattr(soul_flow, "_cancel_soul_timer", lambda _a: None)
+
+    turn._run_loop(agent)
+
+    assert calls["n"] == 2
+    assert not any(name == "aed_client_error_noop" for name, _ in agent._logs)
+    assert getattr(agent, "rebuilds", 0) == 1


### PR DESCRIPTION
Fixes #593.

## Problem

429 (rate limit) and 400 (bad request) provider errors were both treated as
non-transient and retried through the same generic AED path: no backoff, no
`Retry-After` header respect, and no differentiation between "wait and retry"
(429) vs "do not retry" (400). 429s burned all 3 AED attempts within seconds
(aggravating the shared-key rate limit), and 400s were retried identically up
to 3 times on an unchanged wire.

## Change (`src/lingtai/kernel/base_agent/turn.py`)

1. **New rate-limit branch in the AED loop** (`_is_rate_limit_error`):
   - 429/quota/rate-limit errors retry with backoff, honoring the
     `Retry-After` header (delta-seconds or HTTP-date) when present, falling
     back to exponential backoff 5s \* 2^n capped at 60s otherwise, up to a
     dedicated `_RATE_LIMIT_RETRY_LIMIT` (3).
   - Rate-limit retries **never compact history** (quota is the problem, not
     the wire — compaction permanently discards context for zero benefit).
   - New `aed_rate_limit_retry` / `aed_rate_limit_exhausted` events; when the
     budget is exhausted the agent goes ASLEEP instead of burning AED
     attempts.
2. **Client-error fail-fast in the AED branch** (`_is_client_error`):
   - Deterministic 4xx errors (400/401/403/404..., excluding 429) only retry
     when retroactive compaction actually changed the wire
     (`compacted_blocks > 0` — this preserves the existing
     `messages_parameter_illegal` + compaction recovery, see #613).
   - Otherwise the remaining AED budget is not spent on guaranteed-to-fail
     retries: new `aed_client_error_noop` event + ASLEEP.
3. **`Retry-After` extraction** (`_rate_limit_retry_after_seconds`) covers the
   SDK shapes in the adapter zoo: `exc.retry_after*` attributes, response
   headers, JSON body (`resets_in_seconds`, zhipu-style), and the error
   string as a last resort.

## Tests

8 new regression tests in `tests/test_aed_recovery.py`:

- classifier unit tests (`_is_rate_limit_error`, `_is_client_error`)
- Retry-After extraction across header/body/string/HTTP-date shapes
- run-loop: 429 honors Retry-After (sleeps exactly the header value), no
  compaction, no AED budget spent
- run-loop: 429 without header uses exponential backoff [5, 10, 20] then
  ASLEEP on exhaustion
- run-loop: 400 with no wire change fails fast after 1 attempt (vs 3)
- run-loop: 400 with compaction that changed the wire still retries

Validation:

- `tests/test_aed_recovery.py`: 21 passed (13 pre-existing + 8 new)
- turn/AED-related kernel suites (aed_tool_pairing, runtime_block_turn,
  openai_overflow, tool_result_recovery, turn_boundary_housekeeping,
  tc_inbox_mid_turn_drain, retroactive_history_compaction): **112 passed**
- full suite: 7995 passed / 43 failed / 14 errors — all failures verified
  pre-existing on pristine main (wheel/windows env, docs line-number checks,
  claude_code adapter `tools=None`, flaky email/nudge timing); no failure
  touches kernel/AED paths
- `git diff --check` clean
