### PR TITLE
squash: Telegram gateway + durable receipts + steering lane (rawpaper123 #1211+#1213+#1212)

### DIFF
--- a/src/lingtai/agent.py
+++ b/src/lingtai/agent.py
@@ -119,6 +119,36 @@ def build_agent_config(manifest: dict[str, Any], *, max_rpm: int) -> AgentConfig
         max_aed_attempts=manifest.get(
             "max_aed_attempts", defaults.max_aed_attempts
         ),
+        # Steering block: per-agent steering.enabled (default true for human
+        # channel) plus optional priority channel / budget overrides. The
+        # kernel default channel set applies when steering.priority_channels is
+        # omitted/empty (see lingtai.kernel.steering.DEFAULT_PRIORITY_CHANNELS).
+        steering_enabled=bool(
+            manifest.get("steering", {}).get(
+                "enabled", defaults.steering_enabled
+            )
+        ),
+        steering_priority_channels=tuple(
+            manifest.get("steering", {}).get(
+                "priority_channels", defaults.steering_priority_channels
+            )
+            or ()
+        ),
+        steering_max_turns=int(
+            manifest.get("steering", {}).get(
+                "max_turns", defaults.steering_max_turns
+            )
+        ),
+        steering_timeout_s=float(
+            manifest.get("steering", {}).get(
+                "timeout_s", defaults.steering_timeout_s
+            )
+        ),
+        steering_tail_messages=int(
+            manifest.get("steering", {}).get(
+                "tail_messages", defaults.steering_tail_messages
+            )
+        ),
         max_rpm=max_rpm,
     )
 

--- a/src/lingtai/kernel/base_agent/__init__.py
+++ b/src/lingtai/kernel/base_agent/__init__.py
@@ -1492,6 +1492,20 @@ class BaseAgent:
                     pass
 
         elif self._state == AgentState.ACTIVE:
+            # Preemptive parallel steering: when the active turn is a tool_call
+            # and a high-priority human-channel message is present, dispatch a
+            # bounded steering lane instead of only deferring. The lane replies
+            # on the channel and may write steering_interrupt.json; the main
+            # tool-call await loop honors it at its next safe boundary.
+            # ``getattr`` keeps minimal test stubs (which never set
+            # ``_active_turn_kind``) on the plain deferral path.
+            if getattr(self, "_active_turn_kind", None) == "tool_call":
+                from ..steering import dispatch_steering_lane
+
+                try:
+                    dispatch_steering_lane(self, notifications)
+                except Exception as exc:
+                    self._log("steering_lane_dispatch_error", error=str(exc)[:300])
             # Do not mutate unrelated tool results while a turn is active.
             # Leave the fingerprint uncommitted so the same on-disk
             # notification state is retried once the run loop transitions

--- a/src/lingtai/kernel/base_agent/turn.py
+++ b/src/lingtai/kernel/base_agent/turn.py
@@ -1789,6 +1789,33 @@ def _process_response(agent, response, *, ledger_source: str = "main") -> dict:
         # can carry the post-batch ACTIVE-turn progress meter.
         guard.record_calls(len(response.tool_calls))
 
+        # Steering interrupt boundary: the preemptive steering lane may have
+        # written steering_interrupt.json while the main loop was mid-turn.
+        # At this safe boundary (before dispatching the next tool batch),
+        # abort the current tool call, mark the turn interrupted, and surface
+        # the steering decision to the next turn.
+        from ..steering import check_steering_interrupt, abort_current_tool_call
+
+        steering_interrupt = check_steering_interrupt(agent)
+        if steering_interrupt is not None:
+            if agent._chat is not None and agent._chat.interface.has_pending_tool_calls():
+                agent._chat.interface.close_pending_tool_calls(
+                    reason="steering_interrupt"
+                )
+            abort_current_tool_call(agent, steering_interrupt)
+            agent._save_chat_history()
+            agent._log(
+                "turn_aborted_by_steering",
+                reason=steering_interrupt.get("reason"),
+                run_id=steering_interrupt.get("run_id"),
+            )
+            return {
+                "text": "\n".join(collected_text_parts),
+                "failed": False,
+                "errors": list(collected_errors),
+                "interrupted_by_steering": True,
+            }
+
         # Delegate to ToolExecutor.  The progress notice is batch-scoped: it is
         # visible on this batch's tool results, then cleared before the next LLM
         # response is processed.

--- a/src/lingtai/kernel/config.py
+++ b/src/lingtai/kernel/config.py
@@ -185,6 +185,15 @@ class AgentConfig:
     soul_voice: str = "inner"  # consultation prompt profile — "inner" (terse, "you are the soul, speak as inner voice"), "observer" (structured stepped-back hook framing), or "custom" (use soul_voice_prompt). One unified prompt per profile; the per-fire cue text differentiates insights (current diary) vs past (future-self diary).
     soul_voice_prompt: str = ""  # custom voice prompt — only used when soul_voice == "custom". Set/cleared by the agent via soul(action="voice", set="custom", prompt="..."). Length-capped at SOUL_VOICE_PROMPT_MAX in soul.py.
     snapshot_interval: float | None = None  # seconds between git snapshots; None = off
+    # Preemptive parallel steering (see lingtai.kernel.steering).
+    # steering_enabled defaults True for the human channel: while a turn is
+    # running a tool call, high-priority human-channel messages dispatch a
+    # bounded steering lane instead of only being deferred.
+    steering_enabled: bool = True
+    steering_priority_channels: tuple[str, ...] = ()  # () = kernel default set
+    steering_max_turns: int = 10
+    steering_timeout_s: float = 300.0
+    steering_tail_messages: int = 8
 
     def __post_init__(self):
         # Clamp max_aed_attempts to at least 1.  A value of 0 or negative

--- a/src/lingtai/kernel/steering.py
+++ b/src/lingtai/kernel/steering.py
@@ -1,0 +1,476 @@
+"""Preemptive parallel steering lane.
+
+When a high-priority (human channel) message arrives while the agent is
+mid-tool-call, the kernel dispatches a lightweight STEERING LANE instead of
+only deferring the notification: a bounded, isolated LLM sub-turn seeded with
+the recent conversation tail + the new message + a steering prompt. The lane
+replies on the original channel and may request an interrupt by writing
+``<lane run_dir>/steering_interrupt.json`` ``{reason, by}``; the main
+tool-call await loop checks for that file at a safe boundary and aborts the
+current tool call when present.
+
+Design doc: stations/control-total/work/steering_design.md (control-total).
+"""
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import threading
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+from ._fsutil import atomic_write_json
+
+# Steering lane budget (design: max_turns ~10, timeout ~300s).
+STEERING_MAX_TURNS_DEFAULT = 10
+STEERING_TIMEOUT_S_DEFAULT = 300.0
+STEERING_TAIL_MESSAGES_DEFAULT = 8
+
+# Channels treated as "human" by default: any MCP-hosted chat channel plus the
+# legacy email surface. Configurable per-agent via ``steering.priority_channels``.
+DEFAULT_PRIORITY_CHANNELS = (
+    "mcp.telegram",
+    "mcp.whatsapp",
+    "mcp.wechat",
+    "mcp.feishu",
+    "email",
+)
+
+# Interrupt contract file name inside a steering lane run dir.
+STEERING_INTERRUPT_FILENAME = "steering_interrupt.json"
+
+STEERING_PROMPT = (
+    "You are the agent's steering voice. A human sent a high-priority message "
+    "while the agent is busy running a tool call. Answer the human now, in the "
+    "first person as the agent, concisely and helpfully, using only the recent "
+    "conversation tail and the new message below. Do not start new long-running "
+    "work. If the new message requires stopping or redirecting the agent's "
+    "current work (e.g. an explicit stop/cancel, a security or safety concern, "
+    "or a hard direction change), end your reply with a line containing exactly "
+    "`[INTERRUPT] <reason>`; otherwise end with `[CONTINUE]`. The kernel will "
+    "deliver your text to the original channel."
+)
+
+
+# ---------------------------------------------------------------------------
+# Channel / payload helpers
+# ---------------------------------------------------------------------------
+
+
+def is_priority_human_channel(channel: str, config: Any = None) -> bool:
+    """Return True when *channel* is a steering-eligible human channel."""
+    if not channel:
+        return False
+    priority = tuple(getattr(config, "steering_priority_channels", None) or ())
+    if not priority:
+        priority = DEFAULT_PRIORITY_CHANNELS
+    return channel in priority
+
+
+def extract_message_text(payload: Any) -> str:
+    """Best-effort extraction of human-readable text from a notification payload."""
+    if isinstance(payload, str):
+        return payload
+    if not isinstance(payload, dict):
+        return ""
+    for key in ("text", "message", "body", "content", "caption"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    data = payload.get("data")
+    if isinstance(data, dict):
+        for key in ("text", "message", "body", "content", "caption"):
+            value = data.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        nested = data.get("message")
+        if isinstance(nested, dict):
+            for key in ("text", "message", "body", "content"):
+                value = nested.get(key)
+                if isinstance(value, str) and value.strip():
+                    return value.strip()
+    # Fall back to a compact serialization of the payload.
+    try:
+        dump = json.dumps(payload, ensure_ascii=False, default=str)
+    except Exception:
+        dump = str(payload)
+    return dump[:2000]
+
+
+def _recent_conversation_tail(agent: Any, limit: int) -> str:
+    """Read the last ``limit`` messages of the agent's chat history as text.
+
+    Uses the persisted ``history/chat_history.jsonl`` (defensive; never
+    touches the live session wire). Returns "" when unavailable.
+    """
+    try:
+        history_path = Path(agent.working_dir) / "history" / "chat_history.jsonl"
+    except Exception:
+        return ""
+    if not history_path.is_file():
+        return ""
+    try:
+        lines = history_path.read_text(encoding="utf-8").splitlines()[-limit:]
+    except OSError:
+        return ""
+    out: list[str] = []
+    for line in lines:
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(entry, dict):
+            continue
+        role = entry.get("role") or entry.get("type") or ""
+        content = entry.get("content") or entry.get("text") or ""
+        if isinstance(content, list):
+            parts: list[str] = []
+            for block in content:
+                if isinstance(block, dict):
+                    parts.append(
+                        str(block.get("text") or block.get("content") or "")
+                    )
+            content = "\n".join(p for p in parts if p)
+        if isinstance(content, str) and content.strip():
+            out.append(f"{role}: {content[:500]}")
+    return "\n".join(out[-limit:])
+
+
+# ---------------------------------------------------------------------------
+# Steering lane dispatch
+# ---------------------------------------------------------------------------
+
+
+def _lane_run_dir(agent: Any) -> Path:
+    """Directory that owns steering lane run dirs (mirrors daemons/ layout)."""
+    root = getattr(agent, "working_dir", None) or getattr(agent, "_working_dir", ".")
+    return Path(root) / "daemons"
+
+
+def dispatch_steering_lane(
+    agent: Any,
+    notifications: dict[str, Any],
+    *,
+    runner: Callable | None = None,
+) -> dict | None:
+    """Dispatch one steering lane for the first priority human notification.
+
+    Returns a result dict (``{"status": "dispatched", "run_id": ...,
+    "channel": ...}``) when a lane was spawned, or ``None`` when there is
+    nothing to steer (no eligible channel / steering disabled / lane spawn
+    failed). ``runner`` is an injectable lane body for tests; the default
+    executes the bounded LLM sub-turn (see ``_default_lane_runner``).
+    """
+    if not getattr(agent, "_config", None):
+        return None
+    if not getattr(agent._config, "steering_enabled", True):
+        return None
+    priority = tuple(getattr(agent._config, "steering_priority_channels", None) or ())
+    if not priority:
+        priority = DEFAULT_PRIORITY_CHANNELS
+    # Only steering-eligible (priority human) channels are considered, in the
+    # configured priority order so e.g. mcp.telegram wins over email.
+    ordered = [ch for ch in priority if ch in notifications]
+    ordered += [
+        ch for ch in sorted(notifications.keys())
+        if ch not in priority and is_priority_human_channel(ch, agent._config)
+    ]
+    for channel in ordered:
+        payload = notifications[channel]
+        run_id = f"steer-{secrets.token_hex(4)}"
+        run_dir = _lane_run_dir(agent) / run_id
+        try:
+            run_dir.mkdir(parents=True, exist_ok=False)
+        except OSError:
+            return None
+        seed = {
+            "channel": channel,
+            "message": extract_message_text(payload),
+            "tail": _recent_conversation_tail(
+                agent, getattr(agent._config, "steering_tail_messages", STEERING_TAIL_MESSAGES_DEFAULT)
+            ),
+            "dispatched_at": time.time(),
+            "max_turns": getattr(
+                agent._config, "steering_max_turns", STEERING_MAX_TURNS_DEFAULT
+            ),
+            "timeout_s": getattr(
+                agent._config, "steering_timeout_s", STEERING_TIMEOUT_S_DEFAULT
+            ),
+        }
+        try:
+            atomic_write_json(run_dir / "steering_seed.json", seed)
+            (run_dir / "steering_prompt.txt").write_text(
+                _build_lane_prompt(seed), encoding="utf-8"
+            )
+        except OSError:
+            return None
+        lane_runner = runner or _default_lane_runner
+        thread = threading.Thread(
+            target=_run_lane_safely,
+            args=(agent, run_dir, seed, lane_runner),
+            name=f"steering-{run_id}",
+            daemon=True,
+        )
+        thread.start()
+        try:
+            agent._log("steering_lane_dispatched", run_id=run_id, channel=channel)
+        except Exception:
+            pass
+        return {"status": "dispatched", "run_id": run_id, "channel": channel}
+    return None
+
+
+def _build_lane_prompt(seed: dict) -> str:
+    tail = seed.get("tail") or "(no recent conversation available)"
+    message = seed.get("message") or "(no message text available)"
+    return (
+        f"{STEERING_PROMPT}\n\n"
+        f"Recent conversation tail:\n{tail}\n\n"
+        f"New high-priority message (channel {seed.get('channel')}):\n{message}\n"
+    )
+
+
+def _run_lane_safely(agent: Any, run_dir: Path, seed: dict, runner: Callable) -> None:
+    """Run the lane body with a bounded timeout; never raise into the agent."""
+    try:
+        runner(agent, run_dir, seed)
+    except Exception as exc:
+        try:
+            agent._log("steering_lane_error", run_id=run_dir.name, error=str(exc)[:300])
+        except Exception:
+            pass
+        try:
+            atomic_write_json(
+                run_dir / "steering_result.json",
+                {"status": "error", "error": str(exc)[:500]},
+            )
+        except OSError:
+            pass
+
+
+def _resolve_llm_service_class():
+    """Lazily resolve the LLMService class (kept out of import time to avoid
+    kernel/tools import cycles; overridable seam for tests)."""
+    from lingtai.llm.service import LLMService
+
+    return LLMService
+
+
+def _default_lane_runner(agent: Any, run_dir: Path, seed: dict) -> None:
+    """Bounded LLM sub-turn: answer + optional interrupt decision.
+
+    Builds an isolated session off the agent's LLM service (same provider
+    config, no shared wire), sends the seeded steering prompt, writes the
+    reply into the run dir, delivers it on the original channel, and requests
+    an interrupt when the model's reply carries the ``[INTERRUPT]`` marker.
+    """
+    LLMService = _resolve_llm_service_class()
+
+    service = getattr(agent, "service", None)
+    if service is None:
+        raise RuntimeError("agent has no LLM service; steering lane cannot run")
+    provider = getattr(service, "provider", None)
+    model = getattr(service, "model", None)
+    api_key = getattr(service, "api_key", None)
+    base_url = getattr(service, "base_url", None)
+    llm = LLMService(
+        provider=provider,
+        model=model,
+        api_key=api_key,
+        base_url=base_url,
+        context_window=getattr(service, "context_window", None),
+    )
+    session = llm.create_session(
+        system_prompt=STEERING_PROMPT,
+        tools=None,
+        model=model,
+        thinking="default",
+        tracked=False,
+    )
+    prompt = (run_dir / "steering_prompt.txt").read_text(encoding="utf-8")
+    deadline = time.monotonic() + float(seed.get("timeout_s") or STEERING_TIMEOUT_S_DEFAULT)
+    response = session.send(prompt, timeout=max(1.0, deadline - time.monotonic()))
+    reply = getattr(response, "text", None) or ""
+    atomic_write_json(
+        run_dir / "steering_result.json",
+        {"status": "done", "reply": reply, "finished_at": time.time()},
+    )
+    interrupt_reason = _interrupt_reason_from_reply(reply)
+    if interrupt_reason:
+        atomic_write_json(
+            run_dir / STEERING_INTERRUPT_FILENAME,
+            {"reason": interrupt_reason, "by": "steering_lane"},
+        )
+    deliver_steering_reply(agent, seed.get("channel"), seed.get("message"), reply)
+
+
+def _interrupt_reason_from_reply(reply: str) -> str | None:
+    """Extract the ``[INTERRUPT] <reason>`` decision from the lane reply."""
+    if not reply:
+        return None
+    for line in reply.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("[INTERRUPT]"):
+            reason = stripped[len("[INTERRUPT]"):].strip()
+            return reason or "steering requested interruption"
+    return None
+
+
+def deliver_steering_reply(agent: Any, channel: str, message: str, reply: str) -> None:
+    """Deliver the lane's reply on the original channel (best effort).
+
+    Order of attempts:
+    1. ``agent._steering_reply_hook`` if set (test seam / station bridge).
+    2. The agent's telegram MCP client ``send`` action when channel is
+       ``mcp.telegram`` and a client is registered.
+    3. Durable ``steering_reply.txt`` in the lane run dir + event log.
+    """
+    if not reply:
+        return
+    hook = getattr(agent, "_steering_reply_hook", None)
+    if callable(hook):
+        try:
+            hook(channel, message, reply)
+            return
+        except Exception:
+            pass
+    if channel == "mcp.telegram":
+        client = None
+        try:
+            client = getattr(agent, "_mcp_clients_by_tool", {}).get("telegram")
+        except Exception:
+            client = None
+        if client is not None and hasattr(client, "call_tool"):
+            try:
+                client.call_tool(
+                    "telegram",
+                    {"action": "send", "chat_id": None, "text": reply},
+                )
+                return
+            except Exception:
+                pass
+    try:
+        atomic_write_json(
+            Path(agent.working_dir) / "daemons" / "steering_reply.txt",
+            {"channel": channel, "reply": reply, "ts": time.time()},
+        )
+        agent._log("steering_reply_stored", channel=channel, chars=len(reply))
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Interrupt contract (checked by the main tool-call await loop)
+# ---------------------------------------------------------------------------
+
+
+def iter_steering_interrupts(agent: Any):
+    """Yield ``(run_dir, interrupt_dict)`` for every unconsumed interrupt file."""
+    root = _lane_run_dir(agent)
+    if not root.is_dir():
+        return
+    for run_dir in sorted(root.glob("steer-*")):
+        target = run_dir / STEERING_INTERRUPT_FILENAME
+        if not target.is_file():
+            continue
+        try:
+            interrupt = json.loads(target.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(interrupt, dict):
+            yield run_dir, interrupt
+
+
+def check_steering_interrupt(agent: Any) -> dict | None:
+    """Return the first pending steering interrupt and consume it.
+
+    Called by the main tool-call await loop at a safe boundary. Consuming
+    renames the file to ``<name>.consumed`` so a single interrupt fires once.
+    """
+    for run_dir, interrupt in iter_steering_interrupts(agent):
+        target = run_dir / STEERING_INTERRUPT_FILENAME
+        try:
+            target.rename(target.with_name(target.name + ".consumed"))
+        except OSError:
+            pass
+        interrupt.setdefault("run_id", run_dir.name)
+        return interrupt
+    return None
+
+
+def abort_current_tool_call(agent: Any, interrupt: dict) -> None:
+    """Abort the current tool call at the safe boundary.
+
+    Marks the turn interrupted, cancels the executor, kills any tracked tool
+    child process tree (Windows: ``taskkill /T /F``), and enqueues the
+    steering message for the next turn.
+    """
+    try:
+        agent._cancel_event.set()
+    except Exception:
+        pass
+    _kill_tracked_tool_process_tree(agent)
+    try:
+        agent._log(
+            "turn_interrupted_by_steering",
+            run_id=interrupt.get("run_id"),
+            reason=interrupt.get("reason"),
+        )
+        agent._active_turn_kind = "interrupted"
+    except Exception:
+        pass
+    _enqueue_steering_message(agent, interrupt)
+
+
+def _kill_tracked_tool_process_tree(agent: Any) -> None:
+    """Kill the current tool's child process tree if the executor tracks one."""
+    pid = None
+    try:
+        pid = getattr(agent, "_steering_current_tool_pid", None)
+    except Exception:
+        pid = None
+    if not pid:
+        return
+    if os.name == "nt":
+        _taskkill_tree_windows(pid)
+    else:
+        try:
+            os.killpg(pid, 9)  # type: ignore[attr-defined]
+        except (AttributeError, OSError):
+            try:
+                os.kill(pid, 9)
+            except OSError:
+                pass
+
+
+def _taskkill_tree_windows(pid: int) -> None:
+    import subprocess
+
+    try:
+        subprocess.run(
+            ["taskkill", "/T", "/F", "/PID", str(pid)],
+            capture_output=True,
+            timeout=15,
+        )
+    except Exception:
+        pass
+
+
+def _enqueue_steering_message(agent: Any, interrupt: dict) -> None:
+    """Surface the steering decision to the next agent turn."""
+    from .message import MSG_REQUEST, _make_message
+
+    reason = interrupt.get("reason") or "steering requested interruption"
+    text = (
+        "[steering] A high-priority message required interrupting your previous "
+        f"turn. Steering reason: {reason}. Re-read the steering lane run dir "
+        f"({interrupt.get('run_id')}) and the pending channel message before "
+        "continuing."
+    )
+    try:
+        agent.inbox.put(_make_message(MSG_REQUEST, "system", text))
+        agent._wake_nap("steering_interrupt")
+    except Exception:
+        pass

--- a/src/lingtai/mcp_servers/telegram/account.py
+++ b/src/lingtai/mcp_servers/telegram/account.py
@@ -198,7 +198,8 @@ class TelegramAccount:
         self._last_update_id: int = 0
         self._bot_info: dict | None = None
         self._last_verified_at: str | None = None
-        self._client: httpx.Client | None = None
+        self._outbound_client: httpx.Client | None = None
+        self._poll_client: httpx.Client | None = None
 
         # Resident Task Card message id per chat: {chat_id_str: compound_id}.
         # Exactly one card stays resident per (account, chat) and ordinary frames
@@ -225,6 +226,15 @@ class TelegramAccount:
 
         self._load_state()
 
+    @property
+    def _client(self) -> httpx.Client | None:
+        """Compatibility alias for existing test doubles and callers."""
+        return self._outbound_client
+
+    @_client.setter
+    def _client(self, value: httpx.Client | None) -> None:
+        self._outbound_client = value
+
     # -- API helpers ---------------------------------------------------------
 
     def _api_url(self, method: str) -> str:
@@ -233,19 +243,22 @@ class TelegramAccount:
     def _file_url(self, file_path: str) -> str:
         return _FILE_BASE.format(token=self._bot_token, file_path=file_path)
 
-    def _ensure_client(self) -> None:
-        """Lazy-import httpx and create client on first use."""
+    def _ensure_client(self, *, polling: bool = False) -> None:
+        """Create only the client needed by this request."""
         global httpx
+        target = "_poll_client" if polling else "_outbound_client"
+        if getattr(self, target) is not None:
+            return
         if httpx is None or isinstance(httpx, type(None)):
             import httpx as _httpx
             httpx = _httpx
-        if self._client is None:
-            self._client = httpx.Client(timeout=httpx.Timeout(60.0, connect=10.0))
+        setattr(self, target, httpx.Client(timeout=httpx.Timeout(60.0, connect=10.0)))
 
     def _request(self, method: str, **kwargs: Any) -> dict:
         """Make one Bot API request. Returns the result or raises immediately."""
-        self._ensure_client()
-        resp = self._client.post(self._api_url(method), **kwargs)
+        self._ensure_client(polling=method == "getUpdates")
+        client = self._poll_client if method == "getUpdates" else self._outbound_client
+        resp = client.post(self._api_url(method), **kwargs)
         if resp.status_code == 429:
             try:
                 data = resp.json()
@@ -312,9 +325,11 @@ class TelegramAccount:
         if self._poll_thread is not None:
             self._poll_thread.join(timeout=5.0)
             self._poll_thread = None
-        if self._client is not None:
-            self._client.close()
-            self._client = None
+        for name in ("_outbound_client", "_poll_client"):
+            client = getattr(self, name)
+            if client is not None:
+                client.close()
+                setattr(self, name, None)
 
     # -- Polling -------------------------------------------------------------
 
@@ -355,9 +370,6 @@ class TelegramAccount:
     def _process_update(self, update: dict) -> None:
         """Process a single update — filter, dispatch, track offset."""
         update_id = update.get("update_id", 0)
-        if update_id > self._last_update_id:
-            self._last_update_id = update_id
-            self._save_state()
 
         if "message" in update:
             # A plain message is a new bottom message in the chat; record it so a
@@ -385,14 +397,23 @@ class TelegramAccount:
         # boundary with their uncertainty recorded on the envelope.
         actor = tg_updates.resolve_update_actor(update)
         if not tg_updates.is_admitted(actor, self._allowed_users):
+            self._commit_update(update_id)
             return
 
         # Intercept slash commands before they reach the agent
         if self._handle_slash_command(update):
+            self._commit_update(update_id)
             return
 
         if self._on_message:
             self._on_message(self.alias, update)
+        self._commit_update(update_id)
+
+    def _commit_update(self, update_id: object) -> None:
+        """Advance the durable offset only after handling succeeds."""
+        if type(update_id) is int and update_id > self._last_update_id:
+            self._last_update_id = update_id
+            self._save_state()
 
     def _handle_slash_command(self, update: dict) -> bool:
         """Handle slash commands locally (no LLM call). Returns True if handled."""
@@ -1175,9 +1196,8 @@ class TelegramAccount:
         file_path = file_info["file_path"]
         filename = Path(file_path).name
         url = self._file_url(file_path)
-        if self._client is None:
-            self._client = httpx.Client(timeout=httpx.Timeout(60.0, connect=10.0))
-        resp = self._client.get(url)
+        self._ensure_client()
+        resp = self._outbound_client.get(url)
         resp.raise_for_status()
         return filename, resp.content
 

--- a/src/lingtai/mcp_servers/telegram/bus.py
+++ b/src/lingtai/mcp_servers/telegram/bus.py
@@ -1,0 +1,235 @@
+"""SQLite WAL command bus between agent-side proxies and the Gateway owner.
+
+Proxy-mode ``TelegramManager`` instances (one per station) never touch the
+Telegram network: every outbound call is serialized into a gateway command and
+submitted through this bus. The single-process Gateway is the sole consumer:
+it claims pending commands one at a time, dispatches them through
+``GatewayCommandRouter``, and writes the result back.
+
+Why SQLite (WAL) and not an in-memory list:
+
+- Agent host and Gateway host are separate processes that share one bus file
+  per station (``<agent_dir>/telegram/gateway.sqlite3`` by default).
+- A submission is durable the moment it is inserted; pending commands survive
+  a Gateway restart (``reset_stale`` re-opens any row a dead owner left in
+  ``running`` state — the single-owner invariant makes every ``running`` row
+  stale on startup).
+- ``claim`` is a single atomic ``UPDATE ... RETURNING`` so exactly one
+  consumer ever executes one command, and the agent's bounded wait reads back
+  exactly the result that consumer wrote.
+
+Test doubles may keep using a plain ``list`` sink; production code paths use
+this module only.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+_STATE_PENDING = "pending"
+_STATE_RUNNING = "running"
+_STATE_DONE = "done"
+
+# Agent-side bounded wait for a gateway result; the command stays queued when
+# it expires so a restart can still execute it (never silently dropped).
+_DEFAULT_SUBMIT_TIMEOUT = 30.0
+# Both sides poll at a small interval; SQLite WAL keeps readers lock-free.
+_POLL_INTERVAL = 0.02
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS gateway_commands (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    method TEXT NOT NULL,
+    params TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending', 'running', 'done')),
+    result TEXT,
+    created_at REAL NOT NULL,
+    claimed_at REAL,
+    completed_at REAL
+)
+"""
+_INDEX_SQL = (
+    "CREATE INDEX IF NOT EXISTS idx_gateway_commands_pending "
+    "ON gateway_commands (status, id)"
+)
+
+
+class SqliteCommandBus:
+    """Durable, single-owner command queue backed by one SQLite WAL database.
+
+    Agent side: :meth:`submit` inserts one command and blocks until the owner
+    completes it (bounded by ``timeout``).
+    Gateway side (single owner): :meth:`claim` atomically moves the oldest
+    pending command to ``running``; :meth:`complete` writes back the JSON
+    result; :meth:`reset_stale` re-opens rows left behind by a dead owner.
+    """
+
+    def __init__(self, db_path: Path | str) -> None:
+        self._path = Path(db_path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(str(self._path), check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        self._lock = threading.RLock()
+        self._closed = False
+        with self._lock:
+            with self._conn:
+                self._conn.execute("PRAGMA journal_mode=WAL")
+                self._conn.execute("PRAGMA busy_timeout=10000")
+                self._conn.execute(_SCHEMA)
+                self._conn.execute(_INDEX_SQL)
+
+    # -- Agent side ------------------------------------------------------------
+
+    def submit(
+        self,
+        command: dict[str, Any],
+        *,
+        timeout: float = _DEFAULT_SUBMIT_TIMEOUT,
+    ) -> Any:
+        """Insert one command and wait (bounded) for the gateway result.
+
+        Returns the JSON-decoded result the gateway owner wrote back, or an
+        error dict when the wait expires (the command remains queued and a
+        Gateway restart will still execute it).
+        """
+        if not isinstance(command, dict):
+            return {"status": "error", "error": "command must be an object"}
+        method = command.get("method")
+        params = command.get("params")
+        if not isinstance(method, str) or not isinstance(params, dict):
+            return {"status": "error", "error": "command needs 'method' and 'params'"}
+        with self._lock:
+            if self._closed:
+                return {"status": "error", "error": "command bus is closed"}
+            with self._conn:
+                cur = self._conn.execute(
+                    "INSERT INTO gateway_commands "
+                    "(method, params, status, created_at) VALUES (?, ?, ?, ?)",
+                    (method, json.dumps(params, default=str), _STATE_PENDING, time.time()),
+                )
+                command_id = int(cur.lastrowid)
+        deadline = time.monotonic() + timeout
+        while True:
+            result = self._result(command_id)
+            if result is not None:
+                return result
+            if time.monotonic() >= deadline:
+                log.warning(
+                    "gateway command %s (%s) timed out after %.1fs; still queued",
+                    command_id, method, timeout,
+                )
+                return {
+                    "status": "error",
+                    "error": "gateway command timed out; it remains queued",
+                    "command_id": command_id,
+                    "method": method,
+                }
+            time.sleep(_POLL_INTERVAL)
+
+    def _result(self, command_id: int) -> Any | None:
+        """Return the completed result for one command, or ``None`` if pending."""
+        with self._lock:
+            if self._closed:
+                return None
+            row = self._conn.execute(
+                "SELECT status, result FROM gateway_commands WHERE id = ?",
+                (command_id,),
+            ).fetchone()
+        if row is None or row["status"] != _STATE_DONE:
+            return None
+        try:
+            return json.loads(row["result"]) if row["result"] is not None else None
+        except (TypeError, ValueError):
+            return None
+
+    # -- Gateway side (single owner) -------------------------------------------
+
+    def claim(self) -> tuple[int, dict[str, Any]] | None:
+        """Atomically claim the oldest pending command.
+
+        Returns ``(command_id, command)`` or ``None`` when nothing is pending.
+        The atomic ``UPDATE ... RETURNING`` guarantees exactly one consumer
+        ever executes one command, even with multiple gateway threads or
+        processes attached to the same file.
+        """
+        with self._lock:
+            if self._closed:
+                return None
+            with self._conn:
+                row = self._conn.execute(
+                    """
+                    UPDATE gateway_commands
+                    SET status = 'running', claimed_at = ?
+                    WHERE id = (
+                        SELECT id FROM gateway_commands
+                        WHERE status = 'pending' ORDER BY id LIMIT 1
+                    )
+                    RETURNING id, method, params
+                    """,
+                    (time.time(),),
+                ).fetchone()
+        if row is None:
+            return None
+        command_id = int(row["id"])
+        try:
+            params = json.loads(row["params"])
+        except (TypeError, ValueError):
+            params = {}
+        return command_id, {"method": row["method"], "params": params}
+
+    def complete(self, command_id: int, result: Any) -> None:
+        """Write back the gateway result for one claimed command."""
+        with self._lock:
+            with self._conn:
+                self._conn.execute(
+                    """
+                    UPDATE gateway_commands
+                    SET status = 'done', result = ?, completed_at = ?
+                    WHERE id = ? AND status = 'running'
+                    """,
+                    (json.dumps(result, default=str), time.time(), command_id),
+                )
+
+    def reset_stale(self) -> int:
+        """Re-open every ``running`` row left by a dead Gateway owner.
+
+        The single-owner invariant makes this safe: only the one Gateway
+        consumes a bus, so at startup any ``running`` row is stale by
+        definition. Returns the number of rows re-opened.
+        """
+        with self._lock:
+            with self._conn:
+                cur = self._conn.execute(
+                    "UPDATE gateway_commands SET status = 'pending', claimed_at = NULL "
+                    "WHERE status = 'running'"
+                )
+                return int(cur.rowcount)
+
+    def pending_count(self) -> int:
+        """Number of commands waiting to be claimed (never raises when open)."""
+        with self._lock:
+            if self._closed:
+                return 0
+            row = self._conn.execute(
+                "SELECT COUNT(*) AS n FROM gateway_commands WHERE status = 'pending'",
+            ).fetchone()
+        return int(row["n"]) if row is not None else 0
+
+    def close(self) -> None:
+        """Close the underlying connection; idempotent."""
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+            try:
+                self._conn.close()
+            except sqlite3.Error:
+                pass

--- a/src/lingtai/mcp_servers/telegram/gateway.py
+++ b/src/lingtai/mcp_servers/telegram/gateway.py
@@ -1,0 +1,471 @@
+"""Gateway/proxy mode: one gateway-owned Telegram transport for stations.
+
+The gateway process owns polling and outbound Bot API calls for every
+configured station by reusing the standalone ``TelegramService``/account
+machinery. Agent-side stations run in proxy mode
+(``lingtai.mcp_servers.telegram.proxy.TelegramGatewayProxy``): they queue
+commands into a sink and never call ``getUpdates`` or construct a network
+client.
+
+The gateway manifest is free of secrets: it only names each station and
+references that station's existing configuration path (which holds the bot
+tokens). ``load_gateway_manifest`` rejects any manifest that tries to carry
+inline secret material.
+
+``run_gateway`` builds a complete ``TelegramManager`` + ``TelegramService``
+per manifest station (not a bare service) and returns a ``GatewayHost`` whose
+``stop()`` closes every manager and command bus. Each manager delivers inbound
+updates to the correct Agent via
+``lingtai.services.mcp_licc.push_inbox_event(..., agent_dir=<station>,
+mcp_name='telegram')`` and uses that station's ``agent_dir`` with a
+``PosixNotificationStoreAdapter``, so resident Task Card state, receipts, and
+the event tail stay per-station.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from pathlib import Path
+from typing import Any, Callable, Iterable
+
+from lingtai.adapters.posix.notification_store import PosixNotificationStoreAdapter
+from lingtai.services.mcp_licc import push_inbox_event
+
+from .bus import SqliteCommandBus
+
+log = logging.getLogger(__name__)
+
+# Keys that are never allowed inside the gateway manifest (secrets-free).
+_FORBIDDEN_MANIFEST_KEYS = frozenset({
+    "bot_token", "token", "api_key", "api_token", "access_token",
+    "secret", "password", "oauth",
+})
+
+# Default per-station command bus file (relative to the station agent_dir).
+_DEFAULT_BUS_FILENAME = "gateway.sqlite3"
+
+
+class GatewayManifestError(ValueError):
+    """Raised when a gateway manifest is malformed or carries secrets."""
+
+
+def load_gateway_manifest(manifest_path: Path | str) -> list[dict[str, Any]]:
+    """Load and validate a secrets-free gateway manifest.
+
+    Schema:
+
+    .. code-block:: json
+
+        {
+          "stations": [
+            {"name": "control-total", "config": "<absolute-or-relative config path>"}
+          ]
+        }
+
+    Returns the normalized station list with absolute config paths. Raises
+    ``GatewayManifestError`` for malformed manifests, unknown top-level keys,
+    or any attempt to embed secret material.
+    """
+    path = Path(manifest_path)
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise GatewayManifestError(f"cannot read gateway manifest {path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise GatewayManifestError(f"invalid gateway manifest JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise GatewayManifestError("gateway manifest must be a JSON object")
+    unknown = set(data) - {"stations"}
+    if unknown:
+        raise GatewayManifestError(f"unknown gateway manifest keys: {sorted(unknown)}")
+    forbidden = set(data) & _FORBIDDEN_MANIFEST_KEYS
+    if forbidden:
+        raise GatewayManifestError(
+            f"gateway manifest must stay secrets-free; remove {sorted(forbidden)}"
+        )
+    stations = data.get("stations")
+    if not isinstance(stations, list) or not stations:
+        raise GatewayManifestError("gateway manifest needs a non-empty 'stations' list")
+
+    base = path.parent
+    normalized: list[dict[str, Any]] = []
+    for index, station in enumerate(stations):
+        if not isinstance(station, dict):
+            raise GatewayManifestError(f"stations[{index}] must be an object")
+        forbidden = set(station) & _FORBIDDEN_MANIFEST_KEYS
+        if forbidden:
+            raise GatewayManifestError(
+                f"stations[{index}] must stay secrets-free; remove {sorted(forbidden)}"
+            )
+        name = station.get("name")
+        config = station.get("config")
+        if not isinstance(name, str) or not name.strip():
+            raise GatewayManifestError(f"stations[{index}] needs a 'name'")
+        if not isinstance(config, str) or not config.strip():
+            raise GatewayManifestError(f"stations[{index}] needs a 'config' path")
+        config_path = Path(config)
+        if not config_path.is_absolute():
+            config_path = base / config_path
+        agent_dir = station.get("agent_dir")
+        if agent_dir is not None and not isinstance(agent_dir, str):
+            raise GatewayManifestError(f"stations[{index}].agent_dir must be a path string")
+        normalized.append(
+            {
+                "name": name.strip(),
+                "config": str(config_path),
+                "agent_dir": str(agent_dir) if agent_dir else str(config_path.parent),
+            }
+        )
+    return normalized
+
+
+def _load_station_config(config_path: Path) -> list[dict[str, Any]]:
+    try:
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise GatewayManifestError(f"cannot read station config {config_path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise GatewayManifestError(f"station config {config_path} must be an object")
+    accounts = data.get("accounts")
+    if not isinstance(accounts, list) or not accounts:
+        raise GatewayManifestError(f"station config {config_path} needs 'accounts'")
+    return accounts
+
+
+def _read_gateway_marker(agent_dir: Path) -> dict | None:
+    """Read the optional ``<agent_dir>/telegram/gateway.json`` marker (proxy mode).
+
+    The marker may carry a ``"bus"`` path (absolute or relative to the
+    agent_dir) pointing at the station's shared command bus; anything else is
+    ignored. Malformed markers degrade to ``None`` so a station still runs.
+    """
+    marker = agent_dir / "telegram" / "gateway.json"
+    if not marker.is_file():
+        return None
+    try:
+        data = json.loads(marker.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        log.warning("unreadable gateway marker %s; ignoring it", marker)
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _station_bus_path(agent_dir: Path, marker: dict | None) -> Path:
+    """Resolve the per-station command bus file path."""
+    default = agent_dir / "telegram" / _DEFAULT_BUS_FILENAME
+    if not marker:
+        return default
+    value = marker.get("bus")
+    if not isinstance(value, str) or not value.strip():
+        return default
+    path = Path(value)
+    return path if path.is_absolute() else agent_dir / path
+
+
+def _default_on_inbound(agent_dir: Path) -> Callable[[dict], None]:
+    """Build the manager inbound callback: LICC push into this station's Agent.
+
+    ``agent_dir`` and ``mcp_name='telegram'`` are explicit so the event lands
+    in the right station's inbox regardless of the process environment.
+    """
+
+    def _on_inbound(event: dict) -> None:
+        push_inbox_event(
+            sender=event.get("from") or "telegram",
+            subject=event.get("subject") or "telegram update",
+            body=event.get("body") or "",
+            metadata=event.get("metadata"),
+            wake=event.get("wake", True),
+            agent_dir=str(agent_dir),
+            mcp_name="telegram",
+        )
+
+    return _on_inbound
+
+
+class GatewayCommandRouter:
+    """Consume proxy-queued commands and dispatch to the owning service account."""
+
+    def __init__(self, services: Iterable[Any]) -> None:
+        self._by_alias: dict[str, Any] = {}
+        for service in services:
+            for alias in service.list_accounts():
+                self._by_alias[alias] = service.get_account(alias)
+
+    def route(self, command: dict[str, Any], alias: str | None = None) -> dict[str, Any]:
+        """Dispatch one queued gateway command; returns the account result.
+
+        Unknown methods fail fast with an explicit error result — they are
+        never silently ignored or routed elsewhere.
+        """
+        if not isinstance(command, dict):
+            return {"status": "error", "error": "command must be an object"}
+        method = command.get("method")
+        params = command.get("params")
+        if not isinstance(method, str) or not isinstance(params, dict):
+            return {"status": "error", "error": "command needs 'method' and 'params'"}
+        params = dict(params)
+        target = alias or params.pop("alias", None) or params.pop("account", None)
+        account = self._by_alias.get(target) if isinstance(target, str) else None
+        if account is None:
+            return {"status": "error", "error": f"unknown account alias: {target}"}
+        handler = _COMMAND_HANDLERS.get(method)
+        if handler is None:
+            return {"status": "error", "error": f"unsupported gateway command: {method}"}
+        return handler(account, params)
+
+
+def _handle_send_message(account: Any, params: dict[str, Any]) -> dict[str, Any]:
+    return account.send_message(
+        params["chat_id"],
+        params["text"],
+        reply_markup=params.get("reply_markup"),
+        reply_to_message_id=params.get("reply_to_message_id"),
+        **{k: v for k, v in params.items() if k not in {
+            "chat_id", "text", "reply_markup", "reply_to_message_id"}},
+    )
+
+
+def _handle_edit_message(account: Any, params: dict[str, Any]) -> dict[str, Any]:
+    return account.edit_message(
+        params["chat_id"], params["message_id"], params["text"],
+        **{k: v for k, v in params.items() if k not in {"chat_id", "message_id", "text"}},
+    )
+
+
+def _handle_edit_caption(account: Any, params: dict[str, Any]) -> dict[str, Any]:
+    return account.edit_message(
+        params["chat_id"], params["message_id"], params.get("caption", ""),
+        is_caption=True,
+        **{k: v for k, v in params.items() if k not in {"chat_id", "message_id", "caption"}},
+    )
+
+
+def _handle_delete_message(account: Any, params: dict[str, Any]) -> dict[str, Any]:
+    return account.delete_message(params["chat_id"], params["message_id"])
+
+
+def _handle_reaction(account: Any, params: dict[str, Any]) -> dict[str, Any]:
+    return account.set_message_reaction(
+        params["chat_id"], params["message_id"],
+        reaction=params.get("reaction"),
+        is_big=bool(params.get("is_big", False)),
+    )
+
+
+def _handle_chat_action(account: Any, params: dict[str, Any]) -> dict[str, Any]:
+    return account.send_chat_action(params["chat_id"], params["action"])
+
+
+def _handle_callback(account: Any, params: dict[str, Any]) -> dict[str, Any]:
+    # The real TelegramAccount auto-answers callbacks during polling and has no
+    # public answer_callback_query surface; the manager never routes this
+    # command. Guard instead of crashing the consumer loop with AttributeError.
+    handler = getattr(account, "answer_callback_query", None)
+    if not callable(handler):
+        return {
+            "status": "error",
+            "error": "account does not support answerCallbackQuery",
+        }
+    return handler(
+        params["callback_query_id"],
+        **{k: v for k, v in params.items() if k != "callback_query_id"},
+    )
+
+
+def _handle_get_me(account: Any, params: dict[str, Any]) -> dict[str, Any]:
+    return account.public_identity()
+
+
+def _handle_send_photo(account: Any, params: dict[str, Any]) -> dict[str, Any]:
+    return account.send_photo(
+        params["chat_id"],
+        params["path"],
+        caption=params.get("caption"),
+        reply_to_message_id=params.get("reply_to_message_id"),
+        **{k: v for k, v in params.items() if k not in {
+            "chat_id", "path", "caption", "reply_to_message_id"}},
+    )
+
+
+def _handle_send_document(account: Any, params: dict[str, Any]) -> dict[str, Any]:
+    return account.send_document(
+        params["chat_id"],
+        params["path"],
+        caption=params.get("caption"),
+        reply_to_message_id=params.get("reply_to_message_id"),
+        **{k: v for k, v in params.items() if k not in {
+            "chat_id", "path", "caption", "reply_to_message_id"}},
+    )
+
+
+_COMMAND_HANDLERS: dict[str, Callable[[Any, dict[str, Any]], dict[str, Any]]] = {
+    "sendMessage": _handle_send_message,
+    "sendPhoto": _handle_send_photo,
+    "sendDocument": _handle_send_document,
+    "editMessageText": _handle_edit_message,
+    "editMessageCaption": _handle_edit_caption,
+    "deleteMessage": _handle_delete_message,
+    "setMessageReaction": _handle_reaction,
+    "sendChatAction": _handle_chat_action,
+    "answerCallbackQuery": _handle_callback,
+    "getMe": _handle_get_me,
+}
+
+
+class GatewayHost:
+    """A running single-process Gateway: managers + command buses + router.
+
+    ``start()`` recovers stale claims and spawns one consumer thread per
+    station bus (the gateway is the single owner). ``stop()`` joins the
+    consumer threads, stops every manager, and closes every command bus so no
+    poll thread or consumer is orphaned.
+    """
+
+    def __init__(
+        self,
+        *,
+        stations: list[dict[str, Any]],
+        managers: list[Any],
+        services: list[Any],
+        router: GatewayCommandRouter,
+        buses: dict[str, SqliteCommandBus],
+    ) -> None:
+        self.stations = stations
+        self.managers = managers
+        self.services = services
+        self.router = router
+        self.buses = buses
+        self._stop = threading.Event()
+        self._threads: list[threading.Thread] = []
+
+    def start(self) -> None:
+        """Recover stale claims and start one consumer thread per station bus."""
+        for bus in self.buses.values():
+            try:
+                bus.reset_stale()
+            except Exception as exc:
+                log.warning("gateway stale-claim recovery failed: %s", exc)
+        for name, bus in self.buses.items():
+            thread = threading.Thread(
+                target=self._consume_loop,
+                args=(name, bus),
+                name=f"gateway-consumer-{name}",
+                daemon=True,
+            )
+            thread.start()
+            self._threads.append(thread)
+
+    def _consume_loop(self, name: str, bus: SqliteCommandBus) -> None:
+        """Single-owner loop: claim one command, route it, write back the result."""
+        while not self._stop.is_set():
+            try:
+                claimed = bus.claim()
+            except Exception as exc:
+                log.warning("gateway claim failed (%s): %s", name, exc)
+                claimed = None
+            if claimed is None:
+                self._stop.wait(0.05)
+                continue
+            command_id, command = claimed
+            try:
+                result = self.router.route(command)
+            except Exception as exc:
+                result = {
+                    "status": "error",
+                    "error": f"{type(exc).__name__}: {exc}",
+                }
+            try:
+                bus.complete(command_id, result)
+            except Exception as exc:
+                log.warning("gateway complete failed (%s): %s", name, exc)
+
+    def stop(self) -> None:
+        """Close consumer threads, managers, and command buses (idempotent)."""
+        self._stop.set()
+        for thread in self._threads:
+            thread.join(timeout=5.0)
+        self._threads = []
+        for manager in self.managers:
+            try:
+                manager.stop()
+            except Exception as exc:
+                log.warning("gateway manager stop failed: %s", exc)
+        for bus in self.buses.values():
+            bus.close()
+
+
+def run_gateway(
+    manifest_path: Path | str,
+    *,
+    on_inbound: Callable[[dict], None] | None = None,
+    command_source: Iterable[dict[str, Any]] | None = None,
+    service_factory: Callable[..., Any] | None = None,
+    start: bool = True,
+) -> GatewayHost:
+    """Start one complete ``TelegramManager`` + ``TelegramService`` per station.
+
+    Each manager uses the station's ``agent_dir``, a
+    ``PosixNotificationStoreAdapter``, and delivers inbound to that station's
+    Agent via ``push_inbox_event(..., agent_dir=<station>, mcp_name='telegram')``.
+    Returns a ``GatewayHost`` whose ``stop()`` closes every manager and command
+    bus. ``service_factory`` is an injectable seam for tests; production uses
+    the real ``TelegramService``.
+    """
+    from .manager import TelegramManager
+    from .service import TelegramService
+
+    stations = load_gateway_manifest(manifest_path)
+    managers: list[TelegramManager] = []
+    services: list[Any] = []
+    buses: dict[str, SqliteCommandBus] = {}
+    factory = service_factory or TelegramService
+
+    for station in stations:
+        accounts_config = _load_station_config(Path(station["config"]))
+        agent_dir = Path(station["agent_dir"])
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        marker = _read_gateway_marker(agent_dir)
+        bus = SqliteCommandBus(_station_bus_path(agent_dir, marker))
+        buses[station["name"]] = bus
+
+        inbound = on_inbound or _default_on_inbound(agent_dir)
+        # Forward declare the manager so the service's on_message callback can
+        # reach it (same pattern as server.build_manager).
+        mgr_ref: list[TelegramManager | None] = [None]
+        svc = factory(
+            working_dir=agent_dir,
+            accounts_config=accounts_config,
+            on_message=lambda alias, update, ref=mgr_ref: ref[0].on_incoming(
+                alias, update,
+            ),
+            config_source=station["config"],
+        )
+        notification_store = PosixNotificationStoreAdapter(agent_dir)
+        mgr = TelegramManager(
+            service=svc,
+            working_dir=agent_dir,
+            notification_store=notification_store,
+            on_inbound=inbound,
+        )
+        mgr_ref[0] = mgr
+        managers.append(mgr)
+        services.append(svc)
+
+    router = GatewayCommandRouter(services)
+    host = GatewayHost(
+        stations=stations,
+        managers=managers,
+        services=services,
+        router=router,
+        buses=buses,
+    )
+    if start:
+        for mgr in managers:
+            mgr.start()
+        host.start()
+    if command_source is not None:
+        for command in command_source:
+            host.router.route(command)
+    return host

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -44,6 +44,8 @@ from .. import _skill
 from . import _family
 from . import updates as tg_updates
 from .account import TelegramRateLimitError
+from .receipts import ReceiptStore, ReceiptWorker, extract_opened_message_ids
+from .task_card_revisions import TaskCardRevisionStore
 
 if TYPE_CHECKING:
     from lingtai.kernel.notification_store import NotificationStorePort
@@ -560,11 +562,13 @@ class TelegramManager:
         working_dir: Path,
         notification_store: "NotificationStorePort",
         on_inbound: "Callable[[dict], None]",
+        proxy_mode: bool = False,
     ) -> None:
         self._service = service
         self._working_dir = Path(working_dir)
         self._notification_store = notification_store
         self._on_inbound = on_inbound
+        self._proxy_mode = proxy_mode
         # Duplicate send protection: (account, chat_id, text) → count
         self._last_sent: dict[tuple[str, int, str], int] = {}
         self._dup_free_passes = 2
@@ -642,6 +646,11 @@ class TelegramManager:
         self._task_card_tail_stop = threading.Event()
         self._programmable_task_card_thread: threading.Thread | None = None
         self._programmable_task_card_stop = threading.Event()
+        self._receipt_store: ReceiptStore | None = None
+        self._receipt_worker: ReceiptWorker | None = None
+        self._receipt_tail_thread: threading.Thread | None = None
+        self._receipt_tail_stop = threading.Event()
+        self._revision_store: TaskCardRevisionStore | None = None
 
     @property
     def _task_card_channels(self) -> dict[str, dict[str, str]]:
@@ -715,12 +724,17 @@ class TelegramManager:
 
     def start(self) -> None:
         self._service.start()
+        if self._proxy_mode:
+            return
         self._start_task_card_tail()
         self._start_programmable_task_card_poller()
+        self._start_receipt_path()
 
     def stop(self) -> None:
-        self._stop_programmable_task_card_poller()
-        self._stop_task_card_tail()
+        if not self._proxy_mode:
+            self._stop_receipt_path()
+            self._stop_programmable_task_card_poller()
+            self._stop_task_card_tail()
         self._service.stop()
 
     # ------------------------------------------------------------------
@@ -889,13 +903,6 @@ class TelegramManager:
             # Issue #8: Start typing indicator immediately
             if account:
                 _typing_manager.start_typing(account, chat_id)
-
-            # Issue #8: Add "seen" reaction (👀)
-            if account:
-                try:
-                    account.set_message_reaction(chat_id, tg_message_id, REACTION_SEEN)
-                except Exception as e:
-                    log.debug("Failed to add 'seen' reaction: %s", e)
 
             # Issue #6: Transcribe voice messages
             if payload.get("media") and payload["media"].get("type") in ("voice", "audio"):
@@ -1225,6 +1232,7 @@ class TelegramManager:
         except Exception as e:
             log.error("on_inbound callback failed for telegram msg %s: %s",
                       payload.get("id"), e)
+            raise
         # Note: typing indicator continues until _send() is called by the agent.
         # _send() stops typing when it sends the response.
 
@@ -2092,11 +2100,20 @@ class TelegramManager:
         *, error: str, resident_id: str | None = None,
         empty_fallback: str | None = None,
     ) -> dict:
-        """Project via the single resident owner."""
-        return self._resident.project(
+        """Project via the resident owner and persist desired/applied revision."""
+        text = self._resident.compose(account, chat_id, channel=channel, frame=frame)
+        if not text and empty_fallback is not None:
+            text = empty_fallback
+        route_key = self._resident.key(account, chat_id)
+        if text:
+            self._ensure_revision_store().propose(route_key, text, time.time())
+        outcome = self._resident.project(
             account, chat_id, channel, frame, error=error,
             resident_id=resident_id, empty_fallback=empty_fallback,
         )
+        if text and outcome.get("status") == "ok":
+            self._ensure_revision_store().applied(route_key, time.time())
+        return outcome
 
     def _deliver_channel_frame_locked(
         self, account: str, chat_id: int, channel: str, frame: str | None,
@@ -2769,6 +2786,129 @@ class TelegramManager:
                 per_call_usages,
             )
         return bool(projected_events) or metadata_changed or result_changed or usage_changed
+
+    def _ensure_receipt_store(self) -> ReceiptStore:
+        if self._receipt_store is None:
+            self._receipt_store = ReceiptStore(
+                self._working_dir / "telegram" / "receipts.sqlite3"
+            )
+            self._receipt_worker = ReceiptWorker(
+                self._receipt_store, apply=self._apply_opened_receipt
+            )
+        return self._receipt_store
+
+    def _apply_opened_receipt(self, message_id: str) -> None:
+        account_alias, chat_id, telegram_message_id = self._parse_compound_id(
+            message_id.removeprefix("telegram:")
+        )
+        self._service.get_account(account_alias).set_message_reaction(
+            chat_id, telegram_message_id, REACTION_SEEN
+        )
+
+    def _poll_receipt_events(self) -> None:
+        store = self._ensure_receipt_store()
+        path = self._task_card_events_path()
+        try:
+            stat = path.stat()
+        except OSError:
+            return
+        offset, _, stored_identity = store.cursor()
+        identity = self._event_file_identity(stat)
+        identity_token = ":".join(map(str, identity)) if identity is not None else None
+        if stat.st_size < offset or (
+            stored_identity is not None
+            and identity_token is not None
+            and stored_identity != identity_token
+        ):
+            store.reset_cursor()
+            offset = 0
+        if stat.st_size <= offset:
+            return
+        try:
+            with open(path, "rb") as stream:
+                stream.seek(offset)
+                data = stream.read(min(
+                    stat.st_size - offset, self._TASK_CARD_EVENT_TAIL_CHUNK
+                ))
+        except OSError:
+            return
+        last_newline = data.rfind(b"\n")
+        if last_newline < 0:
+            return
+        complete = data[:last_newline + 1]
+        opened_ids: list[str] = []
+        for raw in complete.split(b"\n"):
+            event = TaskCardEventProjection.decode_event_line(raw)
+            if event is not None:
+                opened_ids.extend(extract_opened_message_ids(event))
+        store.enqueue_many_and_advance(
+            opened_ids,
+            offset + len(complete),
+            stat.st_size,
+            time.time(),
+            identity_token,
+        )
+
+    def _start_receipt_path(self) -> None:
+        self._ensure_receipt_store()
+        if self._receipt_tail_thread is not None and self._receipt_tail_thread.is_alive():
+            return
+        self._resume_pending_task_card_revisions()
+        self._receipt_tail_stop.clear()
+
+        def run() -> None:
+            while not self._receipt_tail_stop.is_set():
+                try:
+                    self._poll_receipt_events()
+                except Exception as exc:
+                    log.debug("Receipt event tail poll failed: %s", exc)
+                if self._receipt_tail_stop.wait(self._TASK_CARD_EVENT_POLL_INTERVAL):
+                    return
+
+        self._receipt_tail_thread = threading.Thread(
+            target=run, name="telegram-receipt-tail", daemon=True
+        )
+        self._receipt_tail_thread.start()
+        if self._receipt_worker is not None:
+            self._receipt_worker.start()
+
+    def _stop_receipt_path(self) -> None:
+        self._receipt_tail_stop.set()
+        if self._receipt_tail_thread is not None:
+            self._receipt_tail_thread.join(timeout=5)
+        self._receipt_tail_thread = None
+        if self._receipt_worker is not None:
+            self._receipt_worker.stop()
+        if self._receipt_store is not None:
+            self._receipt_store.close()
+        if self._revision_store is not None:
+            self._revision_store.close()
+        self._receipt_store = self._receipt_worker = self._revision_store = None
+
+    def _ensure_revision_store(self) -> TaskCardRevisionStore:
+        if self._revision_store is None:
+            self._revision_store = TaskCardRevisionStore(
+                self._working_dir / "telegram" / "taskcard_revisions.sqlite3"
+            )
+        return self._revision_store
+
+    def _resume_pending_task_card_revisions(self) -> None:
+        store = self._ensure_revision_store()
+        for route_key, _, text in store.pending_routes():
+            account, separator, chat_raw = route_key.partition(":")
+            if not separator:
+                continue
+            try:
+                chat_id = int(chat_raw)
+                outcome = self._resident.ensure(
+                    account, chat_id, text,
+                    error="Failed to resume pending task card revision",
+                )
+            except Exception as exc:
+                log.debug("Pending task card resume failed for %s: %s", route_key, exc)
+                continue
+            if outcome.get("status") == "ok":
+                store.applied(route_key, time.time())
 
     def _resident_task_card_targets(self) -> list[tuple[str, int]]:
         """Enumerate every ``(account, chat_id)`` with a resident Task Card.

--- a/src/lingtai/mcp_servers/telegram/proxy.py
+++ b/src/lingtai/mcp_servers/telegram/proxy.py
@@ -1,0 +1,230 @@
+"""Agent-side Telegram gateway proxy (proxy mode).
+
+A ``TelegramGatewayProxy`` exposes the same account surface the manager uses
+but serializes each outbound call into a gateway command delivered to the
+injected ``command_sink`` — it never calls ``getUpdates``, never constructs a
+Telegram network client, and never imports httpx. The real transport stays in
+the gateway process (see ``gateway.py``), which owns polling and outbound
+Bot API calls for all configured stations.
+
+The production ``command_sink`` is the SQLite WAL command bus
+(``SqliteCommandBus.submit``): the proxy waits (bounded) for the gateway
+result and returns it to the manager, so compound message ids built from
+``message_id`` keep working in proxy mode. A plain ``list`` sink keeps the
+older queue-only behavior for tests.
+
+``TelegramGatewayProxyService`` is the minimal proxy-mode service surface: it
+reuses ``TelegramService``'s durable taskcard-settings implementation and
+adds only the account/service surface the manager really needs — it never
+copies the whole service and never builds a network client.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable, Iterable
+
+from .service import TelegramService
+
+
+class TelegramGatewayProxy:
+    """Queue-only Telegram account surface for gateway/proxy deployments."""
+
+    def __init__(
+        self,
+        alias: str,
+        command_sink: Callable[[dict], None] | list[dict],
+    ) -> None:
+        self.alias = alias
+        self._sink = command_sink
+        # Proxy mode never constructs a Telegram network client.
+        self._network_client: Any = None
+        self._poll_thread: Any = None
+
+    def _queue(self, method: str, **params: Any) -> dict:
+        # The gateway resolves the target account from the alias; a station may
+        # own several accounts, so every command carries its own.
+        params.setdefault("alias", self.alias)
+        command = {"method": method, "params": params}
+        if isinstance(self._sink, list):
+            self._sink.append(command)
+            return {"status": "queued", "method": method}
+        result = self._sink(command)
+        # Production sink (SqliteCommandBus.submit) returns the gateway result;
+        # test doubles may return None, in which case keep the queue-only shape.
+        if isinstance(result, dict):
+            return result
+        return {"status": "queued", "method": method}
+
+    # -- Outbound surface (queued to the gateway) ----------------------------
+
+    def send_message(self, chat_id, text, reply_markup=None, reply_to_message_id=None, **kwargs):
+        params: dict[str, Any] = {"chat_id": chat_id, "text": text}
+        if reply_markup is not None:
+            params["reply_markup"] = reply_markup
+        if reply_to_message_id is not None:
+            params["reply_to_message_id"] = reply_to_message_id
+        params.update(kwargs)
+        return self._queue("sendMessage", **params)
+
+    def send_photo(self, chat_id, path, caption=None, reply_to_message_id=None, **kwargs):
+        params: dict[str, Any] = {"chat_id": chat_id, "path": path}
+        if caption is not None:
+            params["caption"] = caption
+        if reply_to_message_id is not None:
+            params["reply_to_message_id"] = reply_to_message_id
+        params.update(kwargs)
+        return self._queue("sendPhoto", **params)
+
+    def send_document(self, chat_id, path, caption=None, reply_to_message_id=None, **kwargs):
+        params: dict[str, Any] = {"chat_id": chat_id, "path": path}
+        if caption is not None:
+            params["caption"] = caption
+        if reply_to_message_id is not None:
+            params["reply_to_message_id"] = reply_to_message_id
+        params.update(kwargs)
+        return self._queue("sendDocument", **params)
+
+    def edit_message(self, chat_id, message_id, text, **kwargs):
+        params: dict[str, Any] = {"chat_id": chat_id, "message_id": message_id, "text": text}
+        params.update(kwargs)
+        return self._queue("editMessageText", **params)
+
+    def edit_message_caption(self, chat_id, message_id, caption=None, **kwargs):
+        params: dict[str, Any] = {"chat_id": chat_id, "message_id": message_id}
+        if caption is not None:
+            params["caption"] = caption
+        params.update(kwargs)
+        return self._queue("editMessageCaption", **params)
+
+    def delete_message(self, chat_id, message_id):
+        return self._queue(
+            "deleteMessage", chat_id=chat_id, message_id=message_id,
+        )
+
+    def set_message_reaction(self, chat_id, message_id, reaction=None, is_big=False):
+        params: dict[str, Any] = {"chat_id": chat_id, "message_id": message_id}
+        if reaction is not None:
+            params["reaction"] = reaction
+        params["is_big"] = is_big
+        return self._queue("setMessageReaction", **params)
+
+    def send_chat_action(self, chat_id, action):
+        return self._queue("sendChatAction", chat_id=chat_id, action=action)
+
+    def answer_callback_query(self, callback_query_id, **kwargs):
+        params: dict[str, Any] = {"callback_query_id": callback_query_id}
+        params.update(kwargs)
+        return self._queue("answerCallbackQuery", **params)
+
+    def get_me(self):
+        return self._queue("getMe")
+
+    def public_identity(self):
+        """Non-secret identity via the gateway's getMe (or alias-only fallback)."""
+        result = self._queue("getMe")
+        if isinstance(result, dict) and result.get("status") != "error":
+            if result.get("alias") is not None:
+                return result
+        return {"alias": self.alias}
+
+    def _request(self, method: str, **kwargs: Any) -> dict:
+        """Minimal Bot-API-shaped passthrough for manager best-effort paths.
+
+        The manager's placeholder-typing shortcut calls
+        ``acct._request('sendChatAction', json={...})``; proxy mode routes it
+        through the gateway like every other outbound call.
+        """
+        params: dict[str, Any] = {}
+        payload = kwargs.get("json")
+        if isinstance(payload, dict):
+            params.update(payload)
+        return self._queue(method, **params)
+
+    # -- Polling is forbidden in proxy mode ----------------------------------
+
+    def get_updates(self):
+        raise NotImplementedError(
+            "proxy mode never calls getUpdates; the gateway owns polling"
+        )
+
+    def start(self) -> None:
+        """Proxy mode has no poll thread; the gateway owns the transport."""
+        return None
+
+    def stop(self) -> None:
+        return None
+
+
+class TelegramGatewayProxyService(TelegramService):
+    """Proxy-mode service: reuses the taskcard settings implementation only.
+
+    Deliberately builds no network account and starts no poll thread: every
+    ``get_account`` returns a ``TelegramGatewayProxy`` bound to the station's
+    command bus. ``start()``/``stop()`` are no-ops — the gateway owns polling
+    and the Task Card/receipt background owners. The manager keeps working
+    because the inherited taskcard settings surface
+    (``taskcard_enabled``, ``taskcard_normal_rows``, ``set_taskcard_listener``,
+    ``set_taskcard_enabled``) is unchanged, and only the account surface the
+    manager really needs is added.
+    """
+
+    def __init__(
+        self,
+        working_dir: Path | str,
+        aliases: Iterable[str],
+        command_sink: Callable[[dict], Any],
+        *,
+        config_source: str | None = None,
+    ) -> None:
+        # Reuse TelegramService's durable taskcard state + LocalCommandCore;
+        # an empty accounts_config means no network account is ever built.
+        super().__init__(
+            working_dir=working_dir,
+            accounts_config=[],
+            on_message=lambda _alias, _update: None,
+            config_source=config_source,
+        )
+        self._proxy_accounts = [
+            TelegramGatewayProxy(alias, command_sink) for alias in aliases
+        ]
+        self._proxy_by_alias = {p.alias: p for p in self._proxy_accounts}
+        # Optional bus reference so stop() can close the process-owned bus.
+        self._command_bus: Any = None
+
+    def get_account(self, alias: str) -> TelegramGatewayProxy:
+        try:
+            return self._proxy_by_alias[alias]
+        except KeyError:
+            raise KeyError(f"unknown account alias: {alias}") from None
+
+    @property
+    def default_account(self) -> TelegramGatewayProxy:
+        return self._proxy_accounts[0]
+
+    def list_accounts(self) -> list[str]:
+        return [proxy.alias for proxy in self._proxy_accounts]
+
+    def account_details(self) -> list[dict[str, Any]]:
+        details: list[dict[str, Any]] = []
+        for proxy in self._proxy_accounts:
+            try:
+                item = proxy.public_identity()
+            except Exception:
+                item = {}
+            item.setdefault("alias", proxy.alias)
+            details.append(item)
+        return details
+
+    def start(self) -> None:
+        """Proxy mode never polls; the gateway owns the transport."""
+        return None
+
+    def stop(self) -> None:
+        """Close the process-owned command bus if one was attached."""
+        bus = self._command_bus
+        if bus is not None:
+            try:
+                bus.close()
+            except Exception:
+                pass
+            self._command_bus = None

--- a/src/lingtai/mcp_servers/telegram/receipts.py
+++ b/src/lingtai/mcp_servers/telegram/receipts.py
@@ -1,0 +1,203 @@
+"""Durable Agent-open receipts for Telegram."""
+from __future__ import annotations
+
+import re
+import logging
+import sqlite3
+import threading
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+from .account import TelegramRateLimitError
+
+_RETRYABLE = {"rate_limit", "network", "server"}
+log = logging.getLogger(__name__)
+
+
+def extract_opened_message_ids(event: dict[str, Any]) -> list[str]:
+    if event.get("type") == "steering_messages_opened":
+        messages = event.get("message_ids")
+    elif event.get("type") == "notification_block_injected":
+        try:
+            messages = event["_meta"]["agent_meta"]["notifications"]["persistent"]["mcp"]["telegram"]["messages"]
+        except (KeyError, TypeError):
+            return []
+    else:
+        return []
+    return [
+        message_id
+        for item in (messages if isinstance(messages, list) else [])
+        if isinstance((message_id := item.get("id") if isinstance(item, dict) else item), str)
+        and message_id
+    ]
+
+
+def classify_receipt_error(exc: Exception) -> tuple[str, int | None]:
+    if isinstance(exc, TelegramRateLimitError):
+        retry_after = exc.retry_after
+        return "rate_limit", retry_after if type(retry_after) is int and retry_after >= 0 else None
+    if isinstance(exc, OSError) or type(exc).__module__.startswith("httpx"):
+        return "network", None
+    if str(exc).startswith("Telegram API error:"):
+        match = re.search(r"\bHTTP (\d{3})\b", str(exc))
+        return ("server" if not match or int(match.group(1)) >= 500 else "invalid"), None
+    return "other", None
+
+
+class ReceiptStore:
+    """SQLite receipt intent and event cursor committed in one transaction."""
+
+    def __init__(self, db_path: Path | str) -> None:
+        path = Path(db_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(str(path), check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        self._lock = threading.RLock()
+        with self._conn:
+            self._conn.execute("PRAGMA journal_mode=WAL")
+            self._conn.execute("""
+                CREATE TABLE IF NOT EXISTS telegram_receipts (
+                    message_id TEXT PRIMARY KEY,
+                    state TEXT NOT NULL CHECK (state IN ('pending','applied','failed')),
+                    attempts INTEGER NOT NULL DEFAULT 0,
+                    next_attempt_at REAL NOT NULL DEFAULT 0,
+                    applied_at REAL,
+                    last_error TEXT,
+                    updated_at REAL NOT NULL
+                )
+            """)
+            self._conn.execute("""
+                CREATE TABLE IF NOT EXISTS telegram_receipt_cursor (
+                    id INTEGER PRIMARY KEY CHECK (id = 1),
+                    offset INTEGER NOT NULL CHECK (offset >= 0),
+                    size INTEGER NOT NULL CHECK (size >= 0),
+                    identity TEXT
+                )
+            """)
+
+    def close(self) -> None:
+        with self._lock:
+            self._conn.close()
+
+    def enqueue_many_and_advance(
+        self, message_ids: list[str], offset: int, size: int, now: float,
+        identity: str | None = None,
+    ) -> None:
+        with self._lock, self._conn:
+            self._conn.executemany(
+                "INSERT OR IGNORE INTO telegram_receipts "
+                "(message_id,state,attempts,next_attempt_at,updated_at) "
+                "VALUES (?,'pending',0,0,?)",
+                [(message_id, now) for message_id in message_ids],
+            )
+            self._conn.execute("""
+                INSERT INTO telegram_receipt_cursor (id,offset,size,identity)
+                VALUES (1,?,?,?) ON CONFLICT(id) DO UPDATE SET
+                offset=excluded.offset,size=excluded.size,identity=excluded.identity
+            """, (offset, size, identity))
+
+    def reset_cursor(self) -> None:
+        with self._lock, self._conn:
+            self._conn.execute("""
+                INSERT INTO telegram_receipt_cursor (id,offset,size,identity)
+                VALUES (1,0,0,NULL) ON CONFLICT(id) DO UPDATE SET
+                offset=0,size=0,identity=NULL
+            """)
+
+    def cursor(self) -> tuple[int, int, str | None]:
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT offset,size,identity FROM telegram_receipt_cursor WHERE id=1"
+            ).fetchone()
+        return (int(row["offset"]), int(row["size"]), row["identity"]) if row else (0, 0, None)
+
+    def pending_due(self, now: float) -> list[dict[str, Any]]:
+        with self._lock:
+            rows = self._conn.execute("""
+                SELECT message_id,attempts FROM telegram_receipts
+                WHERE state='pending' AND next_attempt_at<=?
+                ORDER BY next_attempt_at LIMIT 100
+            """, (now,)).fetchall()
+        return [dict(row) for row in rows]
+
+    def get(self, message_id: str) -> dict[str, Any] | None:
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT * FROM telegram_receipts WHERE message_id=?", (message_id,)
+            ).fetchone()
+        return dict(row) if row else None
+
+    def mark_applied(self, message_id: str, now: float) -> None:
+        with self._lock, self._conn:
+            self._conn.execute("""
+                UPDATE telegram_receipts SET state='applied',applied_at=?,updated_at=?
+                WHERE message_id=?
+            """, (now, now, message_id))
+
+    def mark_failed(
+        self, message_id: str, now: float, attempts: int,
+        next_attempt_at: float | None, error_class: str,
+    ) -> None:
+        state = "pending" if next_attempt_at is not None else "failed"
+        with self._lock, self._conn:
+            self._conn.execute("""
+                UPDATE telegram_receipts SET state=?,attempts=?,next_attempt_at=?,
+                last_error=?,updated_at=? WHERE message_id=?
+            """, (state, attempts, next_attempt_at, error_class[:40], now, message_id))
+
+
+class ReceiptWorker:
+    BACKOFF_CAP = 60.0
+
+    def __init__(
+        self, store: ReceiptStore, apply: Callable[[str], None], *, poll_interval: float = 1.0,
+    ) -> None:
+        self._store = store
+        self._apply = apply
+        self._poll_interval = poll_interval
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def poll_once(self, now: float | None = None) -> int:
+        now = time.time() if now is None else now
+        applied = 0
+        for row in self._store.pending_due(now):
+            message_id = row["message_id"]
+            try:
+                self._apply(message_id)
+            except Exception as exc:
+                error_class, retry_after = classify_receipt_error(exc)
+                attempts = int(row["attempts"]) + 1
+                next_at = None
+                if error_class in _RETRYABLE:
+                    delay = retry_after if retry_after is not None else min(self.BACKOFF_CAP, 2 ** attempts)
+                    next_at = now + delay
+                self._store.mark_failed(message_id, now, attempts, next_at, error_class)
+            else:
+                self._store.mark_applied(message_id, now)
+                applied += 1
+        return applied
+
+    def start(self) -> None:
+        if self._thread is not None and self._thread.is_alive():
+            return
+        self._stop.clear()
+
+        def run() -> None:
+            while not self._stop.is_set():
+                try:
+                    self.poll_once()
+                except Exception as exc:
+                    log.warning("Telegram receipt worker poll failed: %s", exc)
+                if self._stop.wait(self._poll_interval):
+                    return
+
+        self._thread = threading.Thread(target=run, name="telegram-receipt-worker", daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+        self._thread = None

--- a/src/lingtai/mcp_servers/telegram/server.py
+++ b/src/lingtai/mcp_servers/telegram/server.py
@@ -48,9 +48,10 @@ from .._results import unknown_resource_error as _unknown_resource
 from .._results import unknown_tool_error as _unknown_tool
 
 from lingtai.adapters.posix.notification_store import PosixNotificationStoreAdapter
+from lingtai.services.mcp_licc import push_inbox_event
 
 from .. import _config
-from .licc import push_inbox_event
+from .bus import SqliteCommandBus
 from .manager import TelegramManager, SCHEMA, DESCRIPTION
 from ._family import handle_telegram
 from .service import TelegramService
@@ -629,6 +630,26 @@ def _accounts_from_config(cfg: dict) -> list[dict]:
 # Manager construction
 # ---------------------------------------------------------------------------
 
+def _gateway_marker(agent_dir: Path) -> dict | None:
+    marker = agent_dir / "telegram" / "gateway.json"
+    if not marker.is_file():
+        return None
+    try:
+        data = json.loads(marker.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        log.warning("unreadable gateway marker %s; ignoring it", marker)
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _proxy_bus_path(agent_dir: Path, marker: dict | None) -> Path:
+    value = marker.get("bus") if marker else None
+    if not isinstance(value, str) or not value.strip():
+        return agent_dir / "telegram" / "gateway.sqlite3"
+    path = Path(value)
+    return path if path.is_absolute() else agent_dir / path
+
+
 def build_manager() -> tuple[TelegramManager, Path]:
     """Construct manager + service from env + config. Returns (manager, working_dir)."""
     cfg = load_config()
@@ -637,6 +658,8 @@ def build_manager() -> tuple[TelegramManager, Path]:
     agent_dir_raw = os.environ.get("LINGTAI_AGENT_DIR")
     working_dir = Path(agent_dir_raw) if agent_dir_raw else Path.cwd()
     working_dir.mkdir(parents=True, exist_ok=True)
+    marker = _gateway_marker(working_dir)
+    proxy_mode = marker is not None
 
     def _on_inbound(event: dict) -> None:
         push_inbox_event(
@@ -645,18 +668,32 @@ def build_manager() -> tuple[TelegramManager, Path]:
             body=event["body"],
             metadata=event.get("metadata"),
             wake=event.get("wake", True),
+            agent_dir=str(working_dir),
+            mcp_name="telegram",
         )
 
     # Forward declare the manager so the service's on_message callback can
     # reach it. Same pattern as the legacy addon's lambda + mgr_ref dance.
     mgr_ref: list[TelegramManager | None] = [None]
 
-    svc = TelegramService(
-        working_dir=working_dir,
-        accounts_config=accounts,
-        on_message=lambda alias, update: mgr_ref[0].on_incoming(alias, update),
-        config_source=os.environ.get("LINGTAI_TELEGRAM_CONFIG"),
-    )
+    if proxy_mode:
+        from .proxy import TelegramGatewayProxyService
+
+        bus = SqliteCommandBus(_proxy_bus_path(working_dir, marker))
+        svc = TelegramGatewayProxyService(
+            working_dir=working_dir,
+            aliases=[str(item["alias"]) for item in accounts if item.get("alias")],
+            command_sink=bus.submit,
+            config_source=os.environ.get("LINGTAI_TELEGRAM_CONFIG"),
+        )
+        svc._command_bus = bus
+    else:
+        svc = TelegramService(
+            working_dir=working_dir,
+            accounts_config=accounts,
+            on_message=lambda alias, update: mgr_ref[0].on_incoming(alias, update),
+            config_source=os.environ.get("LINGTAI_TELEGRAM_CONFIG"),
+        )
 
     notification_store = PosixNotificationStoreAdapter(working_dir)
     mgr = TelegramManager(
@@ -664,6 +701,7 @@ def build_manager() -> tuple[TelegramManager, Path]:
         working_dir=working_dir,
         notification_store=notification_store,
         on_inbound=_on_inbound,
+        proxy_mode=proxy_mode,
     )
     mgr_ref[0] = mgr
     return mgr, working_dir

--- a/src/lingtai/mcp_servers/telegram/task_card_revisions.py
+++ b/src/lingtai/mcp_servers/telegram/task_card_revisions.py
@@ -1,0 +1,76 @@
+"""Durable desired/applied revisions for resident Telegram Task Cards."""
+from __future__ import annotations
+
+import sqlite3
+import threading
+from pathlib import Path
+
+
+class TaskCardRevisionStore:
+    def __init__(self, db_path: Path | str) -> None:
+        path = Path(db_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(str(path), check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        self._lock = threading.RLock()
+        with self._conn:
+            self._conn.execute("PRAGMA journal_mode=WAL")
+            self._conn.execute("""
+                CREATE TABLE IF NOT EXISTS telegram_task_card_revisions (
+                    route_key TEXT PRIMARY KEY,
+                    desired_rev INTEGER NOT NULL DEFAULT 0,
+                    desired_text TEXT NOT NULL DEFAULT '',
+                    applied_rev INTEGER NOT NULL DEFAULT 0,
+                    applied_text TEXT NOT NULL DEFAULT '',
+                    updated_at REAL NOT NULL
+                )
+            """)
+
+    def close(self) -> None:
+        with self._lock:
+            self._conn.close()
+
+    def _row(self, route_key: str):
+        return self._conn.execute(
+            "SELECT * FROM telegram_task_card_revisions WHERE route_key=?", (route_key,)
+        ).fetchone()
+
+    def propose(self, route_key: str, text: str, now: float) -> bool:
+        with self._lock, self._conn:
+            row = self._row(route_key)
+            if row is not None and row["desired_text"] == text:
+                return False
+            revision = (int(row["desired_rev"]) if row else 0) + 1
+            self._conn.execute("""
+                INSERT INTO telegram_task_card_revisions
+                (route_key,desired_rev,desired_text,applied_rev,applied_text,updated_at)
+                VALUES (?,?,?,0,'',?) ON CONFLICT(route_key) DO UPDATE SET
+                desired_rev=excluded.desired_rev,desired_text=excluded.desired_text,
+                updated_at=excluded.updated_at
+            """, (route_key, revision, text, now))
+            return True
+
+    def applied(self, route_key: str, now: float) -> None:
+        with self._lock, self._conn:
+            self._conn.execute("""
+                UPDATE telegram_task_card_revisions SET applied_rev=desired_rev,
+                applied_text=desired_text,updated_at=? WHERE route_key=?
+            """, (now, route_key))
+
+    def pending_routes(self) -> list[tuple[str, int, str]]:
+        with self._lock:
+            rows = self._conn.execute("""
+                SELECT route_key,desired_rev,desired_text
+                FROM telegram_task_card_revisions WHERE applied_rev<desired_rev
+            """).fetchall()
+        return [(row["route_key"], int(row["desired_rev"]), row["desired_text"]) for row in rows]
+
+    def desired_rev(self, route_key: str) -> int:
+        with self._lock:
+            row = self._row(route_key)
+        return int(row["desired_rev"]) if row else 0
+
+    def applied_rev(self, route_key: str) -> int:
+        with self._lock:
+            row = self._row(route_key)
+        return int(row["applied_rev"]) if row else 0

--- a/tests/test_steering_lane.py
+++ b/tests/test_steering_lane.py
@@ -1,0 +1,277 @@
+"""Focused unit tests for the preemptive parallel steering lane.
+
+Covers: lane spawned during tool_call; reply delivered on channel; interrupt
+request aborts at the boundary; no-interrupt leaves the main turn running.
+"""
+from __future__ import annotations
+
+import json
+import queue
+import threading
+from pathlib import Path
+
+import pytest
+
+from lingtai.kernel import steering
+from lingtai.kernel.config import AgentConfig
+
+
+class _FakeAgent:
+    """Minimal agent surface the steering module touches."""
+
+    def __init__(self, tmp_path: Path, *, steering_enabled: bool = True):
+        self.working_dir = tmp_path
+        self._config = AgentConfig(steering_enabled=steering_enabled)
+        self._active_turn_kind = "tool_call"
+        self._cancel_event = threading.Event()
+        self._events: list[dict] = []
+        self.inbox: queue.Queue = queue.Queue()
+        self._woke: list[str] = []
+        self._steering_reply_hook = None
+        self._steering_current_tool_pid = None
+        self._mcp_clients_by_tool = {}
+
+    def _log(self, event_type: str, **fields) -> None:
+        self._events.append({"type": event_type, **fields})
+
+    def _wake_nap(self, reason: str) -> None:
+        self._woke.append(reason)
+
+    @property
+    def _chat(self):
+        return None
+
+
+@pytest.fixture()
+def fake_agent(tmp_path):
+    return _FakeAgent(tmp_path)
+
+
+def _wait_for(predicate, timeout=5.0):
+    deadline = __import__("time").monotonic() + timeout
+    while __import__("time").monotonic() < deadline:
+        if predicate():
+            return True
+        __import__("time").sleep(0.02)
+    return False
+
+
+class TestLaneSpawnedDuringToolCall:
+    def test_dispatch_creates_lane_run_dir_and_seed(self, fake_agent):
+        notifications = {
+            "mcp.telegram": {"data": {"text": "Stop the current run now"}},
+            "email": {"body": "low priority"},
+        }
+        captured: dict = {}
+
+        def runner(agent, run_dir, seed):
+            captured["seed"] = seed
+            captured["run_dir"] = run_dir
+
+        result = steering.dispatch_steering_lane(
+            fake_agent, notifications, runner=runner
+        )
+        assert result is not None
+        assert result["status"] == "dispatched"
+        assert result["channel"] == "mcp.telegram"
+        # Lane run dir created under daemons/ with seed + prompt.
+        run_dir = Path(fake_agent.working_dir) / "daemons" / result["run_id"]
+        assert run_dir.is_dir()
+        assert (run_dir / "steering_seed.json").is_file()
+        prompt = (run_dir / "steering_prompt.txt").read_text(encoding="utf-8")
+        assert "Stop the current run now" in prompt
+        # Thread ran the runner.
+        assert _wait_for(lambda: "seed" in captured)
+        assert captured["seed"]["channel"] == "mcp.telegram"
+        assert "Stop the current run now" in captured["seed"]["message"]
+
+    def test_no_dispatch_when_steering_disabled(self, tmp_path):
+        agent = _FakeAgent(tmp_path, steering_enabled=False)
+        notifications = {"mcp.telegram": {"text": "hi"}}
+        assert (
+            steering.dispatch_steering_lane(agent, notifications, runner=lambda *a: None)
+            is None
+        )
+
+    def test_no_dispatch_for_non_priority_channel(self, fake_agent):
+        notifications = {"cron": {"text": "tick"}}
+        assert (
+            steering.dispatch_steering_lane(fake_agent, notifications, runner=lambda *a: None)
+            is None
+        )
+
+
+class TestReplyDelivered:
+    def test_reply_hook_called(self, fake_agent):
+        delivered: list[tuple] = []
+        fake_agent._steering_reply_hook = (
+            lambda channel, message, reply: delivered.append((channel, message, reply))
+        )
+        steering.deliver_steering_reply(
+            fake_agent, "mcp.telegram", "the message", "I'm on it."
+        )
+        assert delivered == [("mcp.telegram", "the message", "I'm on it.")]
+
+    def test_reply_stored_when_no_hook(self, fake_agent):
+        steering.deliver_steering_reply(
+            fake_agent, "mcp.telegram", "the message", "I'm on it."
+        )
+        stored = (
+            Path(fake_agent.working_dir) / "daemons" / "steering_reply.txt"
+        )
+        assert stored.is_file()
+        data = json.loads(stored.read_text(encoding="utf-8"))
+        assert data["reply"] == "I'm on it."
+        assert data["channel"] == "mcp.telegram"
+
+    def test_empty_reply_not_delivered(self, fake_agent):
+        fake_agent._steering_reply_hook = (
+            lambda channel, message, reply: delivered.append((channel, reply))
+        )
+        delivered: list = []
+        steering.deliver_steering_reply(fake_agent, "mcp.telegram", "m", "")
+        assert delivered == []
+
+
+class TestInterruptContract:
+    def test_interrupt_request_aborts_at_boundary(self, fake_agent):
+        run_dir = Path(fake_agent.working_dir) / "daemons" / "steer-test1"
+        run_dir.mkdir(parents=True)
+        (run_dir / "steering_interrupt.json").write_text(
+            json.dumps({"reason": "human said stop", "by": "steering_lane"}),
+            encoding="utf-8",
+        )
+
+        interrupt = steering.check_steering_interrupt(fake_agent)
+        assert interrupt is not None
+        assert interrupt["reason"] == "human said stop"
+        assert interrupt["run_id"] == "steer-test1"
+
+        steering.abort_current_tool_call(fake_agent, interrupt)
+        # Turn marked interrupted, cancel event set, steering message queued.
+        assert fake_agent._active_turn_kind == "interrupted"
+        assert fake_agent._cancel_event.is_set()
+        assert fake_agent._woke == ["steering_interrupt"]
+        msg = fake_agent.inbox.get_nowait()
+        assert msg.type == "request"
+        assert "steering" in msg.content.lower()
+        # Interrupt file consumed (renamed) so it fires exactly once.
+        assert not (run_dir / "steering_interrupt.json").exists()
+        assert (
+            run_dir / "steering_interrupt.json.consumed"
+        ).exists()
+        assert steering.check_steering_interrupt(fake_agent) is None
+
+    def test_no_interrupt_leaves_turn_running(self, fake_agent):
+        # No lane / no interrupt file anywhere.
+        assert steering.check_steering_interrupt(fake_agent) is None
+        assert not fake_agent._cancel_event.is_set()
+        assert fake_agent._active_turn_kind == "tool_call"
+
+    def test_interrupt_not_consumed_for_non_lane_dir(self, fake_agent):
+        # A daemon run dir without steering_interrupt.json is ignored.
+        run_dir = Path(fake_agent.working_dir) / "daemons" / "em-other"
+        run_dir.mkdir(parents=True)
+        (run_dir / "daemon.json").write_text("{}", encoding="utf-8")
+        assert steering.check_steering_interrupt(fake_agent) is None
+
+    def test_taskkill_windows_tree(self, monkeypatch):
+        calls: list[list] = []
+
+        class _Popen:
+            def __init__(self, argv, **kw):
+                calls.append(argv)
+                self.returncode = 0
+
+        monkeypatch.setattr("subprocess.run", _Popen)
+        steering._taskkill_tree_windows(4242)
+        assert calls and calls[0] == ["taskkill", "/T", "/F", "/PID", "4242"]
+
+
+class TestLaneRunnerDecision:
+    def test_interrupt_marker_detected(self):
+        reply = "Okay, stopping now.\n[INTERRUPT] user explicitly asked to cancel"
+        assert (
+            steering._interrupt_reason_from_reply(reply)
+            == "user explicitly asked to cancel"
+        )
+
+    def test_continue_marker_no_interrupt(self):
+        reply = "Will do, one moment.\n[CONTINUE]"
+        assert steering._interrupt_reason_from_reply(reply) is None
+
+    def test_default_lane_runner_writes_result_and_interrupt(
+        self, fake_agent, monkeypatch
+    ):
+        class _FakeSession:
+            def send(self, prompt, timeout=None):
+                class _Resp:
+                    text = "Hold on, I will stop.\n[INTERRUPT] stop now"
+
+                return _Resp()
+
+        class _FakeLLM:
+            def __init__(self, **kw):
+                self.kw = kw
+
+            def create_session(self, **kw):
+                return _FakeSession()
+
+        monkeypatch.setattr(steering, "_resolve_llm_service_class", lambda: _FakeLLM)
+        fake_agent.service = object()  # type: ignore[attr-defined]
+        run_dir = Path(fake_agent.working_dir) / "daemons" / "steer-test2"
+        run_dir.mkdir(parents=True)
+        (run_dir / "steering_prompt.txt").write_text(
+            steering._build_lane_prompt(
+                {"channel": "mcp.telegram", "message": "stop", "tail": ""}
+            ),
+            encoding="utf-8",
+        )
+        seed = {
+            "channel": "mcp.telegram",
+            "message": "stop",
+            "tail": "",
+            "timeout_s": 60.0,
+        }
+        steering._default_lane_runner(fake_agent, run_dir, seed)
+        result = json.loads(
+            (run_dir / "steering_result.json").read_text(encoding="utf-8")
+        )
+        assert result["status"] == "done"
+        assert "Hold on" in result["reply"]
+        interrupt = json.loads(
+            (run_dir / "steering_interrupt.json").read_text(encoding="utf-8")
+        )
+        assert interrupt["reason"] == "stop now"
+        assert interrupt["by"] == "steering_lane"
+
+    def test_default_lane_runner_continue_no_interrupt(
+        self, fake_agent, monkeypatch
+    ):
+        class _FakeSession:
+            def send(self, prompt, timeout=None):
+                class _Resp:
+                    text = "Noted, continuing.\n[CONTINUE]"
+
+                return _Resp()
+
+        class _FakeLLM:
+            def __init__(self, **kw):
+                pass
+
+            def create_session(self, **kw):
+                return _FakeSession()
+
+        monkeypatch.setattr(steering, "_resolve_llm_service_class", lambda: _FakeLLM)
+        fake_agent.service = object()  # type: ignore[attr-defined]
+        run_dir = Path(fake_agent.working_dir) / "daemons" / "steer-test3"
+        run_dir.mkdir(parents=True)
+        (run_dir / "steering_prompt.txt").write_text("prompt", encoding="utf-8")
+        seed = {
+            "channel": "mcp.telegram",
+            "message": "ok",
+            "tail": "",
+            "timeout_s": 60.0,
+        }
+        steering._default_lane_runner(fake_agent, run_dir, seed)
+        assert not (run_dir / "steering_interrupt.json").exists()

--- a/tests/test_telegram_account_last_message_id.py
+++ b/tests/test_telegram_account_last_message_id.py
@@ -47,6 +47,20 @@ def test_inbound_message_bumps_last_message_id(tmp_path):
     assert seen
 
 
+def test_failed_delivery_does_not_commit_update_offset(tmp_path):
+    def fail(_alias, _update):
+        raise RuntimeError("inbox unavailable")
+
+    acct = _account(tmp_path, on_message=fail)
+    with pytest.raises(RuntimeError, match="inbox unavailable"):
+        acct._process_update({
+            "update_id": 7,
+            "message": {"message_id": 42, "chat": {"id": 555},
+                        "from": {"id": 9}, "text": "retry me"},
+        })
+    assert acct._last_update_id == 0
+
+
 def test_last_message_id_is_monotonic_per_chat(tmp_path):
     acct = _account(tmp_path)
     acct._note_chat_message_id(555, 10)

--- a/tests/test_telegram_agent_open_receipts.py
+++ b/tests/test_telegram_agent_open_receipts.py
@@ -1,0 +1,104 @@
+import json
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+
+from lingtai.mcp_servers.telegram.manager import TelegramManager
+from lingtai.mcp_servers.telegram.receipts import ReceiptStore
+from lingtai.mcp_servers.telegram.task_card_revisions import TaskCardRevisionStore
+from tests._notification_store_helpers import FakeNotificationStore
+
+
+class _Account:
+    alias = "bot"
+
+    def __init__(self, failures=0):
+        self.failures = failures
+        self.reactions = []
+        self.task_cards = {}
+
+    def set_message_reaction(self, chat_id, message_id, reaction):
+        if self.failures:
+            self.failures -= 1
+            raise ConnectionError("offline")
+        self.reactions.append((chat_id, message_id, reaction))
+
+    def get_task_card(self, chat_id):
+        return self.task_cards.get(str(chat_id))
+
+    def set_task_card(self, chat_id, message_id):
+        self.task_cards[str(chat_id)] = message_id
+
+    def get_last_message_id(self, chat_id):
+        return None
+
+    def edit_message(self, chat_id, message_id, text, **kwargs):
+        return {"ok": True}
+
+
+class _Service:
+    def __init__(self, account):
+        self.default_account = account
+
+    def get_account(self, alias):
+        return self.default_account
+
+    def list_accounts(self):
+        return [self.default_account.alias]
+
+    def taskcard_enabled(self):
+        return True
+
+    def taskcard_normal_rows(self):
+        return 1
+
+
+def _manager(path: Path, account: _Account) -> TelegramManager:
+    return TelegramManager(
+        _Service(account), working_dir=path, on_inbound=lambda _: None,
+        notification_store=FakeNotificationStore(),
+    )
+
+
+def test_receipt_survives_failure_and_restart(tmp_path: Path):
+    events = tmp_path / "logs" / "events.jsonl"
+    events.parent.mkdir(parents=True)
+    events.write_text(json.dumps({
+        "type": "notification_block_injected",
+        "_meta": {"agent_meta": {"notifications": {"persistent": {"mcp": {
+            "telegram": {"messages": [{"id": "telegram:bot:123:55"}]},
+        }}}}},
+    }) + "\n", encoding="utf-8")
+
+    first = _manager(tmp_path, _Account(failures=1))
+    first._poll_receipt_events()
+    first._receipt_worker.poll_once(now=time.time())
+    assert first._ensure_receipt_store().get("telegram:bot:123:55")["state"] == "pending"
+
+    healthy = _Account()
+    restarted = _manager(tmp_path, healthy)
+    restarted._receipt_worker = None
+    restarted._ensure_receipt_store()
+    restarted._receipt_worker.poll_once(now=time.time() + 3600)
+    assert [(chat, message) for chat, message, _ in healthy.reactions] == [(123, 55)]
+    assert restarted._ensure_receipt_store().get("telegram:bot:123:55")["state"] == "applied"
+
+
+def test_receipt_and_cursor_are_atomic(tmp_path: Path):
+    store = ReceiptStore(tmp_path / "receipts.sqlite3")
+    with pytest.raises(sqlite3.IntegrityError):
+        store.enqueue_many_and_advance(["telegram:bot:1:2"], -1, 0, time.time())
+    assert store.pending_due(time.time() + 1) == []
+    assert store.cursor()[:2] == (0, 0)
+
+
+def test_task_card_revisions_keep_only_the_latest_pending_text(tmp_path: Path):
+    store = TaskCardRevisionStore(tmp_path / "taskcards.sqlite3")
+    assert store.propose("bot:123", "第一版", 1.0)
+    assert not store.propose("bot:123", "第一版", 2.0)
+    assert store.propose("bot:123", "第二版", 3.0)
+    assert store.pending_routes() == [("bot:123", 2, "第二版")]
+    store.applied("bot:123", 4.0)
+    assert store.pending_routes() == []

--- a/tests/test_telegram_single_owner_gateway.py
+++ b/tests/test_telegram_single_owner_gateway.py
@@ -1,0 +1,175 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from lingtai.mcp_servers.telegram.account import TelegramAccount
+from lingtai.mcp_servers.telegram.bus import SqliteCommandBus
+from lingtai.mcp_servers.telegram.gateway import GatewayManifestError, load_gateway_manifest, run_gateway
+from lingtai.mcp_servers.telegram.proxy import TelegramGatewayProxy
+
+
+class _Account:
+    def __init__(self, alias):
+        self.alias = alias
+        self.calls = []
+        self._next_id = 100
+        self._task_cards = {}
+
+    def send_message(self, chat_id, text, **kwargs):
+        message_id = self._next_id
+        self._next_id += 1
+        self.calls.append(("send_message", chat_id, message_id, text))
+        return {"message_id": message_id}
+
+    def edit_message(self, chat_id, message_id, text, **kwargs):
+        return {"ok": True}
+
+    def delete_message(self, chat_id, message_id):
+        return {"ok": True}
+
+    def send_chat_action(self, chat_id, action="typing"):
+        return {"ok": True}
+
+    def public_identity(self):
+        return {"alias": self.alias}
+
+    def set_message_reaction(self, chat_id, message_id, reaction):
+        return {"ok": True}
+
+    def get_task_card(self, chat_id):
+        return self._task_cards.get(str(chat_id))
+
+    def set_task_card(self, chat_id, message_id):
+        self._task_cards[str(chat_id)] = message_id
+
+    def clear_task_card(self, chat_id):
+        self._task_cards.pop(str(chat_id), None)
+
+    def list_task_card_chats(self):
+        return [int(chat_id) for chat_id in self._task_cards]
+
+    def get_last_message_id(self, chat_id):
+        return None
+
+
+class _Service:
+    def __init__(self, account):
+        self.default_account = account
+        self._account = account
+
+    def get_account(self, alias):
+        return self._account
+
+    def list_accounts(self):
+        return [self._account.alias]
+
+    def taskcard_enabled(self):
+        return False
+
+    def taskcard_normal_rows(self):
+        return 1
+
+    def set_taskcard_listener(self, listener):
+        self._listener = listener
+
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+
+def test_proxy_queues_commands_without_a_network_client():
+    commands = []
+    proxy = TelegramGatewayProxy(alias="bot", command_sink=commands)
+    assert proxy.send_message(123, "你好")["status"] == "queued"
+    assert commands[-1]["method"] == "sendMessage"
+    assert proxy._network_client is None
+    with pytest.raises(NotImplementedError):
+        proxy.get_updates()
+
+
+def test_manifest_references_configs_and_rejects_embedded_secrets(tmp_path: Path):
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(json.dumps({
+        "stations": [{"name": "control", "config": "telegram.json"}],
+    }), encoding="utf-8")
+    assert load_gateway_manifest(manifest)[0]["config"] == str(tmp_path / "telegram.json")
+
+    manifest.write_text(json.dumps({
+        "stations": [{"name": "control", "config": "x", "bot_token": "secret"}],
+    }), encoding="utf-8")
+    with pytest.raises(GatewayManifestError):
+        load_gateway_manifest(manifest)
+
+
+def test_polling_and_outbound_clients_are_independent(monkeypatch):
+    import lingtai.mcp_servers.telegram.account as account_module
+
+    class _Httpx:
+        Timeout = staticmethod(lambda *args, **kwargs: None)
+        Client = staticmethod(lambda *args, **kwargs: _Client())
+
+    class _Client:
+        def close(self):
+            pass
+
+    monkeypatch.setattr(account_module, "httpx", _Httpx)
+    account = TelegramAccount("bot", "123:not-real", None)
+    account._ensure_client()
+    account._ensure_client(polling=True)
+    assert account._poll_client is not account._outbound_client
+    account.stop()
+    assert account._poll_client is account._outbound_client is None
+
+
+def test_two_station_gateway_routes_inbound_and_bus_commands(tmp_path: Path):
+    agents = [tmp_path / "a", tmp_path / "b"]
+    configs = [tmp_path / "a.json", tmp_path / "b.json"]
+    aliases = ["botA", "botB"]
+    for agent, config, alias in zip(agents, configs, aliases):
+        (agent / "telegram").mkdir(parents=True)
+        config.write_text(json.dumps({
+            "accounts": [{"alias": alias, "bot_token": "123:not-real"}],
+        }), encoding="utf-8")
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(json.dumps({"stations": [
+        {"name": "a", "config": str(configs[0]), "agent_dir": str(agents[0])},
+        {"name": "b", "config": str(configs[1]), "agent_dir": str(agents[1])},
+    ]}), encoding="utf-8")
+
+    accounts = {alias: _Account(alias) for alias in aliases}
+
+    def service_factory(working_dir, accounts_config, on_message, config_source=None):
+        service = _Service(accounts[accounts_config[0]["alias"]])
+        service.on_message = on_message
+        return service
+
+    host = run_gateway(manifest, service_factory=service_factory)
+    update = lambda message_id, chat_id, text: {
+        "update_id": message_id,
+        "message": {
+            "message_id": message_id, "date": 1700000000, "text": text,
+            "chat": {"id": chat_id, "type": "private"},
+            "from": {"id": 7, "first_name": "Human"},
+        },
+    }
+    host.managers[0].on_incoming("botA", update(1, 111, "hello A"))
+    host.managers[1].on_incoming("botB", update(2, 222, "hello B"))
+    assert len(list((agents[0] / ".mcp_inbox" / "telegram").glob("*.json"))) == 1
+    assert len(list((agents[1] / ".mcp_inbox" / "telegram").glob("*.json"))) == 1
+
+    client = SqliteCommandBus(agents[0] / "telegram" / "gateway.sqlite3")
+    result = client.submit({
+        "method": "sendMessage",
+        "params": {"alias": "botA", "chat_id": 111, "text": "ping"},
+    }, timeout=10)
+    assert result["message_id"] == 100
+    assert len([call for call in accounts["botA"].calls if call[0] == "send_message"]) == 1
+    assert accounts["botB"].calls == []
+    client.close()
+
+    host.stop()
+    assert not any(thread.is_alive() for thread in host._threads)
+    assert all(bus._closed for bus in host.buses.values())

--- a/tests/test_telegram_task_card_event_tail.py
+++ b/tests/test_telegram_task_card_event_tail.py
@@ -1216,8 +1216,7 @@ def test_start_stop_run_exactly_one_tail_worker(tmp_path):
         assert service.start_calls == 1
         new_threads = set(threading.enumerate()) - before_threads
         tail_threads = [
-            t for t in new_threads if "task_card" in t.name.lower()
-            or "event_tail" in t.name.lower() or "tail" in t.name.lower()
+            t for t in new_threads if t.name.lower() == "telegram-task-card-event-tail"
         ]
         assert len(tail_threads) == 1, f"expected exactly one tail worker, got {new_threads}"
     finally:
@@ -1246,8 +1245,12 @@ def test_start_called_twice_does_not_start_a_second_worker(tmp_path):
     manager.start()
     try:
         new_threads = set(threading.enumerate()) - before_threads
-        tail_threads = [t for t in new_threads if "tail" in t.name.lower()]
+        tail_threads = [
+            t for t in new_threads if t.name.lower() == "telegram-task-card-event-tail"
+        ]
         assert len(tail_threads) == 1
+        assert len([t for t in new_threads if t.name == "telegram-receipt-tail"]) == 1
+        assert len([t for t in new_threads if t.name == "telegram-receipt-worker"]) == 1
     finally:
         manager.stop()
 


### PR DESCRIPTION
squash of rawpaper123 DRAFTs #1211 + #1213 + #1212 (Telegram gateway + durable receipts + steering lane), per Jason instruction to see the combined effect.

- #1211: Add a preemptive steering lane for human guidance (+833, 6 files)
- #1213: Add a single-owner Telegram Gateway (+1190, 7 files)
- #1212: Make Telegram read receipts Agent-open durable (+556, 7 files)

Squash resolution: applied #1211 → #1213 → #1212 onto live main; single conflict in manager.py (_stop_receipt_path vs proxy_mode guard) resolved by start() symmetry.

Validation: 80 focused tests passed (gateway/receipts/steering/account/taskcard); compile PASS.