### PR TITLE
feat(telegram): place single API-call timestamp above metadata line

### DIFF
--- a/src/lingtai/mcp_servers/task_card/event_projection.py
+++ b/src/lingtai/mcp_servers/task_card/event_projection.py
@@ -135,7 +135,7 @@ class TaskCardEventProjection:
         if isinstance(action, str) and action:
             row["tool_action"] = action
         # No per-row wall-clock stamp: each API-call group renders exactly one
-        # timestamp below its API metadata line (Jason 2026-08-09), so tool rows
+        # timestamp above its API metadata line (Jason 2026-08-09), so tool rows
         # stay compact and the API-call timeline is uncluttered.
         raw_ts = event.get("ts")
         if type(raw_ts) in (int, float) and not isinstance(raw_ts, bool):
@@ -447,16 +447,17 @@ class TaskCardEventProjection:
                     usage = u
                 if api_delay_s is not None and usage is not None:
                     break
-            info = cls.format_divider_info(api_delay_s, usage)
-            if info:
-                rows.append({"kind": "api_info", "text": info})
-            # One wall-clock stamp per API call, below the API metadata line
+            # One wall-clock stamp per API call, above the API metadata line
             # (Jason 2026-08-09): the first progress row of the group marks the
-            # round trip's start.
+            # round trip's start; Jason later asked for the stamp to sit above
+            # the metadata line (2026-08-09 follow-up).
             if group_ts is not None:
                 stamp = cls.format_row_timestamp(group_ts)
                 if stamp:
                     rows.append({"kind": "api_ts", "text": stamp})
+            info = cls.format_divider_info(api_delay_s, usage)
+            if info:
+                rows.append({"kind": "api_info", "text": info})
             rows.extend(group.get("events", []))
         text = cls.format_task_card_text(
             "",

--- a/tests/test_task_card_event_projection_shared.py
+++ b/tests/test_task_card_event_projection_shared.py
@@ -136,10 +136,11 @@ def test_shared_render_is_byte_identical_to_telegram_golden_surface() -> None:
     )
 
 
-def test_api_call_renders_single_timestamp_below_metadata() -> None:
-    """Each API-call group renders exactly one wall-clock stamp below its API
-    metadata line (Jason 2026-08-09): per-tool-row stamps are gone, and the
-    group's first progress ts becomes the single per-API-call timestamp."""
+def test_api_call_renders_single_timestamp_above_metadata() -> None:
+    """Each API-call group renders exactly one wall-clock stamp above its API
+    metadata line (Jason 2026-08-09, follow-up): per-tool-row stamps are gone,
+    and the group's first progress ts becomes the single per-API-call
+    timestamp."""
     ts = datetime(2026, 8, 3, 2, 30, tzinfo=timezone(timedelta(hours=8))).timestamp()
     stamp = TaskCardEventProjection.format_row_timestamp(ts)
     groups = [
@@ -165,11 +166,11 @@ def test_api_call_renders_single_timestamp_below_metadata() -> None:
     assert "↻ 2.3s" in text
     assert f"· {stamp}" not in text
     assert stamp in text
-    # The single stamp sits below the API metadata line, before the tool row.
-    api_idx = text.index("↻ 2.3s")
+    # The single stamp sits above the API metadata line, before the tool row.
     ts_idx = text.index(stamp)
+    api_idx = text.index("↻ 2.3s")
     tool_idx = text.index("bash.run")
-    assert api_idx < ts_idx < tool_idx
+    assert ts_idx < api_idx < tool_idx
 
 
 def test_metadata_renders_device_and_working_dir_lines() -> None:

--- a/tests/test_telegram_task_card_blockers.py
+++ b/tests/test_telegram_task_card_blockers.py
@@ -176,7 +176,7 @@ def test_timestamped_moderate_rows_stay_under_text_limit():
         assert f"tool{i}" in text
     assert _TASK_CARD_FOOTER in text
     # Tool rows no longer carry inline stamps (Jason 2026-08-09: one timestamp
-    # per API call below the API metadata line), so the stamp text is never
+    # per API call above the API metadata line), so the stamp text is never
     # rendered into a row even when supplied.
     for ln in text.splitlines():
         if ln.startswith(("•", "✓")):

--- a/tests/test_telegram_task_card_event_tail.py
+++ b/tests/test_telegram_task_card_event_tail.py
@@ -727,7 +727,7 @@ def test_row_started_at_is_derived_from_event_ts_and_rendered(tmp_path):
     edits = [call for call in acct.calls if call[0] == "edit_message"]
     assert edits
     # The row itself carries no inline stamp; the single per-API-call stamp is
-    # rendered below the API metadata line (Jason 2026-08-09).
+    # rendered above the API metadata line (Jason 2026-08-09).
     row_line = next(ln for ln in edits[-1][3].splitlines() if "bash.run" in ln)
     assert "UTC" not in row_line
     assert f"\n{expected}\n" in f"\n{edits[-1][3]}"

--- a/tests/test_telegram_task_card_timestamp.py
+++ b/tests/test_telegram_task_card_timestamp.py
@@ -2,7 +2,7 @@
 
 Presentation contract (manager render, Jason 2026-08-09): per-tool-row inline
 stamps are retired — each API-call group renders exactly ONE wall-clock stamp,
-below its API metadata line (``api_ts``), and the card's final standalone line
+above its API metadata line (``api_ts``), and the card's final standalone line
 reports the RENDER instant (not any row's start instant) as ``Last Updated:
 HH:MM:SS UTC±HH``, always present. An injected ``now`` keeps these assertions
 deterministic.


### PR DESCRIPTION
Follow-up to #1302 (Jason 2026-08-09):

- The one wall-clock stamp per API call now renders ABOVE the API metadata line
- New order: divider → timestamp → api metadata (↻ delay ↓↑ tokens ◯ ctx | rate) → tool rows
- Updates the timestamp-position test and doc comments (above, not below)

Task card tests: 358 passed (2 pre-existing failures on main unrelated to this change).

Author: @homewinlingtaibot / 深一