### PR TITLE
feat(telegram): add leading symbol to per-API-call timestamp row

### DIFF
--- a/src/lingtai/mcp_servers/task_card/event_projection.py
+++ b/src/lingtai/mcp_servers/task_card/event_projection.py
@@ -450,11 +450,12 @@ class TaskCardEventProjection:
             # One wall-clock stamp per API call, above the API metadata line
             # (Jason 2026-08-09): the first progress row of the group marks the
             # round trip's start; Jason later asked for the stamp to sit above
-            # the metadata line (2026-08-09 follow-up).
+            # the metadata line and carry a leading symbol (2026-08-09
+            # follow-up).
             if group_ts is not None:
                 stamp = cls.format_row_timestamp(group_ts)
                 if stamp:
-                    rows.append({"kind": "api_ts", "text": stamp})
+                    rows.append({"kind": "api_ts", "text": f"· {stamp}"})
             info = cls.format_divider_info(api_delay_s, usage)
             if info:
                 rows.append({"kind": "api_info", "text": info})

--- a/tests/test_task_card_event_projection_shared.py
+++ b/tests/test_task_card_event_projection_shared.py
@@ -164,10 +164,11 @@ def test_api_call_renders_single_timestamp_above_metadata() -> None:
         groups, normal_rows=1, metadata=None, now=now,
     )
     assert "↻ 2.3s" in text
-    assert f"· {stamp}" not in text
-    assert stamp in text
+    tool_row = next(ln for ln in text.splitlines() if "bash.run" in ln)
+    assert stamp not in tool_row
+    assert f"· {stamp}" in text
     # The single stamp sits above the API metadata line, before the tool row.
-    ts_idx = text.index(stamp)
+    ts_idx = text.index(f"· {stamp}")
     api_idx = text.index("↻ 2.3s")
     tool_idx = text.index("bash.run")
     assert ts_idx < api_idx < tool_idx

--- a/tests/test_telegram_task_card_event_tail.py
+++ b/tests/test_telegram_task_card_event_tail.py
@@ -727,10 +727,11 @@ def test_row_started_at_is_derived_from_event_ts_and_rendered(tmp_path):
     edits = [call for call in acct.calls if call[0] == "edit_message"]
     assert edits
     # The row itself carries no inline stamp; the single per-API-call stamp is
-    # rendered above the API metadata line (Jason 2026-08-09).
+    # rendered above the API metadata line with a leading symbol (Jason
+    # 2026-08-09).
     row_line = next(ln for ln in edits[-1][3].splitlines() if "bash.run" in ln)
     assert "UTC" not in row_line
-    assert f"\n{expected}\n" in f"\n{edits[-1][3]}"
+    assert f"\n· {expected}\n" in f"\n{edits[-1][3]}"
 
 
 def test_event_log_final_carrier_projects_session_telemetry_into_final_render(tmp_path):
@@ -799,10 +800,12 @@ def test_event_log_final_carrier_projects_session_telemetry_into_final_render(tm
     assert edits
     rendered = edits[-1][3]
     assert "• bash.run: event-log row" in rendered
-    assert f"· {expected_stamp}" not in rendered
-    # The single per-API-call stamp renders as its own line below the API
-    # metadata line (Jason 2026-08-09), not inline on the tool row.
-    assert f"\n{expected_stamp}\n" in f"\n{rendered}"
+    tool_row = next(ln for ln in rendered.splitlines() if "bash.run" in ln)
+    assert expected_stamp not in tool_row
+    # The single per-API-call stamp renders as its own line above the API
+    # metadata line with a leading symbol (Jason 2026-08-09), not inline on the
+    # tool row.
+    assert f"\n· {expected_stamp}\n" in f"\n{rendered}"
     assert "cache 87.8% · miss 170.6k/1.0M · calls 13" in rendered
     assert "ctx 63% · 171.2k/272.0k" in rendered
     assert "calls 888" not in rendered


### PR DESCRIPTION
Jason 2026-08-09 follow-up to #1303: the single wall-clock stamp per API call now renders with a leading '·' symbol (· HH:MM:SS UTC±HH) above the API metadata line, matching the old inline stamp style.

Task card tests: 133 pass (symbol-position assertions updated).

Author: @homewinlingtaibot / 深一