### PR TITLE
feat(telegram): three-boundary reactions — received, seen, replied

### DIFF
--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -256,9 +256,15 @@ def _mirror_identity_account(value: str) -> str | None:
     return parts[0]
 
 
-# Emoji reactions for different states (Bot API 7.0+)
-REACTION_SEEN = [{"type": "emoji", "emoji": "👀"}]      # Message received
-REACTION_DONE = [{"type": "emoji", "emoji": "✅"}]       # Response sent
+# Emoji reactions for different states (Bot API 7.0+). Three explicit
+# boundaries so a human can see how far an inbound message has travelled:
+#   📧 received  - transport/ingress received the update
+#   👀 seen       - successfully delivered into the agent inbox
+#   ✔️ replied    - a reply targeting that message was sent
+REACTION_RECEIVED = [{"type": "emoji", "emoji": "📧"}]   # Ingress received
+REACTION_SEEN = [{"type": "emoji", "emoji": "👀"}]        # Delivered to agent inbox
+REACTION_REPLIED = [{"type": "emoji", "emoji": "✔️"}]   # Reply sent
+REACTION_DONE = REACTION_REPLIED  # deprecated alias
 
 
 class TypingIndicatorManager:
@@ -537,7 +543,7 @@ DESCRIPTION = (
     "'contacts' to manage saved contacts. "
     "'accounts' to list configured bot accounts. "
     "Voice messages are automatically transcribed using Whisper (local) and delivered as text. "
-    "Rich feedback: automatic typing indicators, emoji reactions (👀 seen, ✅ done), "
+    "Rich feedback: automatic typing indicators, emoji reactions (📧 received, 👀 seen, ✔️ replied), "
     "and live-status messages for long-running tasks (placeholder + edit-in-place). "
     "Automatic Task Card progress is separate: when the current agent setting is "
     "`taskcard: True`, every tool call with an explicit `reasoning` argument may be "
@@ -890,12 +896,12 @@ class TelegramManager:
             if account:
                 _typing_manager.start_typing(account, chat_id)
 
-            # Issue #8: Add "seen" reaction (👀)
-            if account:
+            # Ingress boundary: the transport received this update (📧).
+            if account and isinstance(chat_id, int) and not isinstance(chat_id, bool):
                 try:
-                    account.set_message_reaction(chat_id, tg_message_id, REACTION_SEEN)
+                    account.set_message_reaction(chat_id, tg_message_id, REACTION_RECEIVED)
                 except Exception as e:
-                    log.debug("Failed to add 'seen' reaction: %s", e)
+                    log.debug("Failed to add 'received' reaction: %s", e)
 
             # Issue #6: Transcribe voice messages
             if payload.get("media") and payload["media"].get("type") in ("voice", "audio"):
@@ -1185,8 +1191,9 @@ class TelegramManager:
         if payload.get("voice_transcript"):
             subject = f"telegram voice message from {username} via {account_alias} (transcribed)"
 
+        delivered = False
         try:
-            self._on_inbound({
+            delivered = bool(self._on_inbound({
                 "from": username,
                 "subject": subject,
                 "body": preview if preview else "(no text — see media or callback)",
@@ -1221,10 +1228,21 @@ class TelegramManager:
                     **preview_metadata,
                 },
                 "wake": should_wake,
-            })
+            }))
         except Exception as e:
             log.error("on_inbound callback failed for telegram msg %s: %s",
                       payload.get("id"), e)
+        # Agent-open boundary: delivered into the agent inbox (👀).
+        if (
+            delivered
+            and account
+            and isinstance(chat_id, int) and not isinstance(chat_id, bool)
+            and tg_message_id
+        ):
+            try:
+                account.set_message_reaction(chat_id, tg_message_id, REACTION_SEEN)
+            except Exception as e:
+                log.debug("Failed to add 'seen' reaction: %s", e)
         # Note: typing indicator continues until _send() is called by the agent.
         # _send() stops typing when it sends the response.
 
@@ -3817,12 +3835,12 @@ class TelegramManager:
                 "separate durable `action='send'` or `action='reply'`."
             )
 
-        # Issue #8: Add "done" reaction (✅) to the original message if reply_to
+        # Reply boundary: a reply targeting the original message was sent (✔️).
         if reply_to:
             try:
-                acct.set_message_reaction(chat_id, reply_to, REACTION_DONE)
+                acct.set_message_reaction(chat_id, reply_to, REACTION_REPLIED)
             except Exception as e:
-                log.debug("Failed to add 'done' reaction: %s", e)
+                log.debug("Failed to add 'replied' reaction: %s", e)
 
         # Issue #8: Stop typing indicator now that response is sent
         _typing_manager.stop_typing(acct, chat_id)

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -258,12 +258,12 @@ def _mirror_identity_account(value: str) -> str | None:
 
 # Emoji reactions for different states (Bot API 7.0+). Three explicit
 # boundaries so a human can see how far an inbound message has travelled:
-#   📧 received  - transport/ingress received the update
+#   👌 received  - transport/ingress received the update
 #   👀 seen       - successfully delivered into the agent inbox
-#   ✔️ replied    - a reply targeting that message was sent
-REACTION_RECEIVED = [{"type": "emoji", "emoji": "📧"}]   # Ingress received
+#   ✍️ replied    - a reply targeting that message was sent
+REACTION_RECEIVED = [{"type": "emoji", "emoji": "👌"}]   # Ingress received
 REACTION_SEEN = [{"type": "emoji", "emoji": "👀"}]        # Delivered to agent inbox
-REACTION_REPLIED = [{"type": "emoji", "emoji": "✔️"}]   # Reply sent
+REACTION_REPLIED = [{"type": "emoji", "emoji": "✍️"}]   # Reply sent
 REACTION_DONE = REACTION_REPLIED  # deprecated alias
 
 

--- a/src/lingtai/mcp_servers/telegram/server.py
+++ b/src/lingtai/mcp_servers/telegram/server.py
@@ -638,8 +638,8 @@ def build_manager() -> tuple[TelegramManager, Path]:
     working_dir = Path(agent_dir_raw) if agent_dir_raw else Path.cwd()
     working_dir.mkdir(parents=True, exist_ok=True)
 
-    def _on_inbound(event: dict) -> None:
-        push_inbox_event(
+    def _on_inbound(event: dict) -> bool:
+        return push_inbox_event(
             sender=event["from"],
             subject=event["subject"],
             body=event["body"],

--- a/tests/test_telegram_reaction_states.py
+++ b/tests/test_telegram_reaction_states.py
@@ -2,9 +2,9 @@
 
 A human should be able to tell how far an inbound message has travelled:
 
-- \U0001f4e7 received: the transport/ingress accepted the update.
+- \U0001f44c received: the transport/ingress accepted the update.
 - \U0001f440 seen: the update was successfully delivered into the agent inbox.
-- \u2714\ufe0f replied: a reply targeting that message was sent.
+- \u270d\ufe0f replied: a reply targeting that message was sent.
 
 These tests drive ``TelegramManager`` with a fake account that records
 reaction calls, so the ordering and the exact emoji are locked.
@@ -113,9 +113,9 @@ def test_received_then_seen_on_delivered_inbox(tmp_path):
     manager = _manager(tmp_path, acct, delivered=True)
     manager.on_incoming("mybot", _incoming_message())
 
-    # Ingress first: received (\U0001f4e7), then delivered: seen (\U0001f440).
+    # Ingress first: received (\U0001f44c), then delivered: seen (\U0001f440).
     assert [(chat, mid, em) for (chat, mid, em) in acct.reactions] == [
-        (12345, 8, "\U0001f4e7"),
+        (12345, 8, "\U0001f44c"),
         (12345, 8, "\U0001f440"),
     ]
 
@@ -127,7 +127,7 @@ def test_seen_skipped_when_inbox_delivery_fails(tmp_path):
 
     # Only the received boundary fires; no seen reaction for a failed inbox push.
     assert [(chat, mid, em) for (chat, mid, em) in acct.reactions] == [
-        (12345, 8, "\U0001f4e7"),
+        (12345, 8, "\U0001f44c"),
     ]
 
 
@@ -143,9 +143,9 @@ def test_replied_reaction_on_reply_to_original_message(tmp_path):
         "text": "hi back",
     })
 
-    # The reply targets the original Telegram message: replied (\u2714\ufe0f).
+    # The reply targets the original Telegram message: replied (\u270d\ufe0f).
     assert [(chat, mid, em) for (chat, mid, em) in acct.reactions] == [
-        (12345, 8, "\u2714\ufe0f"),
+        (12345, 8, "\u270d\ufe0f"),
     ]
 
 

--- a/tests/test_telegram_reaction_states.py
+++ b/tests/test_telegram_reaction_states.py
@@ -1,0 +1,154 @@
+"""Three-boundary Telegram reactions: received / seen / replied.
+
+A human should be able to tell how far an inbound message has travelled:
+
+- \U0001f4e7 received: the transport/ingress accepted the update.
+- \U0001f440 seen: the update was successfully delivered into the agent inbox.
+- \u2714\ufe0f replied: a reply targeting that message was sent.
+
+These tests drive ``TelegramManager`` with a fake account that records
+reaction calls, so the ordering and the exact emoji are locked.
+"""
+from __future__ import annotations
+
+import threading
+from datetime import datetime
+from pathlib import Path
+
+from lingtai.mcp_servers.telegram.manager import (
+    TelegramManager,
+    REACTION_RECEIVED,
+    REACTION_SEEN,
+    REACTION_REPLIED,
+)
+from tests._notification_store_helpers import FakeNotificationStore
+
+
+def _emoji(reaction) -> str:
+    if not reaction:
+        return None
+    first = reaction[0]
+    return first.get("emoji") if isinstance(first, dict) else None
+
+
+class ReactionAccount:
+    """Fake account that records every set_message_reaction call."""
+
+    def __init__(self, alias="mybot"):
+        self.alias = alias
+        self.reactions: list[tuple[str, int, list]] = []
+        self._next_id = 100
+
+    def send_message(self, chat_id, text, reply_to_message_id=None, **kwargs):
+        msg_id = self._next_id
+        self._next_id += 1
+        return {"message_id": msg_id}
+
+    def edit_message(self, chat_id, message_id, text, **kwargs):
+        return {"ok": True}
+
+    def delete_message(self, chat_id, message_id):
+        return {"ok": True}
+
+    def get_task_card(self, chat_id):
+        return None
+
+    def set_task_card(self, chat_id, compound_id):
+        return None
+
+    def clear_task_card(self, chat_id):
+        return None
+
+    def list_task_card_chats(self):
+        return []
+
+    def get_last_message_id(self, chat_id):
+        return None
+
+    def set_message_reaction(self, chat_id, message_id, reaction):
+        self.reactions.append((chat_id, message_id, _emoji(reaction)))
+
+
+class ReactionService:
+    def __init__(self, account):
+        self._acct = account
+        self.default_account = account
+
+    def get_account(self, alias):
+        return self._acct
+
+    def list_accounts(self):
+        return [self._acct.alias]
+
+    def taskcard_enabled(self):
+        return True
+
+    def taskcard_normal_rows(self):
+        return 1
+
+
+def _manager(tmp_path, acct, delivered=True):
+    service = ReactionService(acct)
+    manager = TelegramManager(
+        service,
+        working_dir=Path(tmp_path),
+        on_inbound=lambda _: delivered,
+        notification_store=FakeNotificationStore(),
+    )
+    return manager
+
+
+def _incoming_message():
+    return {"message": {
+        "message_id": 8,
+        "date": 1781600000,
+        "from": {"username": "alice"},
+        "chat": {"id": 12345, "type": "private"},
+        "text": "hello",
+    }}
+
+
+def test_received_then_seen_on_delivered_inbox(tmp_path):
+    acct = ReactionAccount()
+    manager = _manager(tmp_path, acct, delivered=True)
+    manager.on_incoming("mybot", _incoming_message())
+
+    # Ingress first: received (\U0001f4e7), then delivered: seen (\U0001f440).
+    assert [(chat, mid, em) for (chat, mid, em) in acct.reactions] == [
+        (12345, 8, "\U0001f4e7"),
+        (12345, 8, "\U0001f440"),
+    ]
+
+
+def test_seen_skipped_when_inbox_delivery_fails(tmp_path):
+    acct = ReactionAccount()
+    manager = _manager(tmp_path, acct, delivered=False)
+    manager.on_incoming("mybot", _incoming_message())
+
+    # Only the received boundary fires; no seen reaction for a failed inbox push.
+    assert [(chat, mid, em) for (chat, mid, em) in acct.reactions] == [
+        (12345, 8, "\U0001f4e7"),
+    ]
+
+
+def test_replied_reaction_on_reply_to_original_message(tmp_path):
+    acct = ReactionAccount()
+    manager = _manager(tmp_path, acct, delivered=True)
+    manager.on_incoming("mybot", _incoming_message())
+    acct.reactions.clear()
+
+    manager._send({
+        "chat_id": 12345,
+        "_reply_to_message_id": 8,
+        "text": "hi back",
+    })
+
+    # The reply targets the original Telegram message: replied (\u2714\ufe0f).
+    assert [(chat, mid, em) for (chat, mid, em) in acct.reactions] == [
+        (12345, 8, "\u2714\ufe0f"),
+    ]
+
+
+def test_deprecated_done_alias_points_to_replied():
+    from lingtai.mcp_servers.telegram.manager import REACTION_DONE
+    assert REACTION_DONE is REACTION_REPLIED


### PR DESCRIPTION
Three explicit Telegram reaction boundaries so a human can see how far an inbound message has travelled:

- \U0001f4e7 **received** — transport/ingress accepted the update (was previously the \U0001f440 seen call site)
- \U0001f440 **seen** — the update was successfully delivered into the agent inbox (new call after push_inbox_event returns True)
- \u2714\ufe0f **replied** — a reply targeting that message was sent (replaces the old \u2705 done reaction)

Implementation: manager.py adds REACTION_RECEIVED/REACTION_SEEN/REACTION_REPLIED constants (REACTION_DONE kept as deprecated alias); server.py on_inbound now returns the push_inbox_event result so the manager only marks seen on successful inbox delivery. Tool description updated to the three-state wording.

Validation: 4 new reaction-state tests passed (received-then-seen on delivered inbox, seen skipped when delivery fails, replied on reply-to, deprecated alias); full collectable Telegram suite 404 passed; diff-check + py_compile PASS. (Two unrelated test files fail collection on this machine because the system mcp package predates SDK v2 \u2014 same environment failure as the live base.)

Telegram: @lingtaidev2bot | Nickname: \u89c2\u4e00