### PR TITLE
feat(telegram): use clock emoji as timestamp row symbol

### DIFF
--- a/src/lingtai/mcp_servers/task_card/event_projection.py
+++ b/src/lingtai/mcp_servers/task_card/event_projection.py
@@ -450,12 +450,12 @@ class TaskCardEventProjection:
             # One wall-clock stamp per API call, above the API metadata line
             # (Jason 2026-08-09): the first progress row of the group marks the
             # round trip's start; Jason later asked for the stamp to sit above
-            # the metadata line and carry a leading symbol (2026-08-09
+            # the metadata line and carry a leading clock symbol (2026-08-09
             # follow-up).
             if group_ts is not None:
                 stamp = cls.format_row_timestamp(group_ts)
                 if stamp:
-                    rows.append({"kind": "api_ts", "text": f"· {stamp}"})
+                    rows.append({"kind": "api_ts", "text": f"🕐 {stamp}"})
             info = cls.format_divider_info(api_delay_s, usage)
             if info:
                 rows.append({"kind": "api_info", "text": info})

--- a/tests/test_task_card_event_projection_shared.py
+++ b/tests/test_task_card_event_projection_shared.py
@@ -166,9 +166,9 @@ def test_api_call_renders_single_timestamp_above_metadata() -> None:
     assert "↻ 2.3s" in text
     tool_row = next(ln for ln in text.splitlines() if "bash.run" in ln)
     assert stamp not in tool_row
-    assert f"· {stamp}" in text
+    assert f"🕐 {stamp}" in text
     # The single stamp sits above the API metadata line, before the tool row.
-    ts_idx = text.index(f"· {stamp}")
+    ts_idx = text.index(f"🕐 {stamp}")
     api_idx = text.index("↻ 2.3s")
     tool_idx = text.index("bash.run")
     assert ts_idx < api_idx < tool_idx

--- a/tests/test_telegram_task_card_event_tail.py
+++ b/tests/test_telegram_task_card_event_tail.py
@@ -727,11 +727,11 @@ def test_row_started_at_is_derived_from_event_ts_and_rendered(tmp_path):
     edits = [call for call in acct.calls if call[0] == "edit_message"]
     assert edits
     # The row itself carries no inline stamp; the single per-API-call stamp is
-    # rendered above the API metadata line with a leading symbol (Jason
+    # rendered above the API metadata line with a leading clock symbol (Jason
     # 2026-08-09).
     row_line = next(ln for ln in edits[-1][3].splitlines() if "bash.run" in ln)
     assert "UTC" not in row_line
-    assert f"\n· {expected}\n" in f"\n{edits[-1][3]}"
+    assert f"\n🕐 {expected}\n" in f"\n{edits[-1][3]}"
 
 
 def test_event_log_final_carrier_projects_session_telemetry_into_final_render(tmp_path):
@@ -803,9 +803,9 @@ def test_event_log_final_carrier_projects_session_telemetry_into_final_render(tm
     tool_row = next(ln for ln in rendered.splitlines() if "bash.run" in ln)
     assert expected_stamp not in tool_row
     # The single per-API-call stamp renders as its own line above the API
-    # metadata line with a leading symbol (Jason 2026-08-09), not inline on the
-    # tool row.
-    assert f"\n· {expected_stamp}\n" in f"\n{rendered}"
+    # metadata line with a leading clock symbol (Jason 2026-08-09), not inline
+    # on the tool row.
+    assert f"\n🕐 {expected_stamp}\n" in f"\n{rendered}"
     assert "cache 87.8% · miss 170.6k/1.0M · calls 13" in rendered
     assert "ctx 63% · 171.2k/272.0k" in rendered
     assert "calls 888" not in rendered


### PR DESCRIPTION
Jason 2026-08-09 follow-up to #1304: replace the '·' prefix with 🕐 on the per-API-call timestamp row (· 00:22:02 UTC-07 → 🕐 00:22:02 UTC-07).

Task card tests: 133 pass.

Author: @homewinlingtaibot / 深一