### PR TITLE
feat(telegram): ride API-call timestamp on a shorter divider

### DIFF
--- a/src/lingtai/mcp_servers/task_card/event_projection.py
+++ b/src/lingtai/mcp_servers/task_card/event_projection.py
@@ -32,7 +32,10 @@ class TaskCardEventProjection:
     EVENT_TEXT_CAP = 500
     MAX_EVENTS_PER_CALL = 24
     MAX_ELAPSED_MS = 9_999_999
-    API_CALL_DIVIDER = "──────────"
+    # Divider is deliberately shorter than the old full-width rule so the
+    # per-API-call wall-clock stamp can ride the same line after it (Jason
+    # 2026-08-09).
+    API_CALL_DIVIDER = "──────"
 
     @classmethod
     def footer(cls, normal_rows: int) -> str:
@@ -427,18 +430,29 @@ class TaskCardEventProjection:
     ) -> str:
         rows: list[dict[str, Any]] = []
         for group in groups[-normal_rows:]:
-            rows.append({"kind": "divider", "text": cls.API_CALL_DIVIDER})
-            # The group's API delay is the LLM round-trip gap since the previous
-            # progress; the per-call usage rides the same divider line, both kept
-            # out of tool rows.
-            api_delay_s: float | None = None
-            usage: dict[str, Any] | None = None
+            # One wall-clock stamp per API call rides the divider line (Jason
+            # 2026-08-09): the first progress row of the group marks the round
+            # trip's start, so the divider carries it — no separate timestamp
+            # line, no marker.
+            stamp = ""
             group_ts: float | None = None
             for row in group.get("events", []):
                 if group_ts is None:
                     v = row.get("_ts")
                     if type(v) in (int, float) and not isinstance(v, bool):
                         group_ts = float(v)
+                if group_ts is not None:
+                    stamp = cls.format_row_timestamp(group_ts)
+                    if stamp:
+                        stamp = f" {stamp}"
+                    break
+            rows.append({"kind": "divider", "text": f"{cls.API_CALL_DIVIDER}{stamp}"})
+            # The group's API delay is the LLM round-trip gap since the previous
+            # progress; the per-call usage rides the same divider line, both kept
+            # out of tool rows.
+            api_delay_s: float | None = None
+            usage: dict[str, Any] | None = None
+            for row in group.get("events", []):
                 v = row.get("api_delay_s")
                 if api_delay_s is None and type(v) in (int, float) and not isinstance(v, bool) and v >= 0:
                     api_delay_s = float(v)
@@ -447,15 +461,6 @@ class TaskCardEventProjection:
                     usage = u
                 if api_delay_s is not None and usage is not None:
                     break
-            # One wall-clock stamp per API call, above the API metadata line
-            # (Jason 2026-08-09): the first progress row of the group marks the
-            # round trip's start; Jason later asked for the stamp to sit above
-            # the metadata line and carry a leading marker — clock emoji was
-            # too flashy, so it settled on a subtle '@' (2026-08-09 follow-up).
-            if group_ts is not None:
-                stamp = cls.format_row_timestamp(group_ts)
-                if stamp:
-                    rows.append({"kind": "api_ts", "text": f"@ {stamp}"})
             info = cls.format_divider_info(api_delay_s, usage)
             if info:
                 rows.append({"kind": "api_info", "text": info})
@@ -710,7 +715,8 @@ class TaskCardEventProjection:
                 continue
             kind = row.get("kind")
             if kind == "divider":
-                api_prepared.append((idx, cls.API_CALL_DIVIDER))
+                divider = redact_text(str(row.get("text", cls.API_CALL_DIVIDER))).strip()
+                api_prepared.append((idx, divider[: cls.EVENT_TEXT_CAP]))
                 continue
             if kind == "api_info":
                 info = redact_text(str(row.get("text", ""))).strip()

--- a/tests/test_task_card_event_projection_shared.py
+++ b/tests/test_task_card_event_projection_shared.py
@@ -125,7 +125,7 @@ def test_shared_render_is_byte_identical_to_telegram_golden_surface() -> None:
     assert shared == telegram
     assert shared == (
         "📋 ACTIVITIES\n"
-        "──────────\n"
+        f"{TaskCardEventProjection.API_CALL_DIVIDER}\n"
         "• public response\n"
         "• bash.run: build (0ms, running)\n"
         "\n"
@@ -136,11 +136,11 @@ def test_shared_render_is_byte_identical_to_telegram_golden_surface() -> None:
     )
 
 
-def test_api_call_renders_single_timestamp_above_metadata() -> None:
-    """Each API-call group renders exactly one wall-clock stamp above its API
-    metadata line (Jason 2026-08-09, follow-up): per-tool-row stamps are gone,
-    and the group's first progress ts becomes the single per-API-call
-    timestamp."""
+def test_api_call_rides_single_timestamp_on_divider() -> None:
+    """Each API-call group rides exactly one wall-clock stamp on its divider
+    line (Jason 2026-08-09, follow-up): per-tool-row stamps are gone, and the
+    group's first progress ts becomes the single per-API-call timestamp that
+    sits on the divider itself — no separate timestamp row, no marker."""
     ts = datetime(2026, 8, 3, 2, 30, tzinfo=timezone(timedelta(hours=8))).timestamp()
     stamp = TaskCardEventProjection.format_row_timestamp(ts)
     groups = [
@@ -166,12 +166,14 @@ def test_api_call_renders_single_timestamp_above_metadata() -> None:
     assert "↻ 2.3s" in text
     tool_row = next(ln for ln in text.splitlines() if "bash.run" in ln)
     assert stamp not in tool_row
-    assert f"@ {stamp}" in text
-    # The single stamp sits above the API metadata line, before the tool row.
-    ts_idx = text.index(f"@ {stamp}")
+    divider = TaskCardEventProjection.API_CALL_DIVIDER
+    # The stamp rides the divider line, before the API metadata line.
+    divider_line = next(ln for ln in text.splitlines() if ln.startswith(divider))
+    assert f"{divider} {stamp}" == divider_line
+    divider_idx = text.index(divider_line)
     api_idx = text.index("↻ 2.3s")
     tool_idx = text.index("bash.run")
-    assert ts_idx < api_idx < tool_idx
+    assert divider_idx < api_idx < tool_idx
 
 
 def test_metadata_renders_device_and_working_dir_lines() -> None:

--- a/tests/test_telegram_task_card_event_tail.py
+++ b/tests/test_telegram_task_card_event_tail.py
@@ -731,7 +731,7 @@ def test_row_started_at_is_derived_from_event_ts_and_rendered(tmp_path):
     # 2026-08-09).
     row_line = next(ln for ln in edits[-1][3].splitlines() if "bash.run" in ln)
     assert "UTC" not in row_line
-    assert f"\n@ {expected}\n" in f"\n{edits[-1][3]}"
+    assert f"\n{manager._TASK_CARD_API_CALL_DIVIDER} {expected}\n" in f"\n{edits[-1][3]}"
 
 
 def test_event_log_final_carrier_projects_session_telemetry_into_final_render(tmp_path):
@@ -805,7 +805,7 @@ def test_event_log_final_carrier_projects_session_telemetry_into_final_render(tm
     # The single per-API-call stamp renders as its own line above the API
     # metadata line with a leading '@' marker (Jason 2026-08-09), not inline
     # on the tool row.
-    assert f"\n@ {expected_stamp}\n" in f"\n{rendered}"
+    assert f"\n{manager._TASK_CARD_API_CALL_DIVIDER} {expected_stamp}\n" in f"\n{rendered}"
     assert "cache 87.8% · miss 170.6k/1.0M · calls 13" in rendered
     assert "ctx 63% · 171.2k/272.0k" in rendered
     assert "calls 888" not in rendered


### PR DESCRIPTION
Jason 2026-08-09 follow-up: no separate timestamp row and no marker — the one wall-clock stamp per API call now rides the divider line (shorter, 6 dashes), e.g. '────── 00:22:02 UTC-07'.

Task card tests: 133 pass.

Author: @homewinlingtaibot / 深一