### PR TITLE
feat(telegram): embed per-API-call timestamp in a symmetric divider

### DIFF
--- a/src/lingtai/mcp_servers/task_card/event_projection.py
+++ b/src/lingtai/mcp_servers/task_card/event_projection.py
@@ -32,10 +32,10 @@ class TaskCardEventProjection:
     EVENT_TEXT_CAP = 500
     MAX_EVENTS_PER_CALL = 24
     MAX_ELAPSED_MS = 9_999_999
-    # Divider is deliberately shorter than the old full-width rule so the
-    # per-API-call wall-clock stamp can ride the same line after it (Jason
-    # 2026-08-09).
-    API_CALL_DIVIDER = "──────"
+    # One symmetric dash run on each side of the per-API-call wall-clock stamp:
+    # the divider becomes a log-style section header `──── 00:22:02 U-7 ────`
+    # (Jason 2026-08-09).
+    API_CALL_DIVIDER = "────"
 
     @classmethod
     def footer(cls, normal_rows: int) -> str:
@@ -43,14 +43,18 @@ class TaskCardEventProjection:
 
     @staticmethod
     def format_current_time(now: datetime) -> str:
-        """Render ``HH:MM:SS UTC±HH`` or empty text for a naive instant."""
+        """Render ``HH:MM:SS U±H`` (e.g. ``00:22:02 U-7``) or empty text.
+
+        The offset is deliberately compact (Jason 2026-08-09): ``UTC-07``
+        became ``U-7`` so the symmetric divider header stays short.
+        """
         offset = now.utcoffset()
         if offset is None:
             return ""
         total = offset.total_seconds()
         sign = "-" if total < 0 else "+"
         hours = int(abs(total) // 3600)
-        return f"{now.strftime('%H:%M:%S')} UTC{sign}{hours:02d}"
+        return f"{now.strftime('%H:%M:%S')} U{sign}{hours}"
 
     @classmethod
     def format_row_timestamp(cls, ts: object) -> str:
@@ -430,10 +434,10 @@ class TaskCardEventProjection:
     ) -> str:
         rows: list[dict[str, Any]] = []
         for group in groups[-normal_rows:]:
-            # One wall-clock stamp per API call rides the divider line (Jason
-            # 2026-08-09): the first progress row of the group marks the round
-            # trip's start, so the divider carries it — no separate timestamp
-            # line, no marker.
+            # One wall-clock stamp per API call sits centered in the divider
+            # line (Jason 2026-08-09): the first progress row of the group
+            # marks the round trip's start, so the symmetric divider carries it
+            # `──── 00:22:02 U-7 ────` — no separate timestamp line, no marker.
             stamp = ""
             group_ts: float | None = None
             for row in group.get("events", []):
@@ -443,10 +447,13 @@ class TaskCardEventProjection:
                         group_ts = float(v)
                 if group_ts is not None:
                     stamp = cls.format_row_timestamp(group_ts)
-                    if stamp:
-                        stamp = f" {stamp}"
                     break
-            rows.append({"kind": "divider", "text": f"{cls.API_CALL_DIVIDER}{stamp}"})
+            if stamp:
+                rows.append(
+                    {"kind": "divider", "text": f"{cls.API_CALL_DIVIDER} {stamp} {cls.API_CALL_DIVIDER}"}
+                )
+            else:
+                rows.append({"kind": "divider", "text": cls.API_CALL_DIVIDER})
             # The group's API delay is the LLM round-trip gap since the previous
             # progress; the per-call usage rides the same divider line, both kept
             # out of tool rows.

--- a/tests/test_task_card_event_projection_shared.py
+++ b/tests/test_task_card_event_projection_shared.py
@@ -132,15 +132,16 @@ def test_shared_render_is_byte_identical_to_telegram_golden_surface() -> None:
         "Don't reply to this Task Card. Use /taskcard on|off to toggle; "
         "/taskcard N sets normal rows (1-10, current: 1).\n"
         "active · calls 2\n"
-        "Last Updated: 02:30:00 UTC+08"
+        "Last Updated: 02:30:00 U+8"
     )
 
 
-def test_api_call_rides_single_timestamp_on_divider() -> None:
-    """Each API-call group rides exactly one wall-clock stamp on its divider
-    line (Jason 2026-08-09, follow-up): per-tool-row stamps are gone, and the
-    group's first progress ts becomes the single per-API-call timestamp that
-    sits on the divider itself — no separate timestamp row, no marker."""
+def test_api_call_embeds_single_timestamp_in_symmetric_divider() -> None:
+    """Each API-call group embeds exactly one wall-clock stamp centered in its
+    divider line (Jason 2026-08-09, follow-up): per-tool-row stamps are gone,
+    and the group's first progress ts becomes the single per-API-call timestamp
+    rendered as a symmetric log-style section header `──── 00:22:02 U-7 ────`
+    — no separate timestamp row, no marker."""
     ts = datetime(2026, 8, 3, 2, 30, tzinfo=timezone(timedelta(hours=8))).timestamp()
     stamp = TaskCardEventProjection.format_row_timestamp(ts)
     groups = [
@@ -167,9 +168,10 @@ def test_api_call_rides_single_timestamp_on_divider() -> None:
     tool_row = next(ln for ln in text.splitlines() if "bash.run" in ln)
     assert stamp not in tool_row
     divider = TaskCardEventProjection.API_CALL_DIVIDER
-    # The stamp rides the divider line, before the API metadata line.
+    # The stamp sits centered between the symmetric dash runs, before the API
+    # metadata line.
     divider_line = next(ln for ln in text.splitlines() if ln.startswith(divider))
-    assert f"{divider} {stamp}" == divider_line
+    assert f"{divider} {stamp} {divider}" == divider_line
     divider_idx = text.index(divider_line)
     api_idx = text.index("↻ 2.3s")
     tool_idx = text.index("bash.run")

--- a/tests/test_telegram_task_card_blockers.py
+++ b/tests/test_telegram_task_card_blockers.py
@@ -182,7 +182,7 @@ def test_timestamped_moderate_rows_stay_under_text_limit():
         if ln.startswith(("•", "✓")):
             assert "04:08:08 UTC-07" not in ln
     # The bottom line is the single render-time stamp, distinct from row stamps.
-    assert text.splitlines()[-1] == "Last Updated: 17:18:36 UTC-07"
+    assert text.splitlines()[-1] == "Last Updated: 17:18:36 U-7"
 
 
 def test_extreme_row_count_exceeds_budget_but_keeps_every_row():
@@ -213,7 +213,7 @@ def test_extreme_row_count_exceeds_budget_but_keeps_every_row():
     assert not text.endswith("…")
     # The fixed footer and the single render-time line still render.
     assert _TASK_CARD_FOOTER in text
-    assert text.splitlines()[-1] == "Last Updated: 17:18:36 UTC-07"
+    assert text.splitlines()[-1] == "Last Updated: 17:18:36 U-7"
 
 
 def test_timestamped_rows_redaction_before_truncation():

--- a/tests/test_telegram_task_card_event_tail.py
+++ b/tests/test_telegram_task_card_event_tail.py
@@ -245,7 +245,9 @@ def test_provider_groups_count_calls_and_exclude_unprojected_fields(tmp_path):
     manager._poll_event_tail()
     rendered = [call for call in acct.calls if call[0] == "edit_message"][-1][3]
     divider = manager._TASK_CARD_API_CALL_DIVIDER
-    assert rendered.count(divider) == 2
+    # Two API groups → two symmetric divider header lines (each line carries the
+    # dash run twice, once per side, so count lines, not substring occurrences).
+    assert sum(ln.startswith(divider) for ln in rendered.splitlines()) == 2
     assert all(value in rendered for value in ("text one", "• bash.run:", "text two", "• read.read:"))
     assert len(rendered) <= manager._TASK_CARD_TEXT_LIMIT
     assert all(secret not in rendered for secret in (
@@ -255,7 +257,7 @@ def test_provider_groups_count_calls_and_exclude_unprojected_fields(tmp_path):
     service.normal_rows = 1
     manager._broadcast_task_card_event_window()
     latest = acct.calls[-1][3]
-    assert latest.count(divider) == 1 and "text two" in latest and "• read.read:" in latest
+    assert sum(ln.startswith(divider) for ln in latest.splitlines()) == 1 and "text two" in latest and "• read.read:" in latest
     assert "text one" not in latest and "• bash.run:" not in latest
 
 
@@ -721,17 +723,22 @@ def test_row_started_at_is_derived_from_event_ts_and_rendered(tmp_path):
     manager._poll_event_tail()
 
     local = datetime.fromtimestamp(event_ts).astimezone()
-    expected = f"{local:%H:%M:%S} UTC{local:%z}"[:-2]
+    off = local.utcoffset()
+    sign = "-" if off.total_seconds() < 0 else "+"
+    hours = int(abs(off.total_seconds()) // 3600)
+    expected = f"{local:%H:%M:%S} U{sign}{hours}"
     window = manager._task_card_event_window()
     assert len(window) == 1
     edits = [call for call in acct.calls if call[0] == "edit_message"]
     assert edits
     # The row itself carries no inline stamp; the single per-API-call stamp is
-    # rendered above the API metadata line with a leading '@' marker (Jason
-    # 2026-08-09).
+    # embedded centered in the symmetric divider line (Jason 2026-08-09).
     row_line = next(ln for ln in edits[-1][3].splitlines() if "bash.run" in ln)
     assert "UTC" not in row_line
-    assert f"\n{manager._TASK_CARD_API_CALL_DIVIDER} {expected}\n" in f"\n{edits[-1][3]}"
+    assert (
+        f"\n{manager._TASK_CARD_API_CALL_DIVIDER} {expected} {manager._TASK_CARD_API_CALL_DIVIDER}\n"
+        in f"\n{edits[-1][3]}"
+    )
 
 
 def test_event_log_final_carrier_projects_session_telemetry_into_final_render(tmp_path):
@@ -795,17 +802,22 @@ def test_event_log_final_carrier_projects_session_telemetry_into_final_render(tm
     manager._poll_event_tail()
 
     local = datetime.fromtimestamp(event_ts).astimezone()
-    expected_stamp = f"{local:%H:%M:%S} UTC{local:%z}"[:-2]
+    off = local.utcoffset()
+    sign = "-" if off.total_seconds() < 0 else "+"
+    hours = int(abs(off.total_seconds()) // 3600)
+    expected_stamp = f"{local:%H:%M:%S} U{sign}{hours}"
     edits = [call for call in acct.calls if call[0] == "edit_message"]
     assert edits
     rendered = edits[-1][3]
     assert "• bash.run: event-log row" in rendered
     tool_row = next(ln for ln in rendered.splitlines() if "bash.run" in ln)
     assert expected_stamp not in tool_row
-    # The single per-API-call stamp renders as its own line above the API
-    # metadata line with a leading '@' marker (Jason 2026-08-09), not inline
-    # on the tool row.
-    assert f"\n{manager._TASK_CARD_API_CALL_DIVIDER} {expected_stamp}\n" in f"\n{rendered}"
+    # The single per-API-call stamp renders centered in the symmetric divider
+    # line (Jason 2026-08-09), not inline on the tool row.
+    assert (
+        f"\n{manager._TASK_CARD_API_CALL_DIVIDER} {expected_stamp} {manager._TASK_CARD_API_CALL_DIVIDER}\n"
+        in f"\n{rendered}"
+    )
     assert "cache 87.8% · miss 170.6k/1.0M · calls 13" in rendered
     assert "ctx 63% · 171.2k/272.0k" in rendered
     assert "calls 888" not in rendered
@@ -1405,9 +1417,9 @@ def test_fingerprint_ignores_last_updated_line_only(tmp_path):
     """The volatile Last Updated line must not change the fingerprint; any
     other content change must."""
     manager, _ = _manager(tmp_path, FakeAccount())
-    a = "\u2699 WORKING\n\u2022 row\n\nfooter\nLast Updated: 10:00:00 UTC+08"
-    b = "\u2699 WORKING\n\u2022 row\n\nfooter\nLast Updated: 10:00:01 UTC+08"
-    c = "\u2699 WORKING\n\u2022 other\n\nfooter\nLast Updated: 10:00:00 UTC+08"
+    a = "\u2699 WORKING\n\u2022 row\n\nfooter\nLast Updated: 10:00:00 U+8"
+    b = "\u2699 WORKING\n\u2022 row\n\nfooter\nLast Updated: 10:00:01 U+8"
+    c = "\u2699 WORKING\n\u2022 other\n\nfooter\nLast Updated: 10:00:00 U+8"
     assert manager._task_card_automatic_fingerprint(a) == \
         manager._task_card_automatic_fingerprint(b)
     assert manager._task_card_automatic_fingerprint(a) != \

--- a/tests/test_telegram_task_card_timestamp.py
+++ b/tests/test_telegram_task_card_timestamp.py
@@ -52,7 +52,7 @@ def test_manager_renders_current_time_line_from_render_instant_not_row_start():
     ], now=_NOW)
     lines = text.splitlines()
     # The bottom line is the labelled render-time stamp, not the row's own start.
-    assert lines[-1] == "Last Updated: 17:18:36 UTC-07"
+    assert lines[-1] == "Last Updated: 17:18:36 U-7"
 
 
 def test_current_time_line_follows_the_footer():
@@ -64,7 +64,7 @@ def test_current_time_line_follows_the_footer():
     footer_idx = next(i for i, ln in enumerate(lines) if _TASK_CARD_FOOTER in ln)
     time_idx = next(i for i, ln in enumerate(lines) if ln.startswith("Last Updated: "))
     assert time_idx > footer_idx
-    assert lines[time_idx] == "Last Updated: 17:18:36 UTC-07"
+    assert lines[time_idx] == "Last Updated: 17:18:36 U-7"
 
 
 def test_parallel_rows_never_renders_any_per_row_stamp():
@@ -80,7 +80,7 @@ def test_parallel_rows_never_renders_any_per_row_stamp():
         if ln.startswith(("•", "✓")):
             assert "UTC" not in ln
     # The bottom line is still the single render-time stamp.
-    assert _current_time_line(text) == "Last Updated: 17:18:36 UTC-07"
+    assert _current_time_line(text) == "Last Updated: 17:18:36 U-7"
 
 
 def test_current_time_line_present_even_when_no_row_has_a_stamp():
@@ -92,7 +92,7 @@ def test_current_time_line_present_even_when_no_row_has_a_stamp():
     ], now=_NOW)
     # Last Updated never depends on any row carrying a stamp — it always
     # reflects the render instant.
-    assert text.splitlines()[-1] == "Last Updated: 17:18:36 UTC-07"
+    assert text.splitlines()[-1] == "Last Updated: 17:18:36 U-7"
     # Tool rows never render an inline stamp even when one is supplied.
     for ln in text.splitlines():
         if ln.startswith(("•", "✓")):
@@ -112,7 +112,7 @@ def test_api_error_row_never_carries_a_stamp_alongside_a_tool_row():
     assert "UTC" not in bash_line
     api_line = next(ln for ln in text.splitlines() if "API error" in ln)
     assert "UTC" not in api_line
-    assert text.splitlines()[-1] == "Last Updated: 17:18:36 UTC-07"
+    assert text.splitlines()[-1] == "Last Updated: 17:18:36 U-7"
 
 
 def test_render_tool_row_without_started_at_is_safe():
@@ -121,4 +121,4 @@ def test_render_tool_row_without_started_at_is_safe():
          "elapsed_s": 1, "done": False},
     ], now=_NOW)
     assert "bash.run" in text
-    assert text.splitlines()[-1] == "Last Updated: 17:18:36 UTC-07"
+    assert text.splitlines()[-1] == "Last Updated: 17:18:36 U-7"


### PR DESCRIPTION
## What
Jason chose a log-style symmetric divider for the per-API-call timestamp (Telegram 4025): the wall-clock stamp is now centered between two short dash runs, like a section header:

```
──── 00:22:02 U-7 ────
↻ 5.2s ↓130 ↑818 ◯ 382.0k | 99.8%
• tool.row ...
```

## Changes
- `API_CALL_DIVIDER` shortened to one symmetric dash run (4 dashes); the stamp is embedded centered: `{divider} {stamp} {divider}`
- Offset format compacted from `UTC-07` to `U-7` (and `UTC+08` → `U+8`) in both the divider stamp and Last Updated footer
- Tool rows still carry no inline stamp; no separate timestamp row, no marker

## Tests
340 taskcard tests pass (updated: symmetric-divider assertion, Last Updated goldens, divider-line counting).

PR handle: @homewinlingtaibot / 深一