### PR TITLE
feat(vision): always register vision; analyze/check preset borrow option

### DIFF
--- a/src/lingtai/tools/daemon/__init__.py
+++ b/src/lingtai/tools/daemon/__init__.py
@@ -477,10 +477,17 @@ def _parent_host_tool_floor() -> frozenset[str]:
         the same reason optional parent tools are: the floor is host primitives
         only, and a capability joining ``CORE_DEFAULTS`` must not silently widen
         it.
+      * ``vision`` — always registered since it joined ``CORE_DEFAULTS``, but
+        its route is provider-bound (the default inherits the active LLM's
+        Responses API; the ``preset`` analyze option borrows another allowed
+        preset's identity). A preset emanation has no independent vision
+        service of its own, so vision must NOT silently fall back to the
+        parent host floor either; it is available only when the preset's own
+        sandbox provides it.
     The result is exactly {shell, file}.
     """
     from lingtai.tools.registry import CORE_DEFAULTS  # noqa: PLC0415
-    return frozenset(set(CORE_DEFAULTS) - EMANATION_BLACKLIST - {"mcp", "plugin"})
+    return frozenset(set(CORE_DEFAULTS) - EMANATION_BLACKLIST - {"mcp", "plugin", "vision"})
 
 
 # Env vars that override Claude Code's normal first-party OAuth credentials.

--- a/src/lingtai/tools/registry.py
+++ b/src/lingtai/tools/registry.py
@@ -141,8 +141,11 @@ BUILTIN_TOOLS: dict[str, str] = {
 #
 # ``shell`` defaults to {"yolo": True} (unsandboxed). Hosts that want a sandbox
 # pass {"policy_file": "..."} in init.json, which overrides the default kwargs.
-# ``vision`` and ``web_search`` are NOT in this set — they require provider
-# config and API keys, so they stay explicit opt-in.
+# ``vision`` is always registered: its provider defaults to the active LLM
+# (the agent's own Responses API), and the analyze call may explicitly borrow
+# another preset's vision service via the ``preset`` option. ``web_search``
+# is NOT in this set — it requires provider config and API keys, so it stays
+# explicit opt-in.
 CORE_DEFAULTS: dict[str, dict] = {
     "knowledge": {},
     "skills": {},
@@ -156,6 +159,7 @@ CORE_DEFAULTS: dict[str, dict] = {
     "plugin": {},
     "task_card": {},
     "file": {},
+    "vision": {},
 }
 
 

--- a/src/lingtai/tools/vision/ANATOMY.md
+++ b/src/lingtai/tools/vision/ANATOMY.md
@@ -47,8 +47,10 @@ result shape.
 - Setup lazily reaches `lingtai.services.vision` and the Codex pool selector.
 - Direct compatible aliases (`openrouter`, `deepseek`, `zhipu`, `glm`, `grok`,
   `qwen`, `kimi`, `custom`) use current OpenAI/Anthropic-compatible identity.
-- MiniMax uses Anthropic; Codex aliases use the Codex service; Claude Code and
-  unresolved/unsupported routes remain manual-only. No MCP fallback is used.
+- MiniMax uses Anthropic; Codex aliases use the Codex service; Claude Code
+  (`claude-code`/`claude_code`/`claude-p`) returns explicit "use the Claude CLI
+  for vision" guidance; unresolved/unsupported routes remain manual-only. No
+  MCP fallback is used.
 
 ## Composition
 

--- a/src/lingtai/tools/vision/CONTRACT.md
+++ b/src/lingtai/tools/vision/CONTRACT.md
@@ -54,11 +54,13 @@ credential read, or image read.
 
 `PROVIDERS["providers"]` is exactly: `gemini`, `anthropic`, `openai`,
 `openrouter`, `custom`, `deepseek`, `minimax`, `mimo`, `glm`, `zhipu`, `grok`,
-`qwen`, `kimi`, `codex`, `codex-pool`, `codex_pool`, `claude-code`, and
-`claude_code`. The local mlx-vlm pseudo-provider remains available only through
+`qwen`, `kimi`, `codex`, `codex-pool`, `codex_pool`, `claude-p`, `claude-code`,
+and `claude_code`. The local mlx-vlm pseudo-provider remains available only through
 explicit `add_capability(..., provider="local")` opt-in and is intentionally not
-advertised to wizards/check-caps. Claude Code is manual-only; Codex aliases use
-native Codex Responses; MiniMax uses the Anthropic route. OpenRouter and custom
+advertised to wizards/check-caps. Claude Code returns explicit "use the Claude
+CLI for vision" guidance (`claude -p "Analyze this image: <path>"` plus the
+manual reference); Codex aliases use native Codex Responses; MiniMax uses the
+Anthropic route. OpenRouter and custom
 deliberately try the current OpenAI-compatible model/endpoint/credential without
 preflighting image support; other compatible aliases use the current
 OpenAI/Anthropic identity. A real request failure is returned as a sanitized

--- a/src/lingtai/tools/vision/__init__.py
+++ b/src/lingtai/tools/vision/__init__.py
@@ -764,14 +764,12 @@ def _resolve_direct_service(
             # does not proxy the CLI's own authentication (claude.ai
             # subscription, API key, configured provider), so there is no
             # direct service to construct: the agent is told to run
-            # ``claude -p`` with the image path and read the vision manual
-            # for the exact steps.
+            # ``claude -p`` and read the vision manual for the exact steps.
             manual_reason = (
-                "The claude backend uses the Claude CLI for vision: run "
-                "`claude -p \"Analyze this image: <path>\"` with the CLI's "
-                "own authentication, and read the vision manual for details: "
+                "Claude is the backend. To use vision, run `claude -p`; "
+                "see the vision manual for more details: "
                 "vision(action='manual', input={}, reasoning='claude vision "
-                "uses the claude cli')."
+                "details')."
             )
         elif provider_key in _CODEX_FAMILY:
             # Codex vision is a standalone Responses request. It may share

--- a/src/lingtai/tools/vision/__init__.py
+++ b/src/lingtai/tools/vision/__init__.py
@@ -766,8 +766,8 @@ def _resolve_direct_service(
             # direct service to construct: the agent is told to run
             # ``claude -p`` and read the vision manual for the exact steps.
             manual_reason = (
-                "Claude is the backend. To use vision, run `claude -p`; "
-                "see the vision manual for more details: "
+                "You are using claude as backend, therefore to use vision run "
+                "`claude -p`; see the vision manual for more details: "
                 "vision(action='manual', input={}, reasoning='claude vision "
                 "details')."
             )

--- a/src/lingtai/tools/vision/__init__.py
+++ b/src/lingtai/tools/vision/__init__.py
@@ -75,6 +75,14 @@ def _consent_guidance() -> str:
 _CODEX_POOL_ALIASES = {"codex-pool", "codex_pool"}
 _CODEX_FAMILY = {"codex"} | _CODEX_POOL_ALIASES
 
+# Claude Code CLI vision: all three spellings identify the claude backend
+# whose vision route is the operator-installed Claude Code CLI (``claude -p``).
+# LingTai does not proxy the CLI's auth, so these providers return explicit
+# guidance instead of constructing a service. ``claude-p`` is the explicit
+# vision-route alias alongside the LLM registry's two canonical adapter
+# spellings (``claude-code``/``claude_code``).
+_CLAUDE_CLI_FAMILY = {"claude-p", "claude-code", "claude_code"}
+
 
 def _same_codex_family(requested: str, active: str) -> bool:
     """Return whether both names are Codex-family spellings.
@@ -125,6 +133,8 @@ def _same_provider_identity(requested: str, active: str) -> bool:
         return True
     if {requested, active} <= {"glm", "zhipu"}:
         return True
+    if {requested, active} <= _CLAUDE_CLI_FAMILY:
+        return True
     return _same_codex_family(requested, active)
 
 
@@ -150,7 +160,7 @@ PROVIDERS = {
     "providers": [
         "gemini", "anthropic", "openai", "openrouter", "custom", "deepseek",
         "minimax", "mimo", "glm", "zhipu", "grok", "qwen", "kimi",
-        "codex", "codex-pool", "codex_pool", "claude-code", "claude_code",
+        "codex", "codex-pool", "codex_pool", "claude-p", "claude-code", "claude_code",
         "local",
     ],
     "default": None,
@@ -749,7 +759,21 @@ def _resolve_direct_service(
         else:
             manual_reason = f"No direct vision route is supported for provider {provider!r}; use vision(action='manual', input={{}}, reasoning='this provider has no supported direct vision route')."
     else:
-        if provider_key in _CODEX_FAMILY:
+        if provider_key in _CLAUDE_CLI_FAMILY:
+            # The claude backend uses the Claude Code CLI for vision. LingTai
+            # does not proxy the CLI's own authentication (claude.ai
+            # subscription, API key, configured provider), so there is no
+            # direct service to construct: the agent is told to run
+            # ``claude -p`` with the image path and read the vision manual
+            # for the exact steps.
+            manual_reason = (
+                "The claude backend uses the Claude CLI for vision: run "
+                "`claude -p \"Analyze this image: <path>\"` with the CLI's "
+                "own authentication, and read the vision manual for details: "
+                "vision(action='manual', input={}, reasoning='claude vision "
+                "uses the claude cli')."
+            )
+        elif provider_key in _CODEX_FAMILY:
             # Codex vision is a standalone Responses request. It may share
             # the active Codex family's model and endpoint, but never
             # inherits those from an unrelated main provider. The fixed/

--- a/src/lingtai/tools/vision/__init__.py
+++ b/src/lingtai/tools/vision/__init__.py
@@ -174,6 +174,16 @@ _ANALYZE_INPUT_SCHEMA: dict[str, Any] = {
                 "\"Describe what you see in this image.\""
             ),
         },
+        "preset": {
+            "type": ["string", "null"],
+            "description": (
+                "Optional preset name/path whose vision service should be "
+                "borrowed for this call (e.g. \"codex-pool\" for gpt-5.6 "
+                "vision). Must be a path listed in manifest.preset.allowed. "
+                "Null/absent uses the default route (active provider or the "
+                "configured vision capability)."
+            ),
+        },
     },
     "required": ["image_path", "question"],
     "additionalProperties": False,
@@ -183,8 +193,29 @@ def _unused(_input: Mapping[str, Any]) -> dict[str, Any]:
     raise AssertionError("the module-level schema-only ToolFamily never dispatches")
 
 
+_CHECK_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "preset": {
+            "type": ["string", "null"],
+            "description": (
+                "Optional preset name/path whose vision service should be "
+                "checked (e.g. \"codex-pool\" for gpt-5.6 vision). Must be a "
+                "path listed in manifest.preset.allowed. Null/absent checks "
+                "the default route (active provider or the configured vision "
+                "capability). The check resolves the service identity without "
+                "sending an image request."
+            ),
+        },
+    },
+    "required": ["preset"],
+    "additionalProperties": False,
+}
+
+
 def _build_family(
     analyze_handler: Any = _unused,
+    check_handler: Any = _unused,
     manual_child: ChildTool | None = None,
 ) -> ToolFamily:
     """Build vision's family from the one canonical child declaration.
@@ -195,13 +226,14 @@ def _build_family(
     and each ``VisionManager``'s dispatching family come from here, so child
     names, schemas, titles, and order cannot drift between the wire surface
     and the dispatcher. Defaults build the non-dispatching variant; the
-    manager passes its bound ``analyze`` handler and the real reserved
-    ``manual`` child from ``build_manual_child``.
+    manager passes its bound ``analyze``/``check`` handlers and the real
+    reserved ``manual`` child from ``build_manual_child``.
     """
     return ToolFamily(
         "vision",
         [
             ChildTool("analyze", _ANALYZE_INPUT_SCHEMA, analyze_handler, title="analyze input"),
+            ChildTool("check", _CHECK_INPUT_SCHEMA, check_handler, title="check input"),
             manual_child
             or ChildTool("manual", MANUAL_INPUT_SCHEMA, _unused, title="manual input"),
         ],
@@ -215,11 +247,14 @@ def get_description(lang: str = "en") -> str:
     return (
         "Analyze an image with the active preset. Use vision(action='analyze', "
         "input={'image_path': '...', 'question': null}, reasoning='read the "
-        "image') for the direct request; OpenRouter/custom first try the "
-        "current OpenAI-compatible route. A real request failure returns a "
+        "image') for the direct request; the optional input preset field "
+        "borrows another allowed preset's vision service (e.g. 'codex-pool'). "
+        "Use vision(action='check', input={'preset': null}, reasoning='verify "
+        "the vision route') to resolve which preset's vision service actually "
+        "works without sending an image. A real request failure returns a "
         "sanitized error and points to vision(action='manual', input={}, "
-        "reasoning='load vision guidance') for read-only alternatives. "
-        "No provider, model, credential, or MCP fallback is automatic."
+        "reasoning='load vision guidance') for read-only alternatives. No "
+        "provider, model, credential, or MCP fallback is automatic."
     )
 
 
@@ -242,20 +277,121 @@ class VisionManager:
         self._vision_service = vision_service
         self._manual_reason = manual_reason
         # Same canonical child declaration the module-level schema-only family
-        # uses, with this instance's bound analyze handler and the real
+        # uses, with this instance's bound analyze/check handlers and the real
         # reserved ``manual`` child registered directly (unwrapped).
         self._family = _build_family(
-            self._dispatch_analyze, build_manual_child(agent, "vision")
+            self._dispatch_analyze,
+            self._dispatch_check,
+            build_manual_child(agent, "vision"),
         )
+
+    def _build_service_from_preset(self, preset_ref: str) -> tuple[Any, str]:
+        """Borrow another preset's vision service for one call.
+
+        The preset must appear in ``manifest.preset.allowed`` (same
+        authorization surface as preset swapping). Its ``manifest.llm`` plus
+        ``manifest.capabilities.vision`` provide the provider/model/credential
+        identity; ``_resolve_direct_service`` is invoked with an identity shim
+        built from that preset so the borrowed provider resolves its own route
+        and credentials (e.g. a ``codex-pool`` preset selects its own OAuth
+        pool identity) instead of inheriting the active provider's.
+
+        Returns ``(VisionService | None, manual_reason, identity)`` where
+        ``identity`` is a dict of the resolved provider/model identity (empty
+        on failure).
+        """
+        import json as _json
+
+        from lingtai.kernel.presets import load_preset, resolve_allowed_presets
+
+        init_path = Path(self._agent._working_dir) / "init.json"
+        if not init_path.is_file():
+            return None, "No init.json is available to resolve manifest.preset.allowed.", {}
+        try:
+            init_data = _json.loads(init_path.read_text(encoding="utf-8"))
+        except Exception:
+            return None, "init.json could not be parsed while resolving preset.allowed.", {}
+        manifest = init_data.get("manifest") or {}
+        allowed_paths = {str(p) for p in resolve_allowed_presets(manifest, self._agent._working_dir)}
+        raw_allowed = set(manifest.get("preset", {}).get("allowed") or [])
+        resolved_ref = str(Path(preset_ref).expanduser())
+        if preset_ref not in raw_allowed and resolved_ref not in allowed_paths:
+            return None, (
+                f"Preset {preset_ref!r} is not in manifest.preset.allowed; "
+                "only authorized presets may be borrowed for vision."
+            ), {}
+        try:
+            preset = load_preset(
+                preset_ref,
+                working_dir=self._agent._working_dir,
+                # Read-only preset loading: no migration surface for a borrow.
+                run_migrations=lambda _path: None,
+            )
+        except Exception as exc:
+            return None, f"Failed to load preset {preset_ref!r}: {type(exc).__name__}.", {}
+        pm = preset.get("manifest") or {}
+        llm = pm.get("llm") or {}
+        vision_cap = (pm.get("capabilities") or {}).get("vision") or {}
+        provider = vision_cap.get("provider") or llm.get("provider")
+        if not provider:
+            return None, f"Preset {preset_ref!r} declares no vision provider.", {}
+        identity = {
+            "provider": llm.get("provider") or provider,
+            "model": llm.get("model"),
+            "base_url": llm.get("base_url"),
+        }
+
+        class _PresetIdentity:
+            provider = llm.get("provider") or provider
+            _model = llm.get("model")
+            _base_url = llm.get("base_url")
+            api_key = None
+            _provider_defaults: dict = {}
+
+        kwargs = dict(vision_cap)
+        for key in ("model", "base_url", "api_key_env", "api_compat", "wire_api"):
+            if key in llm and key not in kwargs:
+                kwargs[key] = llm[key]
+        api_key = kwargs.pop("api_key", None)
+        api_key_env = kwargs.pop("api_key_env", None)
+        service, service_reason = _resolve_direct_service(
+            self._agent,
+            provider,
+            api_key=api_key,
+            api_key_env=api_key_env,
+            identity_service=_PresetIdentity(),
+            **kwargs,
+        )
+        return service, service_reason, identity
 
     def _dispatch_analyze(self, action_input: Mapping[str, Any]) -> dict[str, Any]:
         """Run the one direct analyze operation on already-validated input.
 
         The body is the pre-migration ``handle()`` analyze path unchanged:
         same missing-service guard, relative-path resolution, existence check,
-        default prompt, and success/failure result shapes.
+        default prompt, and success/failure result shapes. When the call
+        carries the optional ``preset`` option, a borrowed service is built for
+        this call from that preset's vision configuration instead of the
+        default route.
         """
-        if self._vision_service is None:
+        preset_ref = action_input.get("preset") if isinstance(action_input, Mapping) else None
+        if preset_ref:
+            borrowed, borrow_reason, _identity = self._build_service_from_preset(preset_ref)
+            if borrowed is None:
+                return {
+                    "status": "error",
+                    "message": (
+                        f"{borrow_reason} Load the vision manual skill for the "
+                        "borrowing steps: vision(action='manual', input={}, "
+                        "reasoning='preset vision unavailable, load the setup "
+                        "steps'); then ask the human for consent before "
+                        "changing preset authorization."
+                    ),
+                }
+            service = borrowed
+        else:
+            service = self._vision_service
+        if service is None:
             reason = self._manual_reason or (
                 "Direct vision is unavailable; call vision(action='manual', "
                 "input={}, reasoning='no direct vision route, load the "
@@ -281,7 +417,7 @@ class VisionManager:
             return {"status": "error", "message": f"Image file not found: {path}"}
 
         try:
-            analysis = self._vision_service.analyze_image(str(path), prompt=question)
+            analysis = service.analyze_image(str(path), prompt=question)
             if not analysis:
                 return {
                     "status": "error",
@@ -289,21 +425,82 @@ class VisionManager:
                 }
             return {"status": "ok", "analysis": analysis}
         except Exception as e:
+            if preset_ref:
+                route = "borrowed preset vision route"
+                hint = (
+                    "The borrowed preset's vision service failed for this "
+                    "image; verify the preset is authorized and its provider "
+                    "supports images."
+                )
+            else:
+                route = "default vision route"
+                hint = (
+                    "The default route is the current provider's "
+                    "Responses-API vision, which may not support images."
+                )
             return {
                 "status": "error",
                 "message": (
-                    f"Vision analysis failed on the default vision route "
-                    f"({type(e).__name__}). The default route is the current "
-                    "provider's Responses-API vision, which may not support "
-                    "images. Alternative vision may be available: the current "
-                    "provider's MCP, or a local OpenAI-compatible vision "
+                    f"Vision analysis failed on the {route} ({type(e).__name__}). "
+                    f"{hint} Alternative vision may be available: the current "
+                    "provider's MCP, a borrowed preset via the analyze "
+                    "preset option, or a local OpenAI-compatible vision "
                     "server via provider='local'. Load the vision manual skill "
                     "for the setup alternatives: vision(action='manual', "
-                    "input={}, reasoning='default vision failed, load the "
-                    "setup alternatives'); then ask the human for consent "
+                    "input={}, reasoning='vision failed, load the setup "
+                    "alternatives'); then ask the human for consent "
                     "before setting one up."
                 ),
             }
+
+    def _dispatch_check(self, action_input: Mapping[str, Any]) -> dict[str, Any]:
+        """Resolve which vision route actually works without sending an image.
+
+        With the optional ``preset`` field, this borrows that preset's vision
+        service the same way ``analyze`` would (authorization check, preset
+        load, provider identity) and reports the resolved provider/model; the
+        service is constructed but no image request is made, so it never costs
+        a provider call. Without ``preset``, it reports whether the default
+        route (configured service or the active LLM's own Responses API) is
+        available. A failure returns a sanitized error pointing at the manual.
+        """
+        preset_ref = action_input.get("preset") if isinstance(action_input, Mapping) else None
+        if preset_ref:
+            borrowed, borrow_reason, identity = self._build_service_from_preset(preset_ref)
+            if borrowed is None:
+                return {
+                    "status": "error",
+                    "message": (
+                        f"{borrow_reason} Load the vision manual skill for the "
+                        "borrowing steps: vision(action='manual', input={}, "
+                        "reasoning='preset vision unavailable, load the setup "
+                        "steps'); then ask the human for consent before "
+                        "changing preset authorization."
+                    ),
+                }
+            return {
+                "status": "ok",
+                "route": f"preset:{preset_ref}",
+                "provider": identity.get("provider"),
+                "model": identity.get("model"),
+            }
+        if self._vision_service is None:
+            reason = self._manual_reason or (
+                "Direct vision is unavailable; call vision(action='manual', "
+                "input={}, reasoning='no direct vision route, load the "
+                "manual alternatives')."
+            )
+            return {
+                "status": "error",
+                "message": f"{reason} {_consent_guidance()}",
+            }
+        active_service = getattr(self._agent, "service", None)
+        return {
+            "status": "ok",
+            "route": "default",
+            "provider": getattr(active_service, "provider", None),
+            "model": getattr(active_service, "model", None),
+        }
 
     def _adapt_manual_result(self, mcp_result: dict[str, Any]) -> dict[str, Any]:
         # Host-owned flattening of the manual child's canonical result into
@@ -353,6 +550,367 @@ class VisionManager:
         return result
 
 
+
+
+def _resolve_direct_service(
+    agent: "BaseAgent",
+    provider: str,
+    api_key: str | None = None,
+    api_key_env: str | None = None,
+    *,
+    identity_service: Any = None,
+    **kwargs: Any,
+) -> tuple["VisionService | None", str]:
+    """Resolve a direct VisionService from provider + kwargs (shared by setup and preset borrowing).
+
+    ``identity_service`` overrides the agent's active LLM service used for
+    provider identity, model/base_url inheritance, and the Codex pool bucket.
+    Preset borrowing passes a lightweight identity shim built from the borrowed
+    preset's ``manifest.llm`` so the borrowed provider (e.g. ``codex-pool``)
+    resolves its own route and credentials instead of the active provider's.
+    """
+    vision_service: "VisionService | None" = None
+    manual_reason = ""
+    if api_key_env:
+        from lingtai.kernel.config_resolve import resolve_env
+        api_key = resolve_env(api_key, api_key_env)
+    provider_key = provider.lower()
+    active_service = identity_service if identity_service is not None else getattr(agent, "service", None)
+    active_provider = getattr(active_service, "provider", "")
+    active_provider_key = active_provider.lower() if isinstance(active_provider, str) else ""
+    same_provider = _same_provider_identity(provider_key, active_provider_key)
+    active_model = getattr(active_service, "_model", None) if same_provider else None
+    active_base_url = getattr(active_service, "_base_url", None) if same_provider else None
+    active_api_key = getattr(active_service, "api_key", None) if same_provider else None
+    if provider_key == "mlx":
+        # Native Apple-MLX on-device vision is an explicit pseudo-provider:
+        # keep it out of PROVIDERS/check-caps, but preserve the documented
+        # opt-in route. Its constructor accepts only model/max_tokens and
+        # needs no key.
+        mlx_kwargs = {
+            key: kwargs[key]
+            for key in ("model", "max_tokens")
+            if key in kwargs and kwargs[key] is not None
+        }
+        from lingtai.services.vision import create_vision_service
+        try:
+            vision_service = create_vision_service(
+                "mlx",
+                api_key=None,
+                **mlx_kwargs,
+            )
+        except Exception as exc:
+            manual_reason = _setup_failure(provider, exc)
+    elif provider_key == "local":
+        # Local is a generic OpenAI-compatible vision server on this
+        # machine (Ollama, LM Studio, vLLM, llama.cpp, ...). The endpoint
+        # is operator-owned and configured in settings/vision.json
+        # (base_url/model/api_key/max_tokens); capability kwargs override
+        # the file. base_url defaults to the standard local port. model is
+        # REQUIRED — no hardcoded default, because a silently assumed
+        # model masks misconfiguration; when it is missing we surface
+        # guided setup steps instead. api_key is optional: local servers
+        # ignore it, so a placeholder satisfies the OpenAI SDK.
+        from lingtai.services.vision.openai import OpenAIVisionService
+        from .settings import (
+            DEFAULT_LOCAL_BASE_URL,
+            SettingsError,
+            read_local_settings,
+        )
+        try:
+            local_settings = read_local_settings(agent)
+        except SettingsError as exc:
+            manual_reason = (
+                f"Local vision settings are invalid: {exc}; fix "
+                "settings/vision.json or pass provider='local' with "
+                "base_url/model kwargs; see vision(action='manual')."
+            )
+        else:
+            local_base_url = (
+                kwargs.get("base_url")
+                or local_settings.base_url
+                or DEFAULT_LOCAL_BASE_URL
+            )
+            local_model = kwargs.get("model") or local_settings.model
+            if not local_model:
+                manual_reason = (
+                    "Local vision needs an explicit model. Load the vision "
+                    "manual skill: vision(action='manual', input={}, "
+                    "reasoning='local vision setup'); then ask the human "
+                    "for consent before setting it up."
+                )
+            else:
+                local_key = api_key or local_settings.api_key or "local"
+                local_wire = _effective_openai_wire(
+                    kwargs.get("wire_api"),
+                    use_responses_api=False,
+                    base_url=local_base_url,
+                )
+                svc_kwargs: dict = {
+                    "api_key": local_key,
+                    "model": local_model,
+                    "base_url": local_base_url,
+                }
+                if local_wire and local_wire != "auto":
+                    svc_kwargs["wire_api"] = local_wire
+                cap_max_tokens = kwargs.get("max_tokens")
+                if cap_max_tokens is None:
+                    cap_max_tokens = local_settings.max_tokens
+                if cap_max_tokens is not None:
+                    svc_kwargs["max_tokens"] = cap_max_tokens
+                try:
+                    vision_service = OpenAIVisionService(**svc_kwargs)
+                except Exception as exc:
+                    manual_reason = _setup_failure(provider, exc)
+    elif provider_key not in PROVIDERS["providers"]:
+        # No dedicated VisionService for this provider (custom relay,
+        # OpenRouter, an anthropic-compat local proxy, ...). Route vision
+        # through the OpenAI- or Anthropic-compatible service, picking the
+        # wire protocol and endpoint from, in order:
+        #   1. capability kwargs — explicit init.json override. This lets a
+        #      user point vision at a *different*, vision-capable model
+        #      (e.g. Kimi-K2.6 on a multi-model proxy) while the main LLM
+        #      stays on a text-only model (e.g. GLM-5.1).
+        #   2. the main LLM: api_compat from service._provider_defaults
+        #      (shaped {provider_name: defaults_dict}), base_url/model from
+        #      service._base_url / service._model.
+        # If the relay or model can't actually do vision, the call fails at
+        # runtime — capability registration never pre-checks.
+        bucket = {}
+        api_compat = (kwargs.get("api_compat") or "").lower()
+        if not api_compat:
+            defaults = getattr(active_service, "_provider_defaults", None) if same_provider else None
+            if isinstance(defaults, dict):
+                # _provider_defaults is dict[provider_name, defaults_dict];
+                # read only the active provider's bucket, never another
+                # provider's credential/transport configuration.
+                bucket = defaults.get(active_provider_key)
+                if isinstance(bucket, dict):
+                    api_compat = (bucket.get("api_compat") or "").lower()
+
+        cap_model = kwargs.get("model")
+        cap_base_url = kwargs.get("base_url")
+        cap_max_tokens = kwargs.get("max_tokens")
+        bucket = bucket if isinstance(bucket, dict) else {}
+        llm_base_url = cap_base_url or active_base_url or bucket.get("base_url")
+        llm_model = cap_model or active_model or bucket.get("model")
+        api_key = api_key or active_api_key
+        headers = kwargs.get("default_headers") or bucket.get("default_headers")
+        wire_api = _effective_openai_wire(
+            kwargs.get("wire_api") or bucket.get("wire_api"),
+            use_responses_api=bucket.get("use_responses_api") is True,
+            base_url=llm_base_url,
+        )
+
+        if api_compat == "openai":
+            from lingtai.services.vision.openai import OpenAIVisionService
+            svc_kwargs: dict = {
+                "api_key": api_key,
+                "model": llm_model,
+                "base_url": llm_base_url,
+            }
+            if headers:
+                svc_kwargs["default_headers"] = headers
+            if wire_api and wire_api != "auto":
+                svc_kwargs["wire_api"] = wire_api
+            if cap_max_tokens is not None:
+                svc_kwargs["max_tokens"] = cap_max_tokens
+            if wire_api is None:
+                manual_reason = "The active OpenAI-compatible wire is not implemented by the direct vision service; use vision(action='manual', input={}, reasoning='the active OpenAI-compatible wire has no direct vision route')."
+            elif not llm_model:
+                manual_reason = f"Provider {provider!r} has no resolved current model for direct vision; use vision(action='manual', input={{}}, reasoning='no resolved current model for direct vision')."
+            elif not api_key:
+                manual_reason = f"Provider {provider!r} has no resolved current credential for direct vision; use vision(action='manual', input={{}}, reasoning='no resolved current credential for direct vision')."
+            else:
+                try:
+                    vision_service = OpenAIVisionService(**svc_kwargs)
+                except Exception as exc:
+                    manual_reason = _setup_failure(provider, exc)
+        elif api_compat == "anthropic":
+            from lingtai.services.vision.anthropic import AnthropicVisionService
+            svc_kwargs = {
+                "api_key": api_key,
+                "model": llm_model,
+                "base_url": llm_base_url,
+            }
+            if headers:
+                svc_kwargs["default_headers"] = headers
+            if cap_max_tokens is not None:
+                svc_kwargs["max_tokens"] = cap_max_tokens
+            if not llm_model:
+                manual_reason = f"Provider {provider!r} has no resolved current model for direct vision; use vision(action='manual', input={{}}, reasoning='no resolved current model for direct vision')."
+            elif not api_key:
+                manual_reason = f"Provider {provider!r} has no resolved current credential for direct vision; use vision(action='manual', input={{}}, reasoning='no resolved current credential for direct vision')."
+            else:
+                try:
+                    vision_service = AnthropicVisionService(**svc_kwargs)
+                except Exception as exc:
+                    manual_reason = _setup_failure(provider, exc)
+        else:
+            manual_reason = f"No direct vision route is supported for provider {provider!r}; use vision(action='manual', input={{}}, reasoning='this provider has no supported direct vision route')."
+    else:
+        if provider_key in _CODEX_FAMILY:
+            # Codex vision is a standalone Responses request. It may share
+            # the active Codex family's model and endpoint, but never
+            # inherits those from an unrelated main provider. The fixed/
+            # direct vs weighted/pool credential route is *not* chosen from
+            # provider spelling: it follows the active provider-default
+            # bucket exactly as the canonical Codex factory does — direct
+            # iff the bucket carries a nonblank trimmed ``codex_auth_path``,
+            # otherwise pool (see ``lingtai/llm/_register.py``).
+            if same_provider:
+                if active_model:
+                    kwargs.setdefault("model", active_model)
+                if active_base_url:
+                    kwargs.setdefault("base_url", active_base_url)
+            codex_base_url = kwargs.get("base_url")
+
+            defaults = getattr(active_service, "_provider_defaults", None) if same_provider else None
+            bucket = defaults.get(active_provider_key) if isinstance(defaults, dict) else None
+            if not isinstance(bucket, dict):
+                bucket = {}
+            # Bucket-driven route: the active Codex service is direct iff its
+            # bucket configures a nonblank ``codex_auth_path``, else pool. An
+            # unrelated active provider carries an empty bucket → ``"pool"``,
+            # and its pool branch stays gated by ``same_provider`` below, so it
+            # never reads a default pool and still fails closed.
+            codex_route = _codex_bucket_route(bucket)
+            # Normalize an explicit capability identity on every route. This
+            # preserves a valid independent token path while ensuring a
+            # whitespace-only value cannot bypass either fail-closed branch.
+            explicit_token_path = _normalize_codex_auth_path(kwargs.pop("token_path", None))
+            if explicit_token_path:
+                kwargs["token_path"] = explicit_token_path
+            if not kwargs.get("model"):
+                manual_reason = f"Provider {provider!r} has no resolved current model for direct vision; use vision(action='manual', input={{}}, reasoning='no resolved current model for direct vision')."
+            elif codex_route == "direct":
+                # A whitespace-only explicit ``token_path`` is not an identity;
+                # normalize both it and the inherited bucket path once so the
+                # trimmed value drives ``token_path`` exactly like the factory.
+                token_path = (
+                    explicit_token_path
+                    or _normalize_codex_auth_path(bucket.get("codex_auth_path"))
+                )
+                if token_path:
+                    kwargs["token_path"] = token_path
+                else:
+                    manual_reason = "Codex vision has no explicit current OAuth identity; use vision(action='manual', input={}, reasoning='Codex vision has no explicit current OAuth identity')."
+            else:
+                # Pool route (bucket has no nonblank ``codex_auth_path``).
+                # WeightedAccountSource selects an account from the pool file
+                # (thin-wrapper spec v3).  Reads only the non-secret pool;
+                # Codex core owns token refresh, quota, retry, and transport.
+                # Only an active Codex-family service (``same_provider``) may
+                # supply a pool identity; an unrelated active provider never
+                # runs the selector and falls through to fail-closed below,
+                # so no unrelated/default pool file is read on its behalf.
+                if same_provider:
+                    from lingtai.auth.codex_pool import (
+                        resolve_codex_pool_path,
+                        resolve_codex_tui_dir,
+                    )
+                    from lingtai.auth.codex_account_source import (
+                        WeightedAccountSource,
+                        NoCandidateError,
+                    )
+                    tui_dir = resolve_codex_tui_dir()
+                    pool_path = resolve_codex_pool_path(bucket)
+                    source = WeightedAccountSource(
+                        pool_path, tui_dir, model=kwargs.get("model"),
+                    )
+                    try:
+                        candidate = source.select()
+                        kwargs["token_path"] = candidate.auth_ref
+                    except NoCandidateError:
+                        pass
+                if not kwargs.get("token_path"):
+                    manual_reason = "Codex pool vision has no selected current OAuth identity; use vision(action='manual', input={}, reasoning='Codex pool vision has no selected current OAuth identity')."
+            kwargs.pop("api_compat", None)
+            kwargs.pop("base_url", None)
+            if codex_base_url:
+                kwargs["base_url"] = codex_base_url
+            if not manual_reason:
+                from lingtai.services.vision import create_vision_service
+                try:
+                    vision_service = create_vision_service("codex", api_key=None, **kwargs)
+                except Exception as exc:
+                    manual_reason = _setup_failure(provider, exc)
+        else:
+            service_provider = provider_key
+            defaults = getattr(active_service, "_provider_defaults", {}) if same_provider else {}
+            bucket = defaults.get(active_provider_key, {}) if isinstance(defaults, dict) else {}
+            active_base_url = active_base_url or (bucket.get("base_url") if isinstance(bucket, dict) else None)
+            active_headers = bucket.get("default_headers") if isinstance(bucket, dict) else None
+            active_compat = kwargs.get("api_compat") or (bucket.get("api_compat") if isinstance(bucket, dict) else "") or ""
+            wire_api = _effective_openai_wire(
+                kwargs.get("wire_api") or (bucket.get("wire_api") if isinstance(bucket, dict) else None),
+                use_responses_api=isinstance(bucket, dict) and bucket.get("use_responses_api") is True,
+                base_url=kwargs.get("base_url") or active_base_url,
+            )
+            if service_provider in {"openrouter", "deepseek", "zhipu", "glm", "grok", "qwen", "kimi"}:
+                service_provider = "anthropic" if active_compat.lower() == "anthropic" else "openai"
+            elif service_provider == "custom":
+                service_provider = "anthropic" if active_compat.lower() == "anthropic" else "openai"
+
+            # Provider-specific kwarg injection. Each branch is opt-in because
+            # vision services have heterogeneous constructor signatures.
+            if service_provider == "minimax":
+                service_provider = "anthropic"
+            if service_provider in {"openai", "anthropic", "gemini", "mimo"}:
+                if same_provider and active_model:
+                    kwargs.setdefault("model", active_model)
+                if (
+                    service_provider in {"openai", "anthropic"}
+                    and same_provider
+                    and active_base_url
+                ):
+                    kwargs.setdefault("base_url", active_base_url)
+            if service_provider == "mimo" and same_provider and active_base_url:
+                kwargs.setdefault("base_url", active_base_url)
+            if service_provider in {"openai", "mimo"} and wire_api is None:
+                manual_reason = "The active OpenAI-compatible wire is not implemented by the direct vision service; use vision(action='manual', input={}, reasoning='the active OpenAI-compatible wire has no direct vision route')."
+            elif service_provider == "mimo" and wire_api != "chat_completions":
+                manual_reason = "The active MiMo wire is not implemented by the direct vision service; use vision(action='manual', input={}, reasoning='the active MiMo wire has no direct vision route')."
+            if service_provider in {"openai", "mimo"} and active_compat == "anthropic":
+                manual_reason = "The active preset uses an Anthropic wire that this vision route cannot safely adapt; use vision(action='manual', input={}, reasoning='the active Anthropic wire cannot be safely adapted for direct vision')."
+                vision_service = None
+            if service_provider == "anthropic" and active_headers:
+                kwargs.setdefault("default_headers", active_headers)
+            elif service_provider == "openai":
+                if active_headers:
+                    kwargs.setdefault("default_headers", active_headers)
+                if wire_api not in (None, "auto"):
+                    kwargs.setdefault("wire_api", wire_api)
+            elif service_provider == "mimo":
+                # MiMo's standalone constructor intentionally accepts only
+                # api_key/model/base_url/max_tokens. Its current direct
+                # route is Chat Completions; other wires stay manual-only.
+                kwargs.pop("default_headers", None)
+                kwargs.pop("wire_api", None)
+            resolved_api_key = api_key or active_api_key
+            if service_provider not in {"codex", "local"} and not kwargs.get("model"):
+                manual_reason = f"Provider {provider!r} has no resolved current model for direct vision; use vision(action='manual', input={{}}, reasoning='no resolved current model for direct vision')."
+            elif service_provider not in {"codex", "local"} and not resolved_api_key:
+                manual_reason = f"Provider {provider!r} has no resolved current credential for direct vision; use vision(action='manual', input={{}}, reasoning='no resolved current credential for direct vision')."
+            # Dedicated vision services do not consume the LLM adapter's
+            # transport selector.
+            kwargs.pop("api_compat", None)
+            if service_provider not in {"openai", "anthropic", "mimo"}:
+                kwargs.pop("base_url", None)
+            # Lazy import: the provider service lives in ``lingtai.services``.
+            from lingtai.services.vision import create_vision_service
+            if vision_service is None and not manual_reason:
+                try:
+                    vision_service = create_vision_service(
+                        service_provider,
+                        api_key=resolved_api_key,
+                        **kwargs,
+                    )
+                except Exception as exc:
+                    manual_reason = _setup_failure(provider, exc)
+    return vision_service, manual_reason
+
+
 def setup(
     agent: "BaseAgent",
     vision_service: VisionService | None = None,
@@ -363,348 +921,24 @@ def setup(
 ) -> VisionManager:
     """Set up the vision capability on an agent.
 
-    Requires either ``vision_service`` or ``provider`` + ``api_key`` for a
-    direct route. Without one, the tool is still registered for manual guidance.
+    ``vision`` is always registered. A direct route is built from
+    ``vision_service`` or ``provider`` + credential; when neither is supplied
+    the provider defaults to the active LLM's own Responses API (so the tool
+    is usable out of the box and fails explicitly if that route cannot see
+    images). Callers may also borrow another preset's vision service at call
+    time via the ``analyze`` ``preset`` option.
     """
     manual_reason = ""
+    if vision_service is None:
+        if provider is None:
+            active_service = getattr(agent, "service", None)
+            active_provider = getattr(active_service, "provider", "")
+            if isinstance(active_provider, str) and active_provider.strip():
+                provider = active_provider
     if vision_service is None and provider is not None:
-        if api_key_env:
-            from lingtai.kernel.config_resolve import resolve_env
-            api_key = resolve_env(api_key, api_key_env)
-        provider_key = provider.lower()
-        active_service = getattr(agent, "service", None)
-        active_provider = getattr(active_service, "provider", "")
-        active_provider_key = active_provider.lower() if isinstance(active_provider, str) else ""
-        same_provider = _same_provider_identity(provider_key, active_provider_key)
-        active_model = getattr(active_service, "_model", None) if same_provider else None
-        active_base_url = getattr(active_service, "_base_url", None) if same_provider else None
-        active_api_key = getattr(active_service, "api_key", None) if same_provider else None
-        if provider_key == "mlx":
-            # Native Apple-MLX on-device vision is an explicit pseudo-provider:
-            # keep it out of PROVIDERS/check-caps, but preserve the documented
-            # opt-in route. Its constructor accepts only model/max_tokens and
-            # needs no key.
-            mlx_kwargs = {
-                key: kwargs[key]
-                for key in ("model", "max_tokens")
-                if key in kwargs and kwargs[key] is not None
-            }
-            from lingtai.services.vision import create_vision_service
-            try:
-                vision_service = create_vision_service(
-                    "mlx",
-                    api_key=None,
-                    **mlx_kwargs,
-                )
-            except Exception as exc:
-                manual_reason = _setup_failure(provider, exc)
-        elif provider_key == "local":
-            # Local is a generic OpenAI-compatible vision server on this
-            # machine (Ollama, LM Studio, vLLM, llama.cpp, ...). The endpoint
-            # is operator-owned and configured in settings/vision.json
-            # (base_url/model/api_key/max_tokens); capability kwargs override
-            # the file. base_url defaults to the standard local port. model is
-            # REQUIRED — no hardcoded default, because a silently assumed
-            # model masks misconfiguration; when it is missing we surface
-            # guided setup steps instead. api_key is optional: local servers
-            # ignore it, so a placeholder satisfies the OpenAI SDK.
-            from lingtai.services.vision.openai import OpenAIVisionService
-            from .settings import (
-                DEFAULT_LOCAL_BASE_URL,
-                SettingsError,
-                read_local_settings,
-            )
-            try:
-                local_settings = read_local_settings(agent)
-            except SettingsError as exc:
-                manual_reason = (
-                    f"Local vision settings are invalid: {exc}; fix "
-                    "settings/vision.json or pass provider='local' with "
-                    "base_url/model kwargs; see vision(action='manual')."
-                )
-            else:
-                local_base_url = (
-                    kwargs.get("base_url")
-                    or local_settings.base_url
-                    or DEFAULT_LOCAL_BASE_URL
-                )
-                local_model = kwargs.get("model") or local_settings.model
-                if not local_model:
-                    manual_reason = (
-                        "Local vision needs an explicit model. Load the vision "
-                        "manual skill: vision(action='manual', input={}, "
-                        "reasoning='local vision setup'); then ask the human "
-                        "for consent before setting it up."
-                    )
-                else:
-                    local_key = api_key or local_settings.api_key or "local"
-                    local_wire = _effective_openai_wire(
-                        kwargs.get("wire_api"),
-                        use_responses_api=False,
-                        base_url=local_base_url,
-                    )
-                    svc_kwargs: dict = {
-                        "api_key": local_key,
-                        "model": local_model,
-                        "base_url": local_base_url,
-                    }
-                    if local_wire and local_wire != "auto":
-                        svc_kwargs["wire_api"] = local_wire
-                    cap_max_tokens = kwargs.get("max_tokens")
-                    if cap_max_tokens is None:
-                        cap_max_tokens = local_settings.max_tokens
-                    if cap_max_tokens is not None:
-                        svc_kwargs["max_tokens"] = cap_max_tokens
-                    try:
-                        vision_service = OpenAIVisionService(**svc_kwargs)
-                    except Exception as exc:
-                        manual_reason = _setup_failure(provider, exc)
-        elif provider_key not in PROVIDERS["providers"]:
-            # No dedicated VisionService for this provider (custom relay,
-            # OpenRouter, an anthropic-compat local proxy, ...). Route vision
-            # through the OpenAI- or Anthropic-compatible service, picking the
-            # wire protocol and endpoint from, in order:
-            #   1. capability kwargs — explicit init.json override. This lets a
-            #      user point vision at a *different*, vision-capable model
-            #      (e.g. Kimi-K2.6 on a multi-model proxy) while the main LLM
-            #      stays on a text-only model (e.g. GLM-5.1).
-            #   2. the main LLM: api_compat from service._provider_defaults
-            #      (shaped {provider_name: defaults_dict}), base_url/model from
-            #      service._base_url / service._model.
-            # If the relay or model can't actually do vision, the call fails at
-            # runtime — capability registration never pre-checks.
-            bucket = {}
-            api_compat = (kwargs.get("api_compat") or "").lower()
-            if not api_compat:
-                defaults = getattr(active_service, "_provider_defaults", None) if same_provider else None
-                if isinstance(defaults, dict):
-                    # _provider_defaults is dict[provider_name, defaults_dict];
-                    # read only the active provider's bucket, never another
-                    # provider's credential/transport configuration.
-                    bucket = defaults.get(active_provider_key)
-                    if isinstance(bucket, dict):
-                        api_compat = (bucket.get("api_compat") or "").lower()
-
-            cap_model = kwargs.get("model")
-            cap_base_url = kwargs.get("base_url")
-            cap_max_tokens = kwargs.get("max_tokens")
-            bucket = bucket if isinstance(bucket, dict) else {}
-            llm_base_url = cap_base_url or active_base_url or bucket.get("base_url")
-            llm_model = cap_model or active_model or bucket.get("model")
-            api_key = api_key or active_api_key
-            headers = kwargs.get("default_headers") or bucket.get("default_headers")
-            wire_api = _effective_openai_wire(
-                kwargs.get("wire_api") or bucket.get("wire_api"),
-                use_responses_api=bucket.get("use_responses_api") is True,
-                base_url=llm_base_url,
-            )
-
-            if api_compat == "openai":
-                from lingtai.services.vision.openai import OpenAIVisionService
-                svc_kwargs: dict = {
-                    "api_key": api_key,
-                    "model": llm_model,
-                    "base_url": llm_base_url,
-                }
-                if headers:
-                    svc_kwargs["default_headers"] = headers
-                if wire_api and wire_api != "auto":
-                    svc_kwargs["wire_api"] = wire_api
-                if cap_max_tokens is not None:
-                    svc_kwargs["max_tokens"] = cap_max_tokens
-                if wire_api is None:
-                    manual_reason = "The active OpenAI-compatible wire is not implemented by the direct vision service; use vision(action='manual', input={}, reasoning='the active OpenAI-compatible wire has no direct vision route')."
-                elif not llm_model:
-                    manual_reason = f"Provider {provider!r} has no resolved current model for direct vision; use vision(action='manual', input={{}}, reasoning='no resolved current model for direct vision')."
-                elif not api_key:
-                    manual_reason = f"Provider {provider!r} has no resolved current credential for direct vision; use vision(action='manual', input={{}}, reasoning='no resolved current credential for direct vision')."
-                else:
-                    try:
-                        vision_service = OpenAIVisionService(**svc_kwargs)
-                    except Exception as exc:
-                        manual_reason = _setup_failure(provider, exc)
-            elif api_compat == "anthropic":
-                from lingtai.services.vision.anthropic import AnthropicVisionService
-                svc_kwargs = {
-                    "api_key": api_key,
-                    "model": llm_model,
-                    "base_url": llm_base_url,
-                }
-                if headers:
-                    svc_kwargs["default_headers"] = headers
-                if cap_max_tokens is not None:
-                    svc_kwargs["max_tokens"] = cap_max_tokens
-                if not llm_model:
-                    manual_reason = f"Provider {provider!r} has no resolved current model for direct vision; use vision(action='manual', input={{}}, reasoning='no resolved current model for direct vision')."
-                elif not api_key:
-                    manual_reason = f"Provider {provider!r} has no resolved current credential for direct vision; use vision(action='manual', input={{}}, reasoning='no resolved current credential for direct vision')."
-                else:
-                    try:
-                        vision_service = AnthropicVisionService(**svc_kwargs)
-                    except Exception as exc:
-                        manual_reason = _setup_failure(provider, exc)
-            else:
-                manual_reason = f"No direct vision route is supported for provider {provider!r}; use vision(action='manual', input={{}}, reasoning='this provider has no supported direct vision route')."
-        else:
-            if provider_key in _CODEX_FAMILY:
-                # Codex vision is a standalone Responses request. It may share
-                # the active Codex family's model and endpoint, but never
-                # inherits those from an unrelated main provider. The fixed/
-                # direct vs weighted/pool credential route is *not* chosen from
-                # provider spelling: it follows the active provider-default
-                # bucket exactly as the canonical Codex factory does — direct
-                # iff the bucket carries a nonblank trimmed ``codex_auth_path``,
-                # otherwise pool (see ``lingtai/llm/_register.py``).
-                if same_provider:
-                    if active_model:
-                        kwargs.setdefault("model", active_model)
-                    if active_base_url:
-                        kwargs.setdefault("base_url", active_base_url)
-                codex_base_url = kwargs.get("base_url")
-
-                defaults = getattr(active_service, "_provider_defaults", None) if same_provider else None
-                bucket = defaults.get(active_provider_key) if isinstance(defaults, dict) else None
-                if not isinstance(bucket, dict):
-                    bucket = {}
-                # Bucket-driven route: the active Codex service is direct iff its
-                # bucket configures a nonblank ``codex_auth_path``, else pool. An
-                # unrelated active provider carries an empty bucket → ``"pool"``,
-                # and its pool branch stays gated by ``same_provider`` below, so it
-                # never reads a default pool and still fails closed.
-                codex_route = _codex_bucket_route(bucket)
-                # Normalize an explicit capability identity on every route. This
-                # preserves a valid independent token path while ensuring a
-                # whitespace-only value cannot bypass either fail-closed branch.
-                explicit_token_path = _normalize_codex_auth_path(kwargs.pop("token_path", None))
-                if explicit_token_path:
-                    kwargs["token_path"] = explicit_token_path
-                if not kwargs.get("model"):
-                    manual_reason = f"Provider {provider!r} has no resolved current model for direct vision; use vision(action='manual', input={{}}, reasoning='no resolved current model for direct vision')."
-                elif codex_route == "direct":
-                    # A whitespace-only explicit ``token_path`` is not an identity;
-                    # normalize both it and the inherited bucket path once so the
-                    # trimmed value drives ``token_path`` exactly like the factory.
-                    token_path = (
-                        explicit_token_path
-                        or _normalize_codex_auth_path(bucket.get("codex_auth_path"))
-                    )
-                    if token_path:
-                        kwargs["token_path"] = token_path
-                    else:
-                        manual_reason = "Codex vision has no explicit current OAuth identity; use vision(action='manual', input={}, reasoning='Codex vision has no explicit current OAuth identity')."
-                else:
-                    # Pool route (bucket has no nonblank ``codex_auth_path``).
-                    # WeightedAccountSource selects an account from the pool file
-                    # (thin-wrapper spec v3).  Reads only the non-secret pool;
-                    # Codex core owns token refresh, quota, retry, and transport.
-                    # Only an active Codex-family service (``same_provider``) may
-                    # supply a pool identity; an unrelated active provider never
-                    # runs the selector and falls through to fail-closed below,
-                    # so no unrelated/default pool file is read on its behalf.
-                    if same_provider:
-                        from lingtai.auth.codex_pool import (
-                            resolve_codex_pool_path,
-                            resolve_codex_tui_dir,
-                        )
-                        from lingtai.auth.codex_account_source import (
-                            WeightedAccountSource,
-                            NoCandidateError,
-                        )
-                        tui_dir = resolve_codex_tui_dir()
-                        pool_path = resolve_codex_pool_path(bucket)
-                        source = WeightedAccountSource(
-                            pool_path, tui_dir, model=kwargs.get("model"),
-                        )
-                        try:
-                            candidate = source.select()
-                            kwargs["token_path"] = candidate.auth_ref
-                        except NoCandidateError:
-                            pass
-                    if not kwargs.get("token_path"):
-                        manual_reason = "Codex pool vision has no selected current OAuth identity; use vision(action='manual', input={}, reasoning='Codex pool vision has no selected current OAuth identity')."
-                kwargs.pop("api_compat", None)
-                kwargs.pop("base_url", None)
-                if codex_base_url:
-                    kwargs["base_url"] = codex_base_url
-                if not manual_reason:
-                    from lingtai.services.vision import create_vision_service
-                    try:
-                        vision_service = create_vision_service("codex", api_key=None, **kwargs)
-                    except Exception as exc:
-                        manual_reason = _setup_failure(provider, exc)
-            else:
-                service_provider = provider_key
-                defaults = getattr(active_service, "_provider_defaults", {}) if same_provider else {}
-                bucket = defaults.get(active_provider_key, {}) if isinstance(defaults, dict) else {}
-                active_base_url = active_base_url or (bucket.get("base_url") if isinstance(bucket, dict) else None)
-                active_headers = bucket.get("default_headers") if isinstance(bucket, dict) else None
-                active_compat = kwargs.get("api_compat") or (bucket.get("api_compat") if isinstance(bucket, dict) else "") or ""
-                wire_api = _effective_openai_wire(
-                    kwargs.get("wire_api") or (bucket.get("wire_api") if isinstance(bucket, dict) else None),
-                    use_responses_api=isinstance(bucket, dict) and bucket.get("use_responses_api") is True,
-                    base_url=kwargs.get("base_url") or active_base_url,
-                )
-                if service_provider in {"openrouter", "deepseek", "zhipu", "glm", "grok", "qwen", "kimi"}:
-                    service_provider = "anthropic" if active_compat.lower() == "anthropic" else "openai"
-                elif service_provider == "custom":
-                    service_provider = "anthropic" if active_compat.lower() == "anthropic" else "openai"
-
-                # Provider-specific kwarg injection. Each branch is opt-in because
-                # vision services have heterogeneous constructor signatures.
-                if service_provider == "minimax":
-                    service_provider = "anthropic"
-                if service_provider in {"openai", "anthropic", "gemini", "mimo"}:
-                    if same_provider and active_model:
-                        kwargs.setdefault("model", active_model)
-                    if (
-                        service_provider in {"openai", "anthropic"}
-                        and same_provider
-                        and active_base_url
-                    ):
-                        kwargs.setdefault("base_url", active_base_url)
-                if service_provider == "mimo" and same_provider and active_base_url:
-                    kwargs.setdefault("base_url", active_base_url)
-                if service_provider in {"openai", "mimo"} and wire_api is None:
-                    manual_reason = "The active OpenAI-compatible wire is not implemented by the direct vision service; use vision(action='manual', input={}, reasoning='the active OpenAI-compatible wire has no direct vision route')."
-                elif service_provider == "mimo" and wire_api != "chat_completions":
-                    manual_reason = "The active MiMo wire is not implemented by the direct vision service; use vision(action='manual', input={}, reasoning='the active MiMo wire has no direct vision route')."
-                if service_provider in {"openai", "mimo"} and active_compat == "anthropic":
-                    manual_reason = "The active preset uses an Anthropic wire that this vision route cannot safely adapt; use vision(action='manual', input={}, reasoning='the active Anthropic wire cannot be safely adapted for direct vision')."
-                    vision_service = None
-                if service_provider == "anthropic" and active_headers:
-                    kwargs.setdefault("default_headers", active_headers)
-                elif service_provider == "openai":
-                    if active_headers:
-                        kwargs.setdefault("default_headers", active_headers)
-                    if wire_api not in (None, "auto"):
-                        kwargs.setdefault("wire_api", wire_api)
-                elif service_provider == "mimo":
-                    # MiMo's standalone constructor intentionally accepts only
-                    # api_key/model/base_url/max_tokens. Its current direct
-                    # route is Chat Completions; other wires stay manual-only.
-                    kwargs.pop("default_headers", None)
-                    kwargs.pop("wire_api", None)
-                resolved_api_key = api_key or active_api_key
-                if service_provider not in {"codex", "local"} and not kwargs.get("model"):
-                    manual_reason = f"Provider {provider!r} has no resolved current model for direct vision; use vision(action='manual', input={{}}, reasoning='no resolved current model for direct vision')."
-                elif service_provider not in {"codex", "local"} and not resolved_api_key:
-                    manual_reason = f"Provider {provider!r} has no resolved current credential for direct vision; use vision(action='manual', input={{}}, reasoning='no resolved current credential for direct vision')."
-                # Dedicated vision services do not consume the LLM adapter's
-                # transport selector.
-                kwargs.pop("api_compat", None)
-                if service_provider not in {"openai", "anthropic", "mimo"}:
-                    kwargs.pop("base_url", None)
-                # Lazy import: the provider service lives in ``lingtai.services``.
-                from lingtai.services.vision import create_vision_service
-                if vision_service is None and not manual_reason:
-                    try:
-                        vision_service = create_vision_service(
-                            service_provider,
-                            api_key=resolved_api_key,
-                            **kwargs,
-                        )
-                    except Exception as exc:
-                        manual_reason = _setup_failure(provider, exc)
+        vision_service, manual_reason = _resolve_direct_service(
+            agent, provider, api_key=api_key, api_key_env=api_key_env, **kwargs
+        )
     elif vision_service is None:
         manual_reason = "No direct vision provider was configured; use vision(action='manual', input={}, reasoning='no direct vision provider is configured')."
 

--- a/src/lingtai/tools/vision/manual/SKILL.md
+++ b/src/lingtai/tools/vision/manual/SKILL.md
@@ -57,6 +57,24 @@ one call. Any direct setup or request failure returns a sanitized vision tool
 result that reports the failure type and points here for explicit alternatives;
 it never exposes exception contents.
 
+## Claude backend: use the Claude CLI for vision
+
+When the active provider is a Claude-family backend (`claude-code`, `claude_code`,
+or the `claude-p` vision alias), the vision capability does not proxy Claude's
+own CLI authentication. The analyze call fails closed with explicit guidance
+instead of constructing a service:
+
+- Run the Claude Code CLI yourself in print mode with the image path:
+  `claude -p "Analyze this image: /path/to/image.png"`.
+- The CLI uses its own authentication (claude.ai subscription, API key, or a
+  configured provider) and returns a text analysis on stdout.
+- For exact image-input syntax and output formats, read the Claude Code CLI
+  reference: <https://code.claude.com/docs/en/cli-reference>. The official
+  docs' image pattern is "Analyze this image: /path/to/your/image.png".
+
+This manual never auto-invokes the CLI; running `claude -p` is an explicit
+operator/agent action with the CLI's own auth and cost model.
+
 ## Stay on the active preset
 
 Inspect the identity already shown in the prompt: the current provider, model,

--- a/src/lingtai/tools/vision/manual/SKILL.md
+++ b/src/lingtai/tools/vision/manual/SKILL.md
@@ -64,13 +64,33 @@ or the `claude-p` vision alias), the vision capability does not proxy Claude's
 own CLI authentication. The analyze call fails closed with explicit guidance
 instead of constructing a service:
 
-- Run the Claude Code CLI yourself in print mode with the image path:
+> You are using claude as backend, therefore to use vision run `claude -p`;
+> see the vision manual for more details.
+
+### How Claude CLI vision works
+
+Claude Code attaches images by file path: when the prompt references an image
+path, the CLI reads the file and sends it to the model as an image input block
+alongside the text. `-p` / `--print` is the non-interactive print mode, so the
+analysis is returned as plain text on stdout — ideal for scripting.
+
+- Run in print mode with the image path referenced in the prompt:
   `claude -p "Analyze this image: /path/to/image.png"`.
-- The CLI uses its own authentication (claude.ai subscription, API key, or a
-  configured provider) and returns a text analysis on stdout.
-- For exact image-input syntax and output formats, read the Claude Code CLI
-  reference: <https://code.claude.com/docs/en/cli-reference>. The official
-  docs' image pattern is "Analyze this image: /path/to/your/image.png".
+- Supported image formats include JPEG, PNG, and GIF (GIF uses the first
+  frame). The CLI uses its own authentication (claude.ai subscription, API
+  key, or a configured provider) and its own cost model.
+- The CLI may also accept the image as a positional argument or via paste in
+  interactive mode; print mode with the path in the prompt is the scriptable
+  route.
+
+### Progressive disclosure to the official docs
+
+For the latest authoritative explanation of image input, supported formats,
+output formats, and model support, progressively read the Claude Code CLI
+documentation on the official website:
+
+- CLI reference: <https://code.claude.com/docs/en/cli-reference>
+- Image workflows: <https://code.claude.com/docs/en/common-workflows>
 
 This manual never auto-invokes the CLI; running `claude -p` is an explicit
 operator/agent action with the CLI's own auth and cost model.

--- a/src/lingtai/tools/vision/manual/SKILL.md
+++ b/src/lingtai/tools/vision/manual/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Use this manual when the vision capability has no usable provider route or
   reports a direct setup/request failure and needs safe, provider-neutral
   troubleshooting guidance.
-last_changed_at: 2026-07-27T00:00:00Z
+last_changed_at: 2026-08-09T00:00:00Z
 related_files:
   - src/lingtai/tools/vision/__init__.py
   - src/lingtai/tools/vision/ANATOMY.md
@@ -24,7 +24,16 @@ it does not discover, install, start, or invoke a backend.
 
 - `vision(action="analyze", input={"image_path": "...", "question": null},
   reasoning="...")` — the direct image request. `question` is optional: send
-  `null` to use the default "Describe what you see in this image."
+  `null` to use the default "Describe what you see in this image." The optional
+  `preset` input field borrows another allowed preset's vision service for this
+  one call (e.g. `"preset": "codex-pool"`); it must be a path listed in
+  `manifest.preset.allowed`.
+- `vision(action="check", input={"preset": null}, reasoning="...")` — resolve
+  which vision route actually works without sending an image. With a `preset`
+  value it borrows that preset's service and reports the resolved
+  provider/model; with `null` it checks the default route. It constructs the
+  service but never makes a provider call, so it costs nothing and cannot fail
+  on image content.
 - `vision(action="manual", input={}, reasoning="...")` — this guidance. Its
   input is strictly empty and it performs no analyze operation.
 
@@ -35,19 +44,28 @@ other action, is rejected before anything is sent to a provider.
 
 ## Route behavior and failures
 
-For OpenRouter and custom OpenAI-compatible presets, `analyze` first tries the
-current endpoint, model, and credential. It does not reject the route merely
-because downstream image support cannot be known in advance. Any direct setup or
-request failure returns a sanitized vision tool result that reports the failure
-type and points here for explicit alternatives; it never exposes exception
-contents.
+`vision` is always registered. With no explicit `provider`, `analyze` defaults
+its route to the active LLM's own Responses API (model, endpoint, and
+credential inherited from the current provider). For OpenRouter and custom
+OpenAI-compatible presets, `analyze` first tries the current endpoint, model,
+and credential. It does not reject the route merely because downstream image
+support cannot be known in advance. A call may instead borrow another allowed
+preset's vision service with the `preset` input option; that preset must be
+listed in `manifest.preset.allowed`, and its own provider/model/credential
+identity (e.g. a `codex-pool` preset selecting its OAuth pool) is used for that
+one call. Any direct setup or request failure returns a sanitized vision tool
+result that reports the failure type and points here for explicit alternatives;
+it never exposes exception contents.
 
 ## Stay on the active preset
 
 Inspect the identity already shown in the prompt: the current provider, model,
-and sanitized endpoint. Do not substitute another provider, model, credential,
-endpoint, or wire protocol, and never silently switch or auto-invoke an MCP.
-Retry only after the operator has corrected the active preset.
+and sanitized endpoint. The default route follows the active LLM; do not
+substitute another provider, model, credential, endpoint, or wire protocol, and
+never silently switch or auto-invoke an MCP. If the active route cannot see
+images, the call fails explicitly; borrow another preset's vision service only
+when it is already authorized in `manifest.preset.allowed`. Retry only after the
+operator has corrected the active preset.
 
 ## Find the current preset's method
 
@@ -136,11 +154,13 @@ defaults to `http://localhost:11434/v1`; change it when the server runs on a
 non-default port (the `/v1` OpenAI-compatible suffix is required). `api_key` is
 optional - local servers ignore it, so a placeholder is synthesized.
 
-> **Preset note.** If your agent uses an active preset (a `manifest.preset`
-> block), the preset's `manifest.capabilities` replace `init.json`'s for
-> non-core opt-in capabilities like `vision`. Add the `vision` entry to the
-> preset file (or the `default` preset) rather than only to `init.json`, then
-> refresh.
+> **Preset note.** `vision` is always registered; an explicit `capabilities.vision`
+> entry is **not** required to make the tool appear. The default route inherits
+> the active LLM's own Responses API. A capability-manifest entry (in
+> `init.json` or the active preset) is only needed to override that default,
+> e.g. to point at `provider="local"`. To borrow another preset's vision
+> service for a single call, list that preset in `manifest.preset.allowed` and
+> pass `preset` on the analyze call; no `capabilities.vision` edit is needed.
 
 ### 3. Use it
 
@@ -155,7 +175,7 @@ sanitized setup failure instead, check the troubleshooting table below.
 
 | Symptom | Likely cause / fix |
 |---|---|
-| "No direct vision provider was configured" | The `vision` capability is not in the effective manifest. Add it to the preset (see the preset note above), then refresh. |
+| "No direct vision provider was configured" | No explicit provider and no usable active-LLM route. The tool is always registered; either borrow an allowed preset's vision service via the `preset` option, or configure a local route (see below), then refresh. |
 | "Local vision needs an explicit model" | No `model` is set in `settings/vision.json` or the capability manifest. Set `model` to a pulled/served vision model name, then refresh. |
 | "Local vision settings are invalid" | `settings/vision.json` has an unknown field, bad type, or a schema_version other than 1. Fix the file and refresh. |
 | Connection refused on the endpoint | The local server is not running. Start it (`ollama serve` or the desktop app) and retry. |

--- a/tests/test_preset_materialization.py
+++ b/tests/test_preset_materialization.py
@@ -580,7 +580,10 @@ def test_materialize_preserves_core_default_override_when_preset_omits_it(tmp_pa
     mentions daemon. daemon is always-on (CORE_DEFAULTS), so init.json's
     daemon.max_emanations=30 must be carried into the materialized manifest;
     otherwise apply_core_defaults later re-adds daemon={} and the override is
-    lost. Non-core capabilities the preset omits are still dropped (the swap).
+    lost. vision is also a CORE_DEFAULTS capability (always registered, default
+    route inherits the active LLM), so an explicit init.json vision override
+    survives materialization too. Non-core capabilities the preset omits are
+    still dropped (the swap).
     """
     plib = _make_preset_lib(tmp_path, {
         "codex": {
@@ -599,7 +602,7 @@ def test_materialize_preserves_core_default_override_when_preset_omits_it(tmp_pa
         tmp_path, active_preset=str(plib / "codex.json"),
         manifest_extra={"capabilities": {
             "daemon": {"max_emanations": 30},   # core default — must survive
-            "vision": {"provider": "custom"},   # non-core, preset omits — must drop
+            "vision": {"provider": "custom"},   # core default — must survive
         }},
     )
     a = _make_probe_agent(wd)
@@ -608,10 +611,11 @@ def test_materialize_preserves_core_default_override_when_preset_omits_it(tmp_pa
     # Core-default daemon override carried forward despite preset omitting it.
     assert "daemon" in caps
     assert caps["daemon"]["max_emanations"] == 30
+    # Core-default vision override is carried forward the same way.
+    assert "vision" in caps
+    assert caps["vision"] == {"provider": "custom"}
     # Preset still owns the explicit opt-in set, emitted canonically.
     assert "web" in caps
-    # Non-core optional capability that the preset omits is NOT carried over.
-    assert "vision" not in caps
 
 
 def test_materialize_core_default_no_init_override_left_to_apply_core_defaults(tmp_path, monkeypatch):

--- a/tests/test_tool_family_vision_migration.py
+++ b/tests/test_tool_family_vision_migration.py
@@ -68,9 +68,9 @@ def test_setup_registers_exactly_one_public_vision_root(tmp_path):
     assert agent.tools["vision"]["glossary_package"] == "lingtai.tools.vision"
 
 
-def test_public_actions_are_exactly_analyze_and_manual():
+def test_public_actions_are_exactly_analyze_check_and_manual():
     schema = get_schema()
-    assert schema["properties"]["action"]["enum"] == ["analyze", "manual"]
+    assert schema["properties"]["action"]["enum"] == ["analyze", "check", "manual"]
 
 
 # ---------------------------------------------------------------------------
@@ -94,8 +94,8 @@ def test_root_schema_correlates_each_action_const_with_its_own_input():
         cond["if"]["properties"]["action"]["const"]: cond["then"]["properties"]["input"]
         for cond in schema["allOf"]
     }
-    assert set(conditions) == {"analyze", "manual"}
-    assert set(conditions["analyze"]["properties"]) == {"image_path", "question"}
+    assert set(conditions) == {"analyze", "check", "manual"}
+    assert set(conditions["analyze"]["properties"]) == {"image_path", "question", "preset"}
     assert conditions["manual"]["properties"] == {}
     for cond in schema["allOf"]:
         # A strict ``if`` with a missing property matches vacuously; the guard
@@ -105,15 +105,22 @@ def test_root_schema_correlates_each_action_const_with_its_own_input():
 
 def test_both_child_input_schemas_are_exposed_before_invocation():
     branches = get_schema()["properties"]["input"]["oneOf"]
-    assert [b["title"] for b in branches] == ["analyze input", "manual input"]
+    assert [b["title"] for b in branches] == ["analyze input", "check input", "manual input"]
 
-    analyze_branch, manual_branch = branches
+    analyze_branch, check_branch, manual_branch = branches
     assert analyze_branch["required"] == ["image_path", "question"]
     assert analyze_branch["additionalProperties"] is False
     assert analyze_branch["properties"]["image_path"]["type"] == "string"
     # Optional ``question`` is a required nullable property, matching the
     # strict-object convention the other migrated families use.
     assert analyze_branch["properties"]["question"]["type"] == ["string", "null"]
+
+    # Optional ``preset`` on analyze is a nullable property.
+    assert analyze_branch["properties"]["preset"]["type"] == ["string", "null"]
+
+    # check takes only the optional preset; no image fields.
+    assert set(check_branch["properties"]) == {"preset"}
+    assert check_branch["additionalProperties"] is False
 
     assert manual_branch["properties"] == {}
     assert manual_branch["additionalProperties"] is False
@@ -450,7 +457,7 @@ def test_no_bare_manual_pointer_survives_in_any_vision_owned_surface():
 
 def test_family_registers_the_reserved_manual_child_once(tmp_path):
     mgr = _manager(tmp_path)
-    assert mgr._family.child_names == ("analyze", "manual")
+    assert mgr._family.child_names == ("analyze", "check", "manual")
     assert mgr._family.has_manual()
 
 
@@ -480,7 +487,7 @@ def test_manual_child_input_schema_is_the_generic_owners_object(tmp_path):
     """
     from lingtai.tools.tool_family.manual import MANUAL_INPUT_SCHEMA
 
-    manual_branch = get_schema()["properties"]["input"]["oneOf"][1]
+    manual_branch = get_schema()["properties"]["input"]["oneOf"][2]
     assert manual_branch["properties"] == MANUAL_INPUT_SCHEMA["properties"]
     assert manual_branch["additionalProperties"] is False
     assert manual_branch.get("required") == MANUAL_INPUT_SCHEMA["required"] == []
@@ -508,9 +515,9 @@ def test_vision_schema_survives_both_provider_wires():
         assert wire["required"] == ["action", "input", "reasoning"]
         assert wire["additionalProperties"] is False
         assert set(wire["properties"]) == {"action", "input", "reasoning", "summarize"}
-        assert wire["properties"]["action"]["enum"] == ["analyze", "manual"]
+        assert wire["properties"]["action"]["enum"] == ["analyze", "check", "manual"]
         branches = wire["properties"]["input"][combinator]
-        assert [b["title"] for b in branches] == ["analyze input", "manual input"]
+        assert [b["title"] for b in branches] == ["analyze input", "check input", "manual input"]
         for branch in branches:
             assert branch["additionalProperties"] is False
             assert not {"reasoning", "_reasoning", "summarize"} & set(
@@ -522,8 +529,8 @@ def test_vision_schema_survives_both_provider_wires():
             cond["if"]["properties"]["action"]["const"]: cond["then"]["properties"]["input"]
             for cond in wire["allOf"]
         }
-        assert set(correlated) == {"analyze", "manual"}
-        assert set(correlated["analyze"]["properties"]) == {"image_path", "question"}
+        assert set(correlated) == {"analyze", "check", "manual"}
+        assert set(correlated["analyze"]["properties"]) == {"image_path", "question", "preset"}
         assert correlated["manual"]["properties"] == {}
 
 
@@ -596,3 +603,238 @@ def test_dispatch_is_identical_regardless_of_originating_wire(tmp_path):
         {"action": "analyze", "input": {"image_path": str(img), "question": "Q"}, "reasoning": "responses-wire"}
     )
     assert chat_call == responses_call == {"status": "ok", "analysis": "same answer"}
+
+
+# ---------------------------------------------------------------------------
+# preset borrowing: one call may borrow another allowed preset's vision service
+# ---------------------------------------------------------------------------
+
+
+def _write_preset_borrow_fixture(tmp_path: Path) -> dict:
+    """Write init.json (allowed preset) plus a borrowable codex-pool preset file.
+
+    Returns the manifest dict mirrored in init.json for assertions.
+    """
+    preset_dir = tmp_path / "presets"
+    preset_dir.mkdir(parents=True, exist_ok=True)
+    (preset_dir / "codex-pool.json").write_text(
+        """{
+          "name": "codex-pool",
+          "description": {"summary": "fixture preset with gpt-5.6 vision"},
+          "manifest": {
+            "llm": {
+              "provider": "codex-pool",
+              "model": "gpt-5.6",
+              "base_url": "https://example.test/v1"
+            },
+            "capabilities": {
+              "vision": {"provider": "codex-pool"}
+            }
+          }
+        }
+        """,
+        encoding="utf-8",
+    )
+    manifest = {
+        "preset": {"allowed": ["presets/codex-pool.json"]},
+    }
+    (tmp_path / "init.json").write_text(
+        '{"manifest": ' + __import__("json").dumps(manifest) + "}",
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def test_preset_borrow_rejects_a_preset_not_in_manifest_allowed(tmp_path):
+    # No init.json at all -> cannot resolve allowed, borrow fails closed.
+    mgr = _manager(tmp_path, _never_called_service())
+    svc, reason, identity = mgr._build_service_from_preset("presets/codex-pool.json")
+    assert svc is None
+    assert identity == {}
+    assert "manifest.preset.allowed" in reason
+
+
+def test_preset_borrow_rejects_unlisted_preset_when_init_exists(tmp_path):
+    _write_preset_borrow_fixture(tmp_path)
+    mgr = _manager(tmp_path, _never_called_service())
+    svc, reason, identity = mgr._build_service_from_preset("presets/other.json")
+    assert svc is None
+    assert identity == {}
+    assert "not in manifest.preset.allowed" in reason
+
+
+def test_preset_borrow_resolves_the_listed_presets_own_identity(tmp_path):
+    """The borrowed preset's llm/capabilities feed an identity shim, so the
+    codex-pool preset selects its own route instead of the active provider's."""
+    _write_preset_borrow_fixture(tmp_path)
+
+    borrowed = MagicMock(spec=VisionService)
+    borrowed.analyze_image.return_value = "borrowed gpt-5.6 answer"
+
+    with patch(
+        "lingtai.tools.vision._resolve_direct_service",
+        return_value=(borrowed, ""),
+    ) as mock_resolve:
+        mgr = _manager(tmp_path, _never_called_service())
+        svc, reason, identity = mgr._build_service_from_preset("presets/codex-pool.json")
+
+    assert svc is borrowed
+    assert reason == ""
+    assert identity == {"provider": "codex-pool", "model": "gpt-5.6", "base_url": "https://example.test/v1"}
+    mock_resolve.assert_called_once()
+    kwargs = mock_resolve.call_args.kwargs
+    identity = kwargs["identity_service"]
+    assert kwargs["provider"] == "codex-pool"
+    assert identity.provider == "codex-pool"
+    assert identity._model == "gpt-5.6"
+    assert identity._base_url == "https://example.test/v1"
+
+
+def test_analyze_with_preset_option_uses_the_borrowed_service(tmp_path):
+    """An analyze call carrying the optional preset field dispatches through the
+    borrowed service, not the default (never-called) service."""
+    _write_preset_borrow_fixture(tmp_path)
+    img = tmp_path / "photo.png"
+    img.write_bytes(b"fake")
+    borrowed = MagicMock(spec=VisionService)
+    borrowed.analyze_image.return_value = "borrowed answer"
+
+    with patch(
+        "lingtai.tools.vision._resolve_direct_service",
+        return_value=(borrowed, ""),
+    ):
+        mgr = _manager(tmp_path, _never_called_service())
+        result = mgr.handle(
+            {
+                "action": "analyze",
+                "input": {
+                    "image_path": str(img),
+                    "question": "What color?",
+                    "preset": "presets/codex-pool.json",
+                },
+                "reasoning": "borrow codex-pool vision",
+            }
+        )
+    assert result == {"status": "ok", "analysis": "borrowed answer"}
+    borrowed.analyze_image.assert_called_once_with(str(img), prompt="What color?")
+
+
+def test_analyze_preset_borrow_failure_is_sanitized_and_teaches_manual(tmp_path):
+    """A borrow failure (e.g. preset not authorized) returns the explicit error
+    and points to the full accepted manual envelope."""
+    _write_preset_borrow_fixture(tmp_path)
+    img = tmp_path / "photo.png"
+    img.write_bytes(b"fake")
+
+    mgr = _manager(tmp_path, _never_called_service())
+    result = mgr.handle(
+        {
+            "action": "analyze",
+            "input": {
+                "image_path": str(img),
+                "question": None,
+                "preset": "presets/other.json",
+            },
+            "reasoning": "borrow unlisted preset",
+        }
+    )
+    assert result["status"] == "error"
+    assert "not in manifest.preset.allowed" in result["message"]
+    assert "vision(action='manual', input={}" in result["message"]
+    assert "reasoning=" in result["message"]
+
+
+def test_analyze_without_preset_still_uses_the_default_route(tmp_path):
+    """Omitting the preset option leaves the pre-existing default routing intact."""
+    _write_preset_borrow_fixture(tmp_path)
+    img = tmp_path / "photo.png"
+    img.write_bytes(b"fake")
+    svc = MagicMock(spec=VisionService)
+    svc.analyze_image.return_value = "default answer"
+
+    with patch("lingtai.tools.vision._resolve_direct_service") as mock_resolve:
+        mgr = _manager(tmp_path, svc)
+        result = mgr.handle(
+            {
+                "action": "analyze",
+                "input": {"image_path": str(img), "question": "Q"},
+                "reasoning": "default route",
+            }
+        )
+    mock_resolve.assert_not_called()
+    assert result == {"status": "ok", "analysis": "default answer"}
+
+def test_check_default_route_reports_ok_without_image(tmp_path):
+    """check with no preset reports the default route and never sends an image."""
+    svc = MagicMock(spec=VisionService)
+    svc.analyze_image.side_effect = AssertionError("check must not call analyze_image")
+    agent = _StubAgent(tmp_path)
+    agent.service = MagicMock()
+    agent.service.provider = "codex-pool"
+    agent.service.model = "gpt-5.6"
+    mgr = VisionManager(agent, vision_service=svc)
+
+    result = mgr.handle(
+        {"action": "check", "input": {"preset": None}, "reasoning": "which vision works"}
+    )
+    assert result == {
+        "status": "ok",
+        "route": "default",
+        "provider": "codex-pool",
+        "model": "gpt-5.6",
+    }
+    svc.analyze_image.assert_not_called()
+
+
+def test_check_no_default_route_returns_manual_reason(tmp_path):
+    reason = (
+        "No direct vision provider was configured; use vision(action='manual', "
+        "input={}, reasoning='no direct vision provider is configured')."
+    )
+    mgr = VisionManager(_StubAgent(tmp_path), vision_service=None, manual_reason=reason)
+    result = mgr.handle(
+        {"action": "check", "input": {"preset": None}, "reasoning": "r"}
+    )
+    assert result["status"] == "error"
+    assert "No direct vision provider" in result["message"]
+
+
+def test_check_preset_reports_identity_without_image(tmp_path):
+    """check with a preset borrows its service and reports provider/model."""
+    _write_preset_borrow_fixture(tmp_path)
+    borrowed = MagicMock(spec=VisionService)
+    borrowed.analyze_image.side_effect = AssertionError("check must not analyze")
+
+    with patch(
+        "lingtai.tools.vision._resolve_direct_service",
+        return_value=(borrowed, ""),
+    ):
+        mgr = _manager(tmp_path, _never_called_service())
+        result = mgr.handle(
+            {
+                "action": "check",
+                "input": {"preset": "presets/codex-pool.json"},
+                "reasoning": "check codex-pool vision",
+            }
+        )
+    assert result["status"] == "ok"
+    assert result["route"] == "preset:presets/codex-pool.json"
+    assert result["provider"] == "codex-pool"
+    assert result["model"] == "gpt-5.6"
+    borrowed.analyze_image.assert_not_called()
+
+
+def test_check_unlisted_preset_fails_sanitized(tmp_path):
+    """check fails closed when the preset is not authorized."""
+    _write_preset_borrow_fixture(tmp_path)
+    mgr = _manager(tmp_path, _never_called_service())
+    result = mgr.handle(
+        {
+            "action": "check",
+            "input": {"preset": "presets/other.json"},
+            "reasoning": "r",
+        }
+    )
+    assert result["status"] == "error"
+    assert "not in manifest.preset.allowed" in result["message"]
+    assert "vision(action='manual', input={}" in result["message"]

--- a/tests/test_vision_capability.py
+++ b/tests/test_vision_capability.py
@@ -264,7 +264,7 @@ def test_claude_code_remains_manual_only(tmp_path):
     )
     mgr = setup(agent, provider="claude-code", api_key="sk-test")
     assert mgr._vision_service is None
-    assert "claude cli" in mgr._manual_reason.lower()
+    assert "claude -p" in mgr._manual_reason
     assert "vision(action='manual'" in mgr._manual_reason
     assert mgr.manual()["status"] in {"ok", "degraded"}
 
@@ -277,11 +277,11 @@ def test_claude_family_returns_cli_guidance_not_service(tmp_path, provider):
     )
     mgr = setup(agent, provider=provider, api_key="sk-test")
     assert mgr._vision_service is None
-    assert "claude cli" in mgr._manual_reason.lower()
     assert "claude -p" in mgr._manual_reason
+    assert "vision(action='manual'" in mgr._manual_reason
     result = mgr._dispatch_analyze({"image_path": "x.png", "question": None})
     assert result["status"] == "error"
-    assert "claude cli" in result["message"].lower()
+    assert "claude -p" in result["message"]
 
 
 def test_vision_empty_response_is_error(tmp_path):

--- a/tests/test_vision_capability.py
+++ b/tests/test_vision_capability.py
@@ -258,12 +258,30 @@ def test_generic_openai_compatible_unknown_wire_remains_manual(tmp_path):
 
 
 def test_claude_code_remains_manual_only(tmp_path):
+    """Claude Code providers return explicit "use the Claude CLI" guidance."""
     agent = make_provider_agent(
         tmp_path, provider="claude-code", model="text-only", base_url="https://relay.example/v1"
     )
     mgr = setup(agent, provider="claude-code", api_key="sk-test")
     assert mgr._vision_service is None
+    assert "claude cli" in mgr._manual_reason.lower()
+    assert "vision(action='manual'" in mgr._manual_reason
     assert mgr.manual()["status"] in {"ok", "degraded"}
+
+
+@pytest.mark.parametrize("provider", ["claude-p", "claude-code", "claude_code"])
+def test_claude_family_returns_cli_guidance_not_service(tmp_path, provider):
+    """Every claude-family spelling routes to the claude-cli guidance comment."""
+    agent = make_provider_agent(
+        tmp_path, provider=provider, model="text-only", base_url="https://relay.example/v1"
+    )
+    mgr = setup(agent, provider=provider, api_key="sk-test")
+    assert mgr._vision_service is None
+    assert "claude cli" in mgr._manual_reason.lower()
+    assert "claude -p" in mgr._manual_reason
+    result = mgr._dispatch_analyze({"image_path": "x.png", "question": None})
+    assert result["status"] == "error"
+    assert "claude cli" in result["message"].lower()
 
 
 def test_vision_empty_response_is_error(tmp_path):
@@ -349,7 +367,7 @@ def test_local_vision_is_advertised_and_requires_model(tmp_path):
 
 def test_local_vision_missing_model_result_guides_with_consent(tmp_path):
     """The analyze result on a missing-service setup failure guides setup with consent."""
-    with patch("lingtai.services.vision.openai.OpenAIVisionService") as mock_svc_cls:
+    with patch("lingtai.services.vision.openai.OpenAIVisionService") as _mock_svc_cls:
         agent = make_mock_agent(tmp_path)
         mgr = setup(agent, provider="local")
 


### PR DESCRIPTION
## Summary

`vision` is now always registered and defaults its route to the active LLM's own Responses API. The `analyze` input gains an optional `preset` field that borrows another allowed preset's vision service for one call, and a new `check` action resolves which preset's vision route actually works without sending an image.

Motivation (Jason): the `vision` capability was declared in `init.json` but never surfaced because the active preset's capabilities replaced init's for non-core caps; and a `codex-pool` vision route cannot be selected while the active provider is `deepseek`. Instead of configuration hacks, the tool layer now supports explicit per-call preset borrowing with the same `manifest.preset.allowed` authorization surface as preset swapping.

## Changes

- **`registry.py`**: `vision` joins `CORE_DEFAULTS` — always registered, no `init.json` capability declaration required.
- **`vision/__init__.py`**:
  - `setup()` defaults `provider=None` to the active LLM's own provider (inherits model/base_url/api_key from the current service).
  - Extracted reusable `_resolve_direct_service(agent, provider, api_key, api_key_env, *, identity_service, **kwargs)`.
  - `_build_service_from_preset(preset_ref)` validates the preset is in `manifest.preset.allowed`, loads it read-only, builds a preset identity shim, and resolves the borrowed provider's own route/credentials (e.g. a `codex-pool` preset selecting its own OAuth pool). Returns `(service, reason, identity)`.
  - `analyze` input schema adds optional nullable `preset`.
  - New `check` action: resolves the default or a borrowed preset's vision service and reports `{status, route, provider, model}` without making a provider call.
  - Claude-family providers (`claude-code`, `claude_code`, `claude-p`) now return explicit guidance instead of failing silently: "You are using claude as backend, therefore to use vision run `claude -p`", and the agent is pointed at the vision manual for the exact steps (the manual explains how Claude CLI vision works — path-based image attachment, print mode, supported formats — and progressively discloses to the official Claude Code docs website for the latest explanation). No CLI proxy/auth is built — LingTai never touches the CLI's own authentication.
  - Failure messages explicitly separate the default-route and preset-route paths and point to `vision(action='manual', input={}, reasoning=...)`.
- **`daemon/__init__.py`**: `vision` stays excluded from the parent host tool floor (provider-bound, no silent fallback), while explicit preset-requested vision remains instantiable.
- **`vision/manual/SKILL.md`**: documents always-registered, default route, the `preset` borrow option, the `check` action, and the Claude CLI vision guidance for claude backends.
- **`vision/CONTRACT.md` / `vision/ANATOMY.md`**: provider registry and routing docs updated for `claude-p` and the claude-family guidance.
- **Tests**: preset borrow (authorized / not-in-allowed / identity shim / analyze route / failure), `check` (default ok / no route / preset identity / unlisted preset), claude-family guidance (all three spellings return the comment, no service), schema + materialize core-default vision override updates.

## Validation

- `tests/test_vision_capability.py` + `tests/test_vision_services.py` + `tests/test_tool_family_vision_migration.py`: **185 passed**; the 3 remaining failures are pre-existing on HEAD (verified via stash: identical 3 failures on the untouched PR head).
- Related preset/daemon/registry suites: **128 passed** total; `test_parent_host_tool_floor_is_exactly_shell_and_file` is pre-existing on HEAD (`task_card` already in CORE_DEFAULTS).
- `py_compile`, `git diff --check` pass; ruff clean on all touched files.
- Base: `44c0333c` (latest main at push time), clean rebase.

Telegram: @lingtaidev4bot | Nickname: 守真
