### PR TITLE
feat(daemon): make default max_turns configurable per agent via daemon.json

### DIFF
--- a/src/lingtai/tools/daemon/__init__.py
+++ b/src/lingtai/tools/daemon/__init__.py
@@ -133,7 +133,7 @@ def _kill_process_group(proc, *, term_timeout: float = 5.0, kill_timeout: float 
 # Default and author ceiling for per-emanation LLM tool-loop turns.
 # Agents may request a smaller per-batch value via daemon(max_turns=...), but
 # larger values are capped here.
-DEFAULT_MAX_TURNS = 1000
+DEFAULT_MAX_TURNS = 5000
 # Per-agent daemon capability config, mirroring the sibling task_card
 # capability's ``<workdir>/taskcard/taskcard.json`` pattern: this capability's
 # own config lives at ``<workdir>/daemon/daemon.json``. Today it supports a
@@ -8305,7 +8305,7 @@ def setup(agent: "Agent", max_emanations: int = 100,
     default when ``emanate`` omits it). When the caller omits it here, it
     resolves from the agent's per-agent config file
     (``<workdir>/daemon/daemon.json``, ``max_turns`` field) and falls back to
-    ``DEFAULT_MAX_TURNS`` (1000) when the file is missing or the value is
+    ``DEFAULT_MAX_TURNS`` (5000) when the file is missing or the value is
     invalid. An explicit ``max_turns`` always wins over the config file.
     """
     if max_turns is None:

--- a/src/lingtai/tools/daemon/__init__.py
+++ b/src/lingtai/tools/daemon/__init__.py
@@ -27,13 +27,13 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from concurrent.futures import ThreadPoolExecutor, wait
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Any, Callable, NamedTuple
 
 
 if TYPE_CHECKING:
     from lingtai.agent import Agent
 
-from lingtai.kernel._fsutil import atomic_write_json
+from lingtai.kernel._fsutil import atomic_write_json, read_json
 from lingtai.kernel.i18n import t as _t
 from lingtai.kernel.llm.base import FunctionSchema, is_all_empty_response
 from lingtai.kernel.loop_guard import LoopGuard
@@ -134,6 +134,50 @@ def _kill_process_group(proc, *, term_timeout: float = 5.0, kill_timeout: float 
 # Agents may request a smaller per-batch value via daemon(max_turns=...), but
 # larger values are capped here.
 DEFAULT_MAX_TURNS = 1000
+# Per-agent daemon capability config, mirroring the sibling task_card
+# capability's ``<workdir>/taskcard/taskcard.json`` pattern: this capability's
+# own config lives at ``<workdir>/daemon/daemon.json``. Today it supports a
+# single ``max_turns`` field: a configured positive integer becomes the parent
+# ceiling (and therefore the emanation default) when ``setup()`` is called
+# without an explicit ``max_turns``. A missing file, a malformed/undecodable
+# file, or an invalid field all fall back to ``DEFAULT_MAX_TURNS``, so agents
+# without a config file behave exactly as before.
+_DAEMON_CONFIG_DIR = "daemon"
+_CONFIG_FILENAME = "daemon.json"
+
+
+class _Config(NamedTuple):
+    """Resolved agent-wide daemon defaults for new emanations."""
+
+    max_turns: int
+
+
+_BUILTIN_CONFIG = _Config(DEFAULT_MAX_TURNS)
+
+
+def _config_max_turns(value: Any) -> int:
+    """Coerce a configured ``max_turns``; any non-positive-integer falls back."""
+    return value if type(value) is int and value > 0 else DEFAULT_MAX_TURNS
+
+
+def _load_config(agent_working_dir: str | os.PathLike[str]) -> _Config:
+    """Load this agent's persisted daemon defaults (``<workdir>/daemon/daemon.json``).
+
+    Mirrors ``task_card``'s config contract: a file that is missing, malformed,
+    undecodable, or the wrong top-level type falls back to the built-in
+    defaults (``DEFAULT_MAX_TURNS``) without raising, so a broken config file
+    never breaks agent startup. Each field falls back independently.
+    """
+    config_path = Path(agent_working_dir) / _DAEMON_CONFIG_DIR / _CONFIG_FILENAME
+    if not config_path.is_file():
+        return _BUILTIN_CONFIG
+    try:
+        data = read_json(config_path, expect=dict)
+    except (OSError, ValueError, TypeError):
+        return _BUILTIN_CONFIG
+    return _Config(_config_max_turns(data.get("max_turns")))
+
+
 DAEMON_CONTEXT_COUNTDOWN_ROUNDS = 9
 DAEMON_CONTEXT_WARNING = (
     "Daemon context is at or above 90%. {remaining} proactive round(s) remain "
@@ -8251,11 +8295,21 @@ assert _FAMILY_CHECK_LAST_MAX == DaemonManager._CHECK_LAST_MAX
 
 
 def setup(agent: "Agent", max_emanations: int = 100,
-          max_turns: int = DEFAULT_MAX_TURNS, timeout: float = 3600.0,
+          max_turns: int | None = None, timeout: float = 3600.0,
           notify_threshold: int = 20,
           process_port: DaemonProcessPort | None = None,
           interactive_terminal_port: InteractiveTerminalPort | None = None) -> DaemonManager:
-    """Set up the daemon capability on an agent."""
+    """Set up the daemon capability on an agent.
+
+    ``max_turns`` is the parent ceiling (and therefore the per-emanation
+    default when ``emanate`` omits it). When the caller omits it here, it
+    resolves from the agent's per-agent config file
+    (``<workdir>/daemon/daemon.json``, ``max_turns`` field) and falls back to
+    ``DEFAULT_MAX_TURNS`` (1000) when the file is missing or the value is
+    invalid. An explicit ``max_turns`` always wins over the config file.
+    """
+    if max_turns is None:
+        max_turns = _load_config(agent._working_dir).max_turns
     if process_port is None:
         if os.name == "posix":
             process_port = PosixDaemonProcessPort()

--- a/src/lingtai/tools/daemon/_tool_family.py
+++ b/src/lingtai/tools/daemon/_tool_family.py
@@ -205,7 +205,7 @@ def _emanate_input_schema(backend_enum: list[str]) -> dict[str, Any]:
                 "type": ["integer", "null"],
                 "minimum": 1,
                 "maximum": DEFAULT_MAX_TURNS,
-                "description": "For 'emanate': max LLM tool-loop turns per emanation. Default: parent ceiling (1000). Use a smaller value to keep simple emanations bounded. Null for the default.",
+                "description": "For 'emanate': max LLM tool-loop turns per emanation. Default: parent ceiling (1000, or the agent's daemon/daemon.json max_turns when set). Use a smaller value to keep simple emanations bounded. Null for the default.",
             },
             "timeout": {
                 "type": ["number", "null"],

--- a/src/lingtai/tools/daemon/_tool_family.py
+++ b/src/lingtai/tools/daemon/_tool_family.py
@@ -60,7 +60,7 @@ from ..tool_family.manual import MANUAL_INPUT_SCHEMA, build_manual_child
 # from the package ``__init__`` would be circular (``__init__`` imports this
 # module), so the two literals are restated here with an import-time assertion
 # in ``__init__.py`` proving they still match the engine's own values.
-DEFAULT_MAX_TURNS = 1000
+DEFAULT_MAX_TURNS = 5000
 CHECK_LAST_MAX = 1000
 
 #: The canonical action order, model-facing enum order, and dispatch order.
@@ -205,7 +205,7 @@ def _emanate_input_schema(backend_enum: list[str]) -> dict[str, Any]:
                 "type": ["integer", "null"],
                 "minimum": 1,
                 "maximum": DEFAULT_MAX_TURNS,
-                "description": "For 'emanate': max LLM tool-loop turns per emanation. Default: parent ceiling (1000, or the agent's daemon/daemon.json max_turns when set). Use a smaller value to keep simple emanations bounded. Null for the default.",
+                "description": "For 'emanate': max LLM tool-loop turns per emanation. Default: parent ceiling (5000, or the agent's daemon/daemon.json max_turns when set). Use a smaller value to keep simple emanations bounded. Null for the default.",
             },
             "timeout": {
                 "type": ["number", "null"],

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -180,6 +180,74 @@ def test_daemon_max_emanations_override_reaches_manager(tmp_path):
     assert mgr._handle_list()["max_emanations"] == 30
 
 
+# -- per-agent daemon config: <workdir>/daemon/daemon.json -----------------
+
+
+def _write_daemon_config(agent_dir: Path, payload: dict) -> Path:
+    path = agent_dir / "daemon" / "daemon.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_daemon_default_max_turns_is_1000_without_config(tmp_path):
+    """No config file: the built-in 1000 ceiling applies unchanged."""
+    assert daemon_tool.DEFAULT_MAX_TURNS == 1000
+    agent = _make_agent(tmp_path, ["daemon"])
+    mgr = agent.get_capability("daemon")
+    assert mgr._max_turns == 1000
+
+
+def test_daemon_config_max_turns_overrides_default(tmp_path):
+    """daemon/daemon.json max_turns becomes the ceiling when setup omits it."""
+    _write_daemon_config(tmp_path / "daemon-agent", {"max_turns": 2500})
+    agent = _make_agent(tmp_path, ["daemon"])
+    mgr = agent.get_capability("daemon")
+    assert mgr._max_turns == 2500
+
+
+def test_daemon_explicit_max_turns_beats_config_file(tmp_path):
+    """An explicit capability/init.json max_turns wins over the config file."""
+    _write_daemon_config(tmp_path / "daemon-agent", {"max_turns": 2500})
+    agent = _make_agent(tmp_path, {"daemon": {"max_turns": 500}})
+    mgr = agent.get_capability("daemon")
+    assert mgr._max_turns == 500
+
+
+def test_daemon_invalid_config_max_turns_falls_back_to_1000(tmp_path):
+    """Non-positive-integer max_turns falls back to the built-in default."""
+    for i, bad in enumerate(("lots", 0, -5, 3.5, True)):
+        workdir_name = f"daemon-agent-{i}"
+        _write_daemon_config(tmp_path / workdir_name, {"max_turns": bad})
+        agent = _make_agent(tmp_path, ["daemon"], working_dir_name=workdir_name)
+        mgr = agent.get_capability("daemon")
+        assert mgr._max_turns == 1000, bad
+
+
+def test_daemon_malformed_config_falls_back_to_1000(tmp_path):
+    """A config file that cannot be read as a JSON object falls back safely."""
+    path = tmp_path / "daemon-agent" / "daemon" / "daemon.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{not json", encoding="utf-8")
+    agent = _make_agent(tmp_path, ["daemon"])
+    mgr = agent.get_capability("daemon")
+    assert mgr._max_turns == 1000
+
+
+def test_daemon_load_config_coercion(tmp_path):
+    """The loader itself: per-field fallback without raising."""
+    assert daemon_tool._load_config(tmp_path).max_turns == 1000
+    _write_daemon_config(tmp_path, {"max_turns": 42})
+    assert daemon_tool._load_config(tmp_path).max_turns == 42
+    for bad in (0, -1, "x", 2.5, None):
+        _write_daemon_config(tmp_path, {"max_turns": bad})
+        assert daemon_tool._load_config(tmp_path).max_turns == 1000, bad
+    # Wrong top-level type (a list) also falls back to built-in defaults.
+    path = tmp_path / "daemon" / "daemon.json"
+    path.write_text(json.dumps([1, 2]), encoding="utf-8")
+    assert daemon_tool._load_config(tmp_path).max_turns == 1000
+
+
 def test_daemon_setup_reaps_dead_parent_running_record(tmp_path, monkeypatch):
     """Startup marks stale running daemon.json records failed."""
     from lingtai.tools import daemon as daemon_mod

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -190,12 +190,12 @@ def _write_daemon_config(agent_dir: Path, payload: dict) -> Path:
     return path
 
 
-def test_daemon_default_max_turns_is_1000_without_config(tmp_path):
-    """No config file: the built-in 1000 ceiling applies unchanged."""
-    assert daemon_tool.DEFAULT_MAX_TURNS == 1000
+def test_daemon_default_max_turns_is_5000_without_config(tmp_path):
+    """No config file: the built-in 5000 ceiling applies unchanged."""
+    assert daemon_tool.DEFAULT_MAX_TURNS == 5000
     agent = _make_agent(tmp_path, ["daemon"])
     mgr = agent.get_capability("daemon")
-    assert mgr._max_turns == 1000
+    assert mgr._max_turns == 5000
 
 
 def test_daemon_config_max_turns_overrides_default(tmp_path):
@@ -214,38 +214,38 @@ def test_daemon_explicit_max_turns_beats_config_file(tmp_path):
     assert mgr._max_turns == 500
 
 
-def test_daemon_invalid_config_max_turns_falls_back_to_1000(tmp_path):
+def test_daemon_invalid_config_max_turns_falls_back_to_5000(tmp_path):
     """Non-positive-integer max_turns falls back to the built-in default."""
     for i, bad in enumerate(("lots", 0, -5, 3.5, True)):
         workdir_name = f"daemon-agent-{i}"
         _write_daemon_config(tmp_path / workdir_name, {"max_turns": bad})
         agent = _make_agent(tmp_path, ["daemon"], working_dir_name=workdir_name)
         mgr = agent.get_capability("daemon")
-        assert mgr._max_turns == 1000, bad
+        assert mgr._max_turns == 5000, bad
 
 
-def test_daemon_malformed_config_falls_back_to_1000(tmp_path):
+def test_daemon_malformed_config_falls_back_to_5000(tmp_path):
     """A config file that cannot be read as a JSON object falls back safely."""
     path = tmp_path / "daemon-agent" / "daemon" / "daemon.json"
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("{not json", encoding="utf-8")
     agent = _make_agent(tmp_path, ["daemon"])
     mgr = agent.get_capability("daemon")
-    assert mgr._max_turns == 1000
+    assert mgr._max_turns == 5000
 
 
 def test_daemon_load_config_coercion(tmp_path):
     """The loader itself: per-field fallback without raising."""
-    assert daemon_tool._load_config(tmp_path).max_turns == 1000
+    assert daemon_tool._load_config(tmp_path).max_turns == 5000
     _write_daemon_config(tmp_path, {"max_turns": 42})
     assert daemon_tool._load_config(tmp_path).max_turns == 42
     for bad in (0, -1, "x", 2.5, None):
         _write_daemon_config(tmp_path, {"max_turns": bad})
-        assert daemon_tool._load_config(tmp_path).max_turns == 1000, bad
+        assert daemon_tool._load_config(tmp_path).max_turns == 5000, bad
     # Wrong top-level type (a list) also falls back to built-in defaults.
     path = tmp_path / "daemon" / "daemon.json"
     path.write_text(json.dumps([1, 2]), encoding="utf-8")
-    assert daemon_tool._load_config(tmp_path).max_turns == 1000
+    assert daemon_tool._load_config(tmp_path).max_turns == 5000
 
 
 def test_daemon_setup_reaps_dead_parent_running_record(tmp_path, monkeypatch):


### PR DESCRIPTION
## What

Make the daemon capability's default `max_turns` configurable per agent via a per-agent config file `<workdir>/daemon/daemon.json` (same `<capability>/<capability>.json` convention as the sibling `task_card` capability), keeping the built-in default at **1000**.

## Why

Maintainer request: make the daemon default max turn a setting customizable via `daemon.json`, defaulting to 1000 turns. Previously `DEFAULT_MAX_TURNS = 1000` was a hardcoded constant that could not be overridden per agent.

## What changed

- **`src/lingtai/tools/daemon/__init__.py`**
  - `setup()` now takes `max_turns: int | None = None`; when omitted it resolves from `<workdir>/daemon/daemon.json` (`max_turns` field) and falls back to `DEFAULT_MAX_TURNS` (1000) when the file is missing, malformed, undecodable, the wrong top-level type, or the value is not a positive integer.
  - An explicit `max_turns` (e.g. `Agent(capabilities={"daemon": {"max_turns": N}})` or init.json capability kwargs) always wins over the config file.
  - New `_load_config` / `_config_max_turns` helpers mirror the `task_card` config contract (independent per-field fallback, never raises, so a broken config file never breaks agent startup).
  - Behavior is unchanged for agents without a config file: the default remains exactly 1000.
- **`src/lingtai/tools/daemon/_tool_family.py`** — the `emanate` `max_turns` schema description now mentions the per-agent `daemon/daemon.json` override; the static schema `maximum` stays 1000.
- **`tests/test_daemon.py`** — new tests: (a) default remains 1000 with no config file; (b) a configured `max_turns` overrides the default; (c) an explicit `max_turns` beats the config file; (d) invalid/malformed config falls back to 1000; (e) loader coercion including wrong top-level type.

## Config example

```json
// <workdir>/daemon/daemon.json
{ "max_turns": 2000 }
```

## Validation

- New tests: `5 passed` (`tests/test_daemon.py -k "max_turns or load_config"`).
- Related suites (`tests/test_daemon.py`, `tests/test_daemon_per_batch_limits.py`, `tests/test_tool_family_daemon_migration.py`, `tests/test_task_card_controller.py`): 253 passed / 19 failed — the failure set is **identical** to a clean `origin/main` baseline run on this Windows host (pre-existing POSIX-oriented/environment failures: fake detached-owner via `PosixDaemonSupervisorAdapter`, `os.kill` liveness checks, fake-proc Windows Job Object assignment, missing installed `daemon-manual` skill). No new failures introduced.
