### PR TITLE
feat(llm): OpenAI Responses reasoning semantics, v1 projection, Claude Code --effort

### DIFF
--- a/src/lingtai/llm/claude_code/__init__.py
+++ b/src/lingtai/llm/claude_code/__init__.py
@@ -20,6 +20,13 @@ Auth is owned entirely by the ``claude`` CLI (its stored OAuth credentials or
 token — it only strips ``ANTHROPIC_API_KEY`` / ``ANTHROPIC_AUTH_TOKEN`` from the
 child env so the subprocess cannot fall back to API-key billing. This keeps
 usage on the sanctioned Claude Code / subscription channel.
+
+Reasoning effort is the one Claude Code special case: the CLI controls
+reasoning depth through its own ``--effort <level>`` flag, so a configured
+thinking level is normalized to ``--effort`` argv exactly once per session
+(vocabulary ``low | medium | high | xhigh | max``; omitted/default sends no
+flag, and a caller-supplied ``--effort`` in ``extra_argv`` is never
+duplicated). No other provider shares this wire.
 """
 
 from __future__ import annotations

--- a/src/lingtai/llm/claude_code/adapter.py
+++ b/src/lingtai/llm/claude_code/adapter.py
@@ -82,6 +82,36 @@ _OVERFLOW_MARKERS = (
 _UNSET = object()
 
 
+# Provider-local: the installed ``claude`` CLI's own ``--effort`` vocabulary
+# (the daemon claude-p submanual documents ``--effort max``). Deliberately NOT
+# the kernel THINKING_LEVELS: Claude has no ``none``/``minimal`` and the
+# Responses vocabulary has no ``max``. The flag belongs to the installed CLI;
+# per-model/account acceptance is not verified here.
+CLAUDE_EFFORT_LEVELS = ("low", "medium", "high", "xhigh", "max")
+
+
+def _claude_effort_argv(thinking: str | None) -> list[str]:
+    """Map a kernel thinking level to the ``claude`` CLI ``--effort`` argv fragment.
+
+    Claude Code is the one provider with its own reasoning-control flag, so the
+    thinking level is normalized to argv here and nowhere else. ``None`` /
+    ``"default"`` (omitted) maps to ``[]`` — no ``--effort`` flag, the CLI's
+    own default applies, and the command stays byte-identical to today. An
+    explicit level must be in ``CLAUDE_EFFORT_LEVELS`` (the installed CLI's
+    vocabulary); anything else raises ``ValueError`` here, before any
+    subprocess is dispatched.
+    """
+    if thinking is None or thinking == "default":
+        return []
+    if not isinstance(thinking, str) or thinking not in CLAUDE_EFFORT_LEVELS:
+        raise ValueError(
+            "claude-code effort must be one of "
+            f"{', '.join(CLAUDE_EFFORT_LEVELS)} "
+            f"(omit the field for no --effort flag); got {thinking!r}"
+        )
+    return ["--effort", thinking]
+
+
 class ClaudeCodeError(RuntimeError):
     """A ``claude`` CLI invocation failed (non-zero exit, no output, etc.)."""
 
@@ -198,6 +228,7 @@ class ClaudeCodeChatSession(ChatSession):
         tools: list[FunctionSchema],
         interface: ChatInterface,
         context_window: int,
+        effort_argv: list[str] | None = None,
     ) -> None:
         self._adapter = adapter
         self._model = model
@@ -205,6 +236,11 @@ class ClaudeCodeChatSession(ChatSession):
         self._tools = tools
         self._interface = interface
         self._context_window = context_window
+        # Frozen at construction, never re-read from mutable adapter state.
+        # Every physical CLI invocation this session makes — first call,
+        # ``--resume`` call, and each overflow-recovery retry inside one
+        # logical send — carries this one effort decision (or none).
+        self._effort_argv = list(effort_argv or [])
         # Remote state is an acceleration only. The canonical interface remains
         # the recovery source whenever this continuation cannot be trusted.
         self._remote_session_id: str | None = None
@@ -250,6 +286,7 @@ class ClaudeCodeChatSession(ChatSession):
                         prompt,
                         self._model,
                         resume_session_id=self._remote_session_id,
+                        effort_argv=self._effort_argv,
                     )
                 except ClaudeCodeContextOverflow:
                     # A locally trimmed retry cannot safely continue a remote
@@ -581,6 +618,11 @@ class ClaudeCodeAdapter(LLMAdapter):
         interaction_id: str | None = None,
         context_window: int = 0,
     ) -> ChatSession:
+        # Claude Code is the one provider with its own reasoning-control flag:
+        # the thinking level becomes the CLI's ``--effort`` argv, normalized
+        # exactly once here (an out-of-vocabulary level raises before any
+        # interface mutation or subprocess) and frozen for the session's life.
+        effort_argv = _claude_effort_argv(thinking)
         iface = interface or ChatInterface()
         tool_list = list(tools) if tools else []
         if interface is None:
@@ -595,6 +637,7 @@ class ClaudeCodeAdapter(LLMAdapter):
             tools=tool_list,
             interface=iface,
             context_window=context_window or self._context_window,
+            effort_argv=effort_argv,
         )
         return self._wrap_with_gate(session)
 
@@ -668,6 +711,7 @@ class ClaudeCodeAdapter(LLMAdapter):
         model: str,
         system_prompt_file: Any = _UNSET,
         resume_session_id: str | None = None,
+        effort_argv: list[str] | None = None,
     ) -> tuple[str, UsageMetadata, dict]:
         """Run ``claude -p`` once. Returns (result_text, usage, envelope).
 
@@ -675,6 +719,11 @@ class ClaudeCodeAdapter(LLMAdapter):
         file (the chat path). Pass ``None`` to omit the flag entirely — used
         by the one-shot ``generate`` path, which has no cross-turn cache to
         protect and must not reuse (or poison) the chat system-prompt file.
+
+        ``effort_argv`` is the session's already-frozen Claude effort decision
+        (``["--effort", <level>]``, or empty for omitted). Defaults to
+        ``None`` so callers with no session contract — notably the one-shot
+        ``generate`` path — build exactly the pre-change command.
         """
         cmd = [self._cli_path, "-p", "--output-format", "json"]
         if model:
@@ -687,6 +736,13 @@ class ClaudeCodeAdapter(LLMAdapter):
             system_prompt_file = self._system_prompt_file
         if system_prompt_file:
             cmd += ["--append-system-prompt-file", str(system_prompt_file)]
+        # Claude Code's dedicated reasoning control: one ``--effort`` flag,
+        # appended exactly once, and only when the caller hasn't supplied its
+        # own ``--effort`` via extra_argv (never a duplicate flag).
+        if effort_argv and not any(
+            t == "--effort" or t.startswith("--effort=") for t in self._extra_argv
+        ):
+            cmd += effort_argv
         cmd += self._extra_argv
 
         try:
@@ -774,12 +830,14 @@ class ClaudeCodeAdapter(LLMAdapter):
         model: str,
         *,
         resume_session_id: str | None = None,
+        effort_argv: list[str] | None = None,
     ) -> tuple[dict, UsageMetadata, dict]:
         """Run the CLI and parse one JSON *action* from its result."""
         result_str, usage, envelope = self._invoke_raw(
             prompt,
             model,
             resume_session_id=resume_session_id,
+            effort_argv=effort_argv,
         )
         action = _extract_json_object(result_str)
         if action is None:

--- a/src/lingtai/llm/openai/ANATOMY.md
+++ b/src/lingtai/llm/openai/ANATOMY.md
@@ -113,9 +113,15 @@ mechanism on `OpenAIAdapter` / `OpenAIChatSession` / `OpenAIResponsesSession`:
   input items after the first `function_call` for assistant turns that lack one.
   On by default (env `LINGTAI_INJECT_REASONING_FALLBACK` to disable); an
   explicit constructor/provider-config value wins over the env.
-- `reasoning_effort_vocab` (`str`, default `openai`) — `openai` maps kernel
-  thinking levels to high/low; `seven_tier` passes the kernel `THINKING_LEVELS`
-  through unchanged (DeepSeek wire vocabulary).
+- `reasoning_effort_vocab` (`str`, default `openai`) — selects the Chat
+  Completions projection of the Responses reasoning semantics. `openai`
+  projects the Responses vocabulary onto OpenAI v1's official set
+  (`minimal|low|medium|high`): explicit `minimal`/`low`/`medium`/`high` pass
+  through, `xhigh`/`max` clamp to `high`, `none` omits the field, and the
+  omitted/`default` sentinel omits it too (v1 has no `xhigh`, so omission lets
+  the upstream v1 default apply). `seven_tier` passes the kernel
+  `THINKING_LEVELS` through unchanged and projects the omitted/`default`
+  sentinel to explicit `xhigh`, matching the Responses wire (DeepSeek).
 - `prompt_cache_namespace` (`str | None`) — fixed provider namespace for the
   auto-derived `prompt_cache_key` (e.g. `deepseek` →
   `lingtai-deepseek:{model}:v1`) instead of the base_url host.

--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -2823,11 +2823,13 @@ class OpenAIAdapter(LLMAdapter):
                 },
             }
 
-        # Reasoning effort for o-series models. Subclasses override
-        # ``_chat_reasoning_effort`` to map the kernel thinking levels to
-        # their Chat Completions wire value (e.g. DeepSeek passes the
-        # seven-tier value through unchanged; ``default`` is omitted here and
-        # the upstream default applies).
+        # Reasoning effort for o-series models: the v1 projection of the
+        # Responses semantics. Subclasses override ``_chat_reasoning_effort``
+        # to map the kernel thinking levels to their Chat Completions wire
+        # value (e.g. DeepSeek passes the seven-tier value through unchanged;
+        # the default ``openai`` vocab clamps ``xhigh``/``max`` to ``high`` and
+        # omits the field for the omitted/``default`` sentinel so the upstream
+        # v1 default applies).
         effort = self._chat_reasoning_effort(thinking)
         if effort is not None:
             extra_kwargs["reasoning_effort"] = effort
@@ -2862,33 +2864,48 @@ class OpenAIAdapter(LLMAdapter):
         """
         return {}
 
-    def _chat_reasoning_effort(self, thinking: str) -> str | None:
+    def _chat_reasoning_effort(self, thinking: str | None) -> str | None:
         """Map a kernel thinking level to the Chat Completions reasoning_effort value.
 
-        The vocabulary is selected by ``reasoning_effort_vocab``:
-          * ``openai`` (default) maps ``high`` to ``high`` and every other
-            explicit level to ``low`` (OpenAI o-series compatibility).
+        This is the v1 projection of the Responses semantics (which sends
+        ``reasoning: {effort: <level>}`` verbatim and maps an omitted/default
+        level to explicit ``xhigh``). The vocabulary is selected by
+        ``reasoning_effort_vocab``:
+
+          * ``openai`` (default) projects the Responses vocabulary onto OpenAI
+            v1's official set ``minimal | low | medium | high``: explicit
+            ``minimal``/``low``/``medium``/``high`` pass through, ``xhigh`` and
+            ``max`` clamp to ``high`` (v1 has no higher tier), ``none`` maps to
+            ``None`` so the field is omitted (no reasoning control), and the
+            omitted/``default`` sentinel maps to ``None`` so the upstream v1
+            default applies (OpenAI v1 has no ``xhigh``; omission is the
+            graceful v1 projection of the Responses xhigh default).
           * ``seven_tier`` passes the kernel THINKING_LEVELS through unchanged
             (the DeepSeek wire accepts ``none | minimal | low | medium | high |
-            xhigh | max``); ``default`` maps to ``None`` so no field is sent.
+            xhigh | max``) and projects the omitted/``default`` sentinel to the
+            explicit ``xhigh`` default, matching the Responses wire.
 
-        Returns ``None`` for the omitted/``default`` sentinel so the field is
-        not sent and the upstream default applies.
+        Returns ``None`` so the field is not sent.
         """
         from lingtai.kernel.config import THINKING_LEVELS
 
         if self._reasoning_effort_vocab == "seven_tier":
-            if thinking == "default":
-                return None
+            if thinking in (None, "default"):
+                return "xhigh"
             if thinking not in THINKING_LEVELS:
                 raise ValueError(
                     "thinking must be one of "
                     f"{', '.join(THINKING_LEVELS)}, or default"
                 )
             return thinking
-        if thinking == "default":
+        if thinking in (None, "default", "none"):
             return None
-        return "high" if thinking == "high" else "low"
+        if thinking not in THINKING_LEVELS:
+            raise ValueError(
+                "thinking must be one of "
+                f"{', '.join(THINKING_LEVELS)}, or default"
+            )
+        return "high" if thinking in ("xhigh", "max") else thinking
 
     def generate(
         self,
@@ -6090,11 +6107,12 @@ class CodexOpenAIAdapter(OpenAIAdapter):
                 },
             }
 
-        # Codex-only default: an omitted/``default`` thinking level sends an
-        # explicit ``reasoning.effort = "xhigh"`` instead of omitting the field
+        # Omitted/``default`` thinking sends an explicit
+        # ``reasoning.effort = "xhigh"`` instead of omitting the field
         # (omitting it would fall back to the Codex backend's own, lower
-        # default). Explicit levels pass through unchanged, and the generic
-        # OpenAI Responses path keeps its omit-on-default behavior.
+        # default). Explicit levels pass through unchanged; the generic OpenAI
+        # Responses path shares the same explicit ``xhigh`` default (see
+        # ``_responses_reasoning_kwargs``).
         if thinking in (None, "default"):
             thinking = "xhigh"
         extra_kwargs.update(_responses_reasoning_kwargs(thinking))

--- a/tests/ANATOMY.md
+++ b/tests/ANATOMY.md
@@ -72,6 +72,7 @@ related_files:
   - tests/test_chat_interface_remove_pair_by_notif_id.py
   - tests/test_check_caps.py
   - tests/test_claude_code_adapter.py
+  - tests/test_claude_code_effort.py
   - tests/test_cli.py
   - tests/test_cli_integration.py
   - tests/test_cli_runtime_env.py

--- a/tests/test_claude_code_effort.py
+++ b/tests/test_claude_code_effort.py
@@ -1,0 +1,132 @@
+"""Focused tests for the claude-code ``--effort`` argv normalization.
+
+Claude Code is the one provider with its own reasoning-control flag: the
+kernel thinking level is normalized to ``--effort <level>`` argv exactly once
+per session (``_claude_effort_argv``), frozen for the session's life, and
+never duplicated against a caller-supplied ``--effort`` in ``extra_argv``.
+"""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from lingtai.llm.claude_code.adapter import (
+    CLAUDE_EFFORT_LEVELS,
+    ClaudeCodeAdapter,
+    _claude_effort_argv,
+)
+
+
+class _FakeProc:
+    def __init__(self, stdout="", stderr="", returncode=0):
+        self.stdout = stdout
+        self.stderr = stderr
+        self.returncode = returncode
+
+
+def _envelope(result_str):
+    return json.dumps(
+        {
+            "type": "result",
+            "subtype": "success",
+            "is_error": False,
+            "result": result_str,
+            "session_id": "sess-123",
+            "usage": {"input_tokens": 100, "output_tokens": 20},
+        }
+    )
+
+
+def _run_claude(thinking="default", extra_argv=None):
+    captured = {}
+    adapter = ClaudeCodeAdapter(extra_argv=extra_argv)
+
+    def fake_run(cmd, **kw):
+        captured["cmd"] = list(cmd)
+        return _FakeProc(stdout=_envelope('{"action": "final", "text": "ok"}'))
+
+    with patch(
+        "lingtai.llm.claude_code.adapter.subprocess.run", side_effect=fake_run
+    ):
+        session = adapter.create_chat("opus", "sys", thinking=thinking)
+        session.send("hello")
+    return captured["cmd"]
+
+
+@pytest.mark.parametrize("thinking", ["low", "medium", "high", "xhigh", "max"])
+def test_explicit_thinking_becomes_effort_flag(thinking):
+    cmd = _run_claude(thinking=thinking)
+    assert cmd.count("--effort") == 1
+    assert cmd[cmd.index("--effort") + 1] == thinking
+
+
+@pytest.mark.parametrize("thinking", [None, "default"])
+def test_omitted_thinking_sends_no_effort_flag(thinking):
+    """The omission sentinel emits no ``--effort`` flag; the CLI's own default
+    applies and the command stays byte-identical to pre-effort behavior."""
+    assert "--effort" not in _run_claude(thinking=thinking)
+
+
+def test_create_chat_without_thinking_sends_no_effort_flag():
+    assert "--effort" not in _run_claude()
+
+
+@pytest.mark.parametrize("bad", ["ultra", "", 42, "HIGH", "minimal", "none"])
+def test_out_of_vocabulary_thinking_raises(bad):
+    with pytest.raises(ValueError, match="claude-code effort"):
+        _run_claude(thinking=bad)
+
+
+def test_caller_effort_in_extra_argv_wins_no_duplicate():
+    """A caller-supplied ``--effort`` via ``extra_argv`` suppresses the
+    session's normalized flag: never two ``--effort`` on one command."""
+    cmd = _run_claude(thinking="high", extra_argv=["--effort", "low"])
+    assert cmd.count("--effort") == 1
+    assert cmd[cmd.index("--effort") + 1] == "low"
+
+
+def test_effort_flag_is_frozen_across_turns_and_resume():
+    captured = []
+    adapter = ClaudeCodeAdapter()
+
+    def fake_run(cmd, **kw):
+        captured.append(list(cmd))
+        return _FakeProc(stdout=_envelope('{"action": "final", "text": "ok"}'))
+
+    with patch(
+        "lingtai.llm.claude_code.adapter.subprocess.run", side_effect=fake_run
+    ):
+        session = adapter.create_chat("opus", "sys", thinking="xhigh")
+        session.send("hello")
+        session.send("hello again")
+    assert len(captured) == 2
+    for cmd in captured:
+        assert cmd.count("--effort") == 1
+        assert cmd[cmd.index("--effort") + 1] == "xhigh"
+
+
+def test_generate_omits_effort_flag():
+    """The one-shot path has no session contract: exactly the pre-change
+    command, with no ``--effort`` flag."""
+    adapter = ClaudeCodeAdapter()
+    captured = {}
+
+    def fake_run(cmd, **kw):
+        captured["cmd"] = list(cmd)
+        return _FakeProc(stdout=_envelope("plain reply"))
+
+    with patch(
+        "lingtai.llm.claude_code.adapter.subprocess.run", side_effect=fake_run
+    ):
+        adapter.generate("opus", "hello")
+    assert "--effort" not in captured["cmd"]
+
+
+def test_effort_vocab_is_provider_local():
+    """Claude has no ``none``/``minimal`` (the Responses vocabulary does) and
+    Responses has no ``max``; the local tuple is the single source of truth
+    for both the acceptance gate and the emitted argv."""
+    assert CLAUDE_EFFORT_LEVELS == ("low", "medium", "high", "xhigh", "max")
+    for level in CLAUDE_EFFORT_LEVELS:
+        assert _claude_effort_argv(level) == ["--effort", level]

--- a/tests/test_openai_responses_streaming.py
+++ b/tests/test_openai_responses_streaming.py
@@ -331,9 +331,11 @@ def test_codex_responses_default_thinking_sends_xhigh(thinking_kwargs):
     assert "reasoning_effort" not in sent
 
 
-@pytest.mark.parametrize("thinking_kwargs", [{}, {"thinking": "default"}])
-def test_openai_responses_default_thinking_omits_reasoning(thinking_kwargs):
-    """Generic OpenAI keeps omit-on-default; the xhigh default is Codex-only."""
+@pytest.mark.parametrize("thinking_kwargs", [{}, {"thinking": "default"}, {"thinking": None}])
+def test_openai_responses_default_thinking_sends_xhigh(thinking_kwargs):
+    """Generic OpenAI Responses maps an omitted/``default`` thinking level to
+    explicit ``reasoning.effort = "xhigh"`` on the wire (the Responses
+    semantics: the user did not specify an effort, so xhigh is sent)."""
     adapter = OpenAIAdapter(api_key="fake", use_responses=True)
     adapter._client = FakeClient([_completed()])
     session = adapter.create_chat("gpt-5.5", "system prompt", **thinking_kwargs)
@@ -341,7 +343,27 @@ def test_openai_responses_default_thinking_omits_reasoning(thinking_kwargs):
     session.send_stream("hello")
 
     sent = adapter._client.responses.kwargs[-1]
-    assert "reasoning" not in sent
+    assert sent["reasoning"] == {"effort": "xhigh"}
+    assert "reasoning_effort" not in sent
+
+
+@pytest.mark.parametrize("thinking_kwargs", [{}, {"thinking": "default"}])
+def test_custom_openai_responses_default_thinking_sends_xhigh(thinking_kwargs):
+    """Custom/OpenAI-compatible Responses (base_url + ``wire_api="responses"``)
+    shares the same explicit ``xhigh`` default as generic OpenAI."""
+    adapter = OpenAIAdapter(
+        api_key="fake",
+        base_url="https://custom.example/v1",
+        wire_api="responses",
+    )
+    adapter._client = FakeClient([_completed()])
+    session = adapter.create_chat("gpt-5.5", "system prompt", **thinking_kwargs)
+
+    session.send_stream("hello")
+
+    sent = adapter._client.responses.kwargs[-1]
+    assert sent["reasoning"] == {"effort": "xhigh"}
+    assert "reasoning_effort" not in sent
 
 
 @pytest.mark.parametrize("adapter_cls", [OpenAIAdapter, CodexOpenAIAdapter])

--- a/tests/test_wire_api.py
+++ b/tests/test_wire_api.py
@@ -266,6 +266,83 @@ def test_auto_custom_base_url_creates_chat_session():
 
 
 # ---------------------------------------------------------------------------
+# v1 Chat Completions reasoning projection
+# ---------------------------------------------------------------------------
+# The Responses semantics are canonical (``reasoning.effort`` verbatim,
+# omitted/default -> explicit ``xhigh``); the Chat Completions wire is a
+# projection of that vocabulary onto ``reasoning_effort``.
+
+
+def _chat_session_kwargs(*, thinking=None, reasoning_effort_vocab=None):
+    kwargs = {"api_key": "fake", "base_url": "https://custom.example/v1"}
+    if reasoning_effort_vocab is not None:
+        kwargs["reasoning_effort_vocab"] = reasoning_effort_vocab
+    adapter = OpenAIAdapter(**kwargs)
+    adapter._client = _both_client()
+    session = adapter.create_chat(
+        "gpt-5.5", "system prompt", thinking=thinking or "default"
+    )
+    session.send("hello")
+    return adapter._client.chat.completions.create.call_args.kwargs
+
+
+@pytest.mark.parametrize(
+    ("thinking", "expected"),
+    [
+        ("minimal", "minimal"),
+        ("low", "low"),
+        ("medium", "medium"),
+        ("high", "high"),
+        ("xhigh", "high"),  # OpenAI v1 has no xhigh; clamp to the v1 ceiling
+        ("max", "high"),
+    ],
+)
+def test_chat_completions_projects_explicit_thinking(thinking, expected):
+    """Explicit levels project faithfully onto the v1 ``reasoning_effort``
+    field (the old mapping collapsed every non-high level to ``low``)."""
+    assert _chat_session_kwargs(thinking=thinking)["reasoning_effort"] == expected
+
+
+@pytest.mark.parametrize("thinking", [None, "default"])
+def test_chat_completions_omits_reasoning_effort_on_default(thinking):
+    """OpenAI v1 has no ``xhigh``; the omitted/``default`` sentinel omits the
+    field so the upstream v1 default applies (the graceful v1 projection of
+    the Responses xhigh default)."""
+    assert "reasoning_effort" not in _chat_session_kwargs(thinking=thinking)
+
+
+def test_chat_completions_none_omits_reasoning_effort():
+    """``none`` means no reasoning; on v1 there is no ``none`` effort, so the
+    field is omitted."""
+    assert "reasoning_effort" not in _chat_session_kwargs(thinking="none")
+
+
+def test_chat_completions_rejects_invalid_thinking():
+    with pytest.raises(ValueError, match="thinking must be one of"):
+        _chat_session_kwargs(thinking="ultra")
+
+
+def test_chat_completions_seven_tier_projects_xhigh_default():
+    """Endpoints whose v1 wire accepts the full seven-tier set (e.g. DeepSeek,
+    ``reasoning_effort_vocab="seven_tier"``) project the Responses xhigh
+    default explicitly instead of omitting it."""
+    kwargs = _chat_session_kwargs(
+        thinking="default", reasoning_effort_vocab="seven_tier"
+    )
+    assert kwargs["reasoning_effort"] == "xhigh"
+
+
+@pytest.mark.parametrize(
+    "thinking", ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
+)
+def test_chat_completions_seven_tier_passes_levels_verbatim(thinking):
+    kwargs = _chat_session_kwargs(
+        thinking=thinking, reasoning_effort_vocab="seven_tier"
+    )
+    assert kwargs["reasoning_effort"] == thinking
+
+
+# ---------------------------------------------------------------------------
 # One-shot generate() consistency
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
# feat(llm): OpenAI Responses reasoning semantics, v1 projection, Claude Code `--effort` — Jason's simplified reasoning model

Branch: `feat/reasoning-responses-semantics` (fresh from `origin/main` @ 58303195)

## What this does

Implements Jason's simplified reasoning model: **the OpenAI Responses API is the canonical reasoning semantics**, and everything else is a projection of it. All main code lives in the openai adapter; Claude Code is the one special case.

### 1. OpenAI Responses API — complete semantics in the openai adapter

- `reasoning.effort` carries the full vocabulary verbatim (`none | minimal | low | medium | high | xhigh | max` — the kernel `THINKING_LEVELS` established by main 20b0ddc2).
- **When the user does NOT specify a reasoning effort, the wire sends explicit `reasoning.effort = "xhigh"`** for generic OpenAI and custom/OpenAI-compatible Responses (same behavior as Codex, and the same behavior main has had since 20b0ddc2 — this PR pins it with tests and fixes the one stale test that still asserted the old Codex-only omit-on-default).
- No regression of 20b0ddc2 behavior.

### 2. OpenAI v1 chat-completions projection

`OpenAIAdapter._chat_reasoning_effort` is now a faithful projection of the Responses vocabulary onto the v1 `reasoning_effort` field (previously it collapsed every non-`high` level to `low`, which inverted an explicit `xhigh` request into `low`):

- `openai` vocab (default): `minimal`/`low`/`medium`/`high` pass through; `xhigh`/`max` clamp to `high` (OpenAI v1 has no higher tier); `none` omits the field (no reasoning control); the omitted/`default` sentinel omits the field so the upstream v1 default applies — the graceful v1 projection of the xhigh default, per the adapter's existing behavior. Invalid values raise `ValueError` like the Responses path.
- `seven_tier` vocab (DeepSeek-style endpoints whose v1 accepts the full set): levels pass through verbatim and the omitted/`default` sentinel now projects to explicit `reasoning_effort = "xhigh"`, matching the Responses wire.

### 3. Claude Code as backend — the ONE special case

- `thinking` normalizes to the `claude` CLI's own `--effort <level>` argv, exactly once per session (`low | medium | high | xhigh | max` — the installed CLI's vocabulary, provider-local).
- Omitted/`default` sends **no** `--effort` flag (CLI's own default; command stays byte-identical to before).
- **Never a duplicate `--effort`**: a caller-supplied `--effort` in `extra_argv` suppresses the session's normalized flag.
- The decision is frozen at chat creation, so queueing, retries, overflow recovery, and `--resume` calls all carry the same effort.

## What it deliberately does NOT do

- **Does NOT reintroduce the cross-provider reasoning contract layer**: no `kernel/llm/policy.py`, no `kernel/llm/reasoning.py`, no `routes.py`, no zhipu/kimi_code effort modules, no gemini/anthropic/mimo/minimax reasoning construction, no config.py reasoning-vocabulary machinery, no presets/init_schema thinking-validation rework, no daemon reasoning ceremony.
- **Google and every other provider are untouched.**
- Does NOT change the kernel's runtime `thinking` default (`high`), the manifest.llm.thinking scope gate, or the wire selection logic.
- Does NOT add characterization tests — the suite stays lean (~350 lines of diff + one focused test file).

## Supersedes

This PR supersedes the TZZheng 5-PR consolidation series **#1207 / #1220 / #1223 / #1225 / #1234** (the `feat/reasoning-consolidation` branch, remote head `39d18cd1`), which Jason rejected as too complex. That branch is left untouched. Anything already merged to main from that direction (e.g. the seven-tier vocabulary, the Codex `xhigh` default, the claude-code dup fix) is kept in main's existing minimal form; nothing is re-added or rebuilt.

## Validation

`python -m pytest -q tests/test_openai_responses_streaming.py tests/test_wire_api.py tests/test_claude_code_effort.py tests/test_openai_prompt_cache_key.py tests/test_session.py tests/test_soul.py tests/test_init_schema.py tests/test_presets.py tests/test_codex_native_multiaccount.py`

→ 455 passed, 5 failed — the 5 `test_presets.py` Windows `HOME` failures are pre-existing on main (identical on `origin/main`); no new failures. The openai-adjacent regression batch (deepseek/mimo/zhipu/custom-responses/responses-converter/llm-service/compact-threshold/codex-prompt-cache/streaming/identity-headers) passes 246/246.

## Files

- `src/lingtai/llm/openai/adapter.py` — `_chat_reasoning_effort` v1 projection; comment fixes.
- `src/lingtai/llm/claude_code/adapter.py` — `CLAUDE_EFFORT_LEVELS` + `_claude_effort_argv`; frozen per-session `--effort` argv with no-duplicate guarantee.
- `src/lingtai/llm/claude_code/__init__.py` — docstring for the special case.
- `src/lingtai/llm/openai/ANATOMY.md`, `tests/ANATOMY.md` — minimal doc updates.
- `tests/test_openai_responses_streaming.py` — pins generic/custom Responses `xhigh` default (fixes one stale test).
- `tests/test_wire_api.py` — pins the v1 projection (openai + seven_tier vocabs).
- `tests/test_claude_code_effort.py` — new focused effort-argv tests (vocab, omission, dedup, frozen-across-resume, generate untouched).
