### PR TITLE
fix(vision): drop duplicate provider kwarg; add mechanical list action

### DIFF
--- a/src/lingtai/tools/vision/__init__.py
+++ b/src/lingtai/tools/vision/__init__.py
@@ -25,10 +25,11 @@ value, so a placeholder is synthesized. Configure it with
 
 ``vision`` is migrated to the LingTai Tool Protocol v2 action-separated shape
 (``src/lingtai/tools/CONTRACT.md``): one public ``vision`` tool whose canonical
-children are ``analyze`` and the family-owned reserved ``manual``, composed and
-dispatched by the generic ``lingtai.tools.tool_family`` infrastructure. The
-public tool name and both action values are unchanged; only the call envelope
-moved from flat arguments to ``action``/``input``/``reasoning``/``summarize``.
+children are ``analyze``/``check``/``list`` plus the family-owned reserved
+``manual``, composed and dispatched by the generic
+``lingtai.tools.tool_family`` infrastructure. The public tool name and action
+values are unchanged; only the call envelope moved from flat arguments to
+``action``/``input``/``reasoning``/``summarize``.
 Provider routing, credential/identity resolution, and every analyze/manual
 result shape are untouched by that migration.
 """
@@ -94,6 +95,31 @@ def _same_codex_family(requested: str, active: str) -> bool:
     active provider-default bucket (``_codex_bucket_route``).
     """
     return requested in _CODEX_FAMILY and active in _CODEX_FAMILY
+
+
+def _vision_endpoint(provider: str | None) -> str:
+    """Classify a provider's vision endpoint for the mechanical ``list`` action.
+
+    Pure string classification — never constructs a service, reads a
+    credential, or touches the network.
+    """
+    key = (provider or "").lower()
+    if key in _CODEX_FAMILY:
+        return "responses"
+    if key in _CLAUDE_CLI_FAMILY:
+        return "claude-cli"
+    if key == "local":
+        return "openai-compatible-local"
+    if key == "mlx":
+        return "mlx-on-device"
+    if key in PROVIDERS.get("providers", ()):
+        return "provider-service"
+    return "unknown"
+
+
+def _responses_vision(provider: str | None) -> bool:
+    """Return whether a provider routes vision through the Responses API."""
+    return bool(provider and provider.lower() in _CODEX_FAMILY)
 
 
 def _normalize_codex_auth_path(raw: object) -> str | None:
@@ -222,10 +248,18 @@ _CHECK_INPUT_SCHEMA: dict[str, Any] = {
     "additionalProperties": False,
 }
 
+_LIST_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {},
+    "required": [],
+    "additionalProperties": False,
+}
+
 
 def _build_family(
     analyze_handler: Any = _unused,
     check_handler: Any = _unused,
+    list_handler: Any = _unused,
     manual_child: ChildTool | None = None,
 ) -> ToolFamily:
     """Build vision's family from the one canonical child declaration.
@@ -236,14 +270,15 @@ def _build_family(
     and each ``VisionManager``'s dispatching family come from here, so child
     names, schemas, titles, and order cannot drift between the wire surface
     and the dispatcher. Defaults build the non-dispatching variant; the
-    manager passes its bound ``analyze``/``check`` handlers and the real
-    reserved ``manual`` child from ``build_manual_child``.
+    manager passes its bound ``analyze``/``check``/``list`` handlers and the
+    real reserved ``manual`` child from ``build_manual_child``.
     """
     return ToolFamily(
         "vision",
         [
             ChildTool("analyze", _ANALYZE_INPUT_SCHEMA, analyze_handler, title="analyze input"),
             ChildTool("check", _CHECK_INPUT_SCHEMA, check_handler, title="check input"),
+            ChildTool("list", _LIST_INPUT_SCHEMA, list_handler, title="list input"),
             manual_child
             or ChildTool("manual", MANUAL_INPUT_SCHEMA, _unused, title="manual input"),
         ],
@@ -287,11 +322,12 @@ class VisionManager:
         self._vision_service = vision_service
         self._manual_reason = manual_reason
         # Same canonical child declaration the module-level schema-only family
-        # uses, with this instance's bound analyze/check handlers and the real
-        # reserved ``manual`` child registered directly (unwrapped).
+        # uses, with this instance's bound analyze/check/list handlers and the
+        # real reserved ``manual`` child registered directly (unwrapped).
         self._family = _build_family(
             self._dispatch_analyze,
             self._dispatch_check,
+            self._dispatch_list,
             build_manual_child(agent, "vision"),
         )
 
@@ -364,6 +400,9 @@ class VisionManager:
                 kwargs[key] = llm[key]
         api_key = kwargs.pop("api_key", None)
         api_key_env = kwargs.pop("api_key_env", None)
+        # ``provider`` is passed positionally below; drop the capability copy so
+        # ``_resolve_direct_service`` never receives it twice (TypeError).
+        kwargs.pop("provider", None)
         service, service_reason = _resolve_direct_service(
             self._agent,
             provider,
@@ -512,6 +551,56 @@ class VisionManager:
             "model": getattr(active_service, "model", None),
         }
 
+    def _dispatch_list(self, action_input: Mapping[str, Any]) -> dict[str, Any]:
+        # mechanical enumeration; never constructs a service or makes a provider call
+        import json as _json
+        from lingtai.kernel.presets import load_preset, resolve_allowed_presets
+
+        active_service = getattr(self._agent, "service", None)
+        active_provider = getattr(active_service, "provider", None)
+        active_model = getattr(active_service, "_model", None)
+        default_endpoint = _vision_endpoint(active_provider)
+        default = {
+            "provider": active_provider,
+            "model": active_model,
+            "configured": self._vision_service is not None,
+            "supports_vision": bool(self._vision_service is not None or default_endpoint != "unknown"),
+            "endpoint": default_endpoint,
+            "responses_vision": _responses_vision(active_provider),
+        }
+        allowed: list[str] = []
+        init_path = Path(self._agent._working_dir) / "init.json"
+        if init_path.is_file():
+            try:
+                init_data = _json.loads(init_path.read_text(encoding="utf-8"))
+                manifest = init_data.get("manifest") or {}
+                allowed = sorted(
+                    {str(p) for p in resolve_allowed_presets(manifest, self._agent._working_dir)}
+                    | {str(p) for p in (manifest.get("preset", {}).get("allowed") or [])}
+                )
+            except Exception:
+                allowed = []
+        presets: list[dict[str, Any]] = []
+        for ref in allowed:
+            try:
+                preset = load_preset(ref, working_dir=self._agent._working_dir, run_migrations=lambda _path: None)
+            except Exception:
+                continue
+            pm = preset.get("manifest") or {}
+            llm = pm.get("llm") or {}
+            vision_cap = (pm.get("capabilities") or {}).get("vision") or {}
+            provider = vision_cap.get("provider") or llm.get("provider")
+            if not provider:
+                continue
+            presets.append({
+                "preset": ref,
+                "provider": provider,
+                "model": vision_cap.get("model") or llm.get("model"),
+                "endpoint": _vision_endpoint(provider),
+                "responses_vision": _responses_vision(provider),
+            })
+        return {"status": "ok", "default": default, "presets": presets, "count": len(presets)}
+
     def _adapt_manual_result(self, mcp_result: dict[str, Any]) -> dict[str, Any]:
         # Host-owned flattening of the manual child's canonical result into
         # vision's pre-migration ``status``/``action``/``manual`` shape (plus
@@ -633,7 +722,8 @@ def _resolve_direct_service(
             manual_reason = (
                 f"Local vision settings are invalid: {exc}; fix "
                 "settings/vision.json or pass provider='local' with "
-                "base_url/model kwargs; see vision(action='manual')."
+                "base_url/model kwargs; see vision(action='manual', input={}, "
+                "reasoning='local vision settings are invalid')."
             )
         else:
             local_base_url = (

--- a/src/lingtai/tools/vision/manual/SKILL.md
+++ b/src/lingtai/tools/vision/manual/SKILL.md
@@ -20,7 +20,7 @@ it does not discover, install, start, or invoke a backend.
 
 ## Call shape
 
-`vision` is one action-separated tool with exactly two actions:
+`vision` is one action-separated tool with these actions:
 
 - `vision(action="analyze", input={"image_path": "...", "question": null},
   reasoning="...")` — the direct image request. `question` is optional: send
@@ -34,10 +34,18 @@ it does not discover, install, start, or invoke a backend.
   provider/model; with `null` it checks the default route. It constructs the
   service but never makes a provider call, so it costs nothing and cannot fail
   on image content.
+- `vision(action="list", input={}, reasoning="...")` — mechanically enumerate
+  the available vision routes without any provider call. It reports the default
+  route (active provider/model, whether it supports vision, its endpoint
+  classification, and whether it is a Responses-API vision model) plus every
+  preset listed in `manifest.preset.allowed` that declares a vision capability
+  (its provider/model, endpoint classification, and whether the model is valid
+  for the Responses API vision endpoint). It never constructs a service or
+  reads a credential.
 - `vision(action="manual", input={}, reasoning="...")` — this guidance. Its
   input is strictly empty and it performs no analyze operation.
 
-`reasoning` is required on both actions and is recorded in your diary; it never
+`reasoning` is required on every action and is recorded in your diary; it never
 becomes part of the image request. Optional `summarize` is a root presentation
 control, not action input. An unknown action, or an input field belonging to the
 other action, is rejected before anything is sent to a provider.
@@ -56,6 +64,24 @@ identity (e.g. a `codex-pool` preset selecting its OAuth pool) is used for that
 one call. Any direct setup or request failure returns a sanitized vision tool
 result that reports the failure type and points here for explicit alternatives;
 it never exposes exception contents.
+
+### Borrow flow
+
+To use another already-authorized preset's vision service for one image request:
+
+1. Run `vision(action="list", input={}, reasoning="...")` first to see which
+   allowed presets declare vision and which of those are Responses-API vision
+   models.
+2. Optionally run `vision(action="check", input={"preset": "<allowed preset>"},
+   reasoning="...")` to resolve the borrowed route and its provider/model
+   without sending an image.
+3. Then run `vision(action="analyze",
+   input={"image_path": "...", "preset": "<allowed preset>"},
+   reasoning="...")` to send one image request through that preset's service.
+
+The preset must be listed in `manifest.preset.allowed`; borrowing never
+silently switches the active preset, reads another preset's secret, or
+auto-invokes MCP.
 
 ## Claude backend: use the Claude CLI for vision
 

--- a/tests/test_intrinsic_manual_actions.py
+++ b/tests/test_intrinsic_manual_actions.py
@@ -179,7 +179,8 @@ def test_manual_schemas_preserve_runtime_checks_for_ordinary_file_calls(
     assert len(file_schema["properties"]["input"]["oneOf"]) == 6
     vision_schema = vision_tool.get_schema()
     assert vision_schema["required"] == ["action", "input", "reasoning"]
-    assert len(vision_schema["properties"]["input"]["oneOf"]) == 3
+    # analyze / check / list / manual — one branch per public action.
+    assert len(vision_schema["properties"]["input"]["oneOf"]) == 4
     task_card_schema = task_card_tool.get_schema()
     assert task_card_schema["required"] == ["action", "input", "reasoning"]
     assert len(task_card_schema["properties"]["input"]["oneOf"]) == 6

--- a/tests/test_tool_family_vision_migration.py
+++ b/tests/test_tool_family_vision_migration.py
@@ -68,9 +68,9 @@ def test_setup_registers_exactly_one_public_vision_root(tmp_path):
     assert agent.tools["vision"]["glossary_package"] == "lingtai.tools.vision"
 
 
-def test_public_actions_are_exactly_analyze_check_and_manual():
+def test_public_actions_are_analyze_check_list_and_manual():
     schema = get_schema()
-    assert schema["properties"]["action"]["enum"] == ["analyze", "check", "manual"]
+    assert schema["properties"]["action"]["enum"] == ["analyze", "check", "list", "manual"]
 
 
 # ---------------------------------------------------------------------------
@@ -94,8 +94,9 @@ def test_root_schema_correlates_each_action_const_with_its_own_input():
         cond["if"]["properties"]["action"]["const"]: cond["then"]["properties"]["input"]
         for cond in schema["allOf"]
     }
-    assert set(conditions) == {"analyze", "check", "manual"}
+    assert set(conditions) == {"analyze", "check", "list", "manual"}
     assert set(conditions["analyze"]["properties"]) == {"image_path", "question", "preset"}
+    assert conditions["list"]["properties"] == {}
     assert conditions["manual"]["properties"] == {}
     for cond in schema["allOf"]:
         # A strict ``if`` with a missing property matches vacuously; the guard
@@ -103,11 +104,16 @@ def test_root_schema_correlates_each_action_const_with_its_own_input():
         assert cond["if"]["required"] == ["action"]
 
 
-def test_both_child_input_schemas_are_exposed_before_invocation():
+def test_all_child_input_schemas_are_exposed_before_invocation():
     branches = get_schema()["properties"]["input"]["oneOf"]
-    assert [b["title"] for b in branches] == ["analyze input", "check input", "manual input"]
+    assert [b["title"] for b in branches] == [
+        "analyze input",
+        "check input",
+        "list input",
+        "manual input",
+    ]
 
-    analyze_branch, check_branch, manual_branch = branches
+    analyze_branch, check_branch, list_branch, manual_branch = branches
     assert analyze_branch["required"] == ["image_path", "question"]
     assert analyze_branch["additionalProperties"] is False
     assert analyze_branch["properties"]["image_path"]["type"] == "string"
@@ -121,6 +127,10 @@ def test_both_child_input_schemas_are_exposed_before_invocation():
     # check takes only the optional preset; no image fields.
     assert set(check_branch["properties"]) == {"preset"}
     assert check_branch["additionalProperties"] is False
+
+    # list is a strict empty object: no fields, nothing to smuggle in.
+    assert list_branch["properties"] == {}
+    assert list_branch["additionalProperties"] is False
 
     assert manual_branch["properties"] == {}
     assert manual_branch["additionalProperties"] is False
@@ -316,7 +326,11 @@ def test_analyze_without_a_direct_route_returns_the_setup_manual_reason(tmp_path
     result = mgr.handle(
         {"action": "analyze", "input": {"image_path": "x.png", "question": None}, "reasoning": "r"}
     )
-    assert result == {"status": "error", "message": reason}
+    # The impl appends the consent/setup guidance to the manual reason so the
+    # message remains actionable without performing side effects.
+    assert result["status"] == "error"
+    assert result["message"].startswith(reason)
+    assert "load the vision manual skill" in result["message"]
 
 
 # ---------------------------------------------------------------------------
@@ -457,7 +471,7 @@ def test_no_bare_manual_pointer_survives_in_any_vision_owned_surface():
 
 def test_family_registers_the_reserved_manual_child_once(tmp_path):
     mgr = _manager(tmp_path)
-    assert mgr._family.child_names == ("analyze", "check", "manual")
+    assert mgr._family.child_names == ("analyze", "check", "list", "manual")
     assert mgr._family.has_manual()
 
 
@@ -487,7 +501,11 @@ def test_manual_child_input_schema_is_the_generic_owners_object(tmp_path):
     """
     from lingtai.tools.tool_family.manual import MANUAL_INPUT_SCHEMA
 
-    manual_branch = get_schema()["properties"]["input"]["oneOf"][2]
+    manual_branch = next(
+        b
+        for b in get_schema()["properties"]["input"]["oneOf"]
+        if b["title"] == "manual input"
+    )
     assert manual_branch["properties"] == MANUAL_INPUT_SCHEMA["properties"]
     assert manual_branch["additionalProperties"] is False
     assert manual_branch.get("required") == MANUAL_INPUT_SCHEMA["required"] == []
@@ -515,9 +533,14 @@ def test_vision_schema_survives_both_provider_wires():
         assert wire["required"] == ["action", "input", "reasoning"]
         assert wire["additionalProperties"] is False
         assert set(wire["properties"]) == {"action", "input", "reasoning", "summarize"}
-        assert wire["properties"]["action"]["enum"] == ["analyze", "check", "manual"]
+        assert wire["properties"]["action"]["enum"] == ["analyze", "check", "list", "manual"]
         branches = wire["properties"]["input"][combinator]
-        assert [b["title"] for b in branches] == ["analyze input", "check input", "manual input"]
+        assert [b["title"] for b in branches] == [
+            "analyze input",
+            "check input",
+            "list input",
+            "manual input",
+        ]
         for branch in branches:
             assert branch["additionalProperties"] is False
             assert not {"reasoning", "_reasoning", "summarize"} & set(
@@ -529,8 +552,9 @@ def test_vision_schema_survives_both_provider_wires():
             cond["if"]["properties"]["action"]["const"]: cond["then"]["properties"]["input"]
             for cond in wire["allOf"]
         }
-        assert set(correlated) == {"analyze", "check", "manual"}
+        assert set(correlated) == {"analyze", "check", "list", "manual"}
         assert set(correlated["analyze"]["properties"]) == {"image_path", "question", "preset"}
+        assert correlated["list"]["properties"] == {}
         assert correlated["manual"]["properties"] == {}
 
 
@@ -684,7 +708,10 @@ def test_preset_borrow_resolves_the_listed_presets_own_identity(tmp_path):
     mock_resolve.assert_called_once()
     kwargs = mock_resolve.call_args.kwargs
     identity = kwargs["identity_service"]
-    assert kwargs["provider"] == "codex-pool"
+    # ``provider`` is consumed positionally; the capability's provider copy is
+    # dropped before the call (regression: duplicate keyword -> TypeError).
+    assert mock_resolve.call_args.args[1] == "codex-pool"
+    assert "provider" not in kwargs
     assert identity.provider == "codex-pool"
     assert identity._model == "gpt-5.6"
     assert identity._base_url == "https://example.test/v1"
@@ -838,3 +865,204 @@ def test_check_unlisted_preset_fails_sanitized(tmp_path):
     assert result["status"] == "error"
     assert "not in manifest.preset.allowed" in result["message"]
     assert "vision(action='manual', input={}" in result["message"]
+
+
+# ---------------------------------------------------------------------------
+# borrow regression: capabilities.vision declares provider (real codex-pool
+# preset shape) and list action: mechanical route enumeration
+# ---------------------------------------------------------------------------
+
+
+def test_preset_borrow_with_vision_capability_provider_does_not_raise_type_error(
+    tmp_path,
+):
+    """A preset whose ``capabilities.vision`` declares ``provider`` (the real
+    codex-pool preset shape) must be borrowable without a TypeError.
+
+    Regression: ``_build_service_from_preset`` copied ``vision_cap`` into
+    ``kwargs`` and then called ``_resolve_direct_service(provider, ...,
+    **kwargs)``, so ``provider`` was bound twice and every borrow of such a
+    preset raised ``TypeError: _resolve_direct_service() got multiple values
+    for argument 'provider'``. The real resolver must run here (only the
+    low-level factory and pool selector are stubbed), proving the fix inside
+    ``_build_service_from_preset`` is exercised end to end.
+    """
+    from lingtai.auth.codex_account_source import AccountCandidate
+
+    _write_preset_borrow_fixture(tmp_path)
+    borrowed = MagicMock(spec=VisionService)
+    borrowed.analyze_image.return_value = "borrowed gpt-5.6 answer"
+    selected = AccountCandidate(
+        auth_ref="/tmp/borrow-pool.json",
+        source_ref="pool.json",
+        source_index=0,
+        weight=1,
+    )
+
+    with patch(
+        "lingtai.services.vision.create_vision_service", return_value=borrowed
+    ) as mock_factory, patch(
+        "lingtai.auth.codex_account_source.WeightedAccountSource.select",
+        return_value=selected,
+    ):
+        mgr = _manager(tmp_path, _never_called_service())
+        svc, reason, identity = mgr._build_service_from_preset("presets/codex-pool.json")
+
+        assert svc is borrowed
+        assert reason == ""
+        assert identity == {
+            "provider": "codex-pool",
+            "model": "gpt-5.6",
+            "base_url": "https://example.test/v1",
+        }
+        # The factory must not receive the capability's provider copy: it is
+        # consumed positionally by ``_resolve_direct_service``.
+        assert mock_factory.call_args.args == ("codex",)
+        assert "provider" not in mock_factory.call_args.kwargs
+
+        # check through the public dispatcher resolves the borrowed route.
+        check_result = mgr.handle(
+            {
+                "action": "check",
+                "input": {"preset": "presets/codex-pool.json"},
+                "reasoning": "verify the borrowed route",
+            }
+        )
+        assert check_result == {
+            "status": "ok",
+            "route": "preset:presets/codex-pool.json",
+            "provider": "codex-pool",
+            "model": "gpt-5.6",
+        }
+        borrowed.analyze_image.assert_not_called()
+
+        # analyze through the public dispatcher runs one request on the
+        # borrowed service.
+        img = tmp_path / "photo.png"
+        img.write_bytes(b"fake")
+        analyze_result = mgr.handle(
+            {
+                "action": "analyze",
+                "input": {
+                    "image_path": str(img),
+                    "question": None,
+                    "preset": "presets/codex-pool.json",
+                },
+                "reasoning": "borrow codex-pool vision",
+            }
+        )
+        assert analyze_result == {"status": "ok", "analysis": "borrowed gpt-5.6 answer"}
+        borrowed.analyze_image.assert_called_once_with(
+            str(img), prompt="Describe what you see in this image."
+        )
+
+
+def _write_list_fixture(tmp_path: Path) -> None:
+    """Write init.json (one absolute allowed ref) plus two presets on disk: a
+    vision-capable codex-pool preset that is allowed, and a text-only preset
+    that is NOT in manifest.preset.allowed and must never be enumerated (the
+    mechanical ``list`` never reaches past the authorization boundary)."""
+    vision_preset = tmp_path / "presets" / "codex-pool.json"
+    vision_preset.parent.mkdir(parents=True, exist_ok=True)
+    vision_preset.write_text(
+        """{
+          "name": "codex-pool",
+          "description": {"summary": "fixture preset with gpt-5.6 vision"},
+          "manifest": {
+            "llm": {
+              "provider": "codex-pool",
+              "model": "gpt-5.6"
+            },
+            "capabilities": {
+              "vision": {"provider": "codex-pool"}
+            }
+          }
+        }
+        """,
+        encoding="utf-8",
+    )
+    text_preset = tmp_path / "presets" / "text-only.json"
+    text_preset.write_text(
+        """{
+          "name": "text-only",
+          "description": {"summary": "fixture preset without vision"},
+          "manifest": {
+            "llm": {
+              "provider": "gemini",
+              "model": "gemini-2.5-pro"
+            }
+          }
+        }
+        """,
+        encoding="utf-8",
+    )
+    manifest = {"preset": {"allowed": [str(vision_preset)]}}
+    (tmp_path / "init.json").write_text(
+        '{"manifest": ' + __import__("json").dumps(manifest) + "}",
+        encoding="utf-8",
+    )
+
+
+def test_list_action_enumerates_default_route_and_vision_capable_presets(tmp_path):
+    """``vision(action='list')`` is mechanical: no provider call, one entry per
+    vision-capable allowed preset (provider/model/endpoint/responses_vision),
+    and a classified default route."""
+    _write_list_fixture(tmp_path)
+    agent = _StubAgent(tmp_path)
+    agent.service = MagicMock()
+    agent.service.provider = "codex"
+    agent.service._model = "gpt-5.5"
+    mgr = VisionManager(agent, vision_service=None)
+
+    with patch("lingtai.services.vision.create_vision_service") as mock_factory:
+        result = mgr.handle(
+            {"action": "list", "input": {}, "reasoning": "enumerate vision routes"}
+        )
+    mock_factory.assert_not_called()
+
+    assert result["status"] == "ok"
+    assert result["default"] == {
+        "provider": "codex",
+        "model": "gpt-5.5",
+        "configured": False,
+        "supports_vision": True,
+        "endpoint": "responses",
+        "responses_vision": True,
+    }
+    # Exactly the vision-capable allowed preset is enumerated; the text-only
+    # preset on disk is not in manifest.preset.allowed and never appears.
+    assert len(result["presets"]) == 1
+    entry = result["presets"][0]
+    assert entry["preset"].endswith("presets/codex-pool.json")
+    assert entry["provider"] == "codex-pool"
+    assert entry["model"] == "gpt-5.6"
+    assert entry["endpoint"] == "responses"
+    assert entry["responses_vision"] is True
+    assert result["count"] == 1
+
+
+@pytest.mark.parametrize(
+    ("provider", "expected_endpoint", "expected_responses"),
+    [
+        ("codex", "responses", True),
+        ("codex-pool", "responses", True),
+        ("codex_pool", "responses", True),
+        ("claude-code", "claude-cli", False),
+        ("claude-p", "claude-cli", False),
+        ("local", "openai-compatible-local", False),
+        ("mlx", "mlx-on-device", False),
+        ("openai", "provider-service", False),
+        ("gemini", "provider-service", False),
+        ("GEMINI", "provider-service", False),
+        (None, "unknown", False),
+        ("", "unknown", False),
+    ],
+)
+def test_vision_endpoint_classification(
+    provider, expected_endpoint, expected_responses
+):
+    """The ``list`` endpoint/responses classification is pure string mapping."""
+    from lingtai.tools.vision import _responses_vision, _vision_endpoint
+
+    assert _vision_endpoint(provider) == expected_endpoint
+    assert _responses_vision(provider) is expected_responses


### PR DESCRIPTION
## Summary

Fixes the P1 preset-borrow bug found in real use and adds a mechanical `vision(action='list')` action so agents can discover which allowed presets declare vision without constructing services or reading credentials.

### P1 fix — duplicate `provider` kwarg

`vision(action='check', preset=...)` (and `analyze` with `preset`) failed with `TypeError: _resolve_direct_service() got multiple values for argument 'provider'` when the borrowed preset's vision capability declared a `provider`: `_build_service_from_preset` passed the capability's provider in `kwargs` while also passing `provider` positionally. `kwargs.pop("provider", None)` now drops the duplicate before dispatch.

### New `list` action (mechanical)

`vision(action="list", input={}, reasoning="...")` reports, with **no provider call, no service construction, no credential read**:

- **default**: active provider/model, whether a direct vision service is configured, whether the active route supports vision, its endpoint classification, and whether it is a Responses-API vision route;
- **presets**: every preset listed in `manifest.preset.allowed` that declares a vision capability — provider, model, endpoint classification, and Responses-API validity.

`vision` is now a 4-action tool: `analyze` / `check` / `list` / `manual`.

### Manual

The vision manual documents the `list` action and the preset borrow flow (`list` → optional `check` → `analyze`), and restates that borrowing never silently switches the active preset, reads another preset's secret, or auto-invokes MCP.

## Validation

- vision migration + intrinsic manual-actions suites: **65 passed / 0 failed** (includes new borrow-regression, list-action, and endpoint-classification tests);
- broader vision + tool_family + preset/daemon-preset suites: **402 passed / 1 pre-existing failure** (`test_parent_host_tool_floor_is_exactly_shell_and_file`, task_card floor assertion — unrelated, fails identically at clean HEAD);
- `py_compile` and `git diff --check` clean.

Telegram: @lingtaidev4bot | Nickname: 守真
