### PR TITLE
fix(vision): dedupe tilde/absolute allowed preset refs in list

### DIFF
--- a/src/lingtai/tools/vision/__init__.py
+++ b/src/lingtai/tools/vision/__init__.py
@@ -575,8 +575,8 @@ class VisionManager:
                 init_data = _json.loads(init_path.read_text(encoding="utf-8"))
                 manifest = init_data.get("manifest") or {}
                 allowed = sorted(
-                    {str(p) for p in resolve_allowed_presets(manifest, self._agent._working_dir)}
-                    | {str(p) for p in (manifest.get("preset", {}).get("allowed") or [])}
+                    {str(Path(p).expanduser()) for p in resolve_allowed_presets(manifest, self._agent._working_dir)}
+                    | {str(Path(p).expanduser()) for p in (manifest.get("preset", {}).get("allowed") or [])}
                 )
             except Exception:
                 allowed = []

--- a/tests/test_tool_family_vision_migration.py
+++ b/tests/test_tool_family_vision_migration.py
@@ -1041,6 +1041,53 @@ def test_list_action_enumerates_default_route_and_vision_capable_presets(tmp_pat
     assert result["count"] == 1
 
 
+def test_list_action_dedupes_tilde_and_absolute_allowed_refs(tmp_path, monkeypatch):
+    """A preset declared both as ``~/.lingtai-tui/...`` and as an absolute path
+    in manifest.preset.allowed is enumerated once: the mechanical list
+    normalizes every allowed ref to its expanded absolute path before merging,
+    so the same file cannot appear twice."""
+    vision_preset = tmp_path / ".lingtai-tui" / "presets" / "saved" / "codex-pool.json"
+    vision_preset.parent.mkdir(parents=True, exist_ok=True)
+    vision_preset.write_text(
+        """{
+          "name": "codex-pool",
+          "description": {"summary": "fixture preset with gpt-5.6 vision"},
+          "manifest": {
+            "llm": {"provider": "codex-pool", "model": "gpt-5.6"},
+            "capabilities": {"vision": {"provider": "codex-pool"}}
+          }
+        }
+        """,
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HOME", str(tmp_path))
+    manifest = {
+        "preset": {
+            "allowed": [
+                "~/.lingtai-tui/presets/saved/codex-pool.json",
+                str(vision_preset),
+            ]
+        }
+    }
+    (tmp_path / "init.json").write_text(
+        '{"manifest": ' + __import__("json").dumps(manifest) + "}",
+        encoding="utf-8",
+    )
+    agent = _StubAgent(tmp_path)
+    agent.service = MagicMock()
+    agent.service.provider = "deepseek"
+    agent.service._model = "deepseek-v4-flash"
+    mgr = VisionManager(agent, vision_service=None)
+
+    result = mgr.handle({"action": "list", "input": {}, "reasoning": "enumerate vision routes"})
+
+    assert result["status"] == "ok"
+    assert result["count"] == 1
+    assert len(result["presets"]) == 1
+    assert result["presets"][0]["preset"] == str(vision_preset)
+    assert result["presets"][0]["provider"] == "codex-pool"
+
+
 @pytest.mark.parametrize(
     ("provider", "expected_endpoint", "expected_responses"),
     [


### PR DESCRIPTION
## Summary

Follow-up to #1315: `vision(action='list')` enumerated the same preset twice when `manifest.preset.allowed` lists it both as `~/.lingtai-tui/...` and as an absolute path (the mechanical list merged `resolve_allowed_presets`, which already expands `~`, with the raw allowed entries). Every allowed ref is now normalized with `Path.expanduser()` before the union, so each preset is reported once.

## Validation

- New regression test: tilde + absolute refs for the same file → `count == 1`.
- vision + manual-schemas suites: **66 passed / 0 failed**.
- `py_compile` and `git diff --check` clean.

Telegram: @lingtaidev4bot | Nickname: 守真
