### PR TITLE
fix(kernel): make setup_logging idempotent for file handlers

### DIFF
--- a/src/lingtai/kernel/ANATOMY.md
+++ b/src/lingtai/kernel/ANATOMY.md
@@ -143,7 +143,7 @@ The kernel root holds the coordinator (`base_agent/`) plus a flat collection of 
 - `trace_redaction.py` — small deterministic redactor for durable trajectory writes. It redacts high-confidence token/key/password shapes in nested dict/list/string payloads before event/chat traces are persisted, without mutating the live in-memory conversation.
 - `time_veil.py` — coarse-time rendering for state-aware prompts.
 - `loop_guard.py` — ACTIVE-turn tool-call progress meter plus narrow loop detectors. The total-call ceiling is a large emergency fuse from `safety_limits.py`, not a normal workflow boundary or manifest-controlled setting; duplicate-call and invalid-tool checks remain focused loop detectors; duplicate keys strip `_reasoning` as metadata so semantically identical poll/list calls cannot bypass detection by changing rationale text.
-- `logging.py` — logger configuration (separate from the `services/logging.py` event-log service).
+- `logging.py` — logger configuration (separate from the `services/logging.py` event-log service). `setup_logging` is idempotent per handler type: repeated calls never stack duplicate stream or file handlers (`logging.py:25`, `logging.py:33`).
 - `llm_utils.py` — small shared helpers used by adapter implementations.
 - `types.py` — shared type aliases.
 

--- a/src/lingtai/kernel/logging.py
+++ b/src/lingtai/kernel/logging.py
@@ -30,7 +30,9 @@ def setup_logging(
         ch.setFormatter(fmt)
         logger.addHandler(ch)
 
-    if log_dir is not None:
+    if log_dir is not None and not any(
+        isinstance(h, logging.FileHandler) for h in logger.handlers
+    ):
         log_path = Path(log_dir)
         log_path.mkdir(parents=True, exist_ok=True)
         fh = logging.FileHandler(log_path / "agent.log")

--- a/tests/test_kernel_logging.py
+++ b/tests/test_kernel_logging.py
@@ -1,0 +1,34 @@
+"""Tests for lingtai.kernel.logging (package logger configuration)."""
+import logging
+
+from lingtai.kernel.logging import get_logger, setup_logging
+
+
+def test_setup_logging_repeated_calls_do_not_duplicate_file_handlers(tmp_path):
+    name = "lingtai-test-logging-idempotent"
+    logger = setup_logging(log_dir=tmp_path, logger_name=name)
+    try:
+        assert setup_logging(log_dir=tmp_path, logger_name=name) is logger
+
+        file_handlers = [h for h in logger.handlers if isinstance(h, logging.FileHandler)]
+        stream_handlers = [
+            h
+            for h in logger.handlers
+            if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler)
+        ]
+        assert len(file_handlers) == 1
+        assert len(stream_handlers) == 1
+    finally:
+        for handler in list(logger.handlers):
+            logger.removeHandler(handler)
+            handler.close()
+
+
+def test_get_logger_console_default_unchanged(monkeypatch):
+    import lingtai.kernel.logging as kernel_logging
+
+    monkeypatch.setattr(kernel_logging, "_logger", None)
+    logger = get_logger()
+    assert isinstance(logger, logging.Logger)
+    assert any(isinstance(h, logging.StreamHandler) for h in logger.handlers)
+    assert not any(isinstance(h, logging.FileHandler) for h in logger.handlers)


### PR DESCRIPTION
Author — Telegram: @lingtaidev1bot | Nickname: 知微

## Summary

Fixes #749 (setup_logging not idempotent) and closes #765 (file-logging dead code, resolved as now-safe rather than removed or wired up).

`setup_logging(log_dir=...)` appended a new `FileHandler` on every call: the stream handler was already guarded by the `if not logger.handlers` check, but the file branch had no guard. The branch is currently dead code — no call site passes `log_dir`; the kernel reaches `setup_logging()` only through `get_logger()` lazy init — but it was unsafe to ever start using. This PR guards the `FileHandler` add with a per-handler-type check (`isinstance(h, logging.FileHandler)` over `logger.handlers`), leaving the public signature and console behavior unchanged.

Changes:
- `src/lingtai/kernel/logging.py` — only add a `FileHandler` when the logger has none (+3/-1).
- `tests/test_kernel_logging.py` — new focused tests: double `setup_logging(log_dir=...)` yields exactly one `FileHandler` and one `StreamHandler` (fails on base with 2 FileHandlers); `get_logger()` console default still works and attaches no `FileHandler`.
- `src/lingtai/kernel/ANATOMY.md` — one-line anchor note on the existing `logging.py` entry recording the per-handler-type idempotency.

## Validation

Base for failing-first check: `aec17593` (origin/main).

```
$ pytest tests/test_kernel_logging.py -q   # against base logging.py
E           assert 2 == 1                  # 2 FileHandlers after two setup_logging calls
1 failed, 1 passed

$ pytest tests/test_kernel_logging.py -q   # with fix
2 passed in 0.05s

$ python -m py_compile src/lingtai/kernel/logging.py tests/test_kernel_logging.py
py_compile OK

$ ruff check src/lingtai/kernel/logging.py tests/test_kernel_logging.py
All checks passed!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
