### PR TITLE
fix(daemon): add missing-finish trace-inspection guidance (#1060)

### DIFF
--- a/src/lingtai/tools/daemon/CONTRACT.md
+++ b/src/lingtai/tools/daemon/CONTRACT.md
@@ -8,7 +8,7 @@ description: >
   terminal notifications, and compaction boundaries.
 status: active
 contract_version: 8
-last_changed_at: "2026-08-08"
+last_changed_at: "2026-08-09"
 related_files:
   - src/lingtai/tools/daemon/ANATOMY.md
   - src/lingtai/tools/daemon/__init__.py
@@ -42,6 +42,7 @@ related_files:
   - tests/test_tool_family_daemon_migration.py
   - tests/test_daemon.py
   - tests/test_daemon_empty_parity.py
+  - tests/test_daemon_missing_finish_guidance.py
   - tests/test_apriori_summary_executor.py
   - tests/test_daemon_backend_options.py
   - tests/test_daemon_claude_p_background_guard.py
@@ -69,6 +70,7 @@ review_triggers:
   - tests/test_daemon.py
   - tests/test_daemon_backend_options.py
   - tests/test_daemon_claude_p_background_guard.py
+  - tests/test_daemon_missing_finish_guidance.py
   - tests/test_daemon_opencode_backend.py
   - tests/test_daemon_cursor_backend.py
   - tests/test_daemon_claude_interactive_backend.py
@@ -316,8 +318,10 @@ Success requires a validated `finish(status="done")`; missing completion,
 invalid JSON, invalid status, run-id mismatch, `failed`, or `incomplete` must
 prevent terminal `done`. A missing-finish failure is a contract failure, not
 by itself proof the underlying task failed: the failure message tells the
-parent to inspect the run's trace/result before concluding, and the daemon
-context/manual carry the same guidance.
+parent that before concluding it should inspect the run's trace and the full
+final text preserved in the run directory's physical `result.txt` (on this
+failure path `result_path` stays null; the physical file is the discoverable
+route), and the daemon context/manual carry the same guidance.
 
 The LingTai loop shares only the pure `LLMResponse` all-empty predicate
 (`text`, `tool_calls`, and `thoughts` all empty) with the main agent. An all-empty

--- a/src/lingtai/tools/daemon/CONTRACT.md
+++ b/src/lingtai/tools/daemon/CONTRACT.md
@@ -314,7 +314,10 @@ exactly once with `done`, `failed`, or `incomplete`. The MCP server writes
 When `daemon_common` is loaded, a conversational final answer is not enough.
 Success requires a validated `finish(status="done")`; missing completion,
 invalid JSON, invalid status, run-id mismatch, `failed`, or `incomplete` must
-prevent terminal `done`.
+prevent terminal `done`. A missing-finish failure is a contract failure, not
+by itself proof the underlying task failed: the failure message tells the
+parent to inspect the run's trace/result before concluding, and the daemon
+context/manual carry the same guidance.
 
 The LingTai loop shares only the pure `LLMResponse` all-empty predicate
 (`text`, `tool_calls`, and `thoughts` all empty) with the main agent. An all-empty

--- a/src/lingtai/tools/daemon/__init__.py
+++ b/src/lingtai/tools/daemon/__init__.py
@@ -1930,7 +1930,8 @@ class DaemonManager:
             "inspect its result in this run, then call `finish`. If the run "
             "ends without calling `finish(status=...)`, the parent will "
             "report it as missing-finish — that is not proof of failure; "
-            "the parent will inspect the trace/result."
+            "the parent should inspect the run's trace and the full final "
+            "text preserved in the run directory's physical `result.txt`."
         )
 
     @staticmethod
@@ -2040,8 +2041,9 @@ class DaemonManager:
         if completion.error == _DAEMON_MISSING_COMPLETION_ERROR:
             detail += (
                 ". The run ended without a finish() signal; this does not "
-                "necessarily mean the task failed — inspect the run's "
-                "trace/result before concluding"
+                "necessarily mean the task failed — before concluding, "
+                "inspect the run's trace and the full final text preserved "
+                "in the run directory's physical result.txt"
             )
         exc = RuntimeError(
             "daemon completion MCP contract did not permit success: "

--- a/src/lingtai/tools/daemon/__init__.py
+++ b/src/lingtai/tools/daemon/__init__.py
@@ -1927,7 +1927,10 @@ class DaemonManager:
             "contract, background-and-wait is invalid: do not start a background "
             "job and end your turn expecting a later notification or re-entry. "
             "Run required validation synchronously with an explicit timeout, "
-            "inspect its result in this run, then call `finish`."
+            "inspect its result in this run, then call `finish`. If the run "
+            "ends without calling `finish(status=...)`, the parent will "
+            "report it as missing-finish — that is not proof of failure; "
+            "the parent will inspect the trace/result."
         )
 
     @staticmethod
@@ -2034,6 +2037,12 @@ class DaemonManager:
             detail += f"; reason: {completion.reason}"
         if completion.summary:
             detail += f"; summary: {completion.summary}"
+        if completion.error == _DAEMON_MISSING_COMPLETION_ERROR:
+            detail += (
+                ". The run ended without a finish() signal; this does not "
+                "necessarily mean the task failed — inspect the run's "
+                "trace/result before concluding"
+            )
         exc = RuntimeError(
             "daemon completion MCP contract did not permit success: "
             f"{detail}. Final text: {final_text[:500]}"

--- a/src/lingtai/tools/daemon/manual/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/SKILL.md
@@ -6,8 +6,8 @@ description: >
   hunch, understand `daemon(action="list", input={})`, use CLI backends and `backend_options`,
   and clean up daemon footprint. Read this after dispatching daemon work that is
   slow, failed, timed out, exited 143 / SIGTERM, or needs backend-specific reasoning.
-version: 0.10.0
-last_changed_at: 2026-07-27T00:00:00Z
+version: 0.10.1
+last_changed_at: 2026-08-09T00:00:00Z
 related_files:
 - src/lingtai/tools/daemon/CONTRACT.md
 - src/lingtai/tools/daemon/ANATOMY.md
@@ -167,9 +167,11 @@ are the three that change state.
     `done`; `failed`/`incomplete`, missing finish, or invalid completion prevents
     silent success. A daemon that ends without calling `finish()` is reported
     as a missing-finish failure; that is not necessarily proof the underlying
-    task failed — inspect the run's trace/result (`check`, `result_path`)
-    before treating the work as lost. Secret `env`/`headers` values are
-    redacted in prompts.
+    task failed — before treating the work as lost, inspect the run's trace
+    and the full final text preserved in the run directory's physical
+    `result.txt` (the run directory is the `path` that `check` reports;
+    `result_path` stays null on this failure path). Secret `env`/`headers`
+    values are redacted in prompts.
   - `preset`: optional body/model/tool-shape override for this daemon — an
     explicit `.json`/`.jsonc` path. On the LingTai backend it must already be
     a member of the parent agent's resolved `manifest.preset.allowed` set

--- a/src/lingtai/tools/daemon/manual/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/SKILL.md
@@ -165,7 +165,11 @@ are the three that change state.
     daemon backends. Its `finish(status, summary?, reason?, artifacts?)` tool is
     the hard terminal-success contract: only `finish(status="done")` permits
     `done`; `failed`/`incomplete`, missing finish, or invalid completion prevents
-    silent success. Secret `env`/`headers` values are redacted in prompts.
+    silent success. A daemon that ends without calling `finish()` is reported
+    as a missing-finish failure; that is not necessarily proof the underlying
+    task failed — inspect the run's trace/result (`check`, `result_path`)
+    before treating the work as lost. Secret `env`/`headers` values are
+    redacted in prompts.
   - `preset`: optional body/model/tool-shape override for this daemon — an
     explicit `.json`/`.jsonc` path. On the LingTai backend it must already be
     a member of the parent agent's resolved `manifest.preset.allowed` set

--- a/tests/ANATOMY.md
+++ b/tests/ANATOMY.md
@@ -121,6 +121,7 @@ related_files:
   - tests/test_daemon_manifest.py
   - tests/test_daemon_mimocode_jsonl.py
   - tests/test_daemon_mimocode_submanual.py
+  - tests/test_daemon_missing_finish_guidance.py
   - tests/test_daemon_oh_my_pi_submanual.py
   - tests/test_daemon_opencode_backend.py
   - tests/test_daemon_opencode_submanual.py

--- a/tests/test_daemon_missing_finish_guidance.py
+++ b/tests/test_daemon_missing_finish_guidance.py
@@ -1,0 +1,68 @@
+"""Missing-finish failures must carry trace-inspection guidance.
+
+Strict semantics are unchanged: a run that ends without calling finish()
+while daemon_common MCP is loaded is still a failure. The failure message,
+the daemon oneshot context, and the manual must tell the reader that
+missing-finish is not by itself proof the task failed and to inspect the
+run's trace/result.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from lingtai.tools.daemon import DaemonManager
+from tests._daemon_helpers import make_daemon_agent, make_daemon_run_dir
+
+_GUIDANCE = "does not necessarily mean the task failed"
+
+
+def test_missing_finish_still_fails_and_message_directs_trace_inspection(tmp_path):
+    agent = make_daemon_agent(tmp_path)
+    mgr = agent.get_capability("daemon")
+    run_dir = make_daemon_run_dir(
+        agent,
+        handle="em-missing-finish-guidance",
+        call_parameters={"mcp": [{"name": "daemon_common", "transport": "stdio"}]},
+    )
+
+    with pytest.raises(RuntimeError, match="missing completion") as excinfo:
+        mgr._require_done_completion(run_dir, "final text without finish")
+
+    message = str(excinfo.value)
+    assert _GUIDANCE in message
+    assert "inspect the run's trace/result" in message
+
+    state = json.loads(run_dir.daemon_json_path.read_text())
+    assert state["state"] == "failed"
+
+    # An explicit finish(failed) is the agent's own verdict — the
+    # trace-inspection wording is reserved for the missing-finish case.
+    (run_dir.path / "daemon_completion.json").write_text(
+        json.dumps(
+            {
+                "schema": "lingtai.daemon_completion.v1",
+                "status": "failed",
+                "run_id": run_dir.run_id,
+                "reason": "blocked",
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(RuntimeError) as explicit:
+        mgr._require_done_completion(run_dir, "final text")
+    assert _GUIDANCE not in str(explicit.value)
+
+
+def test_daemon_context_and_manual_carry_missing_finish_guidance():
+    context = DaemonManager._daemon_common_context()
+    assert "missing-finish" in context
+    assert "not proof of failure" in context
+
+    manual = (
+        Path(__file__).resolve().parents[1]
+        / "src/lingtai/tools/daemon/manual/SKILL.md"
+    ).read_text(encoding="utf-8")
+    assert "missing-finish failure" in manual
+    assert "inspect the run's trace/result" in manual

--- a/tests/test_daemon_missing_finish_guidance.py
+++ b/tests/test_daemon_missing_finish_guidance.py
@@ -1,10 +1,14 @@
-"""Missing-finish failures must carry trace-inspection guidance.
+"""Missing-finish failures must carry truthful trace-inspection guidance.
 
 Strict semantics are unchanged: a run that ends without calling finish()
-while daemon_common MCP is loaded is still a failure. The failure message,
-the daemon oneshot context, and the manual must tell the reader that
-missing-finish is not by itself proof the task failed and to inspect the
-run's trace/result.
+while daemon_common MCP is loaded is still a failure. The guidance the
+feature adds must (1) appear only for a physically missing completion file,
+never for invalid/failed/incomplete completions, (2) name an evidence route
+the missing-finish state actually provides — the run directory's physical
+result.txt, not the null ``result_path`` field — with the full final text
+discoverable there, and (3) exist on every documentation surface the change
+touched: the failure message, the daemon oneshot context, the manual, and
+the daemon Contract.
 """
 
 import json
@@ -16,53 +20,117 @@ from lingtai.tools.daemon import DaemonManager
 from tests._daemon_helpers import make_daemon_agent, make_daemon_run_dir
 
 _GUIDANCE = "does not necessarily mean the task failed"
+_ROUTE = "the run directory's physical result.txt"
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_MANUAL = _REPO_ROOT / "src/lingtai/tools/daemon/manual/SKILL.md"
+_CONTRACT = _REPO_ROOT / "src/lingtai/tools/daemon/CONTRACT.md"
 
 
-def test_missing_finish_still_fails_and_message_directs_trace_inspection(tmp_path):
-    agent = make_daemon_agent(tmp_path)
-    mgr = agent.get_capability("daemon")
-    run_dir = make_daemon_run_dir(
+def _normalized(text: str) -> str:
+    """Collapse whitespace and strip backticks so one canonical route
+    fragment can be asserted across plain-string and Markdown surfaces."""
+    return " ".join(text.replace("`", "").split())
+
+
+def _fresh_run(agent, handle):
+    return make_daemon_run_dir(
         agent,
-        handle="em-missing-finish-guidance",
+        handle=handle,
         call_parameters={"mcp": [{"name": "daemon_common", "transport": "stdio"}]},
     )
 
+
+def test_missing_finish_result_discoverable_at_the_advertised_physical_route(
+    tmp_path,
+):
+    agent = make_daemon_agent(tmp_path)
+    mgr = agent.get_capability("daemon")
+    run_dir = _fresh_run(agent, "em-missing-finish-guidance")
+    # Longer than the message's 500-char preview: discovery must not depend
+    # on the truncated "Final text:" excerpt.
+    final_text = "head " * 60 + "FULL-RESULT-MARKER " + "tail " * 60
+    assert len(final_text) > 500
+
     with pytest.raises(RuntimeError, match="missing completion") as excinfo:
-        mgr._require_done_completion(run_dir, "final text without finish")
+        mgr._require_done_completion(run_dir, final_text)
 
     message = str(excinfo.value)
     assert _GUIDANCE in message
-    assert "inspect the run's trace/result" in message
+    assert _ROUTE in _normalized(message)
+    # The guidance must name the physical file, not the result_path field —
+    # daemon.json/artifacts.json/check all persist result_path=null here.
+    assert "result_path" not in message
 
-    state = json.loads(run_dir.daemon_json_path.read_text())
+    state = json.loads(run_dir.daemon_json_path.read_text(encoding="utf-8"))
+    assert state["state"] == "failed"
+    assert state.get("result_path") is None
+
+    # The full final text is discoverable at the advertised route.
+    result_file = run_dir.path / "result.txt"
+    assert result_file.is_file()
+    assert result_file.read_text(encoding="utf-8") == final_text
+
+
+_COMPLETION_MATRIX = [
+    ("missing-completion", None, True),
+    ("invalid-json", "not-json{", False),
+    ("non-object-json", '"a bare string"', False),
+    ("invalid-status", {"status": "victory"}, False),
+    ("run-id-mismatch", {"status": "done", "run_id": "someone-else"}, False),
+    ("invalid-field-type", {"status": "done", "summary": 123}, False),
+    ("explicit-failed", {"status": "failed", "reason": "blocked"}, False),
+    ("explicit-incomplete", {"status": "incomplete", "reason": "later"}, False),
+]
+
+
+@pytest.mark.parametrize(
+    ("case", "completion", "expect_guidance"),
+    _COMPLETION_MATRIX,
+    ids=[case for case, _, _ in _COMPLETION_MATRIX],
+)
+def test_guidance_only_for_physically_missing_completion(
+    tmp_path, case, completion, expect_guidance
+):
+    agent = make_daemon_agent(tmp_path)
+    mgr = agent.get_capability("daemon")
+    run_dir = _fresh_run(agent, f"em-{case}")
+    if completion is not None:
+        payload = completion if isinstance(completion, str) else json.dumps(completion)
+        (run_dir.path / "daemon_completion.json").write_text(
+            payload, encoding="utf-8"
+        )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        mgr._require_done_completion(run_dir, "final text")
+
+    message = str(excinfo.value)
+    assert (_GUIDANCE in message) is expect_guidance
+    assert (_ROUTE in _normalized(message)) is expect_guidance
+
+    state = json.loads(run_dir.daemon_json_path.read_text(encoding="utf-8"))
     assert state["state"] == "failed"
 
-    # An explicit finish(failed) is the agent's own verdict — the
-    # trace-inspection wording is reserved for the missing-finish case.
-    (run_dir.path / "daemon_completion.json").write_text(
-        json.dumps(
-            {
-                "schema": "lingtai.daemon_completion.v1",
-                "status": "failed",
-                "run_id": run_dir.run_id,
-                "reason": "blocked",
-            }
-        ),
-        encoding="utf-8",
-    )
-    with pytest.raises(RuntimeError) as explicit:
-        mgr._require_done_completion(run_dir, "final text")
-    assert _GUIDANCE not in str(explicit.value)
 
-
-def test_daemon_context_and_manual_carry_missing_finish_guidance():
+def test_daemon_context_carries_guidance_with_truthful_modal_wording():
     context = DaemonManager._daemon_common_context()
     assert "missing-finish" in context
     assert "not proof of failure" in context
+    assert _ROUTE in _normalized(context)
+    # The runtime performs no automatic inspection: the context must say the
+    # parent *should* inspect, never promise that it *will*.
+    assert "should inspect" in context
+    assert "will inspect" not in context
 
-    manual = (
-        Path(__file__).resolve().parents[1]
-        / "src/lingtai/tools/daemon/manual/SKILL.md"
-    ).read_text(encoding="utf-8")
+
+def test_manual_and_contract_name_the_physical_result_route():
+    manual = _MANUAL.read_text(encoding="utf-8")
     assert "missing-finish failure" in manual
-    assert "inspect the run's trace/result" in manual
+    assert _ROUTE in _normalized(manual)
+    # The old route claim (`check`, `result_path`) advertised a field that is
+    # null in the exact missing-finish state; it must not come back.
+    assert "(`check`, `result_path`)" not in manual
+
+    contract = _CONTRACT.read_text(encoding="utf-8")
+    assert "missing-finish failure is a contract failure" in _normalized(contract)
+    assert _ROUTE in _normalized(contract)


### PR DESCRIPTION
## Summary

This PR was pivoted per Jason's decision (Telegram 12847/12849): the original
text-only-stop → partial-success exception approach is **dropped entirely** (the
pre-pivot work is preserved locally at `archive/daemon-partial-finish-20260809-pre-pivot`).
Strict missing-finish semantics are retained unchanged: a run that ends without a
validated `finish(status="done")` while `daemon_common` is loaded still fails.

What this PR now adds is guidance only:

- The missing-finish failure message states that the run ending without `finish()` does
  not necessarily mean the task failed and directs the parent to inspect the run's trace
  and the **full final text preserved in the run directory's physical `result.txt`** — the
  route the missing-finish state actually provides (`result_path` stays null on this
  failure path; no surface claims it is populated). Applied only to the missing-finish
  case; an explicit `finish(failed)` is the agent's own verdict and does not get this
  wording.
- `_daemon_common_context()` (the daemon oneshot completion contract) gains one sentence
  telling the daemon that missing-finish is reported but is not proof of failure and the
  parent **should** inspect the trace/result.
- The daemon manual `SKILL.md` and `CONTRACT.md` §3 carry the same note, naming the
  physical `result.txt` route and the truthful modal (should inspect).
- Tests (`tests/test_daemon_missing_finish_guidance.py`, 4 functions / 11 items): fresh-run
  parser/status matrix (guidance only for physically missing completion), >500-char
  result-discovery at the advertised physical route, docs-surface parity across all four
  surfaces, fresh-run negative for explicit `finish(failed)`, and truthful-wording check.

No exception machinery, terminal detectors, partial/reminder run-dir fields, or
winner-preservation logic — none of the previous approach survives.

## Validation

Base `c1f9789ff39fa2c4f20c644a9d3d9214b5e11d0b`; exact head `2315c1e86e31c16aec0315d68dcd0dd9bb4ace7a`.
Diffstat: 5 files (4 modified + 1 new test), 167 insertions, 6 deletions (cumulative vs base).

Owner venv, `PYTHONPATH=<worktree>/src`:

```
pytest tests/test_daemon_missing_finish_guidance.py -q                      → 11 passed
pytest tests/test_daemon_missing_finish_guidance.py \
       tests/test_daemon_empty_parity.py tests/test_daemon_backend_options.py \
       tests/test_daemon_contract_doc.py -q                                 → 92 passed
pytest tests/test_daemon_claude_interactive_backend.py \
       tests/test_daemon_claude_p_background_guard.py \
       tests/test_daemon_claude_p_usage_backend.py \
       tests/test_daemon_common_finish_mcp.py -q                            → 52 passed
pytest tests/test_architecture_documents.py -q                             → 5 orphans == base's exact 5 (pre-existing debt)
python -m py_compile <changed .py>                                          → OK
git diff --check                                                            → clean
```

Telegram: @lingtaidev1bot | Nickname: 知微
