### PR TITLE
fix(aed,telegram): sanitized AED-exhaust notice + typing TTL lease (lingtai#672)

### DIFF
--- a/src/lingtai/kernel/base_agent/turn.py
+++ b/src/lingtai/kernel/base_agent/turn.py
@@ -149,6 +149,91 @@ def _report_api_error_to_task_card(
         pass
 
 
+# lingtai#672: user-visible, sanitized notice sent exactly once when AED
+# exhausts. Fixed text — never embeds ``err_desc`` (which may carry
+# secrets, absolute paths, or provider internals).
+_AED_EXHAUSTED_USER_MESSAGE = (
+    "\u26a0\ufe0f The model service is temporarily unavailable and I couldn't "
+    "finish processing your request. I've paused to recover \u2014 please try "
+    "again in a little while."
+)
+
+
+def _aed_origin_route(agent):
+    """Derive ``(account, chat_id)`` of the current turn's originating
+    Telegram chat from the notification store, or ``None`` when unavailable.
+
+    Mirrors ``BaseAgent._setup_telegram_task_card``: the first Telegram
+    preview's ``message_ref`` is ``<account>:<chat_id>:<message_id>``.
+    Fail-open — any anomaly returns ``None`` and never raises.
+    """
+    try:
+        from ..notifications import is_channel_allowed
+        store = getattr(agent, "_notification_store", None)
+        if store is None:
+            return None
+        notifications = store.snapshot(is_channel_allowed)
+        telegram_data = notifications.get("mcp.telegram")
+        if not telegram_data or not isinstance(telegram_data, dict):
+            return None
+        data = telegram_data.get("data", {})
+        previews = data.get("previews", []) if isinstance(data, dict) else []
+        if not previews:
+            return None
+        first = previews[0] if isinstance(previews, list) and previews else {}
+        message_ref = first.get("message_ref", "") if isinstance(first, dict) else ""
+        if not message_ref or not isinstance(message_ref, str):
+            return None
+        parts = message_ref.split(":", 2)
+        if len(parts) < 2:
+            return None
+        account = parts[0]
+        try:
+            chat_id = int(parts[1])
+        except (ValueError, TypeError):
+            return None
+        return account, chat_id
+    except Exception:
+        return None
+
+
+def _notify_aed_exhaustion_origin(agent) -> None:
+    """Best-effort one-shot sanitized notice to the originating chat.
+
+    lingtai#672: when AED exhausts the agent falls ASLEEP without any
+    user-visible reply, leaving IM users (and Telegram's typing indicator)
+    hanging. Send exactly ONE sanitized failure notice to the conversation
+    that originated the current turn through the existing ``telegram`` tool
+    handler (the same seam an LLM tool call would use) — never a new
+    outbound channel, never ``err_desc``. Strictly fail-open: any failure is
+    logged and swallowed so the AED/ASLEEP decision is never affected.
+    """
+    try:
+        handler = getattr(agent, "_tool_handlers", {}).get("telegram")
+        if handler is None:
+            return
+        route = _aed_origin_route(agent)
+        if route is None:
+            return
+        account, chat_id = route
+        handler({
+            "action": "send",
+            "input": {
+                "account": account,
+                "chat_id": chat_id,
+                "text": _AED_EXHAUSTED_USER_MESSAGE,
+                "rendering_mode": "plain_text",
+            },
+            "reasoning": "aed_exhausted_notice",
+        })
+        agent._log("aed_exhausted_notice", status="sent")
+    except Exception as exc:
+        try:
+            agent._log("aed_exhausted_notice_failed", error=str(exc)[:200])
+        except Exception:
+            pass
+
+
 def _recover_api_error_on_task_card(agent) -> None:
     """Observe-only companion to :func:`_report_api_error_to_task_card`."""
     recover = getattr(agent, "_recover_task_card_api_error", None)
@@ -904,6 +989,12 @@ def _run_loop(agent) -> None:
                             )
 
                         agent._log("aed_exhausted", attempts=aed_attempts, error=err_desc)
+                        # lingtai#672: send ONE sanitized, user-visible failure
+                        # notice to the originating IM conversation through the
+                        # existing telegram tool handler before going ASLEEP, so
+                        # the human is not left staring at an unanswered request
+                        # (and a typing indicator that never stops). Fail-open.
+                        _notify_aed_exhaustion_origin(agent)
                         sleep_state = AgentState.ASLEEP
                         agent._asleep.set()
                         break

--- a/src/lingtai/kernel/base_agent/turn.py
+++ b/src/lingtai/kernel/base_agent/turn.py
@@ -159,13 +159,44 @@ _AED_EXHAUSTED_USER_MESSAGE = (
 )
 
 
-def _aed_origin_route(agent):
+def _parse_telegram_route(message_ref: Any) -> tuple[str, int] | None:
+    """Strictly parse ``'<account>:<chat_id>:<message_id>'`` to ``(account, chat_id)``.
+
+    Mirrors the Telegram manager's ``_parse_compound_id`` route grammar:
+    exactly three colon-separated parts, a non-empty account, an integer
+    ``chat_id`` that is not the reserved synthetic ``updates`` bucket, and an
+    integer ``message_id``.  Anything else — malformed refs, empty account,
+    extra segments, non-numeric ids, the synthetic events bucket — returns
+    ``None`` (never raises).  This rejects ambiguous/malformed routes so an
+    AED notice can never be mis-sent to a fabricated chat.
+    """
+    if not isinstance(message_ref, str) or not message_ref:
+        return None
+    parts = message_ref.split(":")
+    if len(parts) != 3 or not parts[0]:
+        return None
+    if parts[1] == "updates":
+        # Reserved synthetic events bucket — no real chat to send into.
+        return None
+    try:
+        chat_id = int(parts[1])
+        message_id = int(parts[2])
+    except (ValueError, TypeError):
+        return None
+    if message_id < 0:
+        return None
+    return parts[0], chat_id
+
+
+def _aed_origin_route(agent) -> tuple[str, int] | None:
     """Derive ``(account, chat_id)`` of the current turn's originating
     Telegram chat from the notification store, or ``None`` when unavailable.
 
-    Mirrors ``BaseAgent._setup_telegram_task_card``: the first Telegram
-    preview's ``message_ref`` is ``<account>:<chat_id>:<message_id>``.
-    Fail-open — any anomaly returns ``None`` and never raises.
+    Mirrors ``BaseAgent._setup_telegram_task_card``: Telegram previews carry
+    ``message_ref`` = ``<account>:<chat_id>:<message_id>``.  Returns the first
+    *valid* Telegram route (rejecting malformed refs and the synthetic
+    ``updates`` bucket so a callback-first preview cannot shadow the real
+    chat).  Fail-open — any anomaly returns ``None`` and never raises.
     """
     try:
         from ..notifications import is_channel_allowed
@@ -180,24 +211,18 @@ def _aed_origin_route(agent):
         previews = data.get("previews", []) if isinstance(data, dict) else []
         if not previews:
             return None
-        first = previews[0] if isinstance(previews, list) and previews else {}
-        message_ref = first.get("message_ref", "") if isinstance(first, dict) else ""
-        if not message_ref or not isinstance(message_ref, str):
-            return None
-        parts = message_ref.split(":", 2)
-        if len(parts) < 2:
-            return None
-        account = parts[0]
-        try:
-            chat_id = int(parts[1])
-        except (ValueError, TypeError):
-            return None
-        return account, chat_id
+        for first in previews:
+            if not isinstance(first, dict):
+                continue
+            route = _parse_telegram_route(first.get("message_ref", ""))
+            if route is not None:
+                return route
+        return None
     except Exception:
         return None
 
 
-def _notify_aed_exhaustion_origin(agent) -> None:
+def _notify_aed_exhaustion_origin(agent, route: tuple[str, int] | None) -> None:
     """Best-effort one-shot sanitized notice to the originating chat.
 
     lingtai#672: when AED exhausts the agent falls ASLEEP without any
@@ -207,16 +232,20 @@ def _notify_aed_exhaustion_origin(agent) -> None:
     handler (the same seam an LLM tool call would use) — never a new
     outbound channel, never ``err_desc``. Strictly fail-open: any failure is
     logged and swallowed so the AED/ASLEEP decision is never affected.
+
+    ``route`` is the immutable origin captured when the turn was dequeued
+    (see ``_run_loop``) — never a live re-read of the coalesced notification
+    snapshot, so a later chat or a dismissed notification cannot lose or
+    misroute the notice.
     """
+    if route is None:
+        return
+    account, chat_id = route
     try:
         handler = getattr(agent, "_tool_handlers", {}).get("telegram")
         if handler is None:
             return
-        route = _aed_origin_route(agent)
-        if route is None:
-            return
-        account, chat_id = route
-        handler({
+        result = handler({
             "action": "send",
             "input": {
                 "account": account,
@@ -226,10 +255,24 @@ def _notify_aed_exhaustion_origin(agent) -> None:
             },
             "reasoning": "aed_exhausted_notice",
         })
-        agent._log("aed_exhausted_notice", status="sent")
+        # Interpret the handler result truthfully: the Telegram family returns
+        # ``{status: 'error', ...}`` mappings for send failures instead of
+        # raising, so record ``failed`` in that case rather than ``sent``.
+        if isinstance(result, dict) and str(result.get("status", "ok")).lower() in (
+            "error", "failed", "failure",
+        ):
+            agent._log("aed_exhausted_notice", status="failed")
+        else:
+            agent._log("aed_exhausted_notice", status="sent")
     except Exception as exc:
+        # Sanitized failure audit: log the exception class and a fixed
+        # category only — never raw handler text, which may carry
+        # secrets/paths/provider internals.
         try:
-            agent._log("aed_exhausted_notice_failed", error=str(exc)[:200])
+            agent._log(
+                "aed_exhausted_notice_failed",
+                error_type=type(exc).__name__,
+            )
         except Exception:
             pass
 
@@ -740,6 +783,12 @@ def _run_loop(agent) -> None:
             aed_attempts = 0
             transient_attempts = 0
             skip_post_turn_save = False
+            # lingtai#672: bind the current turn's immutable Telegram origin
+            # ONCE at dequeue time, before any LLM/tool work can read or
+            # replace the notification snapshot.  The AED-exhaust notice
+            # consumes this captured route, never a live re-read, so a later
+            # chat or a dismissed notification cannot lose/misroute it.
+            turn_origin = _aed_origin_route(agent)
             while True:
                 try:
                     # Fail closed: if a prior turn already poisoned the
@@ -994,7 +1043,15 @@ def _run_loop(agent) -> None:
                         # existing telegram tool handler before going ASLEEP, so
                         # the human is not left staring at an unanswered request
                         # (and a typing indicator that never stops). Fail-open.
-                        _notify_aed_exhaustion_origin(agent)
+                        # Publish the observable ASLEEP state explicitly (like
+                        # the worker-hang exit) so supervisors/humans see
+                        # ASLEEP, not a terminal STUCK, even though the final
+                        # guard skips `_set_state` once `_asleep` is set.
+                        agent._set_state(
+                            AgentState.ASLEEP,
+                            reason=f"AED exhausted after {aed_attempts} attempts",
+                        )
+                        _notify_aed_exhaustion_origin(agent, turn_origin)
                         sleep_state = AgentState.ASLEEP
                         agent._asleep.set()
                         break

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -277,8 +277,17 @@ class TypingIndicatorManager:
     indicator can never run forever even if ``stop_typing`` is never
     called (e.g. the turn ends without a successful send — AED
     exhaustion, provider failure, cancellation). The lease is a hard
-    guarantee, not a best-effort hint: the loop exits once the deadline
-    passes and the chat is removed from the active set.
+    guarantee, not a best-effort hint:
+
+    - the deadline is checked *before* every API send and recomputed
+      after it, so no action can be issued at/after expiry;
+    - every lease has its own identity; a worker only removes its own
+      mapping (``current is lease``), so a stale worker can never delete
+      a newer lease for the same chat;
+    - workers are tracked and ``stop_all`` boundedly joins them;
+    - ``start_typing`` after shutdown has begun is a no-op, and repeated
+      starts renew/replace the active lease instead of silently
+      inheriting an expiring one.
     """
 
     #: Default lease for one typing indicator loop. Generous enough for
@@ -286,59 +295,129 @@ class TypingIndicatorManager:
     #: leave the chat stuck in "typing…" for minutes.
     DEFAULT_TYPING_TTL_SECONDS = 120.0
 
-    def __init__(self, ttl_seconds: float = DEFAULT_TYPING_TTL_SECONDS) -> None:
-        self._active_chats: dict[tuple[str, int], threading.Event] = {}
+    #: Bounded join timeout for workers when stopping all typing.
+    STOP_JOIN_TIMEOUT_SECONDS = 5.0
+
+    def __init__(
+        self,
+        ttl_seconds: float = DEFAULT_TYPING_TTL_SECONDS,
+        *,
+        clock: Callable[[], float] | None = None,
+    ) -> None:
+        # Validate custom TTL: finite and strictly positive, so a bad
+        # config cannot silently disable the hard bound.
+        try:
+            ttl = float(ttl_seconds)
+        except (TypeError, ValueError):
+            raise ValueError(f"ttl_seconds must be a finite positive number, got {ttl_seconds!r}")
+        if not math.isfinite(ttl) or ttl <= 0:
+            raise ValueError(f"ttl_seconds must be a finite positive number, got {ttl_seconds!r}")
+        self._active_chats: dict[tuple[str, int], _TypingLease] = {}
         self._lock = threading.Lock()
-        self._ttl_seconds = ttl_seconds
+        self._ttl_seconds = ttl
+        self._shutdown = False
+        # Injectable monotonic clock (defaults to wall monotonic).  Tests use
+        # a fake clock to prove the hard deadline deterministically.
+        self._clock = clock if clock is not None else time.monotonic
 
     def start_typing(self, account: Any, chat_id: int) -> None:
-        """Start sending typing indicators for a chat."""
+        """Start sending typing indicators for a chat.
+
+        Repeated start for an already-active chat renews/replaces the lease
+        (signals the old one, installs a fresh deadline) instead of inheriting
+        an expiring lease. After shutdown begins this is a no-op.
+        """
         key = (account.alias, chat_id)
         with self._lock:
-            if key in self._active_chats:
-                return  # Already typing
-            stop_event = threading.Event()
-            self._active_chats[key] = stop_event
-        deadline = time.monotonic() + self._ttl_seconds
+            if self._shutdown:
+                return
+            previous = self._active_chats.get(key)
+            lease = _TypingLease(chat_id=chat_id)
+            if previous is not None:
+                previous.stop_event.set()  # signal old worker; it will remove only its own mapping
+            self._active_chats[key] = lease
+        deadline = self._clock() + self._ttl_seconds
 
         def _typing_loop() -> None:
-            while not stop_event.is_set():
+            while not lease.stop_event.is_set():
+                # Hard bound: check remaining BEFORE every API call so a
+                # send can never be issued at/after the deadline, then
+                # recompute after the send before deciding to wait.
+                remaining = deadline - self._clock()
+                if remaining <= 0:
+                    break
                 try:
                     account.send_chat_action(chat_id, "typing")
                 except Exception as e:
                     log.debug("Typing indicator failed for %s:%s: %s",
                               account.alias, chat_id, e)
-                # Wait 4 seconds (Telegram expires at 5s), but never past the
-                # TTL lease — a stuck turn must not leave "typing…" forever.
-                remaining = deadline - time.monotonic()
+                remaining = deadline - self._clock()
                 if remaining <= 0:
                     break
-                stop_event.wait(min(4.0, remaining))
-            # Clean up
+                # Wait 4 seconds (Telegram expires at 5s), but never past the
+                # TTL lease — a stuck turn must not leave "typing…" forever.
+                lease.stop_event.wait(min(4.0, remaining))
+            # Clean up — only if this lease is still the active one for the
+            # chat, so a stale worker cannot delete a newer lease.
             with self._lock:
-                self._active_chats.pop(key, None)
+                if self._active_chats.get(key) is lease:
+                    self._active_chats.pop(key, None)
 
         thread = threading.Thread(
             target=_typing_loop,
             daemon=True,
             name=f"typing-{account.alias}-{chat_id}",
         )
+        # Start first, then publish the handle: a concurrent ``stop_all``
+        # between start and assignment sees ``thread is None`` and skips the
+        # join, but the stop event is already set so the worker exits on its
+        # first loop check (bounded, no deadlock).  Assigning before start
+        # would let ``join()`` race a not-yet-started thread.
         thread.start()
+        with self._lock:
+            lease.thread = thread
 
     def stop_typing(self, account: Any, chat_id: int) -> None:
         """Stop sending typing indicators for a chat."""
         key = (account.alias, chat_id)
         with self._lock:
-            stop_event = self._active_chats.get(key)
-        if stop_event:
-            stop_event.set()
+            lease = self._active_chats.get(key)
+        if lease is not None:
+            lease.stop_event.set()
 
     def stop_all(self) -> None:
-        """Stop all typing indicators."""
+        """Stop all typing indicators and boundedly join their workers.
+
+        Signals every active lease, clears the active map, and joins each
+        tracked worker for a bounded time. After this call no background
+        typing worker is left alive.
+        """
         with self._lock:
-            for stop_event in self._active_chats.values():
-                stop_event.set()
+            self._shutdown = True
+            leases = list(self._active_chats.values())
+            for lease in leases:
+                lease.stop_event.set()
             self._active_chats.clear()
+        for lease in leases:
+            thread = lease.thread
+            if thread is not None:
+                thread.join(timeout=self.STOP_JOIN_TIMEOUT_SECONDS)
+
+
+class _TypingLease:
+    """Per-chat typing lease: stop signal plus the owning worker thread.
+
+    Identity comes from object identity — a worker removes its mapping only
+    when ``self._active_chats[key] is lease``, so a stale worker cannot
+    delete a lease that replaced it.
+    """
+
+    __slots__ = ("stop_event", "thread", "chat_id")
+
+    def __init__(self, chat_id: int) -> None:
+        self.stop_event = threading.Event()
+        self.thread: threading.Thread | None = None
+        self.chat_id = chat_id
 
 
 # Global typing indicator manager
@@ -745,10 +824,13 @@ class TelegramManager:
     def stop(self) -> None:
         self._stop_programmable_task_card_poller()
         self._stop_task_card_tail()
-        # lingtai#672: stop any in-flight typing indicators on shutdown so a
-        # dying process cannot leave a chat stuck in "typing…".
-        _typing_manager.stop_all()
+        # lingtai#672: quiesce the producers FIRST (service.stop() signals and
+        # joins every account poll thread, so no in-flight callback can start
+        # a new typing lease), then stop_all() signals and boundedly joins
+        # every typing worker. Order matters: stopping typing before the
+        # producers lets a late callback re-enter after the clear.
         self._service.stop()
+        _typing_manager.stop_all()
 
     # ------------------------------------------------------------------
     # Action dispatch

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -272,11 +272,24 @@ class TypingIndicatorManager:
 
     Sends typing indicator immediately, then re-sends every 5 seconds
     (Telegram auto-expires them). Best-effort — never blocks or fails.
+
+    lingtai#672: each typing loop carries a bounded TTL lease so the
+    indicator can never run forever even if ``stop_typing`` is never
+    called (e.g. the turn ends without a successful send — AED
+    exhaustion, provider failure, cancellation). The lease is a hard
+    guarantee, not a best-effort hint: the loop exits once the deadline
+    passes and the chat is removed from the active set.
     """
 
-    def __init__(self) -> None:
+    #: Default lease for one typing indicator loop. Generous enough for
+    #: normal multi-minute turns; short enough that a stuck turn cannot
+    #: leave the chat stuck in "typing…" for minutes.
+    DEFAULT_TYPING_TTL_SECONDS = 120.0
+
+    def __init__(self, ttl_seconds: float = DEFAULT_TYPING_TTL_SECONDS) -> None:
         self._active_chats: dict[tuple[str, int], threading.Event] = {}
         self._lock = threading.Lock()
+        self._ttl_seconds = ttl_seconds
 
     def start_typing(self, account: Any, chat_id: int) -> None:
         """Start sending typing indicators for a chat."""
@@ -286,6 +299,7 @@ class TypingIndicatorManager:
                 return  # Already typing
             stop_event = threading.Event()
             self._active_chats[key] = stop_event
+        deadline = time.monotonic() + self._ttl_seconds
 
         def _typing_loop() -> None:
             while not stop_event.is_set():
@@ -294,8 +308,12 @@ class TypingIndicatorManager:
                 except Exception as e:
                     log.debug("Typing indicator failed for %s:%s: %s",
                               account.alias, chat_id, e)
-                # Wait 4 seconds (Telegram expires at 5s)
-                stop_event.wait(4.0)
+                # Wait 4 seconds (Telegram expires at 5s), but never past the
+                # TTL lease — a stuck turn must not leave "typing…" forever.
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                stop_event.wait(min(4.0, remaining))
             # Clean up
             with self._lock:
                 self._active_chats.pop(key, None)
@@ -727,6 +745,9 @@ class TelegramManager:
     def stop(self) -> None:
         self._stop_programmable_task_card_poller()
         self._stop_task_card_tail()
+        # lingtai#672: stop any in-flight typing indicators on shutdown so a
+        # dying process cannot leave a chat stuck in "typing…".
+        _typing_manager.stop_all()
         self._service.stop()
 
     # ------------------------------------------------------------------

--- a/tests/ANATOMY.md
+++ b/tests/ANATOMY.md
@@ -346,6 +346,7 @@ related_files:
   - tests/test_telegram_task_card_transport.py
   - tests/test_telegram_terra_repairs.py
   - tests/test_telegram_toolfamily_ltpv2.py
+  - tests/test_telegram_typing_ttl.py
   - tests/test_three_agent_email.py
   - tests/test_time_awareness_email.py
   - tests/test_time_awareness_mail.py

--- a/tests/test_aed_recovery.py
+++ b/tests/test_aed_recovery.py
@@ -358,6 +358,85 @@ def test_transient_provider_error_counts_as_aed_after_retry_budget(tmp_path, mon
     assert agent._asleep.is_set()
 
 
+def test_aed_exhaust_sends_one_sanitized_notice_to_origin(tmp_path, monkeypatch):
+    """lingtai#672: when AED exhausts (deterministic provider failure), the
+    run loop sends exactly ONE sanitized, user-safe Telegram message to the
+    originating conversation through the existing telegram tool handler
+    before going ASLEEP. The notice must never embed the raw error text."""
+    agent = _make_run_loop_agent(tmp_path)
+    agent._config.max_aed_attempts = 1
+
+    sent: list[dict] = []
+
+    def fake_telegram(args: dict) -> dict:
+        sent.append(args)
+        return {"status": "sent", "message_id": "acct:123:1"}
+
+    agent._tool_handlers = {"telegram": fake_telegram}
+
+    class _FakeNotificationStore:
+        def snapshot(self, _allow):
+            return {
+                "mcp.telegram": {
+                    "data": {
+                        "previews": [
+                            {"message_ref": "acct:123:456"},
+                        ],
+                    },
+                },
+            }
+
+    agent._notification_store = _FakeNotificationStore()
+
+    def fake_handle(_agent, _msg):
+        raise RuntimeError("HTTP 429 Too Many Requests")
+
+    monkeypatch.setattr(turn, "_handle_message", fake_handle)
+
+    import lingtai.tools.soul.flow as soul_flow
+    monkeypatch.setattr(soul_flow, "_cancel_soul_timer", lambda _a: _a._shutdown.set())
+
+    turn._run_loop(agent)
+
+    # Exactly one sanitized send, targeting the origin chat, plain text.
+    assert len(sent) == 1
+    args = sent[0]
+    assert args["action"] == "send"
+    assert args["input"]["account"] == "acct"
+    assert args["input"]["chat_id"] == 123
+    assert args["input"]["rendering_mode"] == "plain_text"
+    # Sanitized: no raw provider error text, no secrets, no paths.
+    assert "429" not in args["input"]["text"]
+    assert "Too Many" not in args["input"]["text"]
+    assert "tmp_path" not in args["input"]["text"]
+    assert any(name == "aed_exhausted" for name, _ in agent._logs)
+    assert any(name == "aed_exhausted_notice" for name, _ in agent._logs)
+    assert agent._asleep.is_set()
+
+
+def test_aed_exhaust_notice_fail_open_when_telegram_handler_missing(tmp_path, monkeypatch):
+    """lingtai#672: without a telegram tool handler (or origin route), the
+    AED-exhaust notice is skipped fail-open and the ASLEEP transition still
+    happens; the AED decision is never affected by the notice."""
+    agent = _make_run_loop_agent(tmp_path)
+    agent._config.max_aed_attempts = 1
+    agent._tool_handlers = {}  # no telegram
+
+    def fake_handle(_agent, _msg):
+        raise RuntimeError("HTTP 429 Too Many Requests")
+
+    monkeypatch.setattr(turn, "_handle_message", fake_handle)
+
+    import lingtai.tools.soul.flow as soul_flow
+    monkeypatch.setattr(soul_flow, "_cancel_soul_timer", lambda _a: _a._shutdown.set())
+
+    turn._run_loop(agent)
+
+    assert any(name == "aed_exhausted" for name, _ in agent._logs)
+    assert not any(name == "aed_exhausted_notice" for name, _ in agent._logs)
+    assert agent._asleep.is_set()
+
+
 def test_structural_error_skips_transient_retry(tmp_path, monkeypatch):
     agent = _make_run_loop_agent(tmp_path)
     agent._config.max_aed_attempts = 1

--- a/tests/test_aed_recovery.py
+++ b/tests/test_aed_recovery.py
@@ -411,7 +411,168 @@ def test_aed_exhaust_sends_one_sanitized_notice_to_origin(tmp_path, monkeypatch)
     assert "tmp_path" not in args["input"]["text"]
     assert any(name == "aed_exhausted" for name, _ in agent._logs)
     assert any(name == "aed_exhausted_notice" for name, _ in agent._logs)
+    # P1-2: the observable agent state is ASLEEP, not a terminal STUCK, and
+    # the sleep event is set.
     assert agent._asleep.is_set()
+    assert agent._state == AgentState.ASLEEP
+    assert AgentState.ASLEEP in agent._states
+
+
+def test_aed_exhaust_notice_uses_origin_captured_at_dequeue(tmp_path, monkeypatch):
+    """P1-1: the AED notice consumes the origin captured when the turn was
+    dequeued, NOT a live re-read of the notification snapshot. If a later chat
+    replaces the snapshot during the failed turn, the notice still goes to the
+    original chat exactly once."""
+    agent = _make_run_loop_agent(tmp_path)
+    agent._config.max_aed_attempts = 1
+
+    sent: list[dict] = []
+
+    def fake_telegram(args: dict) -> dict:
+        sent.append(args)
+        return {"status": "sent", "message_id": "acct:111:1"}
+
+    agent._tool_handlers = {"telegram": fake_telegram}
+
+    # Snapshot state AT DEQUEUE: origin chat 111.
+    dequeue_snapshot = {
+        "mcp.telegram": {
+            "data": {"previews": [{"message_ref": "acct:111:456"}]},
+        },
+    }
+    # Snapshot state AT EXHAUSTION: a later chat (222) replaced it.
+    later_snapshot = {
+        "mcp.telegram": {
+            "data": {"previews": [{"message_ref": "acct:222:789"}]},
+        },
+    }
+    state = {"n": 0}
+
+    class _FakeNotificationStore:
+        def snapshot(self, _allow):
+            state["n"] += 1
+            # First read = dequeue-time capture; any later read = live snapshot.
+            return dequeue_snapshot if state["n"] == 1 else later_snapshot
+
+    agent._notification_store = _FakeNotificationStore()
+
+    def fake_handle(_agent, _msg):
+        raise RuntimeError("HTTP 429 Too Many Requests")
+
+    monkeypatch.setattr(turn, "_handle_message", fake_handle)
+
+    import lingtai.tools.soul.flow as soul_flow
+    monkeypatch.setattr(soul_flow, "_cancel_soul_timer", lambda _a: _a._shutdown.set())
+
+    turn._run_loop(agent)
+
+    # Exactly one notice to the ORIGINAL chat, never to the later one.
+    assert len(sent) == 1
+    assert sent[0]["input"]["account"] == "acct"
+    assert sent[0]["input"]["chat_id"] == 111
+
+
+def test_aed_exhaust_notice_rejects_malformed_route(tmp_path, monkeypatch):
+    """P1-1: ambiguous/malformed Telegram routes (empty account, missing
+    message-id, extra segment, synthetic updates bucket, non-numeric ids) are
+    rejected; no notice is sent to a fabricated chat and AED still exhausts."""
+    agent = _make_run_loop_agent(tmp_path)
+    agent._config.max_aed_attempts = 1
+
+    sent: list[dict] = []
+
+    def fake_telegram(args: dict) -> dict:
+        sent.append(args)
+        return {"status": "sent"}
+
+    agent._tool_handlers = {"telegram": fake_telegram}
+
+    malformed_refs = [
+        ":123:456",        # empty account
+        "acct:123",         # missing message-id
+        "acct:123:456:789", # extra segment
+        "acct:updates:456", # synthetic events bucket
+        "acct:abc:456",     # non-numeric chat id
+        "acct:123:xyz",     # non-numeric message id
+        "acct:123:-1",      # negative message id
+        "",                 # empty ref
+        12345,              # non-string
+    ]
+
+    # Run one iteration per malformed ref: use a fresh agent each time so the
+    # sleep event / shutdown state cannot leak across runs.
+    import lingtai.tools.soul.flow as soul_flow
+    monkeypatch.setattr(soul_flow, "_cancel_soul_timer", lambda _a: _a._shutdown.set())
+
+    for ref in malformed_refs:
+        agent = _make_run_loop_agent(tmp_path)
+        agent._config.max_aed_attempts = 1
+        agent._tool_handlers = {"telegram": fake_telegram}
+        sent.clear()
+
+        class _PerRefStore:
+            def snapshot(self, _allow):
+                return {
+                    "mcp.telegram": {
+                        "data": {"previews": [{"message_ref": ref}]},
+                    },
+                }
+
+        agent._notification_store = _PerRefStore()
+
+        def fake_handle(_agent, _msg):
+            raise RuntimeError("HTTP 429 Too Many Requests")
+
+        monkeypatch.setattr(turn, "_handle_message", fake_handle)
+        turn._run_loop(agent)
+
+        assert not sent, f"malformed ref {ref!r} produced a send"
+        assert agent._asleep.is_set()
+        assert agent._state == AgentState.ASLEEP
+
+
+def test_aed_exhaust_notice_records_returned_error_as_failed(tmp_path, monkeypatch):
+    """P2-1: when the telegram handler RETURNS an error mapping (instead of
+    raising), the notice is recorded as failed — not falsely as sent — and the
+    ASLEEP transition still happens fail-open."""
+    agent = _make_run_loop_agent(tmp_path)
+    agent._config.max_aed_attempts = 1
+
+    def fake_telegram(args: dict) -> dict:
+        return {"status": "error", "error": "send failed: token=sk-secret /tmp/private"}
+
+    agent._tool_handlers = {"telegram": fake_telegram}
+
+    class _FakeNotificationStore:
+        def snapshot(self, _allow):
+            return {
+                "mcp.telegram": {
+                    "data": {"previews": [{"message_ref": "acct:123:456"}]},
+                },
+            }
+
+    agent._notification_store = _FakeNotificationStore()
+
+    def fake_handle(_agent, _msg):
+        raise RuntimeError("HTTP 429 Too Many Requests")
+
+    monkeypatch.setattr(turn, "_handle_message", fake_handle)
+
+    import lingtai.tools.soul.flow as soul_flow
+    monkeypatch.setattr(soul_flow, "_cancel_soul_timer", lambda _a: _a._shutdown.set())
+
+    turn._run_loop(agent)
+
+    assert any(
+        name == "aed_exhausted_notice" and fields.get("status") == "failed"
+        for name, fields in agent._logs
+    )
+    assert not any(
+        name == "aed_exhausted_notice" and fields.get("status") == "sent"
+        for name, fields in agent._logs
+    )
+    assert agent._asleep.is_set()
+    assert agent._state == AgentState.ASLEEP
 
 
 def test_aed_exhaust_notice_fail_open_when_telegram_handler_missing(tmp_path, monkeypatch):

--- a/tests/test_telegram_typing_ttl.py
+++ b/tests/test_telegram_typing_ttl.py
@@ -4,11 +4,21 @@ The Telegram ``TypingIndicatorManager`` carries a bounded TTL lease per chat.
 Even when ``stop_typing`` is never called (AED exhaustion, provider failure,
 cancellation, turn ends without a send), the typing loop must exit once the
 lease expires and remove the chat from the active set.
+
+P1-3/P1-4 contracts locked here:
+- no Bot API send can be issued at/after the lease deadline (hard bound);
+- stale workers cannot delete a newer lease for the same chat (identity);
+- repeated starts renew/replace the active lease;
+- ``stop_all`` signals + joins workers and forbids new starts;
+- invalid (non-finite / non-positive) TTL config is rejected.
 """
 from __future__ import annotations
 
+import threading
 import time
 from types import SimpleNamespace
+
+import pytest
 
 from lingtai.mcp_servers.telegram.manager import TypingIndicatorManager
 
@@ -20,6 +30,31 @@ class _FakeAccount:
 
     def send_chat_action(self, chat_id: int, action: str) -> None:
         self.actions.append((chat_id, action))
+
+
+class _FakeClock:
+    """Manually advanced monotonic clock for deterministic TTL tests."""
+
+    def __init__(self, start: float = 1000.0) -> None:
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def _wait_active(manager, key, timeout=2.0):
+    deadline = time.monotonic() + timeout
+    while key not in manager._active_chats and time.monotonic() < deadline:
+        time.sleep(0.01)
+
+
+def _wait_inactive(manager, key, timeout=2.0):
+    deadline = time.monotonic() + timeout
+    while key in manager._active_chats and time.monotonic() < deadline:
+        time.sleep(0.01)
 
 
 def test_typing_stops_after_ttl_even_without_stop_typing() -> None:
@@ -52,9 +87,7 @@ def test_stop_typing_still_stops_before_ttl() -> None:
     manager.stop_typing(account, 456)
 
     # Loop exits promptly once the stop event is set.
-    deadline = time.monotonic() + 2.0
-    while ("acct", 456) in manager._active_chats and time.monotonic() < deadline:
-        time.sleep(0.01)
+    _wait_inactive(manager, ("acct", 456))
     assert ("acct", 456) not in manager._active_chats
 
 
@@ -67,12 +100,98 @@ def test_typing_loop_uses_lease_bound_even_with_slow_stop() -> None:
 
     start = time.monotonic()
     manager.start_typing(account, 789)
-    deadline = time.monotonic() + 2.0
-    while ("acct", 789) in manager._active_chats and time.monotonic() < deadline:
-        time.sleep(0.01)
+    _wait_inactive(manager, ("acct", 789))
     elapsed = time.monotonic() - start
 
     assert ("acct", 789) not in manager._active_chats
     # Generous upper bound: the loop must exit within a couple seconds even
     # though the inner wait is 4s, proving the lease clamps the wait.
     assert elapsed < 3.0
+
+
+def test_no_send_after_deadline_with_fake_clock() -> None:
+    """P1-4: the hard TTL bound is real — no Bot API send may be issued at or
+    after the deadline. A fake clock proves it deterministically."""
+    account = _FakeAccount()
+    clock = _FakeClock()
+    manager = TypingIndicatorManager(ttl_seconds=0.1, clock=clock)
+
+    manager.start_typing(account, 321)
+    _wait_active(manager, ("acct", 321))
+    # Let the first send land, then jump the clock PAST the deadline.
+    time.sleep(0.02)
+    clock.advance(10.0)
+    time.sleep(0.1)  # worker observes the deadline and must exit without sending
+
+    assert ("acct", 321) not in manager._active_chats
+    # All sends must have happened strictly before the deadline.
+    for chat_id, _action in account.actions:
+        assert chat_id == 321
+    # The worker cannot have sent after we advanced the clock: the only send
+    # window is the first loop iteration before the advance.
+    assert len(account.actions) <= 2
+
+
+def test_stale_worker_cannot_delete_new_lease() -> None:
+    """P1-3: a stale worker for a replaced lease must not remove the new lease
+    from the active map (identity-safe cleanup)."""
+    account = _FakeAccount()
+    manager = TypingIndicatorManager(ttl_seconds=5.0)
+
+    manager.start_typing(account, 555)
+    _wait_active(manager, ("acct", 555))
+    # Replace the lease with a fresh one (repeated start = renewal).
+    manager.start_typing(account, 555)
+    time.sleep(0.05)
+
+    # The new lease is still tracked; stop_typing can still signal it.
+    assert ("acct", 555) in manager._active_chats
+    manager.stop_typing(account, 555)
+    _wait_inactive(manager, ("acct", 555))
+
+
+def test_repeated_start_renews_deadline() -> None:
+    """P1-3: a repeated ``start_typing`` for an already-active chat renews the
+    lease instead of inheriting an expiring one — the chat remains active past
+    the original deadline."""
+    account = _FakeAccount()
+    clock = _FakeClock()
+    manager = TypingIndicatorManager(ttl_seconds=0.3, clock=clock)
+
+    manager.start_typing(account, 777)
+    _wait_active(manager, ("acct", 777))
+    time.sleep(0.02)
+    # Renew near the original deadline.
+    clock.advance(0.25)
+    manager.start_typing(account, 777)
+    time.sleep(0.05)
+    # Original deadline passed, but the renewed lease keeps the chat active.
+    assert ("acct", 777) in manager._active_chats
+    manager.stop_typing(account, 777)
+    _wait_inactive(manager, ("acct", 777))
+
+
+def test_stop_all_joins_workers_and_blocks_new_starts() -> None:
+    """P1-3: ``stop_all`` signals and joins every worker, clears the map, and
+    makes later ``start_typing`` calls no-ops."""
+    account = _FakeAccount()
+    manager = TypingIndicatorManager(ttl_seconds=60.0)
+
+    manager.start_typing(account, 888)
+    _wait_active(manager, ("acct", 888))
+    manager.stop_all()
+
+    assert ("acct", 888) not in manager._active_chats
+    # No background typing worker may be left alive: a later start is a no-op.
+    before = len(account.actions)
+    manager.start_typing(account, 999)
+    time.sleep(0.05)
+    assert ("acct", 999) not in manager._active_chats
+    assert len(account.actions) == before
+
+
+def test_invalid_ttl_rejected() -> None:
+    """P1-4: custom TTL must be finite and strictly positive."""
+    for bad in (0, -1, float("nan"), float("inf"), float("-inf"), "nope"):
+        with pytest.raises(ValueError):
+            TypingIndicatorManager(ttl_seconds=bad)

--- a/tests/test_telegram_typing_ttl.py
+++ b/tests/test_telegram_typing_ttl.py
@@ -1,0 +1,78 @@
+"""lingtai#672: typing indicators must never run forever.
+
+The Telegram ``TypingIndicatorManager`` carries a bounded TTL lease per chat.
+Even when ``stop_typing`` is never called (AED exhaustion, provider failure,
+cancellation, turn ends without a send), the typing loop must exit once the
+lease expires and remove the chat from the active set.
+"""
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+from lingtai.mcp_servers.telegram.manager import TypingIndicatorManager
+
+
+class _FakeAccount:
+    def __init__(self) -> None:
+        self.alias = "acct"
+        self.actions: list[tuple[int, str]] = []
+
+    def send_chat_action(self, chat_id: int, action: str) -> None:
+        self.actions.append((chat_id, action))
+
+
+def test_typing_stops_after_ttl_even_without_stop_typing() -> None:
+    """A typing loop that is never explicitly stopped still exits after its
+    TTL lease expires and is removed from the active set."""
+    account = _FakeAccount()
+    manager = TypingIndicatorManager(ttl_seconds=0.2)
+
+    manager.start_typing(account, 123)
+    assert ("acct", 123) in manager._active_chats
+
+    # Give the loop a few send ticks, then wait past the lease without calling
+    # stop_typing.
+    time.sleep(0.15)
+    assert manager._active_chats.get(("acct", 123)) is not None
+    time.sleep(0.35)
+
+    assert ("acct", 123) not in manager._active_chats
+    assert len(account.actions) >= 1
+    assert all(chat_id == 123 and action == "typing" for chat_id, action in account.actions)
+
+
+def test_stop_typing_still_stops_before_ttl() -> None:
+    """Explicit stop_typing keeps working and wins over the TTL."""
+    account = _FakeAccount()
+    manager = TypingIndicatorManager(ttl_seconds=60.0)
+
+    manager.start_typing(account, 456)
+    time.sleep(0.05)
+    manager.stop_typing(account, 456)
+
+    # Loop exits promptly once the stop event is set.
+    deadline = time.monotonic() + 2.0
+    while ("acct", 456) in manager._active_chats and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert ("acct", 456) not in manager._active_chats
+
+
+def test_typing_loop_uses_lease_bound_even_with_slow_stop() -> None:
+    """The loop wait is bounded by the remaining lease, so a 4s sleep can never
+    overrun a much shorter TTL (deterministic regression for the 8-minute
+    typing bug)."""
+    account = _FakeAccount()
+    manager = TypingIndicatorManager(ttl_seconds=0.1)
+
+    start = time.monotonic()
+    manager.start_typing(account, 789)
+    deadline = time.monotonic() + 2.0
+    while ("acct", 789) in manager._active_chats and time.monotonic() < deadline:
+        time.sleep(0.01)
+    elapsed = time.monotonic() - start
+
+    assert ("acct", 789) not in manager._active_chats
+    # Generous upper bound: the loop must exit within a couple seconds even
+    # though the inner wait is 4s, proving the lease clamps the wait.
+    assert elapsed < 3.0


### PR DESCRIPTION
Closes https://github.com/Lingtai-AI/lingtai/issues/672

## Problem

When AED (API-error detector) exhausts its retry budget, the agent goes ASLEEP without any user-visible reply to the originating IM conversation. On Telegram the user is left staring at a typing indicator that never stops (the indicator only stops after a successful `_send`), in the worst case for 8+ minutes.

## Narrow fix

1. **Kernel `turn.py` — AED-exhaust sanitized notice.** On AED exhaustion, send exactly ONE sanitized, user-safe message to the originating Telegram conversation through the existing `telegram` tool handler (the same seam an LLM tool call uses) before going ASLEEP. The text is fixed and never embeds `err_desc` (which may carry secrets/paths/provider internals). Fail-open: any failure is logged and swallowed; the AED/ASLEEP decision is never affected.
   - **Immutable origin binding (Fable P1-1).** The `(account, chat_id)` route is captured ONCE at turn dequeue time (`_run_loop` → `turn_origin`), before any LLM/tool work can read or replace the notification snapshot. The AED-exhaust notice consumes that captured route — never a live re-read of the coalesced notification store — so a later chat or a dismissed notification cannot lose or misroute the notice. Routes are parsed strictly (`_parse_telegram_route`: exactly `<account>:<chat_id>:<message_id>`, non-empty account, integer ids, synthetic `updates` bucket rejected), so ambiguous/malformed refs are never sent to a fabricated chat.
   - **Observable ASLEEP (Fable P1-2).** The AED-exhaust branch now calls `_set_state(AgentState.ASLEEP, ...)` explicitly (like the worker-hang exit) so supervisors/humans observe ASLEEP — not a terminal STUCK — in addition to setting the `_asleep` event.
   - **Truthful failure audit (Fable P2-1).** The handler result is interpreted: returned `{status: error}` mappings are recorded as `failed` (not `sent`), and raised errors log only the exception class (never raw handler text that may carry secrets/paths).

2. **Telegram `manager.py` — typing indicator lifecycle guarantees.** `TypingIndicatorManager` now guarantees typing can never run forever:
   - **Hard TTL bound (Fable P1-4).** The deadline is checked *before* every Bot API send and recomputed after it, so no action can be issued at/after expiry. Custom TTL is validated finite and positive. An injectable clock makes the bound testable deterministically.
   - **Generation-safe workers (Fable P1-3).** Each lease has object identity; a worker removes its mapping only when `self._active_chats[key] is lease`, so a stale worker cannot delete a newer lease. Workers are tracked and `stop_all` boundedly joins them. `start_typing` after shutdown began is a no-op; repeated starts renew/replace the active lease.
   - **Shutdown ordering (Fable P1-3).** `TelegramManager.stop()` now quiesces producers first (`service.stop()` signals+joins account poll threads) then calls `stop_all()` — no in-flight callback can start a new lease after the clear.

3. **Tests (Fable P2-2/P2-3).** Added deterministic, failing-first lifecycle tests with fake-clock/event synchronization covering: no send after deadline, stale-worker/new-lease identity, repeated-start renewal, stop_all join + shutdown no-op, invalid TTL rejection, immutable dequeue-bound origin (later-chat replacement + notification dismissal), malformed-route rejection, returned-error `failed` status, and observable ASLEEP state. `test_telegram_typing_ttl.py` is linked into the Anatomy graph.

## Validation

- `tests/test_telegram_typing_ttl.py`: 8 passed (incl. fake-clock hard-deadline + identity/join/shutdown).
- `tests/test_aed_recovery.py`: 18 passed (incl. origin-capture, malformed rejection, returned-error status, ASLEEP observable).
- Broader Telegram adjacent matrix: 204 passed; Feishu native-progress file has the pre-existing `lark_channel` env collection error (reproduces on exact base).
- `compileall` clean; `git diff --check` clean.
- Architecture docs: candidate orphan set now matches exact base (5 pre-existing orphans; the new typing TTL test is linked).

## Boundaries

- No new outbound channel: the notice rides the existing telegram tool handler.
- No changes to AED retry/fallback logic, Task Card behavior, or config.
- Avoids kernel PR #1194 (ZigongXu token-expired recovery) and open lingtai#791.

Telegram: @lingtaidev3bot | Nickname: 澄一
