### PR TITLE
fix(telegram): token redaction, null fields, taskcard drift (squash #1298+#1296+#1273)

### DIFF
--- a/src/lingtai/agent.py
+++ b/src/lingtai/agent.py
@@ -1170,7 +1170,6 @@ class Agent(BaseAgent):
         """Restore canonical reasoning only for mounted strict MCP ToolFamilies.
 
         ``ToolExecutor`` deliberately renames model-facing ``reasoning`` to the
-<<<<<<< HEAD
         private ``_reasoning`` audit key before every dispatch.  Ordinary
         in-process and legacy MCP handlers consume that existing shape.  A native
         MCP ToolFamily instead validates the original closed LTP-v2 envelope, so

--- a/src/lingtai/agent.py
+++ b/src/lingtai/agent.py
@@ -123,6 +123,22 @@ def build_agent_config(manifest: dict[str, Any], *, max_rpm: int) -> AgentConfig
     )
 
 
+def _schema_declares_reasoning_param(schema: Any) -> bool:
+    """True if a tool's own parameter schema has somewhere for reasoning to go.
+
+    Covers both the LTP-v2 envelope's ``reasoning`` and any third-party tool
+    that happens to declare its own ``reasoning``/``_reasoning`` parameter
+    directly. Used by ``_dispatch_tool`` to decide whether the ``_reasoning``
+    audit key is safe to forward as-is or must be dropped before dispatch.
+    """
+    if not isinstance(schema, dict):
+        return False
+    properties = schema.get("properties")
+    if not isinstance(properties, dict):
+        return False
+    return "reasoning" in properties or "_reasoning" in properties
+
+
 class Agent(BaseAgent):
     """BaseAgent with composable capabilities.
 
@@ -1154,26 +1170,35 @@ class Agent(BaseAgent):
         """Restore canonical reasoning only for mounted strict MCP ToolFamilies.
 
         ``ToolExecutor`` deliberately renames model-facing ``reasoning`` to the
-        private ``_reasoning`` audit key before every dispatch. Ordinary
-        in-process handlers retain that shape; MCP handler wrappers adapt it to
-        the captured server schema. A native MCP ToolFamily instead validates the
-        original closed LTP-v2 envelope, so the wrapper composition root restores
-        the public key immediately before inherited handler dispatch. The input
-        ToolCall is never mutated.
+<<<<<<< HEAD
+        private ``_reasoning`` audit key before every dispatch.  Ordinary
+        in-process and legacy MCP handlers consume that existing shape.  A native
+        MCP ToolFamily instead validates the original closed LTP-v2 envelope, so
+        the wrapper composition root restores the public key immediately before
+        the inherited handler dispatch.  Third-party MCP tools with flat,
+        auto-generated parameter schemas declare no ``reasoning``/``_reasoning``
+        at all; forwarding the audit key would fail their strict schema-validated
+        calls, so it is dropped instead.  The input ToolCall is never mutated.
         """
         if tc.name in getattr(self, "_mcp_tool_names", set()):
             from .services.mcp import is_strict_ltp_v2_family_schema
 
             schemas = [schema for schema in self._tool_schemas if schema.name == tc.name]
-            if (
-                len(schemas) == 1
-                and is_strict_ltp_v2_family_schema(schemas[0].parameters)
-                and "_reasoning" in tc.args
-            ):
-                args = dict(tc.args)
-                reasoning = args.pop("_reasoning")
-                args.setdefault("reasoning", reasoning)
-                tc = ToolCall(name=tc.name, args=args, id=tc.id)
+            if len(schemas) == 1 and "_reasoning" in tc.args:
+                params = schemas[0].parameters
+                if is_strict_ltp_v2_family_schema(params):
+                    args = dict(tc.args)
+                    reasoning = args.pop("_reasoning")
+                    args.setdefault("reasoning", reasoning)
+                    tc = ToolCall(name=tc.name, args=args, id=tc.id)
+                elif not _schema_declares_reasoning_param(params):
+                    # Third-party MCP tools expose flat, auto-generated parameter
+                    # schemas with no LTP-v2 envelope and no reasoning parameter
+                    # of their own; the audit key has nowhere to go, so drop it
+                    # instead of failing a strict schema-validated call.
+                    args = dict(tc.args)
+                    args.pop("_reasoning", None)
+                    tc = ToolCall(name=tc.name, args=args, id=tc.id)
         return super()._dispatch_tool(tc)
 
     def _expand_agent_placeholders(self, value):

--- a/src/lingtai/kernel/trace_redaction.py
+++ b/src/lingtai/kernel/trace_redaction.py
@@ -22,6 +22,13 @@ _SECRET_PLACEHOLDER = "<REDACTED:secret>"
 # redacted mechanically before trajectory writes.
 _TOKEN_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     (re.compile(r"\b\d{6,12}:[A-Za-z0-9_-]{30,}\b"), "<REDACTED:telegram_bot_token>"),
+    # Telegram Bot API URLs embed the token in the request path itself
+    # (https://api.telegram.org/bot<id>:<secret>/<method> and the
+    # /file/bot<id>:<secret>/... download form). The generic pattern above
+    # cannot match there: the digit run directly follows "/bot", so the leading
+    # word boundary is missing. Match the URL form explicitly and keep the
+    # "/bot" prefix so the redaction is recognizable in context.
+    (re.compile(r"(/bot)\d{6,12}:[A-Za-z0-9_-]{30,}(?![A-Za-z0-9_-])"), r"\1<REDACTED:telegram_bot_token>"),
     (re.compile(r"\bsk-proj-[A-Za-z0-9_-]{40,}\b"), "<REDACTED:openai_project_key>"),
     (re.compile(r"\bsk-[A-Za-z0-9_-]{20,}\b"), "<REDACTED:api_key>"),
     (re.compile(r"\bghp_[A-Za-z0-9]{30,}\b"), "<REDACTED:github_token>"),

--- a/src/lingtai/mcp_servers/_entrypoint.py
+++ b/src/lingtai/mcp_servers/_entrypoint.py
@@ -14,6 +14,11 @@ credential leakage:
 2. A redaction filter is attached to the root logger so any record that still
    contains a Telegram bot token or a ``api.telegram.org/bot<TOKEN>/...`` URL
    is rewritten to a fixed placeholder before any handler renders it.
+
+Additional per-logger filters (``_protect_http_loggers``, #1298) attach the
+same Telegram credential redaction directly to the HTTP client loggers for
+belt-and-braces coverage when those loggers are reconfigured independently of
+the root.
 """
 from __future__ import annotations
 
@@ -61,6 +66,38 @@ class _RedactTelegramCredentials(logging.Filter):
 _telegram_credential_filter = _RedactTelegramCredentials()
 
 
+# Matches the Telegram Bot API URL path segment that embeds the bot token
+# (https://api.telegram.org/bot<id>:<secret>/<method> and the
+# /file/bot<id>:<secret>/... download form). Keeps the "/bot" prefix visible so
+# the redacted record remains recognizable. Mirrors the trajectory redactor in
+# ``lingtai.kernel.trace_redaction``.
+_TELEGRAM_BOT_URL_RE_SEGMENT = re.compile(
+    r"(/bot)\d{6,12}:[A-Za-z0-9_-]{30,}(?![A-Za-z0-9_-])"
+)
+_TELEGRAM_BOT_URL_REDACTED = r"\1<REDACTED:telegram_bot_token>"
+
+
+class _HttpUrlCredentialFilter(logging.Filter):
+    """Redact credential-bearing URL path segments from HTTP client logs."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        try:
+            message = record.getMessage()
+        except Exception:
+            return True  # malformed record: leave it to the normal formatter
+        redacted = _TELEGRAM_BOT_URL_RE_SEGMENT.sub(_TELEGRAM_BOT_URL_REDACTED, message)
+        if redacted != message:
+            record.msg = redacted
+            record.args = ()
+        return True
+
+
+def _protect_http_loggers() -> None:
+    """Attach the credential-redacting filter to HTTP client loggers."""
+    for name in ("httpx", "httpcore"):
+        logging.getLogger(name).addFilter(_HttpUrlCredentialFilter())
+
+
 def configure_stdio_logging() -> None:
     """Configure INFO stderr logging for a curated MCP stdio server.
 
@@ -86,6 +123,7 @@ def configure_stdio_logging() -> None:
     for handler in root_logger.handlers:
         if _telegram_credential_filter not in handler.filters:
             handler.addFilter(_telegram_credential_filter)
+    _protect_http_loggers()
 
 
 def run_stdio_server_main(serve: Callable[[], Awaitable[None]]) -> None:

--- a/src/lingtai/mcp_servers/telegram/_family.py
+++ b/src/lingtai/mcp_servers/telegram/_family.py
@@ -99,8 +99,8 @@ def _telegram_input_schemas() -> dict[str, dict[str, Any]]:
             "account": _nullable({"type": "string"}),
             "chat_id": _chat_id(),
             "text": {"type": "string"},
-            "media": media,
-            "reply_markup": {"type": "object"},
+            "media": _nullable(media),
+            "reply_markup": _nullable({"type": "object"}),
             "placeholder": _nullable({"type": "boolean"}),
             "chat_action": _nullable({
                 "type": "string",
@@ -130,7 +130,7 @@ def _telegram_input_schemas() -> dict[str, dict[str, Any]]:
             {"required": ["structured_message"]},
         ],
     )
-    send["properties"]["media"]["description"] = (
+    send["properties"]["media"]["anyOf"][0]["description"] = (
         "Media attachment: {type: 'photo'|'document', path: '/path/to/file'}. "
         "For charts, HTML/SVG/PNG reports, CSVs, PDFs, and other generated artifacts "
         "that should arrive as an intact file, use type='document'. Use type='photo' "
@@ -197,7 +197,7 @@ def _telegram_input_schemas() -> dict[str, dict[str, Any]]:
             {
                 "message_id": {"type": "string"},
                 "text": {"type": "string"},
-                "reply_markup": {"type": "object"},
+                "reply_markup": _nullable({"type": "object"}),
                 "rendering_mode": {
                     "type": "string", "enum": list(_RENDERING_MODES),
                     "description": (

--- a/src/lingtai/mcp_servers/telegram/_runtime.py
+++ b/src/lingtai/mcp_servers/telegram/_runtime.py
@@ -1,0 +1,94 @@
+"""Telegram Task Card loaded-vs-installed runtime identity (issue #987).
+
+The non-deletable Task Card self-heal (PR #984) can only run after the live
+Telegram manager process has loaded the repair code. If the on-disk checkout
+is updated underneath a long-lived manager process, the installed source
+contains the repair while the loaded runtime predates it: the old card stays
+frozen, ``/taskcard`` still reports a healthy ``enabled`` setting, and nothing
+says that one refresh is required.
+
+This module captures the source identity of the Task Card runtime the current
+*process* imported (a non-secret SHA-256 prefix over the curated Task Card
+source files) and compares it with the same files as they exist on disk at
+query time. A deterministic ``refresh required`` hint is returned only when
+loaded != installed, so the plain settings response never implies resident
+health it cannot prove.
+"""
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+# Curated files whose loaded-vs-installed mismatch changes resident Task Card
+# lifecycle behavior (mirrors the kernel's ``_FP_KEY_FILES`` approach in
+# ``lingtai.kernel.base_agent.lifecycle``). The kernel fingerprint covers only
+# ``lingtai.kernel`` sources; the Telegram manager lives outside it, so the
+# exact #987 drift (``manager.py`` / ``task_card`` gaining the repair under a
+# live process) is invisible to that fingerprint and needs its own identity.
+_TASK_CARD_SOURCE_FILES: tuple[str, ...] = (
+    "manager.py",
+    "task_card/__init__.py",
+    "task_card/controller.py",
+    "task_card/interface.py",
+    "task_card/resident.py",
+)
+
+#: Bounded, actionable hint surfaced when the loaded runtime predates the
+#: installed checkout. One refresh is exactly the remediation the live manager
+#: needs; nothing here toggles Task Card or deletes/re-sends anything.
+DRIFT_HINT = (
+    "\u26a0\ufe0f Task Card runtime drift: this process predates the installed "
+    "checkout \u2014 one /refresh is required to apply the installed Task Card "
+    "self-heal."
+)
+
+
+def _task_card_source_dir() -> Path:
+    """The telegram package directory this module was imported from."""
+    return Path(__file__).resolve().parent
+
+
+def _digest_source_files(root: Path) -> str | None:
+    """SHA-256 prefix (12 hex) of the curated Task Card source files.
+
+    Returns ``None`` only when the source directory itself cannot be read, so
+    the caller stays silent rather than misreporting drift. Missing individual
+    files hash a ``\x00`` marker (kernel convention) so removals still change
+    the digest.
+    """
+    hasher = hashlib.sha256()
+    for rel in _TASK_CARD_SOURCE_FILES:
+        try:
+            hasher.update((root / rel).read_bytes())
+        except OSError:
+            hasher.update(b"\x00")
+    return hasher.hexdigest()[:12]
+
+
+# Loaded identity: computed once at import time by this process. If the disk is
+# updated underneath a running process, this constant still describes the code
+# that actually executed.
+LOADED_TASK_CARD_SOURCE_DIGEST: str | None = _digest_source_files(
+    _task_card_source_dir()
+)
+
+
+def installed_task_card_source_digest() -> str | None:
+    """Re-read the same curated files from disk now (the installed runtime)."""
+    return _digest_source_files(_task_card_source_dir())
+
+
+def task_card_drift_hint() -> str | None:
+    """Return :data:`DRIFT_HINT` when the loaded runtime predates installed source.
+
+    Returns ``None`` when the digests match or either side is unprovable, i.e.
+    absence of the hint means the loaded Task Card runtime matches the
+    installed checkout (the healthy state).
+    """
+    loaded = LOADED_TASK_CARD_SOURCE_DIGEST
+    installed = installed_task_card_source_digest()
+    if loaded is None or installed is None:
+        return None
+    if loaded == installed:
+        return None
+    return DRIFT_HINT

--- a/src/lingtai/mcp_servers/telegram/account.py
+++ b/src/lingtai/mcp_servers/telegram/account.py
@@ -23,6 +23,7 @@ from lingtai.mcp_servers.local_commands import (
     TaskCardSettingsPort,
 )
 
+from . import _runtime as tg_runtime
 from . import updates as tg_updates
 
 logger = logging.getLogger(__name__)
@@ -521,11 +522,14 @@ class TelegramAccount:
                 "automatic and programmable Task Cards are hidden for this agent; "
                 "internal mechanics still run."
             )
-        self.send_message(
-            chat_id,
+        payload = (
             f"📋 taskcard: {enabled} · normal rows: {normal_rows} · lang: {locale} — {description}\n"
-            "Usage: /taskcard on | /taskcard off | /taskcard N (1-10) | /taskcard lang zh|en",
+            "Usage: /taskcard on | /taskcard off | /taskcard N (1-10) | /taskcard lang zh|en"
         )
+        hint = tg_runtime.task_card_drift_hint()
+        if hint is not None:
+            payload += f"\n{hint}"
+        self.send_message(chat_id, payload)
 
     def _cmd_taskcard_menu(self, chat_id: int, message_id: int | None = None) -> None:
         """Show the interactive Task Card settings menu (kanban-style)."""
@@ -540,6 +544,9 @@ class TelegramAccount:
             f"🌐 Lang: {locale}\n\n"
             "Tap to change:"
         )
+        hint = tg_runtime.task_card_drift_hint()
+        if hint is not None:
+            menu_text += f"\n\n{hint}"
         keyboard = inline_keyboard_options(
             [
                 {"text": "◀️ Rows −", "data": "tc:rows_dec"},

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from lingtai.kernel.base_agent import BaseAgent
-from lingtai.agent import Agent
+from lingtai.agent import Agent, _schema_declares_reasoning_param
 from lingtai.kernel.message import Message, _make_message, MSG_REQUEST, MSG_USER_INPUT, MSG_TC_WAKE
 from lingtai.kernel.state import AgentState
 from lingtai.kernel.types import UnknownToolError
@@ -405,6 +405,77 @@ def test_execute_single_tool_unknown(tmp_path):
     tc = ToolCall(name="nonexistent_tool", args={})
     with pytest.raises(UnknownToolError):
         agent._dispatch_tool(tc)
+
+
+def _dispatch_agent(tmp_path):
+    """Full Agent instance (the class that owns the reasoning restore wrapper)."""
+    return Agent(service=make_mock_service(), agent_name="test", working_dir=tmp_path / "test", workdir_lease=make_test_lease(), agent_presence=make_test_presence_store(), snapshot_port=make_test_snapshot_port(), lifecycle_clock=make_test_lifecycle_clock(), source_revision_port=make_test_source_revision_port(), notification_store=notification_store_for(tmp_path / "test"))
+
+
+def _capturing_tool(agent, name, schema, seen):
+    agent.add_tool(name, schema=schema, handler=lambda args: (seen.update(args=dict(args)), {"status": "ok"})[1])
+    agent._mcp_tool_names = {name}
+
+
+def test_dispatch_drops_reasoning_for_flat_third_party_mcp_tool(tmp_path):
+    """_reasoning must never reach a flat third-party tool that didn't declare it (#1237)."""
+    from lingtai.kernel.llm.base import ToolCall
+    agent = _dispatch_agent(tmp_path)
+    seen = {}
+    flat = {"type": "object", "properties": {"source": {"type": "string"}, "tags": {"type": "array"}}, "required": ["source"]}
+    _capturing_tool(agent, "add_item", flat, seen)
+
+    result = agent._dispatch_tool(ToolCall(name="add_item", args={"source": "x", "_reasoning": "audit"}))
+    assert result["status"] == "ok"
+    assert seen["args"] == {"source": "x"}
+
+
+def test_dispatch_keeps_reasoning_restore_for_strict_ltp_v2_family(tmp_path):
+    """Strict LTP-v2 envelope tools still get _reasoning renamed back to reasoning (#1237)."""
+    from lingtai.kernel.llm.base import ToolCall
+    agent = _dispatch_agent(tmp_path)
+    seen = {}
+    envelope = {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "action": {"type": "string"},
+            "input": {"type": "object"},
+            "reasoning": {"type": "string"},
+            "summarize": {"type": "boolean"},
+        },
+        "required": ["action", "input", "reasoning"],
+    }
+    _capturing_tool(agent, "family_tool", envelope, seen)
+
+    result = agent._dispatch_tool(ToolCall(name="family_tool", args={"action": "go", "input": {}, "_reasoning": "audit"}))
+    assert result["status"] == "ok"
+    assert seen["args"]["reasoning"] == "audit"
+    assert "_reasoning" not in seen["args"]
+
+
+def test_dispatch_forwards_reasoning_when_third_party_tool_declares_it(tmp_path):
+    """A non-envelope tool that declares its own reasoning param keeps the key (#1237)."""
+    from lingtai.kernel.llm.base import ToolCall
+    agent = _dispatch_agent(tmp_path)
+    seen = {}
+    custom = {"type": "object", "properties": {"reasoning": {"type": "string"}, "x": {"type": "integer"}}}
+    _capturing_tool(agent, "custom_tool", custom, seen)
+
+    result = agent._dispatch_tool(ToolCall(name="custom_tool", args={"x": 1, "_reasoning": "audit"}))
+    assert result["status"] == "ok"
+    assert seen["args"] == {"x": 1, "_reasoning": "audit"}
+
+
+def test_schema_declares_reasoning_param():
+    """Unit checks for the third-party schema probe used by _dispatch_tool (#1237)."""
+    assert _schema_declares_reasoning_param({"type": "object", "properties": {"reasoning": {"type": "string"}}})
+    assert _schema_declares_reasoning_param({"type": "object", "properties": {"_reasoning": {"type": "string"}}})
+    assert not _schema_declares_reasoning_param({"type": "object", "properties": {"source": {"type": "string"}}})
+    assert not _schema_declares_reasoning_param({"type": "object"})
+    assert not _schema_declares_reasoning_param({})
+    assert not _schema_declares_reasoning_param(None)
+    assert not _schema_declares_reasoning_param("nope")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_server_scaffold.py
+++ b/tests/test_mcp_server_scaffold.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import importlib
 import json
+import logging
 from pathlib import Path
 
 import pytest
@@ -46,6 +47,64 @@ def test_run_stdio_server_main_swallows_keyboard_interrupt(monkeypatch):
     monkeypatch.setattr(_entrypoint.asyncio, "run", boom)
     # Must not propagate — Ctrl-C is a clean shutdown.
     assert _entrypoint.run_stdio_server_main(lambda: None) is None
+
+
+# ---------------------------------------------------------------------------
+# HTTP client credential logging (issue Lingtai-AI/lingtai#680)
+# ---------------------------------------------------------------------------
+
+def test_http_url_credential_filter_redacts_telegram_token():
+    token = "1234567890:" + "A" * 35
+    record = logging.LogRecord(
+        name="httpx",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg=f"HTTP Request: GET https://api.telegram.org/bot{token}/getUpdates",
+        args=(),
+        exc_info=None,
+    )
+    assert _entrypoint._HttpUrlCredentialFilter().filter(record) is True
+    assert token not in record.getMessage()
+    assert "/bot<REDACTED:telegram_bot_token>/getUpdates" in record.getMessage()
+
+
+def test_http_url_credential_filter_passes_ordinary_records(caplog):
+    filt = _entrypoint._HttpUrlCredentialFilter()
+    record = logging.LogRecord(
+        name="httpx",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="HTTP Request: GET https://api.example.com/ping",
+        args=(),
+        exc_info=None,
+    )
+    assert filt.filter(record) is True
+    assert record.getMessage() == "HTTP Request: GET https://api.example.com/ping"
+
+
+def test_run_stdio_server_main_attaches_http_credential_filter():
+    # The entrypoint must attach the filter to httpx/httpcore loggers so HTTP
+    # client INFO lines never reach stderr with a token-bearing URL.
+    _entrypoint._protect_http_loggers()
+    for name in ("httpx", "httpcore"):
+        logger = logging.getLogger(name)
+        assert any(
+            isinstance(f, _entrypoint._HttpUrlCredentialFilter)
+            for f in logger.filters
+        ), name
+
+
+def test_run_stdio_server_main_logs_redact_telegram_urls(caplog):
+    _entrypoint._protect_http_loggers()
+    token = "987654321:" + "B" * 40
+    with caplog.at_level(logging.INFO, logger="httpx"):
+        logging.getLogger("httpx").info(
+            "HTTP Request: GET https://api.telegram.org/bot%s/getUpdates", token
+        )
+    assert token not in caplog.text
+    assert "<REDACTED:telegram_bot_token>" in caplog.text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_telegram_send_media_contract.py
+++ b/tests/test_telegram_send_media_contract.py
@@ -52,7 +52,10 @@ def test_send_schema_advertises_exactly_runtime_supported_media_types():
         branch for branch in SCHEMA["properties"]["input"].get("oneOf", SCHEMA["properties"]["input"]["anyOf"])
         if branch.get("title") == "send input"
     )
-    advertised = send["properties"]["media"]["properties"]["type"]["enum"]
+    # media is nullable (anyOf wrapper, object branch first) since #1237.
+    media_schema = send["properties"]["media"]
+    assert {"type": "null"} in media_schema["anyOf"]
+    advertised = media_schema["anyOf"][0]["properties"]["type"]["enum"]
 
     assert advertised == list(SUPPORTED_SEND_MEDIA_TYPES) == ["photo", "document"]
 

--- a/tests/test_telegram_task_card_runtime_drift.py
+++ b/tests/test_telegram_task_card_runtime_drift.py
@@ -1,0 +1,117 @@
+"""Focused contract tests for the Task Card loaded-runtime drift diagnostic (issue #987).
+
+When the on-disk checkout gains the non-deletable Task Card self-heal under a
+long-lived manager process, the loaded runtime predates the installed source:
+``/taskcard`` must stop implying resident health and emit one bounded
+``/refresh``-required hint instead.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from lingtai.mcp_servers.telegram import _runtime as tg_runtime
+from tests.test_telegram_task_card_toggle import _service
+
+
+def _write_source_tree(root: Path) -> None:
+    for rel in tg_runtime._TASK_CARD_SOURCE_FILES:
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(rel, encoding="utf-8")
+
+
+# Pure runtime-identity helpers -------------------------------------------------
+
+
+def test_loaded_digest_is_deterministic_hex_prefix() -> None:
+    loaded = tg_runtime.LOADED_TASK_CARD_SOURCE_DIGEST
+    assert isinstance(loaded, str)
+    assert len(loaded) == 12
+    assert all(c in "0123456789abcdef" for c in loaded)
+
+
+def test_installed_digest_tracks_on_disk_changes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root = tmp_path / "pkg"
+    _write_source_tree(root)
+    monkeypatch.setattr(tg_runtime, "_task_card_source_dir", lambda: root)
+
+    first = tg_runtime.installed_task_card_source_digest()
+    assert first is not None
+    # The exact #987 drift: the on-disk manager gains the repair without the
+    # running process importing it again.
+    (root / "manager.py").write_text("repaired\n", encoding="utf-8")
+    second = tg_runtime.installed_task_card_source_digest()
+    assert second is not None
+    assert second != first
+
+
+def test_drift_hint_none_when_loaded_matches_installed(monkeypatch: pytest.MonkeyPatch) -> None:
+    loaded = tg_runtime.LOADED_TASK_CARD_SOURCE_DIGEST
+    monkeypatch.setattr(tg_runtime, "installed_task_card_source_digest", lambda: loaded)
+    assert tg_runtime.task_card_drift_hint() is None
+
+
+def test_drift_hint_returned_when_loaded_predates_installed(monkeypatch: pytest.MonkeyPatch) -> None:
+    loaded = tg_runtime.LOADED_TASK_CARD_SOURCE_DIGEST
+    monkeypatch.setattr(tg_runtime, "installed_task_card_source_digest", lambda: "0" * 12)
+    hint = tg_runtime.task_card_drift_hint()
+    assert hint is not None
+    assert "one /refresh is required" in hint
+    assert loaded != "0" * 12
+
+
+def test_drift_hint_silent_when_unprovable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(tg_runtime, "installed_task_card_source_digest", lambda: None)
+    assert tg_runtime.task_card_drift_hint() is None
+
+
+# /taskcard surfaces -----------------------------------------------------------
+
+
+def _account_and_replies(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    service = _service(tmp_path, "main", allowed_users=[7])
+    account = service.get_account("main")
+    replies: list[str] = []
+    monkeypatch.setattr(
+        account,
+        "send_message",
+        lambda _chat_id, text, **_kwargs: replies.append(text) or {"message_id": 1},
+    )
+    return account, replies
+
+
+def test_taskcard_settings_response_carries_drift_hint_only_when_drifting(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    account, replies = _account_and_replies(tmp_path, monkeypatch)
+
+    # Healthy state: loaded matches installed — plain settings response, no hint.
+    monkeypatch.setattr(tg_runtime, "task_card_drift_hint", lambda: None)
+    account._cmd_taskcard(123, "/taskcard on")
+    assert "taskcard: True" in replies[-1]
+    assert "one /refresh" not in replies[-1]
+
+    # Drift: loaded predates installed — one bounded, actionable hint appended.
+    monkeypatch.setattr(tg_runtime, "task_card_drift_hint", lambda: tg_runtime.DRIFT_HINT)
+    account._cmd_taskcard(123, "/taskcard on")
+    assert "taskcard: True" in replies[-1]
+    assert "one /refresh is required" in replies[-1]
+    assert "on | /taskcard off" in replies[-1]  # usage line still intact
+
+
+def test_taskcard_menu_carries_drift_hint_only_when_drifting(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    account, replies = _account_and_replies(tmp_path, monkeypatch)
+
+    monkeypatch.setattr(tg_runtime, "task_card_drift_hint", lambda: None)
+    account._cmd_taskcard_menu(123)
+    assert "Task Card — settings" in replies[-1]
+    assert "one /refresh" not in replies[-1]
+
+    monkeypatch.setattr(tg_runtime, "task_card_drift_hint", lambda: tg_runtime.DRIFT_HINT)
+    account._cmd_taskcard_menu(123)
+    assert "Task Card — settings" in replies[-1]
+    assert "one /refresh is required" in replies[-1]

--- a/tests/test_telegram_toolfamily_ltpv2.py
+++ b/tests/test_telegram_toolfamily_ltpv2.py
@@ -84,6 +84,67 @@ def test_telegram_send_schema_requires_rendering_mode_and_preserves_content_alte
     assert not _basic_validate({"text": "missing chat", "rendering_mode": "plain_text"}, send)
     assert not _basic_validate({"chat_id": 3, "rendering_mode": "plain_text", "text": 17}, send)
 
+
+def test_telegram_send_accepts_explicit_nulls_for_optional_fields():
+    """send must accept the model's own nulls for media/reply_markup (issue #1237)."""
+    manager = _CountingManager()
+    result = handle_telegram(manager, {
+        "action": "send",
+        "input": {
+            "chat_id": 2,
+            "text": "hi",
+            "media": None,
+            "reply_markup": None,
+            "rendering_mode": "plain_text",
+        },
+        "reasoning": "schema probe",
+    })
+    assert result["status"] == "ok"
+    assert manager.calls == [{
+        "action": "send",
+        "chat_id": 2,
+        "text": "hi",
+        "media": None,
+        "reply_markup": None,
+        "rendering_mode": "plain_text",
+    }]
+
+
+def test_telegram_edit_accepts_null_reply_markup():
+    """edit must accept reply_markup: null like every other optional field (#1237)."""
+    manager = _CountingManager()
+    result = handle_telegram(manager, {
+        "action": "edit",
+        "input": {
+            "message_id": "acct:1:2",
+            "text": "x",
+            "reply_markup": None,
+            "rendering_mode": "plain_text",
+        },
+        "reasoning": "schema probe",
+    })
+    assert result["status"] == "ok"
+
+
+def test_telegram_send_nullable_schema_keeps_validation_strictness():
+    """Nullable media/reply_markup must not loosen required/type validation (#1237)."""
+    send = _branches(TELEGRAM_SCHEMA)["send"]
+    assert "anyOf" in send["properties"]["media"]
+    assert "anyOf" in send["properties"]["reply_markup"]
+    assert send["properties"]["media"]["anyOf"][0]["description"]
+    assert _basic_validate(
+        {"chat_id": 3, "rendering_mode": "plain_text", "text": "hi", "media": None, "reply_markup": None},
+        send,
+    )
+    # Wrong media type is still rejected even though media itself is nullable.
+    assert not _basic_validate(
+        {"chat_id": 3, "rendering_mode": "plain_text", "text": "hi", "media": {"type": "bogus", "path": "x"}},
+        send,
+    )
+    # Missing required fields are still rejected.
+    assert not _basic_validate({"chat_id": 3, "rendering_mode": "plain_text", "text": "hi", "media": "not-an-object"}, send)
+
+
 def test_taskcard_refresh_setting_defaults_invalid_values_preserves_valid_siblings(
     tmp_path, caplog
 ):

--- a/tests/test_trace_redaction.py
+++ b/tests/test_trace_redaction.py
@@ -124,6 +124,58 @@ def test_credential_key_near_words_are_not_redacted():
     assert redact_for_trajectory(event)["tool_args"]["client_id"] == "public-client-identifier"
 
 
+def test_redact_text_telegram_bot_url_forms():
+    # Telegram Bot API embeds the token in the request path itself, so the
+    # generic \b\d{6,12}:... pattern cannot match (no leading word boundary
+    # after "/bot"). The URL form must be redacted explicitly.
+    token = "1234567890:" + "A" * 35
+    api_url = f"https://api.telegram.org/bot{token}/getUpdates"
+    file_url = f"https://api.telegram.org/file/bot{token}/photos/file_1.jpg"
+    for url in (api_url, file_url):
+        redacted = redact_text(url)
+        assert token not in redacted, url
+        assert "/bot<REDACTED:telegram_bot_token>" in redacted, url
+        # The rest of the URL survives so operators can still identify the call.
+        assert redacted.startswith("https://api.telegram.org"), redacted
+
+
+def test_redact_text_telegram_bot_url_form_inside_log_line():
+    token = "987654321:" + "B" * 40
+    line = (
+        '2026-07-18 10:00:00 INFO httpx HTTP Request: '
+        f'GET https://api.telegram.org/bot{token}/getUpdates "HTTP/1.1 200 OK"'
+    )
+    redacted = redact_text(line)
+    assert token not in redacted
+    assert "/bot<REDACTED:telegram_bot_token>/getUpdates" in redacted
+
+
+def test_redact_for_trajectory_telegram_bot_url_in_tool_result():
+    token = "112233445566:" + "C" * 30
+    event = {
+        "type": "tool_result",
+        "result": (
+            "2026-07-18 10:00:00 INFO httpx HTTP Request: "
+            f"POST https://api.telegram.org/bot{token}/setMyCommands"
+        ),
+    }
+    redacted = redact_for_trajectory(event)
+    assert token not in json.dumps(redacted)
+    assert "<REDACTED:telegram_bot_token>" in redacted["result"]
+
+
+def test_redact_text_does_not_mangle_ordinary_urls_or_prose():
+    # Ordinary URLs and prose without token shapes must pass through untouched.
+    ordinary = (
+        "GET https://api.telegram.org/botFather/getMe "
+        "the botched request was dropped"
+    )
+    assert redact_text(ordinary) == ordinary
+    # A short secret below the 30-char confidence floor is left alone.
+    short = "https://api.telegram.org/bot1234567890:short/getUpdates"
+    assert redact_text(short) == short
+
+
 def test_save_chat_history_redacts_persisted_copy_without_mutation(tmp_path):
     svc = MagicMock()
     svc.get_adapter.return_value = MagicMock()


### PR DESCRIPTION
## Squash: Telegram/kernel fixes for review (#1298 + #1296 + #1273)

Squashed three independent fixes into one reviewable PR, per Jason request to group open PRs by area.

- **#1298** — redact Bot API token from HTTP request URL logs
- **#1296** — accept null optional fields; drop `_reasoning` for flat third-party tools
- **#1273** — surface taskcard loaded-runtime drift hint before refresh (Fixes #987)

> Note: this rebuilt head intentionally EXCLUDES #1321 (sanitized AED-exhaust notice + typing TTL lease). Its strengthened version was already merged to main separately (3b84d650); including the old copy caused real conflicts with main (turn.py/manager.py/test_aed_recovery.py/test_telegram_typing_ttl.py).

## Conflict resolution

#1296 was based on an older base; its `agent.py` changes conflicted with main (the `_LTP_V2_FAMILY_*` helpers were migrated to `services.mcp`). Resolution: keep main `is_strict_ltp_v2_family_schema` import, add #1296 new `_schema_declares_reasoning_param` helper, and keep the flat third-party tool `_reasoning` drop logic.

## Verification

- 182 focused tests passed (AED recovery, typing TTL, MCP scaffold, trace redaction, taskcard drift, toolfamily ltpv2, send media contract, agent)
- Full suite: 488 passed + 1 pre-existing orphan (agent_readme ANATOMY, also red on main)