### PR TITLE
Add provider-aware DeepSeek reasoning-effort support

### DIFF
--- a/src/lingtai/agent.py
+++ b/src/lingtai/agent.py
@@ -18,7 +18,11 @@ from typing import Any
 from lingtai.kernel.base_agent import BaseAgent
 from lingtai.kernel.base_agent.prompt import _refresh_meta_guidance_section
 from lingtai.kernel._frontmatter import strip_frontmatter as _strip_frontmatter
-from lingtai.kernel.config import AgentConfig, THINKING_PROVIDERS
+from lingtai.kernel.config import (
+    AgentConfig,
+    LEGACY_MAIN_SESSION_THINKING,
+    THINKING_PROVIDERS,
+)
 from lingtai.kernel.llm.base import ToolCall
 from lingtai.llm.service import (
     CONSERVATIVE_CONTEXT_WINDOW,
@@ -63,9 +67,68 @@ def load_preset(name: str, working_dir: "Path | None" = None) -> dict:
     """
     from lingtai.kernel.presets import load_preset as _core_load_preset
 
-    return _core_load_preset(
+    preset = _core_load_preset(
         name, working_dir=working_dir, run_migrations=_run_preset_library_migrations
     )
+    _validate_preset_provider_thinking(preset, name)
+    return preset
+
+
+def _validate_preset_provider_thinking(preset: dict, name: str) -> None:
+    """Enforce a provider-owned effort contract on a loaded preset.
+
+    The kernel's preset validator only decides whether ``manifest.llm.thinking``
+    is in scope at all — it must not import provider modules (the DAG is
+    lingtai -> tools -> lingtai.kernel, enforced by
+    tests/test_kernel_isolation.py). The exact per-model, per-wire accepted set
+    is owned by the provider and applied here, on the one shared preset-loading
+    path.
+    """
+    from lingtai.llm.deepseek.reasoning import (
+        owns_provider as _deepseek_route,
+        validate_configured_thinking as _validate_deepseek_thinking,
+        validate_supported_config as _validate_deepseek_config,
+        wire_for as _deepseek_wire,
+    )
+
+    llm = (preset or {}).get("manifest", {}).get("llm")
+    if not isinstance(llm, dict) or not _deepseek_route(llm.get("provider")):
+        return
+    try:
+        # Generic knobs this route has superseded fail loudly rather than
+        # silently doing nothing.
+        _validate_deepseek_config(llm)
+        if "thinking" in llm:
+            _validate_deepseek_thinking(
+                model=llm.get("model"),
+                wire=_deepseek_wire(llm),
+                thinking=llm["thinking"],
+            )
+    except ValueError as exc:
+        raise ValueError(f"preset {name!r}: {exc}") from exc
+
+
+def _omitted_thinking_default(llm: dict[str, Any], defaults: AgentConfig) -> str:
+    """Return what an OMITTED manifest ``llm.thinking`` hydrates to.
+
+    Routes that own their own omitted-effort default keep the ``"default"``
+    sentinel; everything else keeps the legacy cross-provider main-session
+    default. DeepSeek's answer comes from the DeepSeek descriptor, not from a
+    global provider table.
+    """
+    from lingtai.llm.deepseek.reasoning import OMITTED, owns_provider
+
+    provider = str(llm.get("provider") or "").lower()
+    if provider in THINKING_PROVIDERS:
+        return "default"
+    if owns_provider(provider):
+        return OMITTED
+    # Manifest hydration for non-owning routes keeps producing the legacy
+    # explicit level, unchanged. This is deliberately the named constant and
+    # NOT ``defaults.thinking``: the AgentConfig default is now the neutral
+    # omission (None), which is about *programmatic* construction and must not
+    # silently change what a manifest hydrates to.
+    return LEGACY_MAIN_SESSION_THINKING
 
 
 def build_agent_config(manifest: dict[str, Any], *, max_rpm: int) -> AgentConfig:
@@ -94,16 +157,14 @@ def build_agent_config(manifest: dict[str, Any], *, max_rpm: int) -> AgentConfig
         cache_miss_budget=manifest.get(
             "cache_miss_budget", defaults.cache_miss_budget
         ),
-        # Codex-family providers own their omitted-thinking default at the
-        # adapter (omitted -> reasoning.effort "xhigh"), so an omitted manifest
-        # value stays the "default" sentinel for them instead of being promoted
-        # to the legacy cross-provider "high" main-session default.
-        thinking=llm.get(
-            "thinking",
-            "default"
-            if str(llm.get("provider") or "").lower() in THINKING_PROVIDERS
-            else defaults.thinking,
-        ),
+        # Providers that own their omitted-thinking default keep the "default"
+        # sentinel instead of being promoted to the legacy cross-provider
+        # "high" main-session default: the Codex family (omitted ->
+        # reasoning.effort "xhigh") and DeepSeek (omitted -> no reasoning field
+        # at all, so DeepSeek's own default applies). This is also the native
+        # LingTai daemon's initial-omission route — it builds its agent config
+        # through this same function.
+        thinking=llm.get("thinking", _omitted_thinking_default(llm, defaults)),
         # Molt thresholds and the context.molt message are kernel-fixed runtime
         # constants and are NOT agent-configurable. Stale manifest
         # molt_notice/molt_pressure/molt_urgency/molt_prompt values are

--- a/src/lingtai/init_schema.py
+++ b/src/lingtai/init_schema.py
@@ -433,20 +433,43 @@ def validate_init(data: dict) -> list[str]:
                     f"provider={llm.get('provider')!r}"
                     + (f" api_compat={llm.get('api_compat')!r}" if llm.get("api_compat") else "")
                 )
+    # DeepSeek owns its own effort surface: what a manifest may carry depends on
+    # the exact model and wire, so validation delegates to the DeepSeek
+    # descriptor rather than to the kernel-global level tuple. The tuple is
+    # deliberately NOT extended with DeepSeek vocabulary.
+    from lingtai.llm.deepseek.reasoning import (
+        owns_provider as _deepseek_route,
+        validate_configured_thinking as _validate_deepseek_thinking,
+        validate_supported_config as _validate_deepseek_config,
+        wire_for as _deepseek_wire,
+    )
+
+    if _deepseek_route(llm.get("provider")):
+        # Reject generic knobs this route has superseded, so a setting that
+        # would silently do nothing fails loudly instead.
+        _validate_deepseek_config(llm)
+
     if "thinking" in llm:
-        if not llm_supports_thinking(llm):
-            raise ValueError(
-                "manifest.llm.thinking is currently supported only for "
-                "the Codex providers "
-                f"({', '.join(THINKING_PROVIDERS)}) or custom "
-                "OpenAI-compatible Responses"
+        if _deepseek_route(llm.get("provider")):
+            _validate_deepseek_thinking(
+                model=llm.get("model"),
+                wire=_deepseek_wire(llm),
+                thinking=llm["thinking"],
             )
-        thinking = llm["thinking"]
-        if not isinstance(thinking, str) or thinking not in THINKING_LEVELS:
-            raise ValueError(
-                "manifest.llm.thinking: expected one of "
-                f"{', '.join(THINKING_LEVELS)}"
-            )
+        else:
+            if not llm_supports_thinking(llm):
+                raise ValueError(
+                    "manifest.llm.thinking is currently supported only for "
+                    "the Codex providers "
+                    f"({', '.join(THINKING_PROVIDERS)}), deepseek, or custom "
+                    "OpenAI-compatible Responses"
+                )
+            thinking = llm["thinking"]
+            if not isinstance(thinking, str) or thinking not in THINKING_LEVELS:
+                raise ValueError(
+                    "manifest.llm.thinking: expected one of "
+                    f"{', '.join(THINKING_LEVELS)}"
+                )
     for key in llm:
         if key not in LLM_KNOWN:
             warnings.append(f"unknown field in manifest.llm: {key}")

--- a/src/lingtai/intrinsic_skills/system-manual/reference/llm-adapters/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/llm-adapters/SKILL.md
@@ -5,13 +5,15 @@ description: >
   named adapter is, how it is configured and dispatched, its special transport
   or protocol behaviors, and the environment variables that control it.
 version: 0.1.0
-last_changed_at: "2026-08-06T00:00:00Z"
+last_changed_at: "2026-08-09T00:00:00Z"
 related_files:
 - src/lingtai/llm/_register.py
 - src/lingtai/llm/service.py
 - src/lingtai/llm/openai/adapter.py
 - src/lingtai/llm/openai/codex_ws.py
 - src/lingtai/llm/custom/adapter.py
+- src/lingtai/llm/deepseek/reasoning.py
+- src/lingtai/llm/openai/reasoning_control.py
 - ENVIRONMENT_VARIABLES.md
 maintenance: |
   Keep one entry per named adapter. Add a section when a new adapter ships;
@@ -40,7 +42,7 @@ LingTai registers the following provider keys (each usable in presets / `init.js
 | `anthropic` | `AnthropicAdapter` | REST | Anthropic Messages API |
 | `gemini` | `GeminiAdapter` | REST | Google Gemini API |
 | `minimax` | `MiniMaxAdapter` | REST | MiniMax API |
-| `deepseek` | `OpenAIAdapter` (generic; `inject_reasoning_fallback=True`, `reasoning_effort_vocab="seven_tier"`, `prompt_cache_namespace="deepseek"`) | REST | DeepSeek API |
+| `deepseek` | `OpenAIAdapter` (generic; no subclass) + provider-local reasoning controller (`deepseek/reasoning.py`); `inject_reasoning_fallback=True`, `prompt_cache_namespace="deepseek"` (no `reasoning_effort_vocab` — superseded) | REST (Chat Completions default; Responses via `wire_api`) | DeepSeek API; owns its per-model/per-wire reasoning-effort contract — see the DeepSeek adapter section |
 | `glm`, `zhipu` | `ZhipuAdapter` | REST | Zhipu / GLM API |
 | `mimo` | `MimoAdapter` | REST | Xiaomi MiMo API |
 | `custom`, `grok`, `qwen`, `kimi` | `create_custom_adapter` (in `custom/adapter.py`) | REST | Generic OpenAI-compatible endpoint (`custom` is the canonical key; `grok`/`qwen`/`kimi` are custom-backed aliases) |
@@ -107,13 +109,76 @@ The Responses API can be selected with `wire_api=responses` or the legacy
 compaction threshold can be passed via the `compact_threshold` provider
 default (see `_register.py`).
 
-## Anthropic / Gemini / MiniMax / DeepSeek / Zhipu / MiMo
+## Anthropic / Gemini / MiniMax / Zhipu / MiMo
 
 Each of these adapters is a straightforward REST provider adapter in
 `src/lingtai/llm/<provider>/adapter.py`. They are configured through the
 standard provider fields (model, api_key / auth, base_url where applicable) and
 have no transport env-var selectors today. See the per-provider source for
 constructor details.
+
+## DeepSeek adapter
+
+DeepSeek has **no adapter class of its own**. It runs on the generic
+`OpenAIAdapter`; what is DeepSeek-specific is a provider-local reasoning
+controller that `_register._deepseek` injects into that generic transport
+(`src/lingtai/llm/deepseek/reasoning.py`). The transport itself holds no
+DeepSeek model names, levels, aliases, or defaults.
+
+**Reasoning effort.** DeepSeek owns its effort contract per model and per wire.
+The controller decides the reasoning fields for both wires; the generic
+`reasoning_effort_vocab` projection is not consulted on this route.
+
+| Model | Wire | Real canonical levels | Accepted compatibility aliases |
+|---|---|---|---|
+| `deepseek-v4-flash` | Chat Completions | `none`, `low`, `high`, `max` | `medium`→`high`, `xhigh`→`high` |
+| `deepseek-v4-pro` | Chat Completions | `none`, `high`, `max` | `medium`→`high`, `xhigh`→`max` |
+| `deepseek-v4-flash` | Responses | `low`, `high`, `max` | none documented |
+| `deepseek-v4-pro` | Responses | *unsupported — rejected* | — |
+
+Aliases are accepted on input and normalized, but are **not** capability
+choices: they never appear in the advertised level list
+(`canonical_levels()`). `minimal` is never accepted anywhere.
+
+**Omission means omission.** An omitted/`None` configured level is Auto: no
+`thinking` switch and no effort field are sent, and DeepSeek applies its own
+default. It is never turned into `high`. Explicit Chat `none` is different — it
+is a real requested value that sends `thinking: {"type": "disabled"}` and no
+effort.
+
+**Wire shapes.** Chat Completions sends a `thinking` enable/disable switch plus
+a flat `reasoning_effort`. `reasoning_effort` is a native OpenAI SDK parameter,
+but `thinking` is a DeepSeek body extension the SDK does not declare (and it
+takes no `**kwargs`), so it is passed via `extra_body` — the SDK merges that
+into the top level of the request JSON, which is the body DeepSeek documents.
+Passing `thinking` as a direct keyword would raise `TypeError` before any
+request. The merge composes with caller/subclass `extra_body` rather than
+replacing it. Responses sends nested `reasoning: {effort: ...}` and carries no
+`thinking` switch.
+
+**Superseded knob.** `reasoning_effort_vocab` selects the *generic* Chat effort
+projection. The DeepSeek route no longer consults it, so the factory neither
+defaults nor lifts it, and supplying it in a DeepSeek `init.json` / preset block
+is a validation error with an actionable message rather than a silent no-op. The
+field is unchanged for `openai` / `custom` routes. `inject_reasoning_fallback`
+and `prompt_cache_namespace` remain live for DeepSeek.
+
+**Fail-closed.** Unsupported values and unsupported routes raise before any SDK
+or network call: `low` on Pro, anything outside `low|high|max` on Responses,
+Pro on Responses (**including when the effort is omitted** — an impossible
+route cannot be made possible by omitting the level), and any explicit effort
+on a model DeepSeek is not known to publish. An *unknown* future model with an
+omitted effort still works and adds no reasoning fields.
+
+**Observation.** Each session captures one immutable application result, and
+the `llm_call` event reports exactly that applied patch as six bounded strings:
+`provider`, `wire`, `effort_requested`, `effort_normalized`, `effort_emitted`,
+`effort_provenance` (`omitted` | `explicit_config` | `compat_alias`).
+
+Source: `src/lingtai/llm/deepseek/reasoning.py` (capability, normalization,
+payloads), `src/lingtai/llm/openai/reasoning_control.py` (neutral carrier and
+hook protocol), `src/lingtai/llm/_register.py` (`_deepseek` injection),
+`src/lingtai/kernel/session.py` (observation).
 
 ## Custom / OpenRouter adapters
 

--- a/src/lingtai/kernel/config.py
+++ b/src/lingtai/kernel/config.py
@@ -19,6 +19,21 @@ THINKING_LEVELS = ("none", "minimal", "low", "medium", "high", "xhigh", "max")
 # ``llm_supports_thinking`` so validators share the complete rule.
 THINKING_PROVIDERS = ("codex", "codex-pool", "codex_pool")
 
+# Providers that own their own reasoning-effort contract on BOTH wires and
+# therefore accept manifest.llm.thinking outside the Responses-only rule below.
+# This is a coarse *scope* gate only — the kernel deliberately holds no
+# provider level vocabulary, model list, alias table, or default. What each
+# route really accepts is owned by that provider's own module and enforced by
+# the lingtai-layer validators (see ``lingtai/init_schema.py`` and
+# ``lingtai/agent.py``); the kernel cannot import them (see
+# tests/test_kernel_isolation.py).
+THINKING_PROVIDER_OWNED = ("deepseek",)
+
+# The legacy cross-provider main-session effort. Applied by the LLM layer to an
+# omitted/falsey configured value for every route that does NOT own its own
+# omitted-effort default, preserving pre-existing wire behavior exactly.
+LEGACY_MAIN_SESSION_THINKING = "high"
+
 
 def llm_supports_thinking(llm: dict) -> bool:
     """Return whether a manifest LLM block accepts explicit thinking effort.
@@ -28,9 +43,11 @@ def llm_supports_thinking(llm: dict) -> bool:
     ``wire_api == "responses"``) is accepted, regardless of provider. The
     Codex family remains accepted through ``THINKING_PROVIDERS`` (it owns its
     own wire/backend), as does any provider explicitly listed there.
+    Providers in ``THINKING_PROVIDER_OWNED`` own their effort contract on both
+    wires, so they are in scope regardless of the wire.
     """
     provider = str(llm.get("provider") or "").lower()
-    if provider in THINKING_PROVIDERS:
+    if provider in THINKING_PROVIDERS or provider in THINKING_PROVIDER_OWNED:
         return True
     return (
         str(llm.get("api_compat") or "").lower() == "openai"
@@ -137,7 +154,15 @@ class AgentConfig:
     max_aed_attempts: int = 3   # max AED retry attempts per inbox message turn
     max_rpm: int = 60  # API requests-per-minute cap for this agent's provider; 0 = no gating. Shared across all agents in the same process that use the same (provider, base_url) pair (adapter cache key).
     thinking_budget: int | None = None
-    thinking: str = "high"  # reasoning/thinking tier passed to the main persistent LLM session
+    # Reasoning/thinking tier passed to the main persistent LLM session.
+    # ``None`` means OMITTED — the caller expressed no preference — and is
+    # deliberately NOT the legacy ``high``: a provider that owns its own
+    # omitted-effort default (DeepSeek) must receive the omission itself rather
+    # than a fabricated level. Resolution is the LLM layer's job
+    # (the selected adapter's ``resolve_configured_thinking`` hook), which
+    # still maps an omitted value to ``LEGACY_MAIN_SESSION_THINKING`` for every
+    # other route, so no non-owning provider's wire bytes change.
+    thinking: str | None = None
     data_dir: str | None = None  # for cache files (e.g., model context windows)
     soul_delay: float = DEFAULT_SOUL_DELAY_SECONDS  # seconds idle before soul whispers; large value = effectively off
     language: str = "en"  # legacy language field retained for compatibility; prompt.py no longer injects prose from it

--- a/src/lingtai/kernel/session.py
+++ b/src/lingtai/kernel/session.py
@@ -64,6 +64,39 @@ def _elapsed_ms(start: float) -> int:
     return max(0, int((time.monotonic() - start) * 1000))
 
 
+#: Allowlisted ``llm_call`` reasoning-observation fields. Bounded plain
+#: strings only — never payloads, prompts, credentials, or arbitrary provider
+#: scalars.
+_REASONING_OBSERVATION_KEYS = (
+    "provider",
+    "wire",
+    "effort_requested",
+    "effort_normalized",
+    "effort_emitted",
+    "effort_provenance",
+)
+
+
+def _reasoning_observation_fields(chat: object) -> dict[str, str]:
+    """Return the reasoning observation for an ``llm_call``, if the session has one.
+
+    Read from the ONE immutable application result the adapter captured when
+    the session was constructed, so what is reported is exactly the patch the
+    request really carries. Nothing here recomputes anything from raw config,
+    and a session on a route that applies no reasoning control contributes no
+    fields at all.
+    """
+    applied = getattr(chat, "reasoning_application", None)
+    if applied is None:
+        return {}
+    fields = applied.observation_fields()
+    return {
+        key: str(fields[key])
+        for key in _REASONING_OBSERVATION_KEYS
+        if key in fields
+    }
+
+
 _SAFE_USAGE_EXTRA_EVENT_KEYS = {
     "codex_account_id_sha8",
     "codex_auth_path_sha8",
@@ -293,7 +326,14 @@ class SessionManager:
                 system_prompt=self._build_system_prompt_fn(),
                 tools=self._build_tool_schemas_fn() or None,
                 model=self._config.model or self._llm_service.model,
-                thinking=self._config.thinking or "high",
+                # Pass the configured value through verbatim. Resolving an
+                # omitted/falsey value is provider knowledge and belongs to the
+                # LLM layer (the selected adapter's
+                # ``resolve_configured_thinking`` hook): most routes still fall
+                # back to "high", while a route that owns its own
+                # omitted-effort default must receive the omission itself
+                # rather than a fabricated level.
+                thinking=self._config.thinking,
                 agent_type=self._display_name,
                 tracked=True,
                 interaction_id=self._interaction_id,
@@ -310,7 +350,9 @@ class SessionManager:
             system_prompt=self._build_system_prompt_fn(),
             tools=self._build_tool_schemas_fn() or None,
             model=self._config.model or self._llm_service.model,
-            thinking=self._config.thinking or "high",
+            # See ensure_session(): omitted-effort resolution is the LLM
+            # layer's call, not the kernel's.
+            thinking=self._config.thinking,
             agent_type=self._display_name,
             tracked=tracked,
             provider=self._config.provider,
@@ -397,6 +439,7 @@ class SessionManager:
             "model": self._config.model or self._llm_service.model or "unknown",
             "api_call_id": api_call_id,
         }
+        llm_call_fields.update(_reasoning_observation_fields(self._chat))
         self._log("llm_call", **llm_call_fields)
 
         retry_timeout = self._config.retry_timeout

--- a/src/lingtai/llm/ANATOMY.md
+++ b/src/lingtai/llm/ANATOMY.md
@@ -14,8 +14,12 @@ related_files:
   - src/lingtai/llm/interface_converters.py
   - src/lingtai/llm/minimax/ANATOMY.md
   - src/lingtai/llm/mimo/ANATOMY.md
+  - src/lingtai/llm/deepseek/__init__.py
+  - src/lingtai/llm/deepseek/reasoning.py
   - src/lingtai/llm/openai/ANATOMY.md
   - src/lingtai/llm/openai/adapter.py
+  - src/lingtai/llm/openai/reasoning_control.py
+  - tests/test_deepseek_reasoning_effort.py
   - src/lingtai/llm/openrouter/ANATOMY.md
   - src/lingtai/llm/service.py
   - src/lingtai/kernel/llm/ANATOMY.md
@@ -52,11 +56,12 @@ LLM adapter layer — multi-provider support with adapter registry, base classes
 | `identity_headers.py` | 53 | Shared non-secret LingTai HTTP identity/version header helper for SDK-backed LLM adapters. |
 | `claude_code/` | — | `claude-code` provider: drives the local `claude` CLI on a Claude subscription, preserving canonical LingTai history while resuming a successful CLI session for incremental prompts (`adapter.py:ClaudeCodeAdapter`). `claude_code/__init__.py` carries the provider's rationale — it is the Claude analogue of the Codex provider, calling the CLI binary rather than the Anthropic API with a key. |
 | `kimi_code/` | — | `kimi-code` provider: drives the local `kimi` CLI as a LingTai brain. Deliberately distinct from both the generic HTTP `kimi` provider and the `kimicode` daemon backend — the adapter owns canonical history, requires LingTai JSON actions back from the CLI, and uses the CLI's opaque resume identity for provider cache affinity (`kimi_code/__init__.py:1-6`). |
+| `deepseek/` | — | `deepseek` provider-local behavior. DeepSeek runs on the generic OpenAI-compatible transport (there is **no** `DeepSeekAdapter` subclass); `deepseek/reasoning.py` (324 LOC) owns the one thing that is genuinely DeepSeek-specific — per-model/per-wire canonical effort levels, the `thinking` enable/disable switch, the officially documented compatibility aliases, the omitted-means-provider-default rule, and each wire's exact payload shape. `_KNOWN_MODELS` separates a *known-unsupported* route (Pro on Responses — rejected even when the effort is omitted) from an *unknown future model* (omission still allowed, explicit effort rejected). Chat emits native flat `reasoning_effort` plus the `thinking` switch through `extra_body` (the installed OpenAI SDK declares no `thinking` parameter and no `**kwargs`, so a direct keyword would `TypeError` before any request; `extra_body` still lands at the JSON top level). `_register._deepseek` injects `DeepSeekReasoningController` into the generic adapter and deliberately no longer defaults/lifts the superseded `reasoning_effort_vocab` — explicit use fails DeepSeek ingress validation; the transport itself holds no DeepSeek vocabulary. |
 | `zhipu/` | — | Zhipu (GLM) provider: a thin OpenAI-compat wrapper whose sole deviation is a `_build_messages` session override merging consecutive same-role messages, because GLM rejects them with error 1214. The workaround is provider-local by design and must not migrate into the generic OpenAI adapter (`zhipu/adapter.py:1-8`). |
 | `api_gate.py` | 112 | `APICallGate` — RPM rate limiter with deque timestamps, `ThreadPoolExecutor`, daemon gate thread |
-| `base.py` | 150 | `LLMAdapter` ABC (4 abstract methods), `_GatedSession` proxy |
+| `base.py` | 218 | `LLMAdapter` ABC (4 abstract methods), `_GatedSession` proxy, and the non-abstract `resolve_configured_thinking` hook — the neutral seam where the ALREADY-SELECTED adapter decides what an omitted thinking level means on its own route. Default is the legacy `configured or LEGACY_MAIN_SESSION_THINKING`, so every non-owning provider is unchanged; `OpenAIAdapter` overrides it to delegate to an installed reasoning controller. |
 | `interface_converters.py` | 335 | Bidirectional converters: `to_*` / `from_*` for Anthropic, OpenAI, OpenAI Responses API, Gemini |
-| `service.py` | 454 | `LLMService` concrete class — adapter registry, session management, one-shot generation |
+| `service.py` | 491 | `LLMService` concrete class — adapter registry, session management, one-shot generation. `create_session` resolves a configured thinking level by calling ONLY the selected adapter's `resolve_configured_thinking` hook: this module deliberately holds no provider import, name, or branch, so per-provider effort rules cannot accumulate here (pinned by source/AST assertions in `tests/test_deepseek_reasoning_effort.py`). |
 
 ## Connections
 

--- a/src/lingtai/llm/_register.py
+++ b/src/lingtai/llm/_register.py
@@ -239,6 +239,7 @@ def register_all_adapters() -> None:
 
     def _deepseek(*, model=None, defaults=None, **kw):
         from .openai.adapter import OpenAIAdapter
+        from .deepseek.reasoning import DeepSeekReasoningController
         kw.pop("model", None)
         adapter_kw = {k: v for k, v in kw.items() if v is not None}
         d = defaults or {}
@@ -252,10 +253,15 @@ def register_all_adapters() -> None:
         if "compact_threshold" in d:
             # Preserve explicit None after the general None-pruning pass above.
             adapter_kw["compact_threshold"] = d["compact_threshold"]
-        # Lift the generic reasoning knobs from manifest defaults so DeepSeek
-        # users get the manifest-level off switch too (fable R2 M); the
-        # setdefaults below then only fill gaps for programmatic callers.
-        for _k in ("inject_reasoning_fallback", "reasoning_effort_vocab", "prompt_cache_namespace"):
+        # Lift the still-live generic reasoning knobs from manifest defaults so
+        # DeepSeek users get the manifest-level off switch too (fable R2 M);
+        # the setdefaults below then only fill gaps for programmatic callers.
+        #
+        # ``reasoning_effort_vocab`` is deliberately NOT lifted: it selects the
+        # generic Chat effort projection, which this route no longer consults —
+        # the provider-local controller below owns model/wire semantics. It is
+        # rejected at DeepSeek ingress validation rather than silently ignored.
+        for _k in ("inject_reasoning_fallback", "prompt_cache_namespace"):
             if _k in d:
                 adapter_kw[_k] = d[_k]
         # DeepSeek defaults collapsed into generic OpenAIAdapter params.
@@ -263,7 +269,6 @@ def register_all_adapters() -> None:
         # matching the neighbouring wire_api/compact_threshold lines (fable F3).
         adapter_kw.setdefault("base_url", "https://api.deepseek.com")
         adapter_kw.setdefault("inject_reasoning_fallback", True)
-        adapter_kw.setdefault("reasoning_effort_vocab", "seven_tier")
         adapter_kw.setdefault("prompt_cache_namespace", "deepseek")
         # Preserve the old DeepSeekAdapter Responses-wire fidelity: stateless
         # replay (no server-side response storage) and no generic
@@ -271,6 +276,12 @@ def register_all_adapters() -> None:
         # precedent). Chat Completions ignores both.
         adapter_kw.setdefault("responses_stateless_replay", True)
         adapter_kw.setdefault("compact_threshold", None)
+        # DeepSeek's reasoning-effort contract is genuinely provider-specific
+        # (per-model canonical levels, a ``thinking`` enable/disable switch,
+        # official compatibility aliases, and an omitted-means-provider-default
+        # rule), so DeepSeek owns it in its own package and injects it here.
+        # The generic transport stays neutral; no adapter subclass is involved.
+        adapter_kw.setdefault("reasoning_controller", DeepSeekReasoningController())
         return OpenAIAdapter(**adapter_kw)
 
     LLMService.register_adapter("deepseek", _deepseek)

--- a/src/lingtai/llm/base.py
+++ b/src/lingtai/llm/base.py
@@ -123,6 +123,23 @@ class LLMAdapter(ABC):
             return session
         return _GatedSession(session, self._gate)  # type: ignore[return-value]
 
+    def resolve_configured_thinking(self, thinking: Any) -> Any:
+        """Resolve a configured thinking value for THIS adapter's route.
+
+        The selected adapter already exists before ``create_chat``, so it — not
+        the generic service — is the neutral place to decide what an omitted
+        level means. The default is the long-standing cross-provider rule and
+        keeps every route that does not own an omitted-effort default
+        behaviorally unchanged.
+
+        A provider whose route owns its own default overrides this (see
+        ``OpenAIAdapter``, which delegates to an installed reasoning
+        controller). Nothing here knows any provider's name.
+        """
+        from lingtai.kernel.config import LEGACY_MAIN_SESSION_THINKING
+
+        return thinking or LEGACY_MAIN_SESSION_THINKING
+
     def static_adapter_comment(self) -> dict[str, Any] | None:
         """Return static, prompt-safe adapter guidance before chat creation.
 

--- a/src/lingtai/llm/deepseek/__init__.py
+++ b/src/lingtai/llm/deepseek/__init__.py
@@ -1,0 +1,8 @@
+"""DeepSeek provider-local behavior.
+
+DeepSeek runs on the generic OpenAI-compatible transport (there is no
+``DeepSeekAdapter`` subclass). What is genuinely DeepSeek-specific — its
+reasoning-effort capability surface, omission/default rule, alias
+normalization, and per-wire payload shape — lives here and is injected into
+that transport by ``lingtai/llm/_register.py``.
+"""

--- a/src/lingtai/llm/deepseek/reasoning.py
+++ b/src/lingtai/llm/deepseek/reasoning.py
@@ -1,0 +1,324 @@
+"""DeepSeek-local reasoning-effort contract.
+
+This module is the single owner of everything DeepSeek-specific about
+reasoning effort: which models exist, which effort levels each model really
+has on each wire, what an omitted value means, which compatibility aliases are
+officially documented and what they normalize to, and the exact payload shape
+for each wire. The generic OpenAI-compatible transport stays neutral; it only
+invokes the controller below and carries its immutable result.
+
+There is deliberately NO ``DeepSeekAdapter`` subclass and no cross-provider
+semantic matrix — DeepSeek owns its route, and nothing else does.
+
+Official contract (https://api-docs.deepseek.com, verified 2026-08-09):
+
+Wire-shape note (Chat): ``reasoning_effort`` is a native parameter of the
+OpenAI SDK's ``chat.completions.create``, but ``thinking`` is a DeepSeek body
+extension and is NOT — the installed SDK declares no such parameter and no
+``**kwargs``, so passing it directly raises ``TypeError`` before any request.
+It therefore travels in ``extra_body``, which the SDK merges into the top level
+of the request JSON, giving DeepSeek exactly the body it documents.
+
+  Chat Completions (``/api/create-chat-completion/``)
+    * ``thinking.type`` accepts ``["enabled", "disabled"]``; default enabled.
+    * ``reasoning_effort`` accepts ``["low", "high", "max"]``; default ``high``.
+    * "currently only ``deepseek-v4-flash`` supports the three effort levels"
+    * "``deepseek-v4-pro`` temporarily supports only ``high`` and ``max``
+      (``low`` is treated as ``high``, ``xhigh`` is treated as ``max``), and is
+      expected to support all three levels in early August 2026"
+    * "For compatibility, ``medium`` and ``xhigh`` are mapped to ``high``."
+
+  Responses (``/guides/responses_api/``)
+    * "The Responses API currently only supports the ``deepseek-v4-flash``
+      model, and does not yet support the ``deepseek-v4-pro`` model."
+    * ``reasoning`` is partially supported: ``effort`` is supported, ``summary``
+      is accepted but never generated. No compatibility alias and no
+      thinking-disable is documented for this wire.
+
+Two deliberate fail-closed decisions, both driven by the product contract that
+the effort control must offer all and only a model's REAL canonical choices:
+
+  1. ``low`` on ``deepseek-v4-pro`` is rejected rather than silently rewritten
+     to ``high``. The server-side "treated as high" leniency is not a
+     documented compatibility alias, and advertising ``low`` on Pro would
+     promise a tier the model does not have. (When Pro gains real three-level
+     support, move ``low`` into its canonical tuple — one line.)
+  2. Responses accepts nothing outside ``low|high|max``. The guide notes that
+     unsupported parameters may be silently ignored, so an undocumented value
+     must fail locally instead of being sent and quietly dropped.
+
+Related files:
+  - src/lingtai/llm/openai/reasoning_control.py — the neutral carrier/protocol
+  - src/lingtai/llm/_register.py — injects this controller into the deepseek route
+  - src/lingtai/init_schema.py, src/lingtai/kernel/presets.py — ingress validation
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Mapping
+
+from ..openai.reasoning_control import ReasoningApplication
+
+
+PROVIDER = "deepseek"
+
+WIRE_CHAT = "chat_completions"
+WIRE_RESPONSES = "responses"
+
+#: Internal omission sentinel. Never emitted on the wire — it means "let
+#: DeepSeek apply its own provider default".
+OMITTED = "default"
+
+#: Explicit Chat-only level meaning ``thinking.type = disabled``. It is a real
+#: requested value, NOT an omission.
+DISABLED = "none"
+
+FLASH = "deepseek-v4-flash"
+PRO = "deepseek-v4-pro"
+
+
+@dataclass(frozen=True)
+class DeepSeekEffortCapability:
+    """The real effort surface of one (model, wire) route.
+
+    ``canonical`` is the advertised choice list — exactly what an effort
+    control may offer. ``aliases`` are accepted on ingress and normalized, but
+    are never advertised as choices.
+    """
+
+    model: str
+    wire: str
+    canonical: tuple[str, ...]
+    aliases: Mapping[str, str]
+
+
+_CAPABILITIES: Mapping[tuple[str, str], DeepSeekEffortCapability] = MappingProxyType({
+    (FLASH, WIRE_CHAT): DeepSeekEffortCapability(
+        model=FLASH,
+        wire=WIRE_CHAT,
+        canonical=("none", "low", "high", "max"),
+        aliases=MappingProxyType({"medium": "high", "xhigh": "high"}),
+    ),
+    (PRO, WIRE_CHAT): DeepSeekEffortCapability(
+        model=PRO,
+        wire=WIRE_CHAT,
+        # ``low`` is intentionally absent: not a real Pro capability today.
+        canonical=("none", "high", "max"),
+        aliases=MappingProxyType({"medium": "high", "xhigh": "max"}),
+    ),
+    (FLASH, WIRE_RESPONSES): DeepSeekEffortCapability(
+        model=FLASH,
+        wire=WIRE_RESPONSES,
+        canonical=("low", "high", "max"),
+        aliases=MappingProxyType({}),
+    ),
+    # (PRO, WIRE_RESPONSES) is absent on purpose — Responses does not support Pro.
+})
+
+#: Models DeepSeek is known to publish today. Membership makes an absent
+#: capability entry a KNOWN-unsupported route (rejected even when effort is
+#: omitted) rather than a merely unrecognized one (omission still allowed).
+#: This is a DeepSeek-local set, not a cross-provider registry.
+_KNOWN_MODELS: frozenset[str] = frozenset({FLASH, PRO})
+
+
+def owns_provider(provider: Any) -> bool:
+    """Return whether *provider* is the DeepSeek route this module owns."""
+    return isinstance(provider, str) and provider.strip().lower() == PROVIDER
+
+
+def wire_for(llm: Mapping[str, Any]) -> str:
+    """Return the wire a manifest/preset ``llm`` block selects for DeepSeek.
+
+    Mirrors ``OpenAIAdapter._should_use_responses()`` for the deepseek factory:
+    the route always has a configured ``base_url``, so only an explicit
+    ``wire_api: responses`` reaches the Responses wire.
+    """
+    if str(llm.get("wire_api") or "").strip().lower() == WIRE_RESPONSES:
+        return WIRE_RESPONSES
+    return WIRE_CHAT
+
+
+def canonical_levels(*, model: str, wire: str) -> tuple[str, ...]:
+    """Return the advertised canonical choices for a route.
+
+    Compatibility aliases are deliberately excluded — they are accepted input,
+    not capability levels. Raises ``ValueError`` for an unsupported route.
+    """
+    cap = _CAPABILITIES.get((model, wire))
+    if cap is None:
+        raise ValueError(_unsupported_route_message(model, wire))
+    return cap.canonical
+
+
+def accepted_values(*, model: str, wire: str) -> tuple[str, ...]:
+    """Return every raw value the route accepts (canonical plus aliases)."""
+    cap = _CAPABILITIES.get((model, wire))
+    if cap is None:
+        raise ValueError(_unsupported_route_message(model, wire))
+    return cap.canonical + tuple(sorted(cap.aliases))
+
+
+def resolve_configured_thinking(value: Any) -> Any:
+    """Map a configured value to what the DeepSeek route should receive.
+
+    Constructor/config omission and an explicit ``None`` both mean Auto: they
+    become the omission sentinel, never the legacy cross-provider ``high``.
+    Every other value — including the empty string, ``False`` and ``0`` — is
+    passed through verbatim so the contract below can reject it.
+    """
+    return OMITTED if value is None else value
+
+
+def _unsupported_route_message(model: Any, wire: str) -> str:
+    supported = sorted({m for (m, w) in _CAPABILITIES if w == wire})
+    return (
+        f"provider deepseek does not support reasoning effort for "
+        f"model {model!r} on the {wire} wire; "
+        f"supported models on this wire: {', '.join(supported) or 'none'}"
+    )
+
+
+def apply_reasoning(*, model: str, wire: str, thinking: Any) -> ReasoningApplication:
+    """Resolve one DeepSeek reasoning decision, or raise before dispatch.
+
+    A KNOWN model on a route DeepSeek does not serve (Pro on Responses) raises
+    first, whether or not an effort was configured — omitting the level cannot
+    make an impossible route work.
+
+    Otherwise an omitted/``default`` value yields an empty payload, including
+    for an unknown future model: omission stays omission and never adds
+    reasoning fields. Any explicit value on a route with no capability entry
+    raises.
+    """
+    if wire not in (WIRE_CHAT, WIRE_RESPONSES):
+        raise ValueError(f"unknown DeepSeek wire {wire!r}")
+
+    # A KNOWN model on a route DeepSeek does not serve (today: Pro on
+    # Responses) is impossible regardless of effort, so it fails here — before
+    # the omission short-circuit and before any adapter/session is built.
+    # Omitting the effort cannot make an unsupported route work.
+    #
+    # This is deliberately narrower than "no capability entry": an UNKNOWN
+    # future model keeps omission/no-fields (and still rejects explicit
+    # effort below), so a new DeepSeek model works on Auto without a release.
+    if model in _KNOWN_MODELS and (model, wire) not in _CAPABILITIES:
+        raise ValueError(_unsupported_route_message(model, wire))
+
+    if thinking is None or thinking == OMITTED:
+        return ReasoningApplication(
+            provider=PROVIDER,
+            wire=wire,
+            requested=OMITTED,
+            normalized=OMITTED,
+            emitted="omitted",
+            provenance="omitted",
+        )
+
+    if not isinstance(thinking, str):
+        raise ValueError(
+            f"provider deepseek: thinking must be a string, "
+            f"got {type(thinking).__name__} ({thinking!r}) "
+            f"for model {model!r} on the {wire} wire"
+        )
+
+    cap = _CAPABILITIES.get((model, wire))
+    if cap is None:
+        raise ValueError(
+            _unsupported_route_message(model, wire)
+            + f"; refusing explicit effort {thinking!r}"
+        )
+
+    if thinking in cap.canonical:
+        normalized, provenance = thinking, "explicit_config"
+    elif thinking in cap.aliases:
+        normalized, provenance = cap.aliases[thinking], "compat_alias"
+    else:
+        raise ValueError(
+            f"provider deepseek: {thinking!r} is not a supported reasoning "
+            f"effort for model {model!r} on the {wire} wire; "
+            f"canonical levels: {', '.join(cap.canonical)}"
+            + (
+                f" (official compatibility aliases: {', '.join(sorted(cap.aliases))})"
+                if cap.aliases
+                else ""
+            )
+        )
+
+    if wire == WIRE_RESPONSES:
+        payload: Mapping[str, Any] = MappingProxyType(
+            {"reasoning": {"effort": normalized}}
+        )
+        emitted = normalized
+    elif normalized == DISABLED:
+        # Chat ``none`` disables thinking and carries no effort at all.
+        payload = MappingProxyType({"extra_body": {"thinking": {"type": "disabled"}}})
+        emitted = "disabled"
+    else:
+        payload = MappingProxyType(
+            {
+                "reasoning_effort": normalized,
+                "extra_body": {"thinking": {"type": "enabled"}},
+            }
+        )
+        emitted = normalized
+
+    return ReasoningApplication(
+        provider=PROVIDER,
+        wire=wire,
+        requested=thinking,
+        normalized=normalized,
+        emitted=emitted,
+        provenance=provenance,
+        payload=payload,
+    )
+
+
+#: Generic knobs that this route has taken ownership of. Configuring one on a
+#: DeepSeek block is an error, not a no-op: it would look like it controls the
+#: effort surface while doing nothing.
+_SUPERSEDED_GENERIC_KEYS: Mapping[str, str] = MappingProxyType({
+    "reasoning_effort_vocab": (
+        "DeepSeek's reasoning-effort surface is provider-owned (per model and "
+        "per wire), so the generic effort-vocabulary projection is not used on "
+        "this route. Remove the field; set manifest.llm.thinking to one of the "
+        "model's real levels instead."
+    ),
+})
+
+
+def validate_supported_config(llm: Mapping[str, Any]) -> None:
+    """Reject DeepSeek config keys this route has superseded.
+
+    Fails closed with an actionable message rather than silently ignoring a
+    setting the operator believes is doing something.
+    """
+    for key, reason in _SUPERSEDED_GENERIC_KEYS.items():
+        if key in llm:
+            raise ValueError(
+                f"provider deepseek: {key!r} is not supported on the DeepSeek "
+                f"route. {reason}"
+            )
+
+
+def validate_configured_thinking(*, model: Any, wire: str, thinking: Any) -> None:
+    """Validate a manifest/preset value for a DeepSeek route.
+
+    Ingress delegates here instead of testing the kernel-global level tuple, so
+    a manifest can only carry what this exact route really accepts.
+    """
+    apply_reasoning(model=model, wire=wire, thinking=thinking)
+
+
+class DeepSeekReasoningController:
+    """The provider-local hook injected into the generic OpenAI transport."""
+
+    __slots__ = ()
+
+    def resolve_configured_thinking(self, thinking: Any) -> Any:
+        """Own what an omitted configured level means on this route."""
+        return resolve_configured_thinking(thinking)
+
+    def apply(self, *, model: str, wire: str, thinking: Any) -> ReasoningApplication:
+        return apply_reasoning(model=model, wire=wire, thinking=thinking)

--- a/src/lingtai/llm/openai/ANATOMY.md
+++ b/src/lingtai/llm/openai/ANATOMY.md
@@ -11,6 +11,8 @@ related_files:
   - src/lingtai/llm/openai/codex_quota.py
   - src/lingtai/llm/openai/codex_ws.py
   - src/lingtai/llm/openai/defaults.py
+  - src/lingtai/llm/openai/reasoning_control.py
+  - src/lingtai/llm/deepseek/reasoning.py
   - src/lingtai/auth/codex_pool.py
   - tests/test_codex_quota.py
   - tests/test_codex_pool_quota_exclusion.py
@@ -46,6 +48,7 @@ OpenAI adapter — wraps the `openai` SDK for Chat Completions and Responses API
 | `adapter.py` | large | 5 classes + helpers: `OpenAIChatSession`, `OpenAIResponsesSession`, `OpenAIAdapter`, `CodexResponsesSession`, `CodexOpenAIAdapter` |
 | `codex_quota.py` | ~330 | `read_remaining_percent(auth_path)` — translates LingTai's flat OAuth file into a process-owned native Codex CLI auth envelope, then reads the CLI's own OAuth rate-limit via `codex app-server`'s `account/rateLimits/read` stdio JSON-RPC call; returns the main window's remaining percent or `None` on any failure/malformed field. Used by `lingtai.auth.codex_pool`'s quota-aware pool exclusion. Tests: `tests/test_codex_quota.py`. |
 | `defaults.py` | 12 | `DEFAULTS` dict: `api_compat="openai"`, `use_responses_api=True`, `wire_api="auto"` |
+| `reasoning_control.py` | 127 | Transport-neutral reasoning seam: the frozen `ReasoningApplication` carrier (provider/wire/requested/normalized/emitted/provenance plus the exact request payload) and the `ReasoningController` protocol. `__post_init__` deep-freezes the payload via `_freeze` (mappings → `MappingProxyType`, sequences → tuples, recursively), so the captured result is immutable all the way down; `request_kwargs()` returns a `_thaw`-ed deep MUTABLE copy for the OpenAI SDK, which the wire builder merges — mutating those kwargs cannot alter the capture or its observation. Both helpers are structural only and carry no provider semantics. The generic transport merely *invokes* an installed controller and attaches its result; it holds no provider models, levels, aliases, or defaults. `OpenAIAdapter._apply_reasoning_control` merges the thawed payload but composes `extra_body` key-by-key instead of overwriting: unrelated existing/subclass keys survive, while keys the controller owns stay authoritative (a conflicting pre-existing `thinking` cannot put `disabled` on the wire while `llm_call` observes `enabled`). A provider body extension, a subclass `_adapter_extra_body()` contribution, and a caller override therefore coexist — required because DeepSeek's `thinking` is not a declared SDK parameter and must ride `extra_body`. Sole implementor today: `src/lingtai/llm/deepseek/reasoning.py`. |
 
 ### adapter.py class map
 

--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -43,6 +43,7 @@ from lingtai.kernel.llm.base import (
 )
 from lingtai.kernel.llm.interface import ToolResultBlock
 from lingtai.llm.base import LLMAdapter
+from lingtai.llm.openai.reasoning_control import ReasoningApplication, ReasoningController
 from lingtai.kernel.llm.interface import ChatInterface, TextBlock, ThinkingBlock, ToolCallBlock
 from ..interface_converters import to_openai, to_responses_input
 from lingtai.kernel.llm.streaming import StreamingAccumulator
@@ -2576,6 +2577,7 @@ class OpenAIAdapter(LLMAdapter):
         inject_reasoning_fallback: bool | None = None,
         reasoning_effort_vocab: str = "openai",
         prompt_cache_namespace: str | None = None,
+        reasoning_controller: "ReasoningController | None" = None,
     ):
         self.base_url = base_url
         self._use_responses = use_responses
@@ -2630,6 +2632,13 @@ class OpenAIAdapter(LLMAdapter):
         # maps kernel levels onto OpenAI's high/low surface; ``seven_tier``
         # passes the kernel THINKING_LEVELS through unchanged (DeepSeek wire).
         self._reasoning_effort_vocab = reasoning_effort_vocab
+        # Optional provider-local reasoning owner (see
+        # ``lingtai/llm/openai/reasoning_control.py``). When a provider route
+        # installs one, it decides the reasoning fields for BOTH wires and the
+        # generic vocabulary projections below are bypassed entirely. When it
+        # is absent — every route except deepseek — this adapter behaves
+        # exactly as before.
+        self._reasoning_controller = reasoning_controller
         # Optional fixed provider namespace for the auto-derived
         # ``prompt_cache_key`` (e.g. ``deepseek`` -> ``lingtai-deepseek:{model}:v1``).
         self._prompt_cache_namespace = prompt_cache_namespace
@@ -2770,9 +2779,17 @@ class OpenAIAdapter(LLMAdapter):
         # Completions SDK's flat `reasoning_effort`. Sending the wrong shape
         # silently drops the field on the OpenAI Responses endpoint and 400s
         # on Codex's `/backend-api/codex/responses`.
-        extra_kwargs.update(_responses_reasoning_kwargs(thinking))
+        #
+        # A provider route that installs a reasoning controller owns this
+        # decision entirely — including whether any field is sent at all — and
+        # may raise before the SDK is ever touched.
+        applied = self._apply_reasoning_control(
+            model=model, wire="responses", thinking=thinking, extra_kwargs=extra_kwargs
+        )
+        if applied is None:
+            extra_kwargs.update(_responses_reasoning_kwargs(thinking))
 
-        return OpenAIResponsesSession(
+        session = OpenAIResponsesSession(
             client=self._client,
             model=model,
             instructions=system_prompt,
@@ -2787,6 +2804,75 @@ class OpenAIAdapter(LLMAdapter):
             stateless_replay=self._responses_stateless_replay,
             inject_reasoning_fallback=self._inject_reasoning_fallback,
         )
+        return self._capture_reasoning_application(session, applied)
+
+    def resolve_configured_thinking(self, thinking: Any) -> Any:
+        """Delegate omission resolution to an installed reasoning controller.
+
+        A provider route that owns its effort contract also owns what an
+        omitted level means there; without a controller this is the inherited
+        legacy fallback, so every other OpenAI-compatible route (including
+        Codex) is unchanged.
+        """
+        controller = self._reasoning_controller
+        resolver = getattr(controller, "resolve_configured_thinking", None)
+        if resolver is None:
+            return super().resolve_configured_thinking(thinking)
+        return resolver(thinking)
+
+    def _apply_reasoning_control(
+        self,
+        *,
+        model: str,
+        wire: str,
+        thinking: Any,
+        extra_kwargs: dict[str, Any],
+    ) -> ReasoningApplication | None:
+        """Let an installed provider-local controller own the reasoning fields.
+
+        Returns the immutable application result and merges its exact payload,
+        or ``None`` when no controller is installed so the caller keeps the
+        generic OpenAI projection. Transport-neutral: this function knows
+        nothing about any provider's models, levels, aliases, or defaults.
+        """
+        controller = self._reasoning_controller
+        if controller is None:
+            return None
+        applied = controller.apply(model=model, wire=wire, thinking=thinking)
+        # Merge a deep MUTABLE copy: the SDK wants plain dicts, and this
+        # per-session kwargs dict stays editable afterwards. The captured
+        # application keeps its own frozen payload, so observation can never be
+        # rewritten by a later edit to the request kwargs.
+        payload = applied.request_kwargs()
+        # ``extra_body`` is a shared channel — a provider extension, a subclass
+        # contribution, and a caller override can all want a key in it — so it
+        # composes instead of overwriting: unrelated existing keys survive.
+        #
+        # For the keys the controller OWNS, the controller wins. The captured
+        # application is reported as the exact emitted decision, so letting a
+        # stale/conflicting existing entry override it would put a different
+        # value on the wire than ``llm_call`` observes — a silent lie about
+        # what the request actually asked for.
+        extra_body = payload.pop("extra_body", None)
+        extra_kwargs.update(payload)
+        if extra_body:
+            existing = extra_kwargs.get("extra_body") or {}
+            extra_kwargs["extra_body"] = {**existing, **extra_body}
+        return applied
+
+    @staticmethod
+    def _capture_reasoning_application(
+        session: Any, applied: ReasoningApplication | None
+    ) -> Any:
+        """Attach the one immutable application result to the session.
+
+        Observation reads this exact object, so what is reported is always the
+        patch that was really applied — never a recomputation from raw config.
+        Sessions on routes without a controller are left untouched.
+        """
+        if applied is not None:
+            session.reasoning_application = applied
+        return session
 
     def _create_completions_session(
         self,
@@ -2830,9 +2916,20 @@ class OpenAIAdapter(LLMAdapter):
         # the default ``openai`` vocab clamps ``xhigh``/``max`` to ``high`` and
         # omits the field for the omitted/``default`` sentinel so the upstream
         # v1 default applies).
-        effort = self._chat_reasoning_effort(thinking)
-        if effort is not None:
-            extra_kwargs["reasoning_effort"] = effort
+        # A provider route that installs a reasoning controller owns this
+        # decision entirely (DeepSeek, for instance, also emits its own
+        # ``thinking`` switch and rejects levels its model does not really
+        # have); the generic vocabulary projection is then never consulted.
+        applied = self._apply_reasoning_control(
+            model=model,
+            wire="chat_completions",
+            thinking=thinking,
+            extra_kwargs=extra_kwargs,
+        )
+        if applied is None:
+            effort = self._chat_reasoning_effort(thinking)
+            if effort is not None:
+                extra_kwargs["reasoning_effort"] = effort
 
         # Subclass-provided extra_body (e.g. OpenRouter's reasoning include).
         # Merge rather than overwrite so callers adding their own extra_body
@@ -2842,7 +2939,7 @@ class OpenAIAdapter(LLMAdapter):
             existing = extra_kwargs.get("extra_body") or {}
             extra_kwargs["extra_body"] = {**sub_extra_body, **existing}
 
-        return self._session_class(
+        session = self._session_class(
             client=self._client,
             model=model,
             interface=interface,
@@ -2854,6 +2951,7 @@ class OpenAIAdapter(LLMAdapter):
             prompt_cache_key=self._resolve_prompt_cache_key(model),
             inject_reasoning_fallback=self._inject_reasoning_fallback,
         )
+        return self._capture_reasoning_application(session, applied)
 
     def _adapter_extra_body(self) -> dict:
         """Return extra_body JSON fields to include on every request.

--- a/src/lingtai/llm/openai/reasoning_control.py
+++ b/src/lingtai/llm/openai/reasoning_control.py
@@ -1,0 +1,127 @@
+"""Transport-neutral reasoning application carrier and hook protocol.
+
+The generic OpenAI-compatible transport owns *invocation* only. It knows that
+a provider route may install a controller which decides what reasoning fields
+a request carries, and it knows how to carry the resulting immutable decision
+on the session so observation can report the patch that was really applied.
+
+It deliberately knows nothing about any provider's model names, effort levels,
+compatibility aliases, defaults, or payload shapes — those live inside the
+provider's own package (see ``lingtai/llm/deepseek/reasoning.py``, the only
+current implementor).
+
+Related files:
+  - src/lingtai/llm/openai/adapter.py — invokes the controller, captures the result
+  - src/lingtai/llm/deepseek/reasoning.py — the DeepSeek implementation
+  - src/lingtai/kernel/session.py — renders ``observation_fields()`` onto llm_call
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Any, Mapping, Protocol, runtime_checkable
+
+
+_EMPTY: Mapping[str, Any] = MappingProxyType({})
+
+
+def _freeze(value: Any) -> Any:
+    """Return a recursively immutable view of a plain request-kwargs value.
+
+    Structural only — this helper carries no provider semantics; it does not
+    know or care what any key means. Mappings become read-only proxies and
+    sequences become tuples, all the way down, so a captured application
+    cannot be edited through a nested container.
+    """
+    if isinstance(value, Mapping):
+        return MappingProxyType({k: _freeze(v) for k, v in value.items()})
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze(v) for v in value)
+    return value
+
+
+def _thaw(value: Any) -> Any:
+    """Return a plain, deeply mutable copy of a frozen request-kwargs value.
+
+    The inverse of :func:`_freeze`. The OpenAI SDK expects ordinary ``dict``/
+    ``list`` objects, and callers must be free to mutate what they are handed
+    without reaching back into the captured application.
+    """
+    if isinstance(value, Mapping):
+        return {k: _thaw(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_thaw(v) for v in value]
+    return value
+
+
+@dataclass(frozen=True)
+class ReasoningApplication:
+    """One immutable reasoning decision, captured at session construction.
+
+    Every field is a bounded plain string except ``payload``, which is the
+    exact set of request kwargs the wire builder merges. The carrier is
+    created once per session and consumed once by the request builder;
+    observation reads the SAME object rather than recomputing anything from
+    raw config.
+
+    Attributes:
+        provider: Provider identity (e.g. ``deepseek``), never the generic wire owner.
+        wire: ``chat_completions`` or ``responses``.
+        requested: The raw configured value — canonical level, official alias,
+            or the ``default`` omission sentinel.
+        normalized: The value after the provider's own alias normalization.
+        emitted: What actually went on the wire (``omitted``/``disabled``/level).
+        provenance: ``omitted``, ``explicit_config``, or ``compat_alias``.
+        payload: Exact request kwargs, deeply frozen at construction (empty for
+            an omission). Read it for inspection/observation; call
+            ``request_kwargs()`` to get something a caller may mutate.
+    """
+
+    provider: str
+    wire: str
+    requested: str
+    normalized: str
+    emitted: str
+    provenance: str
+    payload: Mapping[str, Any] = field(default=_EMPTY)
+
+    def __post_init__(self) -> None:
+        # Deep-freeze whatever the provider handed us, so "immutable applied
+        # result" holds all the way down rather than only at the top level.
+        # ``object.__setattr__`` is the standard frozen-dataclass escape.
+        object.__setattr__(self, "payload", _freeze(self.payload))
+
+    def request_kwargs(self) -> dict[str, Any]:
+        """Return a fresh, deeply mutable copy of the request kwargs.
+
+        The OpenAI SDK needs plain ``dict``s, and the wire builder merges this
+        into a per-session kwargs dict that other code may still edit. Handing
+        out a copy keeps the captured application — and therefore observation —
+        authoritative and untouched no matter what happens downstream.
+        """
+        return _thaw(self.payload)
+
+    def observation_fields(self) -> dict[str, str]:
+        """Return the bounded, allowlisted observation fields for this result.
+
+        Plain strings only — never payload contents, prompts, or credentials.
+        """
+        return {
+            "provider": self.provider,
+            "wire": self.wire,
+            "effort_requested": self.requested,
+            "effort_normalized": self.normalized,
+            "effort_emitted": self.emitted,
+            "effort_provenance": self.provenance,
+        }
+
+
+@runtime_checkable
+class ReasoningController(Protocol):
+    """Provider-local owner of the reasoning decision for one request."""
+
+    def apply(
+        self, *, model: str, wire: str, thinking: Any
+    ) -> ReasoningApplication:
+        """Return the application result, or raise ``ValueError`` before dispatch."""
+        ...

--- a/src/lingtai/llm/service.py
+++ b/src/lingtai/llm/service.py
@@ -419,7 +419,10 @@ class LLMService(LLMServiceABC):
             model=session_model,
             system_prompt=system_prompt,
             tools=tools,
-            thinking=thinking,
+            # What an omitted level means belongs to the route, so the already
+            # selected adapter resolves it. This service holds no provider
+            # name, import, or branch of its own.
+            thinking=adapter.resolve_configured_thinking(thinking),
             interaction_id=interaction_id,
             json_schema=json_schema,
             force_tool_call=force_tool_call,

--- a/tests/test_deepseek_adapter.py
+++ b/tests/test_deepseek_adapter.py
@@ -584,24 +584,29 @@ def test_provider_defaults_lift_new_reasoning_keys():
     assert a._reasoning_effort_vocab == "seven_tier"
     assert a._prompt_cache_namespace == "custom-ns"
 
-    # fable R3-L2: the deepseek factory must lift the same keys from
+    # fable R3-L2: the deepseek factory must lift the STILL-LIVE keys from
     # defaults (its lift sits ABOVE the setdefault block; a reorder would
     # silently regress manifest opt-out back to True with all tests green).
+    #
+    # ``reasoning_effort_vocab`` is deliberately absent here: it selects the
+    # GENERIC Chat projection, which the DeepSeek route no longer consults —
+    # model/wire semantics are owned by the provider-local controller
+    # (src/lingtai/llm/deepseek/reasoning.py). Supplying it explicitly on a
+    # DeepSeek route is now a validation error rather than a live knob; see
+    # tests/test_deepseek_reasoning_effort.py A7 coverage.
     ds_defaults = build_provider_defaults_from_manifest_llm(
         {
             "provider": "deepseek",
             "inject_reasoning_fallback": False,
-            "reasoning_effort_vocab": "seven_tier",
             "prompt_cache_namespace": "custom-ns",
         },
         max_rpm=0,
     )
     assert ds_defaults is not None
     assert ds_defaults["deepseek"]["inject_reasoning_fallback"] is False
-    assert ds_defaults["deepseek"]["reasoning_effort_vocab"] == "seven_tier"
     assert ds_defaults["deepseek"]["prompt_cache_namespace"] == "custom-ns"
     ds_factory = LLMService._adapter_registry["deepseek"]
     dsa = ds_factory(model="deepseek-chat", api_key="sk-test", defaults=ds_defaults["deepseek"])
     assert dsa._inject_reasoning_fallback is False
-    assert dsa._reasoning_effort_vocab == "seven_tier"
     assert dsa._prompt_cache_namespace == "custom-ns"
+    assert dsa._reasoning_effort_vocab != "seven_tier"

--- a/tests/test_deepseek_reasoning_effort.py
+++ b/tests/test_deepseek_reasoning_effort.py
@@ -1,0 +1,1181 @@
+"""DeepSeek reasoning-effort vertical — provider-local capability/omission/
+validation/emission/observation contract.
+
+The eventual ``/effort`` control must offer all and only the *real* canonical
+choices of the current DeepSeek model on the current wire.  DeepSeek owns that
+vocabulary inside its own route; the generic OpenAI transport stays neutral and
+other providers keep current-main behavior byte-for-byte.
+
+Official contract (api-docs.deepseek.com, verified 2026-08-09):
+
+  Chat Completions
+    * ``thinking.type`` is ``enabled|disabled``; omission defaults to enabled.
+    * ``reasoning_effort`` accepts ``["low", "high", "max"]``; default ``high``.
+    * "currently only ``deepseek-v4-flash`` supports the three effort levels"
+    * "``deepseek-v4-pro`` temporarily supports only ``high`` and ``max``
+      (``low`` is treated as ``high``, ``xhigh`` is treated as ``max``)"
+    * "For compatibility, ``medium`` and ``xhigh`` are mapped to ``high``."
+
+  Responses
+    * "The Responses API currently only supports the ``deepseek-v4-flash``
+      model, and does not yet support the ``deepseek-v4-pro`` model."
+    * ``reasoning`` is partially supported: ``effort`` supported.  No
+      compatibility alias and no thinking-disable is documented, so anything
+      outside the canonical ``low|high|max`` fails closed locally.
+
+``low`` on Pro is deliberately REJECTED rather than silently normalized: the
+brief's product contract forbids advertising a level the model does not really
+have, and the server-side "treated as high" leniency is not a documented
+compatibility alias.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from lingtai.agent import build_agent_config
+from lingtai.init_schema import validate_init
+from lingtai.kernel.config import AgentConfig, THINKING_LEVELS
+from lingtai.kernel.llm.base import LLMResponse
+from lingtai.kernel.llm.interface import ChatInterface
+from lingtai.kernel.session import SessionManager
+from lingtai.llm._register import register_all_adapters
+from lingtai.llm.service import LLMService
+
+
+FLASH = "deepseek-v4-flash"
+PRO = "deepseek-v4-pro"
+UNKNOWN = "deepseek-v9-unreleased"
+
+
+# ---------------------------------------------------------------------------
+# helpers — real registered factory, real adapter, real session construction
+# ---------------------------------------------------------------------------
+
+
+def _deepseek_adapter(*, wire: str = "chat_completions"):
+    """Build the REAL registered ``deepseek`` adapter for a wire."""
+    register_all_adapters()
+    factory = LLMService._adapter_registry["deepseek"]
+    return factory(model=None, api_key="sk-test", defaults={"wire_api": wire})
+
+
+def _extra(model: str, thinking: str, *, wire: str = "chat_completions") -> dict:
+    """Return the exact per-request extra kwargs the adapter would send."""
+    adapter = _deepseek_adapter(wire=wire)
+    iface = ChatInterface()
+    iface.add_system("sys")
+    session = adapter.create_chat(
+        model=model, system_prompt="sys", interface=iface, thinking=thinking
+    )
+    return dict(session._extra_kwargs)
+
+
+def _thinking_switch(extra: dict):
+    """Return DeepSeek's ``thinking`` switch as the SDK would send it.
+
+    ``thinking`` is a DeepSeek body extension, NOT a named parameter of the
+    OpenAI SDK's ``chat.completions.create``. It therefore travels in
+    ``extra_body``, which the SDK merges into the top level of the request
+    JSON — the shape DeepSeek requires.
+    """
+    return (extra.get("extra_body") or {}).get("thinking")
+
+
+def _sdk_chat_signature():
+    """The signature of the REAL installed OpenAI SDK Chat create call."""
+    import inspect
+
+    import openai
+
+    client = openai.OpenAI(api_key="sk-test", base_url="https://api.deepseek.com")
+    return inspect.signature(client.chat.completions.create)
+
+
+def _applied(model: str, thinking: str, *, wire: str = "chat_completions"):
+    """Return the immutable application result captured on the session."""
+    adapter = _deepseek_adapter(wire=wire)
+    iface = ChatInterface()
+    iface.add_system("sys")
+    session = adapter.create_chat(
+        model=model, system_prompt="sys", interface=iface, thinking=thinking
+    )
+    return getattr(session, "reasoning_application", None)
+
+
+def _init_data(llm: dict) -> dict:
+    return {
+        "manifest": {
+            "agent_name": "test-agent",
+            "language": "en",
+            "llm": llm,
+            "capabilities": {},
+            "soul": {"delay": 60},
+            "context_limit": None,
+            "admin": {"karma": True},
+            "streaming": False,
+        },
+        "principle": "",
+        "covenant": "",
+        "pad": "",
+        "lingtai": "",
+        "soul": "",
+    }
+
+
+# ---------------------------------------------------------------------------
+# clause 2 — Chat Completions, deepseek-v4-flash
+# ---------------------------------------------------------------------------
+
+
+def test_chat_flash_auto_omits_every_reasoning_field():
+    """Auto/omitted must send NO thinking switch and NO effort — DeepSeek's own
+    provider default applies.  Current main fabricates ``xhigh``."""
+    extra = _extra(FLASH, "default")
+    assert "reasoning_effort" not in extra
+    assert "thinking" not in extra
+
+
+def test_chat_flash_none_disables_thinking_and_sends_no_effort():
+    extra = _extra(FLASH, "none")
+    assert _thinking_switch(extra) == {"type": "disabled"}
+    assert "thinking" not in extra
+    assert "reasoning_effort" not in extra
+
+
+@pytest.mark.parametrize("level", ["low", "high", "max"])
+def test_chat_flash_canonical_levels_enable_thinking_with_flat_effort(level):
+    extra = _extra(FLASH, level)
+    assert _thinking_switch(extra) == {"type": "enabled"}
+    assert "thinking" not in extra
+    assert extra["reasoning_effort"] == level
+
+
+# ---------------------------------------------------------------------------
+# clause 3 — Chat Completions, deepseek-v4-pro
+# ---------------------------------------------------------------------------
+
+
+def test_chat_pro_auto_omits_every_reasoning_field():
+    extra = _extra(PRO, "default")
+    assert "reasoning_effort" not in extra
+    assert "thinking" not in extra
+
+
+def test_chat_pro_none_disables_thinking_and_sends_no_effort():
+    extra = _extra(PRO, "none")
+    assert _thinking_switch(extra) == {"type": "disabled"}
+    assert "thinking" not in extra
+    assert "reasoning_effort" not in extra
+
+
+@pytest.mark.parametrize("level", ["high", "max"])
+def test_chat_pro_canonical_levels_enable_thinking_with_flat_effort(level):
+    extra = _extra(PRO, level)
+    assert _thinking_switch(extra) == {"type": "enabled"}
+    assert "thinking" not in extra
+    assert extra["reasoning_effort"] == level
+
+
+def test_chat_pro_low_fails_before_any_sdk_call():
+    """``low`` is not a real Pro capability; it must not reach the SDK."""
+    with pytest.raises(ValueError) as exc:
+        _extra(PRO, "low")
+    msg = str(exc.value)
+    assert "deepseek" in msg.lower()
+    assert PRO in msg
+    assert "low" in msg
+
+
+# ---------------------------------------------------------------------------
+# clause 4 — official Chat compatibility aliases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "model,alias,normalized",
+    [
+        (FLASH, "medium", "high"),
+        (FLASH, "xhigh", "high"),
+        (PRO, "medium", "high"),
+        (PRO, "xhigh", "max"),
+    ],
+)
+def test_chat_official_aliases_normalize_exactly_as_documented(model, alias, normalized):
+    extra = _extra(model, alias)
+    assert _thinking_switch(extra) == {"type": "enabled"}
+    assert "thinking" not in extra
+    assert extra["reasoning_effort"] == normalized
+
+
+@pytest.mark.parametrize("model", [FLASH, PRO])
+def test_chat_aliases_are_not_advertised_capability_levels(model):
+    """Aliases are accepted on ingress but never offered as choices."""
+    from lingtai.llm.deepseek.reasoning import canonical_levels
+
+    levels = canonical_levels(model=model, wire="chat_completions")
+    assert "medium" not in levels
+    assert "xhigh" not in levels
+    assert "minimal" not in levels
+    assert levels == (("none", "low", "high", "max") if model == FLASH
+                      else ("none", "high", "max"))
+
+
+@pytest.mark.parametrize("model", [FLASH, PRO])
+def test_chat_minimal_is_never_accepted(model):
+    with pytest.raises(ValueError):
+        _extra(model, "minimal")
+
+
+# ---------------------------------------------------------------------------
+# clause 5 — Responses wire, deepseek-v4-flash
+# ---------------------------------------------------------------------------
+
+
+def test_responses_flash_auto_omits_reasoning_entirely():
+    extra = _extra(FLASH, "default", wire="responses")
+    assert "reasoning" not in extra
+
+
+@pytest.mark.parametrize("level", ["low", "high", "max"])
+def test_responses_flash_canonical_levels_nest_under_reasoning_effort(level):
+    extra = _extra(FLASH, level, wire="responses")
+    assert extra["reasoning"] == {"effort": level}
+    assert "reasoning_effort" not in extra
+
+
+@pytest.mark.parametrize("value", ["none", "minimal", "medium", "xhigh", "insane", ""])
+def test_responses_flash_rejects_undocumented_values(value):
+    """No disable and no compatibility alias is documented for Responses."""
+    with pytest.raises(ValueError):
+        _extra(FLASH, value, wire="responses")
+
+
+# ---------------------------------------------------------------------------
+# clause 6 — Responses Pro and unknown DeepSeek models
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", ["low", "high", "max", "none", "medium"])
+def test_responses_pro_fails_before_sdk_for_any_explicit_effort(value):
+    with pytest.raises(ValueError) as exc:
+        _extra(PRO, value, wire="responses")
+    msg = str(exc.value)
+    assert PRO in msg
+    assert "responses" in msg.lower()
+
+
+def test_responses_pro_is_rejected_even_when_effort_is_omitted():
+    """A2 (parent amendment 1): Responses supports Flash only.
+
+    ``deepseek-v4-pro`` on the Responses wire is a KNOWN-unsupported route, so
+    it must fail before adapter/session construction even with no effort
+    configured — omission cannot make an impossible route succeed. This
+    supersedes the earlier ``test_responses_pro_omission_adds_no_fields``,
+    which asserted the opposite and contradicted the shipped claim that
+    Pro+Responses fails at session construction.
+    """
+    with pytest.raises(ValueError) as exc:
+        _extra(PRO, "default", wire="responses")
+    msg = str(exc.value)
+    assert PRO in msg
+    assert "responses" in msg.lower()
+
+
+def test_responses_pro_omission_is_rejected_through_real_session_ingress():
+    manager, events = _session_manager(model=PRO, wire="responses")
+    with pytest.raises(ValueError):
+        manager.ensure_session()
+    assert [t for t, _ in events if t == "llm_call"] == []
+
+
+def test_unknown_model_omission_still_survives_on_both_wires():
+    """A2 boundary: an UNKNOWN future model keeps omission/no-fields.
+
+    Only known-unsupported routes fail closed on omission; the brief
+    deliberately preserves unknown-model omission while rejecting explicit
+    effort (already covered above).
+    """
+    for wire in ("chat_completions", "responses"):
+        extra = _extra(UNKNOWN, "default", wire=wire)
+        assert "reasoning" not in extra
+        assert "reasoning_effort" not in extra
+        assert "thinking" not in extra
+
+
+@pytest.mark.parametrize("wire", ["chat_completions", "responses"])
+def test_unknown_deepseek_model_omission_adds_no_reasoning_fields(wire):
+    extra = _extra(UNKNOWN, "default", wire=wire)
+    assert "reasoning" not in extra
+    assert "reasoning_effort" not in extra
+    assert "thinking" not in extra
+
+
+@pytest.mark.parametrize("wire", ["chat_completions", "responses"])
+def test_unknown_deepseek_model_explicit_effort_fails_before_sdk(wire):
+    with pytest.raises(ValueError) as exc:
+        _extra(UNKNOWN, "high", wire=wire)
+    assert UNKNOWN in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# clause 1 / clause 10 — real ingress omission (manifest, config, session)
+# ---------------------------------------------------------------------------
+
+
+def test_manifest_omitted_thinking_for_deepseek_hydrates_to_omission_sentinel():
+    """DeepSeek owns its omitted-effort default, so hydration must not promote
+    an omitted manifest value to the legacy cross-provider ``high``.
+
+    This is also the native LingTai daemon's initial-omission parity route:
+    the daemon builds its agent config through this same function.
+    """
+    manifest = _init_data({"provider": "deepseek", "model": FLASH, "api_key": "k"})["manifest"]
+    cfg = build_agent_config(manifest, max_rpm=0)
+    assert cfg.thinking == "default"
+
+
+def test_manifest_explicit_thinking_for_deepseek_is_preserved():
+    manifest = _init_data(
+        {"provider": "deepseek", "model": FLASH, "api_key": "k", "thinking": "max"}
+    )["manifest"]
+    cfg = build_agent_config(manifest, max_rpm=0)
+    assert cfg.thinking == "max"
+
+
+#: Marks "no ``thinking=`` argument was passed at all" — distinct from an
+#: explicit ``None``. Used to exercise pure constructor omission.
+_UNSET = object()
+
+
+def _session_manager(
+    thinking=_UNSET, *, model=FLASH, wire="chat_completions", provider="deepseek"
+):
+    register_all_adapters()
+    service = LLMService(
+        provider=provider,
+        model=model,
+        api_key="sk-test",
+        provider_defaults={provider: {"wire_api": wire}} if wire else None,
+    )
+    config_kw = {"provider": provider, "model": model}
+    if thinking is not _UNSET:
+        config_kw["thinking"] = thinking
+    config = AgentConfig(**config_kw)
+    events: list[tuple[str, dict]] = []
+    manager = SessionManager(
+        llm_service=service,
+        config=config,
+        agent_name="test-agent",
+        streaming=False,
+        build_system_prompt_fn=lambda: "sys",
+        build_tool_schemas_fn=lambda: [],
+        logger_fn=lambda event_type, **fields: events.append((event_type, fields)),
+    )
+    return manager, events
+
+
+# --- A1: programmatic constructor omission (parent amendment 1) -------------
+
+
+@pytest.mark.parametrize("wire", ["chat_completions", "responses"])
+def test_programmatic_agentconfig_omission_reaches_deepseek_as_omission(wire):
+    """``AgentConfig(provider="deepseek", model=...)`` with NO ``thinking=``.
+
+    Constructor omission is Auto: it must be indistinguishable from an explicit
+    ``None`` and must never be fabricated into ``high`` before the DeepSeek
+    contract sees it.
+    """
+    manager, _ = _session_manager(wire=wire)
+    chat = manager.ensure_session()
+    extra = dict(chat._extra_kwargs)
+    assert "reasoning" not in extra
+    assert "reasoning_effort" not in extra
+    assert "thinking" not in extra
+
+
+def test_programmatic_agentconfig_omission_observes_omitted_provenance():
+    manager, _ = _session_manager()
+    chat = manager.ensure_session()
+    applied = chat.reasoning_application
+    assert applied.requested == "default"
+    assert applied.normalized == "default"
+    assert applied.emitted == "omitted"
+    assert applied.provenance == "omitted"
+
+
+def test_programmatic_agentconfig_omission_matches_explicit_none():
+    """Constructor omission and explicit ``None`` must resolve identically."""
+    omitted = _session_manager()[0].ensure_session()
+    explicit_none = _session_manager(None)[0].ensure_session()
+    assert dict(omitted._extra_kwargs) == dict(explicit_none._extra_kwargs)
+    assert (
+        omitted.reasoning_application.observation_fields()
+        == explicit_none.reasoning_application.observation_fields()
+    )
+
+
+def test_programmatic_agentconfig_omission_keeps_legacy_high_off_deepseek():
+    """A1 leakage guard: a default ``AgentConfig()`` on a non-DeepSeek route
+    still reaches its adapter as the legacy ``high``."""
+    manager, _ = _session_manager(model="gpt-4o", wire=None, provider="openai")
+    chat = manager.ensure_session()
+    assert chat._extra_kwargs["reasoning_effort"] == "high"
+    assert getattr(chat, "reasoning_application", None) is None
+
+
+def test_explicit_deepseek_high_survives_the_omission_change():
+    """A1 regression: explicit values keep their existing intended semantics."""
+    manager, _ = _session_manager("high")
+    chat = manager.ensure_session()
+    assert _thinking_switch(chat._extra_kwargs) == {"type": "enabled"}
+    assert chat._extra_kwargs["reasoning_effort"] == "high"
+    assert chat.reasoning_application.provenance == "explicit_config"
+
+
+@pytest.mark.parametrize("wire", ["chat_completions", "responses"])
+def test_config_none_thinking_reaches_deepseek_as_omission(wire):
+    """An explicit ``None`` is Auto, not the legacy ``or "high"`` fallback."""
+    manager, _ = _session_manager(None, wire=wire)
+    chat = manager.ensure_session()
+    extra = dict(chat._extra_kwargs)
+    assert "reasoning" not in extra
+    assert "reasoning_effort" not in extra
+    assert "thinking" not in extra
+
+
+@pytest.mark.parametrize("bad", ["", 0, False])
+def test_config_falsey_non_none_thinking_is_invalid_for_deepseek(bad):
+    """Empty string / False / 0 are invalid explicit values — never ``high``."""
+    manager, _ = _session_manager(bad)
+    with pytest.raises(ValueError):
+        manager.ensure_session()
+
+
+def test_non_deepseek_provider_keeps_legacy_high_fallback():
+    """Leakage guard: the DeepSeek omission rule must not touch other providers.
+
+    An OpenAI route with a falsey configured level still resolves to the legacy
+    cross-provider ``high`` and still emits a flat ``reasoning_effort``.
+    """
+    register_all_adapters()
+    service = LLMService(provider="openai", model="gpt-4o", api_key="sk-test")
+    config = AgentConfig(provider="openai", model="gpt-4o", thinking=None)
+    manager = SessionManager(
+        llm_service=service,
+        config=config,
+        agent_name="a",
+        streaming=False,
+        build_system_prompt_fn=lambda: "sys",
+        build_tool_schemas_fn=lambda: [],
+        logger_fn=None,
+    )
+    chat = manager.ensure_session()
+    assert chat._extra_kwargs["reasoning_effort"] == "high"
+    assert getattr(chat, "reasoning_application", None) is None
+
+
+# ---------------------------------------------------------------------------
+# clause 7 — manifest/init/preset validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "model,wire,value",
+    [
+        (FLASH, None, "none"),
+        (FLASH, None, "low"),
+        (FLASH, None, "high"),
+        (FLASH, None, "max"),
+        (FLASH, None, "medium"),
+        (PRO, None, "max"),
+        (PRO, None, "xhigh"),
+        (FLASH, "responses", "low"),
+        (FLASH, "responses", "max"),
+    ],
+)
+def test_init_schema_accepts_the_routes_exact_raw_set(model, wire, value):
+    llm = {"provider": "deepseek", "model": model, "api_key": "k", "thinking": value}
+    if wire:
+        llm["wire_api"] = wire
+    validate_init(_init_data(llm))
+
+
+@pytest.mark.parametrize(
+    "model,wire,value",
+    [
+        (PRO, None, "low"),
+        (FLASH, None, "minimal"),
+        (PRO, "responses", "high"),
+        (FLASH, "responses", "none"),
+        (FLASH, "responses", "medium"),
+        (UNKNOWN, None, "high"),
+    ],
+)
+def test_init_schema_rejects_values_outside_the_route(model, wire, value):
+    llm = {"provider": "deepseek", "model": model, "api_key": "k", "thinking": value}
+    if wire:
+        llm["wire_api"] = wire
+    with pytest.raises(ValueError) as exc:
+        validate_init(_init_data(llm))
+    msg = str(exc.value)
+    assert "deepseek" in msg.lower()
+    assert model in msg
+
+
+@pytest.mark.parametrize(
+    "thinking,wire,ok",
+    [
+        ("max", None, True),
+        ("none", None, True),
+        ("xhigh", None, True),
+        ("minimal", None, False),
+        ("low", "responses", True),
+        ("none", "responses", False),
+    ],
+)
+def test_preset_validation_uses_the_deepseek_route(tmp_path, thinking, wire, ok):
+    """A preset carrying DeepSeek thinking is validated against the real route.
+
+    Chat Completions presets used to be rejected outright; Responses presets
+    used to accept every kernel level.
+    """
+    import json
+
+    from lingtai.agent import load_preset
+
+    llm = {
+        "provider": "deepseek",
+        "model": FLASH,
+        "api_key": "k",
+        "thinking": thinking,
+    }
+    if wire:
+        llm["wire_api"] = wire
+    path = tmp_path / "ds.json"
+    path.write_text(json.dumps({
+        "name": str(path),
+        "description": {"summary": "deepseek preset"},
+        "manifest": {"llm": llm, "capabilities": {}},
+    }))
+
+    if ok:
+        assert load_preset(str(path))["manifest"]["llm"]["thinking"] == thinking
+    else:
+        with pytest.raises(ValueError, match="deepseek"):
+            load_preset(str(path))
+
+
+# --- A7: the superseded seven-tier projection knob (parent amendment 1) -----
+
+
+def test_deepseek_factory_no_longer_defaults_the_dead_vocab_knob():
+    """The provider-local controller owns model/wire semantics outright.
+
+    ``reasoning_effort_vocab`` selects the GENERIC projection, which the
+    DeepSeek route now bypasses entirely — defaulting it to ``seven_tier``
+    advertised a control that no longer does anything.
+    """
+    adapter = _deepseek_adapter()
+    assert adapter._reasoning_effort_vocab != "seven_tier"
+    assert adapter._reasoning_effort_vocab == "openai"
+
+
+def test_deepseek_factory_still_lifts_the_live_generic_knobs():
+    from lingtai.llm.service import build_provider_defaults_from_manifest_llm
+
+    register_all_adapters()
+    defaults = build_provider_defaults_from_manifest_llm(
+        {
+            "provider": "deepseek",
+            "inject_reasoning_fallback": False,
+            "prompt_cache_namespace": "custom-ns",
+        },
+        max_rpm=0,
+    )
+    factory = LLMService._adapter_registry["deepseek"]
+    adapter = factory(model=FLASH, api_key="sk-test", defaults=defaults["deepseek"])
+    assert adapter._inject_reasoning_fallback is False
+    assert adapter._prompt_cache_namespace == "custom-ns"
+
+
+def test_explicit_deepseek_reasoning_effort_vocab_fails_init_validation():
+    """Fail closed and say why — never silently ignore a user's setting."""
+    data = _init_data(
+        {
+            "provider": "deepseek",
+            "model": FLASH,
+            "api_key": "k",
+            "reasoning_effort_vocab": "seven_tier",
+        }
+    )
+    with pytest.raises(ValueError) as exc:
+        validate_init(data)
+    msg = str(exc.value)
+    assert "reasoning_effort_vocab" in msg
+    assert "deepseek" in msg.lower()
+
+
+def test_explicit_deepseek_reasoning_effort_vocab_fails_preset_validation(tmp_path):
+    import json
+
+    from lingtai.agent import load_preset
+
+    path = tmp_path / "ds-vocab.json"
+    path.write_text(json.dumps({
+        "name": str(path),
+        "description": {"summary": "deepseek preset"},
+        "manifest": {
+            "llm": {
+                "provider": "deepseek",
+                "model": FLASH,
+                "api_key": "k",
+                "reasoning_effort_vocab": "seven_tier",
+            },
+            "capabilities": {},
+        },
+    }))
+    with pytest.raises(ValueError, match="reasoning_effort_vocab"):
+        load_preset(str(path))
+
+
+@pytest.mark.parametrize("provider", ["openai", "custom"])
+def test_reasoning_effort_vocab_still_works_for_other_routes(provider):
+    """A7 leakage guard: the generic knob is untouched off the DeepSeek route."""
+    register_all_adapters()
+    data = _init_data(
+        {
+            "provider": provider,
+            "model": "m",
+            "api_key": "k",
+            "base_url": "https://example.invalid/v1",
+            "reasoning_effort_vocab": "seven_tier",
+        }
+    )
+    validate_init(data)
+
+    factory = LLMService._adapter_registry[provider]
+    kw = {
+        "model": "m",
+        "api_key": "sk-test",
+        "defaults": {"reasoning_effort_vocab": "seven_tier"},
+    }
+    if provider != "openai":
+        kw["base_url"] = "https://example.invalid/v1"
+    adapter = factory(**kw)
+    assert adapter._reasoning_effort_vocab == "seven_tier"
+    assert adapter._chat_reasoning_effort("default") == "xhigh"
+
+
+# --- A8: generic service holds no provider branch (parent amendment 1) ------
+
+
+def test_generic_llm_service_source_never_names_deepseek():
+    """Structural: the provider switch must not live in the generic service.
+
+    A provider name in ``llm/service.py`` is how Kimi/GLM/Claude branches would
+    accumulate there. Resolution belongs to the already-selected adapter.
+    """
+    import pathlib
+
+    import lingtai.llm.service as service_mod
+
+    source = pathlib.Path(service_mod.__file__).read_text()
+    assert "deepseek" not in source.lower()
+
+
+def test_generic_llm_service_module_has_no_deepseek_import():
+    """Dependency: no import of the provider package, at any nesting level."""
+    import ast
+    import pathlib
+
+    import lingtai.llm.service as service_mod
+
+    tree = ast.parse(pathlib.Path(service_mod.__file__).read_text())
+    imported: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported += [a.name for a in node.names]
+        elif isinstance(node, ast.ImportFrom):
+            imported.append(node.module or "")
+            imported += [f"{node.module or ''}.{a.name}" for a in node.names]
+    assert not [m for m in imported if "deepseek" in m.lower()], imported
+
+
+def test_adapter_hook_default_preserves_the_legacy_fallback():
+    """Every adapter inherits the non-owning legacy rule unchanged."""
+    from lingtai.kernel.config import LEGACY_MAIN_SESSION_THINKING
+
+    register_all_adapters()
+    adapter = LLMService._adapter_registry["openai"](
+        model="m", api_key="sk-test", defaults={}
+    )
+    assert adapter.resolve_configured_thinking(None) == LEGACY_MAIN_SESSION_THINKING
+    assert adapter.resolve_configured_thinking("") == LEGACY_MAIN_SESSION_THINKING
+    assert adapter.resolve_configured_thinking("xhigh") == "xhigh"
+
+
+def test_openai_adapter_delegates_the_hook_to_its_installed_controller():
+    """DeepSeek's omission rule arrives through the controller, not a branch."""
+    assert _deepseek_adapter().resolve_configured_thinking(None) == "default"
+    # falsey-but-not-None stays verbatim so the contract can reject it
+    assert _deepseek_adapter().resolve_configured_thinking("") == ""
+    assert _deepseek_adapter().resolve_configured_thinking("max") == "max"
+
+
+def test_create_session_consults_only_the_selected_adapter_hook():
+    """Behavioral: whatever the selected adapter resolves is what is used."""
+    from lingtai.llm.base import LLMAdapter
+
+    seen: dict = {}
+
+    class _StubAdapter(LLMAdapter):
+        def resolve_configured_thinking(self, thinking):
+            return "adapter-owned"
+
+        def create_chat(self, model, system_prompt, **kwargs):
+            seen["thinking"] = kwargs.get("thinking")
+            return MagicMock()
+
+        def generate(self, *a, **kw):  # pragma: no cover - unused
+            raise NotImplementedError
+
+        def make_tool_result_message(self, *a, **kw):  # pragma: no cover
+            raise NotImplementedError
+
+        def is_quota_error(self, *a, **kw):  # pragma: no cover
+            return False
+
+    service = LLMService(provider="openai", model="m", api_key="sk-test")
+    service.get_adapter = lambda *a, **kw: _StubAdapter()
+    service.create_session(system_prompt="sys", thinking=None, tracked=False)
+    assert seen["thinking"] == "adapter-owned"
+
+
+# --- A9: conflicting extra_body must not falsify observation ----------------
+
+
+def _assert_decision_is_consistent(session, *, emitted, effort):
+    """The wire, the captured application, and observation must agree."""
+    body = session._extra_kwargs.get("extra_body") or {}
+    applied = session.reasoning_application
+    fields = applied.observation_fields()
+    assert body["thinking"] == {"type": emitted}
+    assert applied.payload["extra_body"]["thinking"] == {"type": emitted}
+    assert fields["effort_emitted"] == effort
+    assert session._extra_kwargs.get("reasoning_effort") == (
+        None if effort == "disabled" else effort
+    )
+
+
+def test_conflicting_caller_extra_body_keeps_wire_and_observation_in_step():
+    """A controller-owned key stays authoritative; unrelated keys survive."""
+    adapter = _deepseek_adapter()
+    extra_kwargs = {
+        "extra_body": {
+            "thinking": {"type": "disabled"},  # a lie the controller must win
+            "unrelated_caller_key": "kept",
+        }
+    }
+    applied = adapter._apply_reasoning_control(
+        model=FLASH, wire="chat_completions", thinking="max",
+        extra_kwargs=extra_kwargs,
+    )
+    body = extra_kwargs["extra_body"]
+    assert body["thinking"] == {"type": "enabled"}
+    assert body["unrelated_caller_key"] == "kept"
+    assert extra_kwargs["reasoning_effort"] == "max"
+    assert applied.observation_fields()["effort_emitted"] == "max"
+
+
+def test_conflicting_subclass_extra_body_keeps_wire_and_observation_in_step():
+    """A subclass ``_adapter_extra_body()`` must not rewrite the decision."""
+    adapter = _deepseek_adapter()
+    adapter._adapter_extra_body = lambda: {
+        "thinking": {"type": "disabled"},
+        "subclass_key": "kept",
+    }
+    iface = ChatInterface()
+    iface.add_system("sys")
+    session = adapter.create_chat(
+        model=FLASH, system_prompt="sys", interface=iface, thinking="max"
+    )
+    assert session._extra_kwargs["extra_body"]["subclass_key"] == "kept"
+    _assert_decision_is_consistent(session, emitted="enabled", effort="max")
+    _sdk_chat_signature().bind(
+        model=FLASH, messages=[], **dict(session._extra_kwargs)
+    )
+
+
+def test_conflicting_extra_body_on_a_disabled_decision_stays_consistent():
+    adapter = _deepseek_adapter()
+    adapter._adapter_extra_body = lambda: {
+        "thinking": {"type": "enabled"},
+        "subclass_key": "kept",
+    }
+    iface = ChatInterface()
+    iface.add_system("sys")
+    session = adapter.create_chat(
+        model=FLASH, system_prompt="sys", interface=iface, thinking="none"
+    )
+    assert session._extra_kwargs["extra_body"]["subclass_key"] == "kept"
+    _assert_decision_is_consistent(session, emitted="disabled", effort="disabled")
+
+
+def test_conflicting_extra_body_leaves_responses_wire_untouched():
+    adapter = _deepseek_adapter(wire="responses")
+    adapter._adapter_extra_body = lambda: {"subclass_key": "kept"}
+    iface = ChatInterface()
+    iface.add_system("sys")
+    session = adapter.create_chat(
+        model=FLASH, system_prompt="sys", interface=iface, thinking="max"
+    )
+    assert session._extra_kwargs["reasoning"] == {"effort": "max"}
+    assert session.reasoning_application.observation_fields()["effort_emitted"] == "max"
+
+
+def test_global_thinking_levels_are_not_extended():
+    """No DeepSeek vocabulary leaks into the kernel-global tuple."""
+    assert THINKING_LEVELS == (
+        "none", "minimal", "low", "medium", "high", "xhigh", "max"
+    )
+
+
+# ---------------------------------------------------------------------------
+# clause 8 — exact observation derived from the real applied result
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "model,wire,thinking,normalized,emitted,provenance",
+    [
+        (FLASH, "chat_completions", "default", "default", "omitted", "omitted"),
+        (FLASH, "chat_completions", "none", "none", "disabled", "explicit_config"),
+        (FLASH, "chat_completions", "low", "low", "low", "explicit_config"),
+        (FLASH, "chat_completions", "xhigh", "high", "high", "compat_alias"),
+        (PRO, "chat_completions", "xhigh", "max", "max", "compat_alias"),
+        (FLASH, "responses", "default", "default", "omitted", "omitted"),
+        (FLASH, "responses", "max", "max", "max", "explicit_config"),
+    ],
+)
+def test_applied_result_records_requested_normalized_emitted(
+    model, wire, thinking, normalized, emitted, provenance
+):
+    applied = _applied(model, thinking, wire=wire)
+    assert applied is not None
+    assert applied.provider == "deepseek"
+    assert applied.wire == wire
+    assert applied.requested == thinking
+    assert applied.normalized == normalized
+    assert applied.emitted == emitted
+    assert applied.provenance == provenance
+
+
+def test_llm_call_observation_comes_from_the_applied_result(monkeypatch):
+    """The llm_call event must report the REAL applied patch, not raw config."""
+    import lingtai.kernel.session as session_mod
+
+    manager, events = _session_manager("xhigh", model=PRO)
+    monkeypatch.setattr(
+        session_mod, "send_with_timeout", lambda **kw: LLMResponse(text="ok")
+    )
+    manager.send("hello")
+
+    calls = [f for t, f in events if t == "llm_call"]
+    assert calls, "no llm_call event was logged"
+    fields = calls[-1]
+    assert fields["provider"] == "deepseek"
+    assert fields["wire"] == "chat_completions"
+    assert fields["effort_requested"] == "xhigh"
+    assert fields["effort_normalized"] == "max"
+    assert fields["effort_emitted"] == "max"
+    assert fields["effort_provenance"] == "compat_alias"
+    # bounded, plain strings only — no payloads, prompts, or credentials
+    assert all(isinstance(v, str) for v in fields.values())
+
+
+# --- A3: the captured application is deeply immutable (parent amendment 1) ---
+
+
+@pytest.mark.parametrize(
+    "model,wire,thinking,path",
+    [
+        (FLASH, "chat_completions", "max", ("extra_body", "thinking")),
+        (FLASH, "responses", "max", ("reasoning",)),
+    ],
+)
+def test_captured_payload_is_recursively_immutable(model, wire, thinking, path):
+    """Every nesting level of the captured payload must reject mutation."""
+    applied = _applied(model, thinking, wire=wire)
+    node = applied.payload
+    for key in path:
+        with pytest.raises(TypeError):
+            node["injected"] = "tampered"
+        node = node[key]
+    with pytest.raises(TypeError):
+        node["type"] = "tampered"
+
+
+def test_request_kwargs_returns_a_deep_mutable_copy():
+    """The SDK needs plain mutable kwargs; the capture must stay frozen."""
+    applied = _applied(FLASH, "max")
+    kwargs = applied.request_kwargs()
+
+    assert kwargs == {
+        "reasoning_effort": "max",
+        "extra_body": {"thinking": {"type": "enabled"}},
+    }
+    assert type(kwargs) is dict
+    assert type(kwargs["extra_body"]) is dict
+    assert type(kwargs["extra_body"]["thinking"]) is dict
+
+    kwargs["extra_body"]["thinking"]["type"] = "disabled"
+    kwargs["reasoning_effort"] = "tampered"
+    kwargs["injected"] = True
+
+    assert applied.payload["extra_body"]["thinking"]["type"] == "enabled"
+    assert applied.payload["reasoning_effort"] == "max"
+    assert "injected" not in applied.payload
+    assert applied.observation_fields()["effort_emitted"] == "max"
+
+    # each call hands out an independent copy
+    assert (
+        applied.request_kwargs()["extra_body"]["thinking"]
+        is not kwargs["extra_body"]["thinking"]
+    )
+
+
+def test_mutating_session_request_kwargs_cannot_alter_the_capture():
+    """The adapter must merge a COPY, not alias the frozen payload."""
+    adapter = _deepseek_adapter()
+    iface = ChatInterface()
+    iface.add_system("sys")
+    session = adapter.create_chat(
+        model=FLASH, system_prompt="sys", interface=iface, thinking="max"
+    )
+    applied = session.reasoning_application
+
+    # what the SDK receives is plain and mutable...
+    assert type(session._extra_kwargs["extra_body"]["thinking"]) is dict
+    session._extra_kwargs["extra_body"]["thinking"]["type"] = "disabled"
+    session._extra_kwargs["reasoning_effort"] = "tampered"
+
+    # ...but the captured application and its observation are untouched
+    assert applied.payload["extra_body"]["thinking"]["type"] == "enabled"
+    assert applied.payload["reasoning_effort"] == "max"
+    assert applied.observation_fields() == {
+        "provider": "deepseek",
+        "wire": "chat_completions",
+        "effort_requested": "max",
+        "effort_normalized": "max",
+        "effort_emitted": "max",
+        "effort_provenance": "explicit_config",
+    }
+
+
+# --- A6: the real OpenAI SDK Chat signature (parent amendment 1) ------------
+
+
+def test_installed_sdk_chat_signature_has_no_thinking_and_no_var_kwargs():
+    """Pin the constraint that makes A6 a real wire blocker, not a style point."""
+    import inspect
+
+    sig = _sdk_chat_signature()
+    assert "thinking" not in sig.parameters
+    assert "reasoning_effort" in sig.parameters
+    assert "extra_body" in sig.parameters
+    assert not any(
+        p.kind is inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()
+    )
+
+
+@pytest.mark.parametrize("thinking", ["max", "none", "high"])
+def test_composed_chat_request_binds_against_the_real_sdk_signature(thinking):
+    """The exact composed request must be callable on the REAL SDK.
+
+    A permissive fake client accepts anything; the installed SDK raises
+    ``TypeError`` before any HTTP request for an unexpected keyword. Binding the
+    real signature is the only honest local proof that the request is well
+    formed.
+    """
+    extra = _extra(FLASH, thinking)
+    assert "thinking" not in extra, (
+        "``thinking`` must never be a top-level SDK keyword — "
+        "the installed SDK has no such parameter and no **kwargs"
+    )
+    _sdk_chat_signature().bind(model=FLASH, messages=[], **extra)
+
+
+def test_chat_thinking_travels_in_extra_body_with_native_flat_effort():
+    extra = _extra(FLASH, "max")
+    assert extra["extra_body"] == {"thinking": {"type": "enabled"}}
+    assert extra["reasoning_effort"] == "max"
+    assert "thinking" not in extra
+
+
+def test_chat_disabled_thinking_travels_in_extra_body():
+    extra = _extra(FLASH, "none")
+    assert extra["extra_body"] == {"thinking": {"type": "disabled"}}
+    assert "reasoning_effort" not in extra
+    assert "thinking" not in extra
+
+
+def test_responses_payload_shape_is_unchanged_by_the_extra_body_move():
+    """A6 must not disturb the Responses wire, which has no ``thinking``."""
+    extra = _extra(FLASH, "max", wire="responses")
+    assert extra["reasoning"] == {"effort": "max"}
+    assert "extra_body" not in extra
+
+
+def test_reasoning_extra_body_merge_preserves_caller_and_subclass_fields():
+    """Composition must not lose either side of ``extra_body``."""
+    adapter = _deepseek_adapter()
+    # a subclass/provider contribution, as OpenRouter does
+    adapter._adapter_extra_body = lambda: {"subclass_key": "kept"}
+    iface = ChatInterface()
+    iface.add_system("sys")
+    session = adapter.create_chat(
+        model=FLASH, system_prompt="sys", interface=iface, thinking="max"
+    )
+    body = session._extra_kwargs["extra_body"]
+    assert body["thinking"] == {"type": "enabled"}
+    assert body["subclass_key"] == "kept"
+    _sdk_chat_signature().bind(
+        model=FLASH, messages=[], **dict(session._extra_kwargs)
+    )
+
+
+def test_reasoning_merge_does_not_clobber_a_preexisting_extra_body():
+    """The neutral merge composes rather than overwrites."""
+    from lingtai.llm.deepseek.reasoning import DeepSeekReasoningController
+
+    adapter = _deepseek_adapter()
+    extra_kwargs = {"extra_body": {"caller_key": "kept"}}
+    applied = adapter._apply_reasoning_control(
+        model=FLASH,
+        wire="chat_completions",
+        thinking="max",
+        extra_kwargs=extra_kwargs,
+    )
+    assert applied is not None
+    assert extra_kwargs["extra_body"]["caller_key"] == "kept"
+    assert extra_kwargs["extra_body"]["thinking"] == {"type": "enabled"}
+    assert "thinking" not in extra_kwargs
+    assert isinstance(adapter._reasoning_controller, DeepSeekReasoningController)
+
+
+def test_rejected_effort_is_never_observed_because_no_call_is_made():
+    manager, events = _session_manager("low", model=PRO)
+    with pytest.raises(ValueError):
+        manager.ensure_session()
+    assert [t for t, _ in events if t == "llm_call"] == []
+
+
+# ---------------------------------------------------------------------------
+# clause 9 — REST and streaming share one physical builder
+# ---------------------------------------------------------------------------
+
+
+def test_rest_and_streaming_emit_identical_reasoning_fields():
+    """Both send paths read the ONE per-session extra-kwargs dict.
+
+    There is no separate streaming reasoning builder to keep in sync, so this
+    drives the real REST and streaming request builders and compares what each
+    actually put on the wire.
+    """
+    from tests._chat_completion_helpers import make_raw_response
+
+    adapter = _deepseek_adapter()
+    iface = ChatInterface()
+    iface.add_system("sys")
+    session = adapter.create_chat(
+        model=FLASH, system_prompt="sys", interface=iface, thinking="max"
+    )
+
+    client = MagicMock()
+    client.chat.completions.create.return_value = make_raw_response(content="ok")
+    session._client = client
+    session.send("hello")
+    rest_kwargs = client.chat.completions.create.call_args.kwargs
+
+    stream_client = MagicMock()
+    stream_client.chat.completions.create.return_value = iter(())
+    session._client = stream_client
+    session.send_stream("hello again")
+    stream_kwargs = stream_client.chat.completions.create.call_args.kwargs
+
+    reasoning_keys = ("thinking", "reasoning_effort", "extra_body")
+    rest_reasoning = {k: rest_kwargs.get(k) for k in reasoning_keys}
+    stream_reasoning = {k: stream_kwargs.get(k) for k in reasoning_keys}
+
+    assert rest_reasoning == {
+        "thinking": None,
+        "reasoning_effort": "max",
+        "extra_body": {"thinking": {"type": "enabled"}},
+    }
+    assert stream_reasoning == rest_reasoning
+    assert stream_kwargs["stream"] is True
+
+
+# ---------------------------------------------------------------------------
+# clause 11 — soul's explicit "high"
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "model,wire,expected",
+    [
+        (FLASH, "chat_completions",
+         {"extra_body": {"thinking": {"type": "enabled"}}, "reasoning_effort": "high"}),
+        (PRO, "chat_completions",
+         {"extra_body": {"thinking": {"type": "enabled"}}, "reasoning_effort": "high"}),
+        (FLASH, "responses", {"reasoning": {"effort": "high"}}),
+    ],
+)
+def test_soul_explicit_high_remains_valid(model, wire, expected):
+    """Soul passes a literal ``thinking="high"``; it must stay supported.
+
+    The exact emitted shape is pinned per wire so this cannot pass for the
+    wrong reason.
+    """
+    extra = _extra(model, "high", wire=wire)
+    assert {k: extra.get(k) for k in expected} == expected
+
+
+# ---------------------------------------------------------------------------
+# clause 12 — no leakage into other OpenAI-compatible routes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("provider", ["openai", "custom", "kimi", "grok", "qwen"])
+def test_other_providers_get_no_deepseek_reasoning_controller(provider):
+    register_all_adapters()
+    factory = LLMService._adapter_registry[provider]
+    kw: dict = {"model": "m", "api_key": "sk-test", "defaults": {}}
+    if provider != "openai":
+        # the custom-compat family requires an explicit endpoint
+        kw["base_url"] = "https://example.invalid/v1"
+    adapter = factory(**kw)
+    assert getattr(adapter, "_reasoning_controller", None) is None
+
+
+def test_generic_seven_tier_vocab_behavior_is_unchanged():
+    """A non-DeepSeek provider on the seven_tier vocab keeps current-main
+    semantics: omitted -> explicit xhigh, levels pass through."""
+    register_all_adapters()
+    factory = LLMService._adapter_registry["openai"]
+    adapter = factory(
+        model="m", api_key="sk-test", defaults={"reasoning_effort_vocab": "seven_tier"}
+    )
+    assert adapter._chat_reasoning_effort("default") == "xhigh"
+    assert adapter._chat_reasoning_effort("none") == "none"
+    assert adapter._chat_reasoning_effort("medium") == "medium"
+
+
+def test_codex_responses_reasoning_kwargs_are_unchanged():
+    from lingtai.llm.openai.adapter import _responses_reasoning_kwargs
+
+    assert _responses_reasoning_kwargs("default") == {"reasoning": {"effort": "xhigh"}}
+    assert _responses_reasoning_kwargs("none") == {"reasoning": {"effort": "none"}}
+    assert _responses_reasoning_kwargs("medium") == {"reasoning": {"effort": "medium"}}

--- a/tests/test_init_schema.py
+++ b/tests/test_init_schema.py
@@ -300,17 +300,52 @@ def test_llm_thinking_valid_for_custom_openai_responses(value):
     validate_init(data)
 
 
-@pytest.mark.parametrize("value", ["none", "minimal", "low", "medium", "high", "xhigh", "max"])
+@pytest.mark.parametrize("value", ["low", "high", "max"])
 def test_llm_thinking_valid_for_deepseek_responses(value):
-    # DeepSeek is OpenAI-compatible; Responses wire accepts thinking by default.
+    """DeepSeek owns its effort contract; Responses accepts exactly low|high|max.
+
+    This route used to inherit the generic "any kernel level on the Responses
+    wire" rule. DeepSeek's Responses guide documents no thinking-disable and no
+    compatibility alias, and notes that unsupported parameters may be silently
+    ignored — so anything else now fails locally instead of being sent and
+    quietly dropped. See tests/test_deepseek_reasoning_effort.py.
+    """
     data = _valid_init()
     data["manifest"]["llm"].update(
         {
             "provider": "deepseek",
+            "model": "deepseek-v4-flash",
             "api_compat": "openai",
             "wire_api": "responses",
             "thinking": value,
         }
+    )
+    validate_init(data)
+
+
+@pytest.mark.parametrize("value", ["none", "minimal", "medium", "xhigh"])
+def test_llm_thinking_outside_deepseek_responses_set_is_rejected(value):
+    data = _valid_init()
+    data["manifest"]["llm"].update(
+        {
+            "provider": "deepseek",
+            "model": "deepseek-v4-flash",
+            "api_compat": "openai",
+            "wire_api": "responses",
+            "thinking": value,
+        }
+    )
+    with pytest.raises(ValueError, match="deepseek"):
+        validate_init(data)
+
+
+@pytest.mark.parametrize("value", ["none", "low", "high", "max", "medium", "xhigh"])
+def test_llm_thinking_valid_for_deepseek_chat_completions(value):
+    """The default DeepSeek wire is Chat Completions, which was previously
+    rejected outright even for levels the model really has."""
+    data = _valid_init()
+    data["manifest"]["llm"].update(
+        {"provider": "deepseek", "model": "deepseek-v4-flash", "thinking": value}
     )
     validate_init(data)
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -71,11 +71,24 @@ def test_ensure_session_passes_interaction_id():
     assert call_kwargs["interaction_id"] == "int-123"
 
 
-def test_ensure_session_defaults_thinking_to_high():
+def test_ensure_session_forwards_omitted_thinking_verbatim():
+    """An unset ``AgentConfig.thinking`` reaches the service as the omission.
+
+    Resolving an omitted level is provider knowledge and now belongs to the LLM
+    layer — specifically the selected adapter's ``resolve_configured_thinking``
+    hook, which still applies the legacy ``high`` for every route that does not
+    own its own omitted-effort default. The kernel no longer fabricates a level
+    of its own, and the generic service holds no provider branch.
+
+    End-to-end proof that a non-DeepSeek route still reaches its adapter as
+    ``high`` lives in
+    tests/test_deepseek_reasoning_effort.py::test_programmatic_agentconfig_omission_keeps_legacy_high_off_deepseek
+    (real ``LLMService`` + real adapter, asserting the emitted wire field).
+    """
     sm, svc, _ = make_session_manager()
     sm.ensure_session()
     call_kwargs = svc.create_session.call_args.kwargs
-    assert call_kwargs["thinking"] == "high"
+    assert call_kwargs["thinking"] is None
 
 
 def test_ensure_session_uses_configured_thinking():
@@ -526,7 +539,9 @@ def test_rebuild_session_uses_current_prompt_and_tools():
     assert call_kw["system_prompt"] == "test prompt"
     assert call_kw["tools"] is None  # [] is falsy → or None
     assert call_kw["model"] == "test-model"
-    assert call_kw["thinking"] == "high"
+    # Omitted config level forwarded verbatim; the LLM layer resolves it.
+    # See test_ensure_session_forwards_omitted_thinking_verbatim.
+    assert call_kw["thinking"] is None
     assert call_kw["tracked"] is True
     assert call_kw["agent_type"] == "test"
     assert call_kw["provider"] is None


### PR DESCRIPTION
## Summary

Add a DeepSeek-owned reasoning-effort contract for the actual model/API combinations LingTai supports today, without reintroducing a cross-provider semantic matrix.

- `deepseek-v4-flash`: Chat Completions and Responses
- `deepseek-v4-pro`: Chat Completions only
- preserve omission as omission, allowing DeepSeek's own default behavior
- validate explicit effort against the selected model and wire before request construction
- emit the real DeepSeek request shape and record the exact applied decision on `llm_call`
- keep OpenAI/custom/Kimi/Codex behavior unchanged
- give main-agent and native-daemon initial configuration the same omission semantics

Related: #1197

## Behavior

| Model / API | Supported configured values | Wire result |
|---|---|---|
| Flash / Chat | `none`, `low`, `high`, `max`; `medium`/`xhigh` compatibility aliases | `extra_body.thinking.type` plus flat `reasoning_effort` when enabled |
| Pro / Chat | `none`, `high`, `max`; `medium` → `high`, `xhigh` → `max` | `extra_body.thinking.type` plus flat `reasoning_effort` when enabled |
| Flash / Responses | `low`, `high`, `max` | nested `reasoning.effort` |
| Pro / Responses | unsupported | rejected before SDK/network dispatch |
| Any supported route / omitted | Auto/default | no DeepSeek reasoning fields are added |

Explicit unsupported values and explicit effort on an unknown DeepSeek model fail closed. Unknown future models with omitted effort remain forward-compatible.

## Ownership and observation

Provider semantics live in `src/lingtai/llm/deepseek/reasoning.py`: model/wire capability, aliases, omission/default behavior, validation, payload construction, and immutable applied-result capture. Generic layers expose only neutral hooks/carriers and contain no executable DeepSeek branch.

The real session stores one immutable `ReasoningApplication`. Both request construction and six bounded `llm_call` fields use that same applied decision, so wire behavior and observation cannot drift through a parallel recomputation.

## Test-first evidence

Authentic behavioral RED was preserved before production changes:

- A1–A5: 9 failed / 91 passed (8 intended behavioral failures)
- A6–A7: 29 failed / 108 passed
- A8–A10: 6 failed / 118 passed (4 intended plus 2 prescribed missing-hook failures)

Final parent validation on exact head `9feff803a2a9e616a8e1803545b070333d7824f0`:

- focused DeepSeek contract: 124 passed
- affected exact gate: 564 passed
- adjacent gate: 450 passed / 3 exact-base inherited failures
- docs/Anatomy gate: 139 passed / 8 exact-base inherited failures
- compile, diff-check, scope, staging, and clean-worktree checks passed

Fresh independent literal `claude-opus-5 --effort high --permission-mode plan` exact-head review: **PASS**, 0 P0 / 0 P1. The reviewer independently reran focused 124, affected 564, 130 reviewer-owned checks, exact-base inherited comparisons, real SDK signature binding, and behavioral base replay.

## Non-blocking review notes

The exact-head reviewer recorded six P2 notes that do not change emitted wire behavior, observation, or any other provider:

- omitted-thinking Pro + Responses can fail earlier during init/preset validation; runtime already rejects it before any SDK/network call
- four generic prose/Anatomy truthfulness updates remain
- `thinking` type annotations can be widened to `str | None`

Any change to the reviewed head will receive fresh parent validation and a fresh literal Opus 5 exact-head review before replacement.

## Scope

This PR does not implement process-local live effort control, persistence/lifecycle, the operator protocol, TUI `/effort`, daemon-local live overrides, or another provider. Those remain separate model-by-model and live-control slices under #1197.
