### PR TITLE
fix(daemon): partial finish, provider_defaults, plugin paths, per-batch timeout, taskcard nudges (squash #1320+#1279+#1248+#1247+#1221)

### DIFF
--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -1343,6 +1343,17 @@ def _parse_tool_calls(raw_tool_calls) -> list[ToolCall]:
 
 def _parse_response(raw) -> LLMResponse:
     """Parse a raw OpenAI ChatCompletion into a provider-agnostic LLMResponse."""
+    if not hasattr(raw, "choices"):
+        # Defense-in-depth: a non-conforming gateway (e.g. an OpenAI-compatible
+        # endpoint that returns a scalar string) must surface a typed protocol
+        # error instead of failing through a bare attribute dereference. This
+        # is deliberately a TypeError, not a ValueError: the response object
+        # has the wrong type, not merely an empty payload.
+        raise TypeError(
+            "OpenAI-compatible endpoint returned a non-ChatCompletion response "
+            "(expected an object with a `choices` list); check the provider's "
+            "wire_api/endpoint compatibility"
+        )
     if not raw.choices:
         return LLMResponse(raw=raw)
 

--- a/src/lingtai/prompts/procedures/procedures.md
+++ b/src/lingtai/prompts/procedures/procedures.md
@@ -168,9 +168,12 @@ operations, preset swaps, notification handling, and karma actions.
 
 ### Task Card Lifecycle
 
-Start a `task_card` watch only for meaningful ongoing work a human is
-following; skip it for quick single-step work or ritual updates. Keep the
-rendered body truthful and current while it runs, and optionally `retry` once
+Start a `task_card` watch for meaningful long-running or parallel work a human
+is following: multi-daemon fleets (two or more), multi-PR batches, long
+review→merge flows, anything running past roughly ten minutes. Skip it for
+quick single-step work or ritual updates. When a watch expires mid-task
+(`max_refreshes`), start a new watch rather than letting the card go dark.
+Keep the rendered body truthful and current while it runs, and optionally `retry` once
 more to publish a final state before winding down. Use `stop` to pause a watch
 while preserving its last body; use `remove` once the work is completed,
 cancelled, or abandoned so `/taskcard` and other consumers cannot keep

--- a/src/lingtai/tools/daemon/CONTRACT.md
+++ b/src/lingtai/tools/daemon/CONTRACT.md
@@ -7,8 +7,8 @@ description: >
   daemon_common completion signaling, support-status honesty, run artifacts,
   terminal notifications, and compaction boundaries.
 status: active
-contract_version: 8
-last_changed_at: "2026-08-09"
+contract_version: 9
+last_changed_at: "2026-08-10"
 related_files:
   - src/lingtai/tools/daemon/ANATOMY.md
   - src/lingtai/tools/daemon/__init__.py
@@ -39,6 +39,7 @@ related_files:
   - src/lingtai/llm/openai/ANATOMY.md
   - src/lingtai/llm/mimo/ANATOMY.md
   - tests/test_daemon_contract_doc.py
+  - tests/test_task_card_proactivity.py
   - tests/test_tool_family_daemon_migration.py
   - tests/test_daemon.py
   - tests/test_daemon_empty_parity.py
@@ -270,6 +271,19 @@ conditional: use the Task Card only when Telegram is connected and a Task Card
 is available for the current turn, and read `telegram(action='manual')` for the
 `Programmable Task Card` details. Daemon does not create or require a watcher
 and does not import or call Telegram/Task Card runtime code.
+
+A card-worthy dispatch — two or more tasks in the batch, or an explicitly
+requested `timeout` at or above 900s — additionally appends one nudge sentence
+to `handoff` naming the dispatched count and suggesting
+`task_card(action='start')`. An omitted `timeout` never qualifies on its own:
+the default ceiling describes no actual run length, so a single daemon
+dispatched without an explicit long `timeout` is not card-worthy. The nudge
+also appears only when the agent has the Task Card capability enabled and no
+watch is currently active, so a quick single daemon, an agent with the
+capability disabled, and a fleet dispatched under a live card all receive the
+plain `handoff` unchanged. The active-watch check is a duck-typed read-only
+probe; daemon still imports no Task Card runtime code and never starts a watch
+itself.
 
 ## Capability Invariants
 
@@ -789,6 +803,7 @@ Re-check this contract when touching:
 | `_DaemonMetaState.snapshot` carries `agent_state.context.system_prompt` only while this daemon's own local rendered prompt is strictly above the effective `LINGTAI_SYSTEM_PROMPT_PRESSURE_RATIO` threshold (default 40%) of its own resolved window, never the parent's | `src/lingtai/tools/daemon/__init__.py`, `src/lingtai/kernel/meta_block.py` | `tests/test_daemon.py::test_daemon_meta_state_system_prompt_warning_is_local_not_parent` |
 | `compact.action` is required; `manual` is read-only, omission is refused, and explicit `run` resets with fresh post-compact metadata | `src/lingtai/tools/daemon/__init__.py` | `tests/test_daemon.py::test_compact_schema_requires_explicit_run_or_manual_action`, `::test_compact_missing_action_is_refused_without_reset`, `::test_compact_success_prunes_to_system_call_and_result` |
 | `reclaim` cancels running emanations; agent stop shuts the daemon down first | `src/lingtai/tools/daemon/__init__.py` | `tests/test_lifecycle_daemon_shutdown.py::test_agent_stop_shuts_down_daemon_before_heartbeat_and_lock` |
+| `emanate`'s explicit `timeout` (schema: `minimum: 5`, no `maximum`) is an uncapped override reaching `daemon.json` and `supervisor_manifest.json` unchanged; omitting it (`null`) falls back to the manager's default. Unlike `timeout`, `max_turns` has a schema `maximum` and IS capped at the manager's ceiling. | `src/lingtai/tools/daemon/__init__.py` | `tests/test_daemon_per_batch_limits.py::test_emanate_honors_explicit_timeout_above_default_ceiling`, `::test_emanate_caps_max_turns_at_ceiling` |
 
 ## Verification Matrix
 

--- a/src/lingtai/tools/daemon/CONTRACT.md
+++ b/src/lingtai/tools/daemon/CONTRACT.md
@@ -224,6 +224,17 @@ rejects the obsolete field before run-dir creation or scheduling. External CLI
 backend tasks reject `prompt` before run-dir creation; CLI behavior remains
 task-as-CLI-prompt.
 
+Optional `tasks[].plugin` is an array of Agent Plugin path strings for this
+one daemon run. Each path resolves against the parent agent's working
+`plugin/` directory; the LingTai backend renders a `## Parent-selected plugins`
+oneshot-context section into the durable `.prompt` the detached child reads,
+merges each plugin's validated `skills/` rows into the task skill catalog, and
+mounts each plugin's validated `mcp.json` servers as task-scoped MCP clients.
+A missing or unreadable plugin path resolves to nothing without failing the
+task; a non-list value fails preflight before run-dir creation. External CLI
+backends receive the plugin's skills and MCP registrations through the normal
+skill/mcp oneshot context and mount no plugin-native surface.
+
 LingTai-backend daemon LLM construction uses one effective context window:
 an explicit daemon preset's canonical `manifest.llm.context_limit` wins,
 otherwise an implicit/no-preset daemon inherits the parent service's valid
@@ -255,7 +266,7 @@ continues on full history and never falls back to a different wire).
 
 | Action | Required inputs | Optional inputs | Success output | Error shapes |
 |---|---|---|---|---|
-| `emanate` | `tasks[]` (each `task`+`tools`) | `backend`, `max_turns`, `timeout`, per-task `prompt` (LingTai only), `skills`/`mcp`/`preset`/`backend_options`/`context_token_limit` | `{status: "dispatched", count, ids: [...], group_id, handoff}`; `handoff` tells the model it may go idle or call `system(action='sleep')` while waiting for the terminal notification, and conditionally says that if Telegram is connected and a Task Card is available for the current turn, the model should use it to report progress via `telegram(action='manual')` and that manual's `Programmable Task Card` section; read `daemon-manual` and `notification-manual` for details | `{status: "error", message}` — obsolete `system_prompt` migration, CLI `prompt`, bad limits, or tool-surface/preset failure |
+| `emanate` | `tasks[]` (each `task`+`tools`) | `backend`, `max_turns`, `timeout`, per-task `prompt` (LingTai only), `skills`/`mcp`/`preset`/`backend_options`/`context_token_limit`/`plugin` | `{status: "dispatched", count, ids: [...], group_id, handoff}`; `handoff` tells the model it may go idle or call `system(action='sleep')` while waiting for the terminal notification, and conditionally says that if Telegram is connected and a Task Card is available for the current turn, the model should use it to report progress via `telegram(action='manual')` and that manual's `Programmable Task Card` section; read `daemon-manual` and `notification-manual` for details | `{status: "error", message}` — obsolete `system_prompt` migration, CLI `prompt`, bad limits, or tool-surface/preset failure |
 | `list` | — | `contains`, `status`, `include_done` (default true), `last` | `{...}` list blob of matching emanations (running + persisted history) | `{status: "error", message}` |
 | `ask` | `id`, `message` | — | `{status: "sent", id, output}` (CLI ask returns immediately; `{status: "sent", id, async: true, ...}`) | `{status: "error", id, message}` — unknown/absent id, backend `ask` unsupported, or busy |
 | `check` | `id` | `last` (default 20), `truncate` (default 500) | `{id, run_id, state, backend, path, turn, current_tool, elapsed_s, finished_at, tokens, result_preview, result_path, last_output, error, events: [...]}` | `{status: "error", message}` — unknown id, no run_dir, invalid `last`/`truncate`, or read failure |
@@ -798,6 +809,7 @@ Re-check this contract when touching:
 | CLI-backend `ask` returns immediately and enforces its own timeout | `src/lingtai/tools/daemon/__init__.py` | `tests/test_daemon.py::test_ask_codex_returns_immediately_when_subprocess_hangs`, `::test_ask_codex_silent_subprocess_enforces_timeout` |
 | Token rows are written to both the daemon and parent ledgers, tagged | `src/lingtai/tools/daemon/run_dir.py` | `tests/test_daemon_run_dir.py::test_append_tokens_writes_daemon_ledger`, `::test_append_tokens_writes_parent_ledger_tagged` |
 | `context_token_limit` is validated, reaches Codex and native `mimo`, and is inert for every other provider and every external CLI backend | `src/lingtai/tools/daemon/__init__.py` | `tests/test_codex_standalone_compaction.py`, `tests/test_mimo_responses_compaction.py` |
+| `tasks[].plugin` renders the `## Parent-selected plugins` section into the durable `.prompt` the detached child reads; plugin skills and mcp.json servers are merged/mounted; missing plugin paths resolve to nothing; non-list fails preflight | `src/lingtai/tools/daemon/__init__.py` | `tests/test_daemon.py::test_task_plugin_context_renders_catalog_and_flattens_skills_mcp`, `::test_task_plugin_context_rejects_bad_plugin_path`, `::test_task_plugin_context_rejects_non_list`, `::test_handle_emanate_writes_plugin_section_to_prompt_before_detach` |
 | LingTai daemon tool results carry daemon-local `_meta.agent_meta`, omit parent notifications/guidance, and carry the exact warning only while current usage is >=90% | `src/lingtai/tools/daemon/__init__.py`, `src/lingtai/kernel/meta_block.py` | `tests/test_daemon.py::test_daemon_agent_meta_is_local_and_warning_tracks_current_usage` |
 | LingTai task-scoped MCP calls remove server-undeclared `_reasoning`, retain ordinary unknown business fields, and preserve strict LTP-v2 restoration | `src/lingtai/services/mcp.py`, `src/lingtai/tools/daemon/__init__.py` | `tests/test_mcp_v2_adapter_metadata.py::test_task_daemon_adapts_host_private_arguments_at_mcp_boundary` |
 | `_DaemonMetaState.snapshot` carries `agent_state.context.system_prompt` only while this daemon's own local rendered prompt is strictly above the effective `LINGTAI_SYSTEM_PROMPT_PRESSURE_RATIO` threshold (default 40%) of its own resolved window, never the parent's | `src/lingtai/tools/daemon/__init__.py`, `src/lingtai/kernel/meta_block.py` | `tests/test_daemon.py::test_daemon_meta_state_system_prompt_warning_is_local_not_parent` |

--- a/src/lingtai/tools/daemon/__init__.py
+++ b/src/lingtai/tools/daemon/__init__.py
@@ -22,6 +22,7 @@ import sys
 import threading
 import time
 import yaml
+from lingtai.services import plugin_registry as _plugin_registry
 from copy import deepcopy
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -453,6 +454,26 @@ _DAEMON_COMPACT_MANUAL_PROCEDURES = (
     "Call compact with action='run' as the sole tool call in its assistant batch; include only action and _reason, and make _reason the handoff and resume instruction.",
     "If the countdown expires first, the runtime mechanically compacts before the next provider call and sends an explicit recovery instruction; re-read the task, inspect the preserved latest tool-call/result pair and durable run artifacts, verify state, then continue.",
     "After the successful non-terminal reset, resume from that surviving call/result pair; the run, state, history, and event paths in the result remain available.",
+)
+
+
+DAEMON_ASYNC_HANDOFF = (
+    "While waiting, go idle or call system(action='sleep'); the terminal result "
+    "will arrive and wake you as a notification; read daemon-manual and "
+    "notification-manual for details. If Telegram is connected and a Task Card "
+    "is available for the current turn, use it to report progress; call "
+    "`telegram(action='manual')` and follow its `Programmable Task Card` "
+    "section for details."
+)
+# A fleet (two or more daemons), or a single one whose caller explicitly asked
+# for a long ceiling, is work a human wants to follow. The default 3600s
+# ceiling does not count: it says nothing about how long the batch will run,
+# and nudging on it would fire for every single quick daemon.
+DAEMON_CARD_NUDGE_MIN_TASKS = 2
+DAEMON_CARD_NUDGE_MIN_TIMEOUT_S = 900.0
+DAEMON_CARD_NUDGE = (
+    " You dispatched {count} daemon(s) with no active task_card watch — consider "
+    "starting one (task_card action='start') so a human can follow progress."
 )
 
 
@@ -1008,6 +1029,7 @@ class _CliTaskContext:
     skill_catalog: str | None
     mcp_catalog: str | None
     mcp_regs: list[dict]
+    plugin_catalog: str | None = None
 
 
 @dataclass(frozen=True)
@@ -1734,6 +1756,218 @@ class DaemonManager:
         return {"name": name, "location": str(skill_file), "description": description}
 
     @staticmethod
+    def _plugin_path_resolution(raw_path: str, working_dir) -> Path:
+        """Resolve one daemon task plugin path to a concrete plugin directory."""
+        p = Path(raw_path).expanduser()
+        if not p.is_absolute():
+            p = working_dir / p
+        return p.resolve(strict=False)
+
+    @staticmethod
+    def _plugin_mcp_spec_to_registration(
+        plugin_name: str, server_name: str, spec: dict
+    ) -> dict:
+        """Translate one resolved plugin mcp.json server into a task MCP registration.
+
+        Mirrors ``plugin_registry.to_registry_record`` transport mapping: the
+        Agent Plugins v1.0.0 transports ``stdio`` / ``streamable-http`` / ``sse``
+        land on the daemon registration transports ``stdio`` / ``http``. The
+        resolved spec already carries absolute, containment-validated paths, so
+        the registration is directly usable by the LingTai backend client.
+        """
+        transport_map = {
+            "stdio": "stdio",
+            "streamable-http": "http",
+            "sse": "http",
+        }
+        transport = transport_map.get(spec.get("type"))
+        if transport is None:
+            raise ValueError(
+                f"plugin {plugin_name!r} mcp server {server_name!r}: unsupported "
+                f"transport {spec.get('type')!r}"
+            )
+        reg: dict = {"name": server_name, "transport": transport}
+        if transport == "stdio":
+            command = spec.get("command")
+            if not isinstance(command, str) or not command:
+                raise ValueError(
+                    f"plugin {plugin_name!r} mcp server {server_name!r}: stdio "
+                    "requires command"
+                )
+            reg["command"] = command
+            args = spec.get("args")
+            if args:
+                reg["args"] = list(args)
+            env = spec.get("env")
+            if env:
+                reg["env"] = dict(env)
+            cwd = spec.get("cwd")
+            if cwd:
+                reg["cwd"] = cwd
+        else:
+            url = spec.get("url")
+            if not isinstance(url, str) or not url:
+                raise ValueError(
+                    f"plugin {plugin_name!r} mcp server {server_name!r}: http "
+                    "requires url"
+                )
+            reg["url"] = url
+            headers = spec.get("headers")
+            if headers:
+                reg["headers"] = dict(headers)
+        return reg
+
+    @staticmethod
+    def _render_task_plugin_catalog(plugins: list[dict]) -> str | None:
+        """Render the compact plugin section injected into a daemon run prompt.
+
+        This mirrors the main agent's resident ``plugins`` prompt field: the
+        daemon sees the same whole-plugin view (name, summary, skills list, mcp
+        list) instead of a flattened skills/mcp split, so it understands that
+        the components belong to one distributable unit. Plugins whose mcp.json
+        servers were also mounted as task MCP clients are marked ``mounted``.
+        """
+        if not plugins:
+            return None
+        lines = [
+            "The parent selected these Agent Plugins for this daemon run. Read/apply their skills only when relevant to your task:",
+            "plugins:",
+        ]
+        for pl in plugins:
+            name = pl.get("name", "")
+            summary = pl.get("summary", "")
+            lines.append(f"  - name: {name}")
+            if summary:
+                lines.append(f"    summary: {summary}")
+            skills = pl.get("skills") or []
+            lines.append(f"    skills ({len(skills)}):")
+            for sk in skills:
+                lines.append(f"      - {sk}")
+            servers = pl.get("mcp_servers") or []
+            mounted = set(pl.get("mounted_mcp") or [])
+            lines.append(f"    mcp ({len(servers)}):")
+            for server in servers:
+                marker = " (mounted)" if server in mounted else ""
+                lines.append(f"      - {server}{marker}")
+        return "\n".join(lines)
+
+    def _task_plugin_context(
+        self, spec: dict
+    ) -> tuple[str | None, list[dict], list[dict]]:
+        """Resolve one daemon task's ``plugin`` paths.
+
+        Returns ``(plugin_catalog, plugin_skill_rows, plugin_mcp_regs)``.
+        ``plugin_skill_rows`` are compact skill catalog rows parsed from each
+        plugin's validated ``skills/``; ``plugin_mcp_regs`` are full MCP
+        registration objects translated from each plugin's validated ``mcp.json``.
+        The LingTai backend mounts ``plugin_mcp_regs`` as task-scoped MCP clients
+        and merges ``plugin_skill_rows`` into the skill catalog; CLI backends that
+        cannot mount plugins still receive the same skills and MCP registrations
+        separately through the normal skill/mcp oneshot context, which is the
+        "inject both separately" fallback.
+        """
+        raw = spec.get("plugin")
+        if raw is None:
+            return None, [], []
+        if not isinstance(raw, list):
+            raise ValueError("plugin must be an array of plugin directory paths")
+        working_dir = self._agent._working_dir
+        resolved_paths: list[Path] = []
+        for idx, item in enumerate(raw):
+            if not isinstance(item, str) or not item.strip():
+                raise ValueError(f"plugin[{idx}] must be a non-empty string path")
+            resolved_paths.append(
+                self._plugin_path_resolution(item.strip(), working_dir)
+            )
+        records, problems, _report = _plugin_registry.read_plugins(
+            working_dir, [str(p) for p in resolved_paths]
+        )
+        # Component problems are reported, not fatal; a plugin that cannot be
+        # read at all (invalid plugin.json) is omitted by read_plugins.
+        for prob in problems:
+            self._log("plugin", warning=str(prob))
+
+        skill_rows: list[dict] = []
+        mcp_regs: list[dict] = []
+        mounted_mcp_by_plugin: dict[str, list[str]] = {}
+        for record in records:
+            name = record["name"]
+            for skill_dir in record.get("skill_paths") or []:
+                try:
+                    skill_file = Path(skill_dir) / "SKILL.md"
+                    skill_rows.append(self._parse_task_skill_file(skill_file))
+                except ValueError as e:
+                    self._log("plugin", warning=f"plugin {name} skill skipped: {e}")
+            for server_name, spec in (record.get("mcp_specs") or {}).items():
+                try:
+                    mcp_regs.append(
+                        self._plugin_mcp_spec_to_registration(
+                            name, server_name, spec
+                        )
+                    )
+                except ValueError as e:
+                    self._log("plugin", warning=str(e))
+            mounted_mcp_by_plugin[name] = list(record.get("mcp_servers") or [])
+
+        # Attach mounted markers for the prompt view (LingTai backend only; CLI
+        # backends still get the flattened skills/mcp separately below).
+        for record in records:
+            record["mounted_mcp"] = mounted_mcp_by_plugin.get(record["name"], [])
+        catalog = self._render_task_plugin_catalog(records)
+        return catalog, skill_rows, mcp_regs
+
+    @staticmethod
+    def _merge_skill_catalog_rows(
+        rendered: str | None, extra_rows: list[dict]
+    ) -> list[dict]:
+        """Merge already-rendered task skill rows with plugin skill rows.
+
+        ``_task_skill_catalog`` returns a rendered string, so to append plugin
+        skill rows we re-render from the original list. This helper parses the
+        rendered YAML back into row dicts when needed; when the base catalog is
+        None (no explicit ``skills``) it simply returns the plugin rows.
+        Deduplicates by canonical skill location.
+        """
+        if rendered is None:
+            return list(extra_rows)
+        rows: list[dict] = []
+        current: dict | None = None
+        lines = rendered.splitlines()
+        i = 0
+        while i < len(lines):
+            line = lines[i]
+            m = re.match(r"^  - name: (.*)$", line)
+            if m:
+                if current is not None:
+                    rows.append(current)
+                current = {"name": m.group(1), "location": "", "description": ""}
+                i += 1
+                continue
+            lm = re.match(r"^    location: (.*)$", line)
+            dm = line == "    description: |"
+            if current is not None and lm:
+                current["location"] = lm.group(1)
+            elif current is not None and dm:
+                desc_lines = []
+                i += 1
+                while i < len(lines) and lines[i].startswith("      "):
+                    desc_lines.append(lines[i][6:])
+                    i += 1
+                current["description"] = "\n".join(desc_lines)
+                continue
+            i += 1
+        if current is not None:
+            rows.append(current)
+        seen = {row.get("location") for row in rows}
+        for row in extra_rows:
+            loc = row.get("location")
+            if loc in seen:
+                continue
+            seen.add(loc)
+            rows.append(row)
+        return rows
+
+    @staticmethod
     def _render_task_skill_catalog(skills: list[dict]) -> str | None:
         if not skills:
             return None
@@ -2042,8 +2276,8 @@ class DaemonManager:
             detail += (
                 ". The run ended without a finish() signal; this does not "
                 "necessarily mean the task failed — before concluding, "
-                "inspect the run's trace and the full final text preserved "
-                "in the run directory's physical result.txt"
+                "inspect the run's trace/result and the full final text "
+                "preserved in the run directory's physical result.txt"
             )
         exc = RuntimeError(
             "daemon completion MCP contract did not permit success: "
@@ -2204,6 +2438,7 @@ class DaemonManager:
         system_prompt: str | None,
         skill_catalog: str | None,
         mcp_catalog: str | None = None,
+        plugin_catalog: str | None = None,
     ) -> str | None:
         parts = []
         if system_prompt:
@@ -2212,6 +2447,8 @@ class DaemonManager:
             parts.append("## Parent-selected skills\n" + skill_catalog)
         if mcp_catalog:
             parts.append("## Parent-provided MCP registrations\n" + mcp_catalog)
+        if plugin_catalog:
+            parts.append("## Parent-selected plugins\n" + plugin_catalog)
         return "\n\n".join(parts) or None
 
     @staticmethod
@@ -2859,6 +3096,21 @@ class DaemonManager:
             base_defaults = effective_preset_llm["_provider_defaults"]
         else:
             base_defaults = self._llm_defaults_from_manifest(effective_preset_llm)
+            # A detached child receives the provider bucket under the public
+            # ``provider_defaults`` key (the private ``_provider_defaults`` alias
+            # never crosses the process boundary). Merge the nested bucket so
+            # provider-specific fields such as ``wire_api`` / ``api_compat`` /
+            # ``max_rpm`` survive the reconstruction; without this a Responses
+            # provider degrades to ``auto`` and is misrouted to Chat Completions.
+            public_defaults = effective_preset_llm.get("provider_defaults")
+            if isinstance(public_defaults, dict):
+                nested = public_defaults.get(provider)
+                if not isinstance(nested, dict):
+                    nested = public_defaults.get(str(provider).lower())
+                if isinstance(nested, dict) and nested:
+                    merged = dict(base_defaults)
+                    merged.update(nested)
+                    base_defaults = merged
         from lingtai.llm.service import CONSERVATIVE_CONTEXT_WINDOW
 
         context_window = effective_preset_llm.get("context_limit")
@@ -4266,9 +4518,10 @@ class DaemonManager:
                 except ValueError as exc:
                     return {"status": "error", "message": f"tasks[{i}].prompt: {exc}"}
 
-        # Per-batch limit overrides — capped at the manager's ceilings.
-        # Author-set ceilings (self._max_turns, self._timeout) are the upper
-        # bounds; the agent picks within them. None means "use ceiling".
+        # Per-batch limit overrides. max_turns is capped at the manager's
+        # ceiling (self._max_turns, also the schema maximum); timeout has no
+        # schema maximum, so self._timeout is only the default when omitted.
+        # None means "use the default/ceiling".
         if max_turns is not None:
             try:
                 mt = int(max_turns)
@@ -4282,6 +4535,10 @@ class DaemonManager:
         else:
             effective_max_turns = self._max_turns
 
+        # The caller's own timeout, kept separate from the effective one: the
+        # default ceiling says nothing about how long this batch will run, but
+        # an explicitly requested long ceiling does.
+        requested_timeout: float | None = None
         if timeout is not None:
             try:
                 to = float(timeout)
@@ -4295,7 +4552,11 @@ class DaemonManager:
             if to < 5:
                 return {"status": "error",
                         "message": f"timeout must be ≥ 5 seconds (got {to})"}
-            effective_timeout = min(to, self._timeout)
+            # Unlike max_turns, the schema advertises no ceiling for timeout
+            # (only minimum: 5) — self._timeout is the default when omitted,
+            # not a cap on an explicit value.
+            effective_timeout = to
+            requested_timeout = effective_timeout
         else:
             effective_timeout = self._timeout
 
@@ -4323,6 +4584,7 @@ class DaemonManager:
                 tasks, backend=backend,
                 effective_max_turns=effective_max_turns,
                 effective_timeout=effective_timeout,
+                requested_timeout=requested_timeout,
             )
 
         # Pre-flight: validate per-task ``context_token_limit`` (LingTai backend
@@ -4466,11 +4728,19 @@ class DaemonManager:
             try:
                 task_mcp_regs, task_mcp_catalog = self._task_mcp_registrations(spec)
                 task_skill_catalog = self._task_skill_catalog(spec)
+                task_plugin_catalog, plugin_skill_rows, plugin_mcp_regs = self._task_plugin_context(spec)
             except Exception as e:
                 self._close_task_mcp_clients(task_mcp_clients)
                 return {"status": "error", "message": str(e)}
+            # Plugin skills join the skill catalog; plugin mcp.json servers join
+            # the task MCP registrations (mounted as task-scoped clients below).
+            if plugin_skill_rows:
+                task_skill_catalog = self._render_task_skill_catalog(
+                    self._merge_skill_catalog_rows(task_skill_catalog, plugin_skill_rows)
+                )
+            task_mcp_regs = list(task_mcp_regs) + list(plugin_mcp_regs)
             task_context = self._combine_oneshot_context(
-                None, task_skill_catalog, task_mcp_catalog
+                None, task_skill_catalog, task_mcp_catalog, task_plugin_catalog
             )
             task_context = self._append_daemon_common_context(task_context)
 
@@ -4588,7 +4858,42 @@ class DaemonManager:
 
         return {"status": "dispatched", "count": len(tasks), "ids": ids,
                 "group_id": group_id,
-                "handoff": "While waiting, go idle or call system(action='sleep'); the terminal result will arrive and wake you as a notification; read daemon-manual and notification-manual for details. If Telegram is connected and a Task Card is available for the current turn, use it to report progress; call `telegram(action='manual')` and follow its `Programmable Task Card` section for details."}
+                "handoff": self._emanate_handoff(len(tasks), requested_timeout)}
+
+    def _emanate_handoff(self, count: int, requested_timeout_s: float | None) -> str:
+        """Async handoff line, plus a Task Card nudge for fleet-scale dispatch.
+
+        The nudge is conditional twice over: only for a fleet or a deliberately
+        long single run, and only when no watch is already running — a quick
+        daemon, or one dispatched under a live card, gets the plain handoff.
+        """
+        if not self._should_nudge_task_card(count, requested_timeout_s):
+            return DAEMON_ASYNC_HANDOFF
+        return DAEMON_ASYNC_HANDOFF + DAEMON_CARD_NUDGE.format(count=count)
+
+    def _should_nudge_task_card(
+        self, count: int, requested_timeout_s: float | None
+    ) -> bool:
+        """True when this dispatch is card-worthy and no watch is active.
+
+        Duck-typed on purpose: daemon still neither imports nor requires Task
+        Card runtime code, so an agent whose capability is disabled simply
+        never gets nudged.
+        """
+        if count < DAEMON_CARD_NUDGE_MIN_TASKS and (
+            requested_timeout_s is None
+            or requested_timeout_s < DAEMON_CARD_NUDGE_MIN_TIMEOUT_S
+        ):
+            return False
+        has_active = getattr(
+            getattr(self._agent, "_task_card_manager", None), "has_active_watch", None
+        )
+        if not callable(has_active):
+            return False
+        try:
+            return not has_active()
+        except Exception:
+            return False
 
     def _handle_emanate_cli(
         self,
@@ -4596,6 +4901,7 @@ class DaemonManager:
         backend: str,
         effective_max_turns: int,
         effective_timeout: float,
+        requested_timeout: float | None = None,
     ) -> dict:
         """Dispatch emanations via an external CLI backend.
 
@@ -4620,6 +4926,7 @@ class DaemonManager:
             try:
                 task_skill_catalog = self._task_skill_catalog(spec)
                 task_mcp_regs, task_mcp_catalog = self._task_mcp_registrations(spec)
+                task_plugin_catalog, plugin_skill_rows, plugin_mcp_regs = self._task_plugin_context(spec)
                 if any(r.get("name") == _DAEMON_COMMON_MCP_NAME for r in task_mcp_regs):
                     raise ValueError(
                         f"MCP registration name {_DAEMON_COMMON_MCP_NAME!r} is reserved"
@@ -4627,6 +4934,22 @@ class DaemonManager:
             except ValueError as e:
                 return {"status": "error",
                         "message": f"tasks[{i}]: {e}"}
+            # CLI backends that cannot mount plugins receive the plugin's skills
+            # and mcp.json servers separately (flattened) in addition to the
+            # whole-plugin prompt view, so the information is never lost.
+            if plugin_skill_rows:
+                task_skill_catalog = self._render_task_skill_catalog(
+                    self._merge_skill_catalog_rows(task_skill_catalog, plugin_skill_rows)
+                )
+            task_mcp_regs = list(task_mcp_regs) + list(plugin_mcp_regs)
+            if task_mcp_catalog:
+                task_mcp_catalog = self._render_task_mcp_catalog(task_mcp_regs)
+            # Per Jason 2026-08-09: external CLI backends do not receive the
+            # whole-plugin prompt section for the next few weeks; they get the
+            # plugin's skills and mcp.json servers flattened into the ordinary
+            # skill/mcp oneshot context (already done above). The LingTai
+            # backend alone injects the ``## Parent-selected plugins`` section.
+            task_plugin_catalog = None
             raw_opts = spec.get("backend_options")
             if raw_opts is None:
                 backend_argv = []
@@ -4848,7 +5171,7 @@ class DaemonManager:
                   tasks=[{"task": s["task"][:80], "tools": s.get("tools", [])} for s in tasks])
         return {"status": "dispatched", "count": len(tasks), "ids": ids,
                 "group_id": group_id, "backend": backend,
-                "handoff": "While waiting, go idle or call system(action='sleep'); the terminal result will arrive and wake you as a notification; read daemon-manual and notification-manual for details. If Telegram is connected and a Task Card is available for the current turn, use it to report progress; call `telegram(action='manual')` and follow its `Programmable Task Card` section for details."}
+                "handoff": self._emanate_handoff(len(tasks), requested_timeout)}
 
     @staticmethod
     def _truncate_list_string(value: object, limit: int = 500) -> object:

--- a/src/lingtai/tools/daemon/__init__.py
+++ b/src/lingtai/tools/daemon/__init__.py
@@ -4795,7 +4795,7 @@ class DaemonManager:
                     )
                 task_mcp_catalog = self._render_task_mcp_catalog(task_mcp_regs)
                 task_context = self._combine_oneshot_context(
-                    None, task_skill_catalog, task_mcp_catalog
+                    None, task_skill_catalog, task_mcp_catalog, task_plugin_catalog
                 )
                 task_context = self._append_daemon_common_context(task_context)
                 # Detached ownership starts task MCP only in the supervisor.

--- a/src/lingtai/tools/daemon/_tool_family.py
+++ b/src/lingtai/tools/daemon/_tool_family.py
@@ -129,6 +129,11 @@ def _emanate_task_schema() -> dict[str, Any]:
                 "items": {"type": "object"},
                 "description": 'Optional one-run MCP registrations for this daemon task. Array of full MCP registration objects: {name, transport/type: stdio|http, command+args+env for stdio or url+headers for http}. The registrations are serialized into the daemon prompt as YAML; LingTai backend also starts them as task-scoped MCP clients and exposes their tools for this run. CLI backends receive the same serialized registrations as context and may load them if their runtime supports MCP. Secret env/header values are redacted in prompts.',
             },
+            "plugin": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional Agent Plugins for this daemon task. Array of paths; each item may be a plugin directory (containing plugin.json) or a plugin search root whose immediate children are plugin directories. Relative paths resolve against the parent agent working directory. The daemon runtime reads each plugin manifest and injects a compact plugin section (name, summary, skills list, mcp list) into this run's system prompt; plugin skills are also injected as skill context and plugin mcp.json servers are registered as task-scoped MCP clients for the LingTai backend, exactly like the main agent mounts plugins. CLI backends that cannot mount plugins receive the plugin's skills and MCP registrations separately as normal skill/mcp context.",
+            },
             "preset": {
                 "type": "string",
                 "description": "Optional preset file path. Must be a .json/.jsonc path as returned by system(action='presets'). Do NOT use shorthand names — use the full 'name' field from the presets listing. Example: '~/.lingtai-tui/presets/saved/cheap.json'. Omit to inherit the parent's regular (non-MCP) tool surface; provide task MCP registrations separately with `mcp`.",
@@ -210,7 +215,7 @@ def _emanate_input_schema(backend_enum: list[str]) -> dict[str, Any]:
             "timeout": {
                 "type": ["number", "null"],
                 "minimum": 5,
-                "description": "For 'emanate': max wall-clock seconds for the whole batch. Default: parent max (3600s). Watchdog kills any emanation still running when the timer fires. Null for the default.",
+                "description": "For 'emanate': max wall-clock seconds for the whole batch. Default when omitted: 3600s. Watchdog kills any emanation still running when the timer fires. Null for the default.",
             },
         },
         "required": ["tasks", "backend", "max_turns", "timeout"],

--- a/src/lingtai/tools/daemon/manual/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/SKILL.md
@@ -6,8 +6,8 @@ description: >
   hunch, understand `daemon(action="list", input={})`, use CLI backends and `backend_options`,
   and clean up daemon footprint. Read this after dispatching daemon work that is
   slow, failed, timed out, exited 143 / SIGTERM, or needs backend-specific reasoning.
-version: 0.10.1
-last_changed_at: 2026-08-09T00:00:00Z
+version: 0.11.0
+last_changed_at: 2026-08-10T00:00:00Z
 related_files:
 - src/lingtai/tools/daemon/CONTRACT.md
 - src/lingtai/tools/daemon/ANATOMY.md
@@ -167,11 +167,23 @@ are the three that change state.
     `done`; `failed`/`incomplete`, missing finish, or invalid completion prevents
     silent success. A daemon that ends without calling `finish()` is reported
     as a missing-finish failure; that is not necessarily proof the underlying
-    task failed — before treating the work as lost, inspect the run's trace
-    and the full final text preserved in the run directory's physical
-    `result.txt` (the run directory is the `path` that `check` reports;
-    `result_path` stays null on this failure path). Secret `env`/`headers`
-    values are redacted in prompts.
+    task failed — before treating the work as lost, inspect the run's trace/result
+    and the full final text preserved in the run directory's
+    physical `result.txt` (the run directory is the `path` that `check`
+    reports; `result_path` stays null on this failure path). Secret
+    `env`/`headers` values are redacted in prompts.
+  - `plugin` answers **which Agent Plugins belong to this daemon run**. It is
+    optional and is an array of paths; each item may be a plugin directory
+    containing `plugin.json`, or a plugin search root whose immediate children
+    are plugin directories. Relative paths resolve against the parent agent
+    working directory. The runtime reads each plugin manifest and injects a
+    compact plugin section (name, summary, skills list, mcp list) into the
+    daemon system prompt. The built-in LingTai backend also mounts the plugin's
+    `skills/` as skill context and its `mcp.json` servers as task-scoped MCP
+    clients, exactly like the main agent mounts plugins. CLI backends that
+    cannot mount plugins yet receive the plugin's skills and mcp.json servers
+    separately as normal skill/mcp oneshot context until the whole-plugin
+    injection matures.
   - `preset`: optional body/model/tool-shape override for this daemon — an
     explicit `.json`/`.jsonc` path. On the LingTai backend it must already be
     a member of the parent agent's resolved `manifest.preset.allowed` set
@@ -279,6 +291,11 @@ are the three that change state.
   `telegram(action='manual')` and follow its `Programmable Task Card` section.
   The daemon tool does not create a Task Card automatically or require a
   watcher; daemon lifecycle and terminal-notification behavior are unchanged.
+  A card-worthy dispatch — two or more tasks, or an explicitly requested
+  `timeout` of 900s or more — appends one extra nudge sentence to `handoff`
+  when you have no active watch: start one with `task_card(action='start')` so
+  a human can follow the fleet instead of watching it run dark. The nudge
+  disappears once a watch is running.
 - **`check` still resolves a daemon after refresh/molt.** A refresh/molt gives
   you a fresh daemon registry with no in-memory entries, but the run folders
   and their notifications survive on disk. New daemon ids are compact run ids

--- a/src/lingtai/tools/task_card/CONTRACT.md
+++ b/src/lingtai/tools/task_card/CONTRACT.md
@@ -1,6 +1,6 @@
 ---
 name: intrinsic-task-card
-contract_version: 3
+contract_version: 4
 root_contract: CONTRACT.md
 related_files:
   - src/lingtai/tools/task_card/ANATOMY.md
@@ -14,6 +14,7 @@ related_files:
   - src/lingtai/mcp_servers/feishu/task_card.py
   - src/lingtai/mcp_servers/feishu/manager.py
   - tests/test_task_card_controller.py
+  - tests/test_task_card_proactivity.py
   - tests/test_telegram_toolfamily_ltpv2.py
   - tests/test_telegram_task_card_programmable.py
   - tests/test_feishu_programmable_task_cards.py
@@ -59,7 +60,12 @@ declarative artifact and one active watch per agent.
    recovery policy.
 7. Renderer execution failures after a watch exists preserve the last valid body
    and emit deduped `task_card.error` and `recovered` notifications. Refresh
-   exhaustion emits one `task_card.limit` notification keyed by watch and limit.
+   exhaustion emits one `task_card.limit` notification keyed by watch and limit;
+   its body tells the agent to start a new watch when the underlying work is
+   still ongoing, so an expired watch does not silently leave the card dark.
+   The capability also exposes a read-only `has_active_watch()` probe so another
+   capability (the daemon fleet nudge) can ask whether a card is already running
+   without creating, mutating, or importing watch state.
 8. Missing, invalid, or inactive producer state is outside this contract.
    Consumers decide what those states mean.
 9. `taskcard/taskcard.json` holds optional `interval_s`, `timeout_s`, and

--- a/src/lingtai/tools/task_card/__init__.py
+++ b/src/lingtai/tools/task_card/__init__.py
@@ -164,7 +164,8 @@ def get_description() -> str:
         "channel-specific readers. Use it proactively for meaningful long-running, "
         "multi-step, or parallel work so a human can follow progress; skip it for "
         "quick single-step work, ritual updates, or a body you cannot keep truthful "
-        "and current. Use stop to pause a watch while preserving its last body, and "
+        "and current. Restart a new watch when one expires mid-task. Use stop to "
+        "pause a watch while preserving its last body, and "
         "remove once the work is completed, cancelled, or abandoned so the artifact "
         "cannot mislead a consumer as stale. Actions: start, inspect, retry, stop, "
         "remove, manual."
@@ -790,7 +791,9 @@ class TaskCardManager:
                 body=(
                     f"Task Card watch {watch.watch_id} reached its refresh limit. "
                     "Refresh or reinspect the underlying task state, and start a new "
-                    "watch only if useful."
+                    "watch only if useful. If this work is still ongoing, start a new "
+                    "watch (task_card action='start') — do not let the card go dark "
+                    "mid-task."
                 ),
                 idempotency_key=f"task_card.limit:{watch.watch_id}:{maximum}",
                 skip_if_idempotency_key_exists=True,
@@ -799,6 +802,20 @@ class TaskCardManager:
             )
         except Exception:
             pass
+
+    def has_active_watch(self) -> bool:
+        """True while exactly one watch is running and not yet retiring.
+
+        Read-only cross-capability probe: the daemon fleet nudge asks this
+        before suggesting a card, so an agent that already keeps one is never
+        told to start another.
+        """
+        with self._lock:
+            watch = self._watch
+        if watch is None:
+            return False
+        with watch.lock:
+            return not (watch.stopping or watch.terminated)
 
     def _require_watch(self, watch_id: Any) -> _Watch:
         if not isinstance(watch_id, str):

--- a/src/lingtai/tools/task_card/manual/SKILL.md
+++ b/src/lingtai/tools/task_card/manual/SKILL.md
@@ -134,6 +134,9 @@ Guidelines:
 
 - Keep one active watch per agent. A second `start` is refused until the first
   watch is stopped.
+- Restart a watch that expires mid-task. Exhausting `max_refreshes` retires the
+  watch and sends one `task_card.limit` notification; if the underlying work is
+  still ongoing, `start` a new watch rather than letting the card go dark.
 - Write the body you want projected. The producer is channel-neutral and does
   not own Telegram/Feishu/portal layout details.
 - Keep renderer output truthful and complete. Projection channels may compare

--- a/tests/ANATOMY.md
+++ b/tests/ANATOMY.md
@@ -317,6 +317,7 @@ related_files:
   - tests/test_task_card_controller.py
   - tests/test_task_card_event_projection_shared.py
   - tests/test_task_card_handoff_guidance.py
+  - tests/test_task_card_proactivity.py
   - tests/test_task_card_resident_shared.py
   - tests/test_taskcard_resident_meta.py
   - tests/test_tc_inbox.py

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1364,6 +1364,40 @@ def test_combine_oneshot_context_includes_plugin_section(tmp_path):
     assert "demo-plugin" in combined
 
 
+def test_handle_emanate_writes_plugin_section_to_prompt_before_detach(tmp_path, monkeypatch):
+    """A daemon task with a plugin path renders the plugin section into the
+    durable .prompt that the detached child reads (regression for the
+    overwritten oneshot context)."""
+    agent = _make_agent(tmp_path, ["daemon"])
+    mgr = agent.get_capability("daemon")
+    plugin_dir = agent._working_dir / "plugin" / "demo-plugin"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.json").write_text(
+        '{"$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json", "name": "demo-plugin", "version": "1.0.0", "description": "Demo plugin for daemon injection."}',
+        encoding="utf-8",
+    )
+    captured = []
+
+    def fake_spawn(run_dir, **kwargs):
+        captured.append((run_dir, kwargs))
+        run_dir.mark_done("ok")
+
+    monkeypatch.setattr(mgr, "_spawn_detached_lingtai_run", fake_spawn)
+    result = mgr.handle({
+        "action": "emanate",
+        "tasks": [
+            {"task": "system task one", "tools": [], "plugin": ["plugin/demo-plugin"]},
+        ],
+    })
+
+    assert result["status"] == "dispatched"
+    prompts = [row[0].prompt_path.read_text(encoding="utf-8") for row in captured]
+    assert len(prompts) == 1
+    assert "## Parent-selected plugins" in prompts[0]
+    assert "demo-plugin" in prompts[0]
+    assert "system task one" in prompts[0]
+
+
 def test_task_plugin_context_rejects_non_list(tmp_path):
     """A non-list plugin field fails before scheduling."""
     agent = _make_agent(tmp_path, ["daemon"])

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1293,6 +1293,90 @@ def test_build_emanation_prompt_includes_selected_skills(tmp_path):
     assert prompt.index("- name: review-skill") < prompt.index("Your task:")
 
 
+def test_task_plugin_context_renders_catalog_and_flattens_skills_mcp(tmp_path):
+    """Daemon task plugin paths render a plugin section plus flattened skills/mcp."""
+    agent = _make_agent(tmp_path, ["daemon"])
+    mgr = agent.get_capability("daemon")
+    plugin_root = agent._working_dir / "plugin"
+    plugin_dir = plugin_root / "demo-plugin"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.json").write_text(
+        '{"$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json", "name": "demo-plugin", "version": "1.0.0", "description": "Demo plugin for daemon injection."}',
+        encoding="utf-8",
+    )
+    skill_dir = plugin_dir / "skills" / "demo-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\n" + "name: demo-skill\n" + "description: Plugin skill for daemon runs.\n" + "---\n",
+        encoding="utf-8",
+    )
+    (plugin_dir / "mcp.json").write_text(
+        '{"$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json", '
+        '"mcpServers": {"demo-mcp": {"type": "stdio", "command": "python3", '
+        '"args": ["-m", "demo"]}}}',
+        encoding="utf-8",
+    )
+
+    catalog, skill_rows, mcp_regs = mgr._task_plugin_context(
+        {"task": "x", "tools": [], "plugin": ["plugin/demo-plugin"]}
+    )
+
+    assert catalog is not None
+    assert "plugins:" in catalog
+    assert "- name: demo-plugin" in catalog
+    assert "Demo plugin for daemon injection." in catalog
+    assert "skills (1):" in catalog
+    assert "- demo-skill" in catalog
+    assert "mcp (1):" in catalog
+    assert "- demo-mcp (mounted)" in catalog
+    assert [r["name"] for r in skill_rows] == ["demo-skill"]
+    assert len(mcp_regs) == 1
+    assert mcp_regs[0]["name"] == "demo-mcp"
+    assert mcp_regs[0]["transport"] == "stdio"
+    assert mcp_regs[0]["command"] == "python3"
+
+
+def test_task_plugin_context_rejects_bad_plugin_path(tmp_path):
+    """A missing plugin path resolves to nothing without failing the whole task."""
+    agent = _make_agent(tmp_path, ["daemon"])
+    mgr = agent.get_capability("daemon")
+
+    catalog, skill_rows, mcp_regs = mgr._task_plugin_context(
+        {"task": "x", "tools": [], "plugin": ["plugin/missing-plugin"]}
+    )
+
+    assert catalog is None
+    assert skill_rows == []
+    assert mcp_regs == []
+
+
+def test_combine_oneshot_context_includes_plugin_section(tmp_path):
+    """The oneshot context combiner renders a dedicated plugin section."""
+    agent = _make_agent(tmp_path, ["daemon"])
+    mgr = agent.get_capability("daemon")
+
+    combined = mgr._combine_oneshot_context(
+        None, None, None, "plugins:\n  - name: demo-plugin\n"
+    )
+
+    assert combined is not None
+    assert "## Parent-selected plugins" in combined
+    assert "demo-plugin" in combined
+
+
+def test_task_plugin_context_rejects_non_list(tmp_path):
+    """A non-list plugin field fails before scheduling."""
+    agent = _make_agent(tmp_path, ["daemon"])
+    mgr = agent.get_capability("daemon")
+
+    try:
+        mgr._task_plugin_context({"task": "x", "tools": [], "plugin": "plugin/demo"})
+    except ValueError as e:
+        assert "plugin must be an array" in str(e)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("non-list plugin should fail")
+
+
 def test_build_emanation_prompt_includes_selected_mcp_context(tmp_path):
     """Selected MCP registrations are rendered into the daemon prompt before the task."""
     agent = _make_agent(tmp_path, ["file", "daemon"])
@@ -2057,6 +2141,8 @@ def test_handle_emanate_dispatches_and_returns_ids(tmp_path, monkeypatch):
         {"task": "task B", "tools": ["file"]},
     ]})
     assert result["status"] == "dispatched"
+    # Two tasks is a fleet, and this agent keeps no watch, so the handoff also
+    # carries the Task Card nudge (see tests/test_task_card_proactivity.py).
     assert result["handoff"] == (
         "While waiting, go idle or call system(action='sleep'); the terminal result "
         "will arrive and wake you as a notification; read daemon-manual and "
@@ -2064,6 +2150,8 @@ def test_handle_emanate_dispatches_and_returns_ids(tmp_path, monkeypatch):
         "is available for the current turn, use it to report progress; call "
         "`telegram(action='manual')` and follow its `Programmable Task Card` "
         "section for details."
+        " You dispatched 2 daemon(s) with no active task_card watch — consider "
+        "starting one (task_card action='start') so a human can follow progress."
     )
     assert result["count"] == 2
     ids = result["ids"]
@@ -4367,6 +4455,90 @@ def test_run_emanation_no_preset_preserves_parent_provider_defaults(
             "max_rpm": 9,
             "default_headers": {"x-test": "1"},
             "codex_base_urls": ["https://a.example", "https://b.example"],
+        }
+    }
+
+
+def test_run_emanation_detached_child_merges_public_provider_defaults(
+    tmp_path, monkeypatch
+):
+    """Detached-child reconstruction must merge the public ``provider_defaults`` map.
+
+    The parent serializes the effective provider bucket into the manifest under
+    the public ``provider_defaults`` key; the private ``_provider_defaults``
+    alias never crosses the process boundary. The child's ``_run_emanation``
+    receives ``preset_llm`` carrying that public map and must merge the nested
+    ``provider_defaults[provider]`` bucket — otherwise fields like
+    ``wire_api: responses`` are dropped, the wire degrades to ``auto``, and a
+    Responses provider is misrouted to Chat Completions.
+    """
+    agent = _make_agent(tmp_path, ["file", "daemon"])
+    agent.service.provider = "custom"
+    agent.service.model = "glm-5.1"
+    agent.service._base_url = "https://proxy.example/v1"
+    agent.service._context_window = 200000
+    agent.service._key_resolver = lambda provider: "token"
+    agent.service._api_key = "sk-effective"
+    agent.service.api_key = "sk-effective"
+    agent.service._provider_defaults = {
+        "custom": {
+            "api_compat": "openai",
+            "wire_api": "responses",
+            "max_rpm": 9,
+            "default_headers": {"x-test": "1"},
+        }
+    }
+
+    captured = {}
+    import lingtai.llm.service as service_mod
+    monkeypatch.setattr(service_mod, "LLMService", _capturing_fake_service(captured))
+
+    mgr = agent.get_capability("daemon")
+    cancel = threading.Event()
+    em_id = "em-detached-defaults"
+    schemas, dispatch = mgr._build_tool_surface(["file"])
+    run_dir = _make_run_dir(agent, em_id=em_id)
+    mgr._emanations[em_id] = {
+        "followup_buffer": "",
+        "followup_lock": threading.Lock(),
+        "run_dir": run_dir,
+    }
+
+    # Exactly what a detached child receives: a manifest ``llm``/``preset_llm``
+    # block whose provider bucket lives under the PUBLIC ``provider_defaults``
+    # key (no ``_provider_defaults`` alias survives serialization).
+    child_preset_llm = {
+        "provider": "custom",
+        "model": "glm-5.1",
+        "api_key": "sk-effective",
+        "base_url": "https://proxy.example/v1",
+        "context_window": 200000,
+        "provider_defaults": {
+            "custom": {
+                "api_compat": "openai",
+                "wire_api": "responses",
+                "max_rpm": 9,
+                "default_headers": {"x-test": "1"},
+            }
+        },
+    }
+
+    result = mgr._run_emanation(
+        em_id, run_dir, schemas, dispatch, "x", cancel, preset_llm=child_preset_llm
+    )
+
+    assert result == "daemon done"
+    # The nested wire_api=responses bucket survives the child reconstruction and
+    # reaches LLMService (merged over the top-level manifest-derived keys, e.g.
+    # base_url), so the adapter selects OpenAIResponsesSession instead of
+    # degrading to auto/Chat Completions.
+    assert captured["init"]["provider_defaults"] == {
+        "custom": {
+            "api_compat": "openai",
+            "base_url": "https://proxy.example/v1",
+            "wire_api": "responses",
+            "max_rpm": 9,
+            "default_headers": {"x-test": "1"},
         }
     }
 

--- a/tests/test_daemon_contract_doc.py
+++ b/tests/test_daemon_contract_doc.py
@@ -45,8 +45,8 @@ def test_daemon_contract_frontmatter_lists_related_files_and_triggers():
     meta = _frontmatter(DOC)
     assert meta["name"] == "daemon-contract"
     assert meta["status"] == "active"
-    # Bumped to 8 by the ToolFamily migration (LTP v2 envelope tool surface).
-    assert meta["contract_version"] == 8
+    # Bumped to 9 by the conditional Task Card nudge on the emanate handoff.
+    assert meta["contract_version"] == 9
     related = set(meta["related_files"])
     triggers = set(meta["review_triggers"])
     for rel in REQUIRED_RELATED:

--- a/tests/test_daemon_missing_finish_guidance.py
+++ b/tests/test_daemon_missing_finish_guidance.py
@@ -134,3 +134,53 @@ def test_manual_and_contract_name_the_physical_result_route():
     contract = _CONTRACT.read_text(encoding="utf-8")
     assert "missing-finish failure is a contract failure" in _normalized(contract)
     assert _ROUTE in _normalized(contract)
+
+
+def test_missing_finish_still_fails_and_message_directs_trace_inspection(tmp_path):
+    agent = make_daemon_agent(tmp_path)
+    mgr = agent.get_capability("daemon")
+    run_dir = make_daemon_run_dir(
+        agent,
+        handle="em-missing-finish-guidance",
+        call_parameters={"mcp": [{"name": "daemon_common", "transport": "stdio"}]},
+    )
+
+    with pytest.raises(RuntimeError, match="missing completion") as excinfo:
+        mgr._require_done_completion(run_dir, "final text without finish")
+
+    message = str(excinfo.value)
+    assert _GUIDANCE in message
+    assert "inspect the run's trace/result" in message
+
+    state = json.loads(run_dir.daemon_json_path.read_text())
+    assert state["state"] == "failed"
+
+    # An explicit finish(failed) is the agent's own verdict — the
+    # trace-inspection wording is reserved for the missing-finish case.
+    (run_dir.path / "daemon_completion.json").write_text(
+        json.dumps(
+            {
+                "schema": "lingtai.daemon_completion.v1",
+                "status": "failed",
+                "run_id": run_dir.run_id,
+                "reason": "blocked",
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(RuntimeError) as explicit:
+        mgr._require_done_completion(run_dir, "final text")
+    assert _GUIDANCE not in str(explicit.value)
+
+
+def test_daemon_context_and_manual_carry_missing_finish_guidance():
+    context = DaemonManager._daemon_common_context()
+    assert "missing-finish" in context
+    assert "not proof of failure" in context
+
+    manual = (
+        Path(__file__).resolve().parents[1]
+        / "src/lingtai/tools/daemon/manual/SKILL.md"
+    ).read_text(encoding="utf-8")
+    assert "missing-finish failure" in manual
+    assert "inspect the run's trace/result" in manual

--- a/tests/test_daemon_per_batch_limits.py
+++ b/tests/test_daemon_per_batch_limits.py
@@ -107,17 +107,28 @@ def test_emanate_respects_per_batch_timeout(tmp_path, monkeypatch):
     assert records[0]["manifest"]["timeout_s"] == 600.0
 
 
-def test_emanate_caps_timeout_at_ceiling(tmp_path, monkeypatch):
+def test_emanate_honors_explicit_timeout_above_default_ceiling(tmp_path, monkeypatch):
+    """An explicit ``timeout`` is a public, uncapped override (schema advertises
+    only ``minimum: 5``, no ``maximum``) — unlike ``max_turns``, which the
+    schema caps at ``DEFAULT_MAX_TURNS``. It must reach both the run's
+    daemon.json state and the detached supervisor_manifest.json unchanged,
+    not get silently clamped down to the parent's default-when-omitted value."""
     agent = _make_agent(tmp_path, ["file", "daemon"])
     mgr = agent.get_capability("daemon")
     records = install_fake_detached_owner(monkeypatch)
 
-    out = mgr.handle({"action": "emanate", "timeout": 99999,
+    assert mgr._timeout == 3600.0  # default ceiling, unrelated to this call's override
+    out = mgr.handle({"action": "emanate", "timeout": 10800,
                       "tasks": [{"task": "x", "tools": ["file"]}]})
 
     assert out["status"] == "dispatched"
-    wait_daemon_terminal(records[0]["run_dir"])
-    assert records[0]["manifest"]["timeout_s"] == mgr._timeout
+    state = wait_daemon_terminal(records[0]["run_dir"])
+    # supervisor_manifest.json (read via the fake supervisor's request.manifest_path)
+    assert records[0]["manifest"]["timeout_s"] == 10800.0
+    # daemon.json durable state
+    assert state["timeout_s"] == 10800.0
+    # the parent's own default-when-omitted ceiling is untouched by this call
+    assert mgr._timeout == 3600.0
 
 
 def test_emanate_rejects_zero_timeout(tmp_path):

--- a/tests/test_task_card_proactivity.py
+++ b/tests/test_task_card_proactivity.py
@@ -1,0 +1,190 @@
+"""Proactivity mechanisms that keep a Task Card open when the work warrants one.
+
+Three independent nudges are covered here: the daemon fleet nudge appended to
+an `emanate` handoff, the continuation hint carried by the expired-watch
+`task_card.limit` event, and the resident/tool wording that names which work is
+card-worthy.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from lingtai.tools.daemon import (
+    DAEMON_ASYNC_HANDOFF,
+    DAEMON_CARD_NUDGE_MIN_TASKS,
+    DAEMON_CARD_NUDGE_MIN_TIMEOUT_S,
+)
+from lingtai.tools.task_card import TaskCardManager, get_description
+
+from tests._daemon_helpers import make_daemon_agent
+from tests.test_task_card_controller import _FakeAgent, _OK_BODY, _write_renderer
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PROCEDURES = ROOT / "src/lingtai/prompts/procedures/procedures.md"
+
+
+class _StubCard:
+    """Minimal duck type for the daemon's read-only active-watch probe."""
+
+    def __init__(self, active: bool) -> None:
+        self._active = active
+
+    def has_active_watch(self) -> bool:
+        return self._active
+
+
+class _RaisingCard:
+    def has_active_watch(self) -> bool:
+        raise RuntimeError("probe exploded")
+
+
+@pytest.fixture
+def daemon(tmp_path):
+    return make_daemon_agent(tmp_path).get_capability("daemon")
+
+
+def _start_watch(manager: TaskCardManager, workdir: Path, *, max_refreshes: int) -> dict:
+    workdir.mkdir(parents=True, exist_ok=True)
+    return manager.handle(
+        {
+            "action": "start",
+            "input": {
+                "renderer_path": _write_renderer(workdir, _OK_BODY),
+                "interval_s": 3600,
+                "max_refreshes": max_refreshes,
+            },
+            "reasoning": "start a task card",
+        }
+    )
+
+
+# --- Mechanism 1: daemon fleet nudge ---
+
+
+def test_fleet_dispatch_without_a_watch_is_nudged(daemon):
+    daemon._agent._task_card_manager = _StubCard(False)
+    handoff = daemon._emanate_handoff(4, None)
+    assert handoff.startswith(DAEMON_ASYNC_HANDOFF)
+    assert "You dispatched 4 daemon(s) with no active task_card watch" in handoff
+    assert "task_card action='start'" in handoff
+
+
+def test_single_quick_dispatch_is_not_nudged(daemon):
+    daemon._agent._task_card_manager = _StubCard(False)
+    assert daemon._emanate_handoff(1, 300.0) == DAEMON_ASYNC_HANDOFF
+
+
+def test_single_dispatch_on_the_default_ceiling_is_not_nudged(daemon):
+    """An omitted timeout must not qualify: the default ceiling is 3600s, so
+    keying on it would nudge on every single quick daemon."""
+    daemon._agent._task_card_manager = _StubCard(False)
+    assert daemon._emanate_handoff(1, None) == DAEMON_ASYNC_HANDOFF
+
+
+def test_single_explicitly_long_dispatch_is_nudged(daemon):
+    daemon._agent._task_card_manager = _StubCard(False)
+    handoff = daemon._emanate_handoff(1, DAEMON_CARD_NUDGE_MIN_TIMEOUT_S)
+    assert "You dispatched 1 daemon(s) with no active task_card watch" in handoff
+
+
+def test_active_watch_suppresses_the_nudge(daemon):
+    daemon._agent._task_card_manager = _StubCard(True)
+    assert daemon._emanate_handoff(4, 3600.0) == DAEMON_ASYNC_HANDOFF
+
+
+def test_agent_without_the_task_card_capability_is_never_nudged(tmp_path):
+    """`task_card` is a core default, but a host may disable it; a daemon
+    dispatch on such an agent must fall back to the plain handoff."""
+    agent = make_daemon_agent(tmp_path)
+    del agent._task_card_manager
+    assert agent.get_capability("daemon")._emanate_handoff(4, None) == DAEMON_ASYNC_HANDOFF
+
+
+def test_probe_failure_falls_back_to_the_plain_handoff(daemon):
+    daemon._agent._task_card_manager = _RaisingCard()
+    assert daemon._emanate_handoff(4, 3600.0) == DAEMON_ASYNC_HANDOFF
+
+
+def test_nudge_thresholds_are_fleet_scale():
+    assert DAEMON_CARD_NUDGE_MIN_TASKS == 2
+    assert DAEMON_CARD_NUDGE_MIN_TIMEOUT_S == 900.0
+
+
+def test_real_task_card_capability_toggles_the_nudge(tmp_path):
+    """End-to-end across the two capabilities: a live watch silences the nudge
+    and retiring it brings the nudge back."""
+    agent = make_daemon_agent(tmp_path, ["daemon", "task_card"])
+    daemon = agent.get_capability("daemon")
+    card = agent.get_capability("task_card")
+    assert card is agent._task_card_manager
+    assert not card.has_active_watch()
+    assert "no active task_card watch" in daemon._emanate_handoff(2, None)
+
+    started = _start_watch(card, Path(agent._working_dir), max_refreshes=10)
+    assert started["status"] == "ok"
+    assert card.has_active_watch()
+    assert daemon._emanate_handoff(2, None) == DAEMON_ASYNC_HANDOFF
+
+    card.handle(
+        {
+            "action": "stop",
+            "input": {"watch_id": started["watch_id"]},
+            "reasoning": "cleanup",
+        }
+    )
+    assert not card.has_active_watch()
+    assert "no active task_card watch" in daemon._emanate_handoff(2, None)
+
+
+# --- Mechanism 2: expired-watch continuation hint ---
+
+
+def test_expired_watch_event_asks_for_a_new_watch(tmp_path):
+    agent = _FakeAgent(tmp_path)
+    manager = TaskCardManager(agent)
+    assert _start_watch(manager, tmp_path, max_refreshes=1)["status"] == "ok"
+    watch = manager._watch
+    assert watch is not None
+
+    manager._tick(watch)
+
+    limit_wakes = [wake for wake in agent.wakes if wake["source"] == "task_card.limit"]
+    assert len(limit_wakes) == 1
+    body = limit_wakes[0]["body"]
+    assert "reached its refresh limit" in body
+    assert "If this work is still ongoing, start a new watch (task_card action='start')" in body
+    assert "do not let the card go dark mid-task" in body
+
+
+def test_exhausted_watch_reports_itself_inactive(tmp_path):
+    """The nudge is only useful if an exhausted watch stops counting as active."""
+    agent = _FakeAgent(tmp_path)
+    manager = TaskCardManager(agent)
+    assert _start_watch(manager, tmp_path, max_refreshes=1)["status"] == "ok"
+    assert manager.has_active_watch()
+    manager._tick(manager._watch)
+    assert not manager.has_active_watch()
+
+
+# --- Mechanism 3: resident + tool trigger wording ---
+
+
+def test_tool_description_asks_for_a_restart_after_expiry():
+    assert "Restart a new watch when one expires mid-task." in get_description()
+
+
+def test_resident_procedures_name_the_card_worthy_triggers():
+    text = PROCEDURES.read_text(encoding="utf-8")
+    section = text.split("### Task Card Lifecycle", 1)[1].split("\n### ", 1)[0]
+    for fragment in (
+        "multi-daemon fleets",
+        "multi-PR batches",
+        "review→merge",
+        "ten minutes",
+        "`max_refreshes`",
+        "go dark",
+    ):
+        assert fragment in section, f"{fragment!r} missing from Task Card Lifecycle"

--- a/tests/test_wire_api.py
+++ b/tests/test_wire_api.py
@@ -627,3 +627,21 @@ def test_daemon_llm_defaults_from_manifest_retains_wire_api():
     }
     defaults = DaemonManager._llm_defaults_from_manifest(llm)
     assert defaults["wire_api"] == "responses"
+
+
+def test_parse_chat_completion_rejects_non_object_response():
+    """A scalar string from a non-conforming gateway yields a typed error.
+
+    Regression for the detached-daemon misroute: when a provider configured
+    with ``wire_api: responses`` was reconstructed as ``auto`` and routed to
+    ``/chat/completions``, a scalar-string response crashed with
+    ``AttributeError: 'str' object has no attribute 'choices'``. The adapter
+    must reject the wrong-typed payload with a clear TypeError instead of
+    dereferencing ``.choices`` on it.
+    """
+    import pytest
+
+    from lingtai.llm.openai.adapter import _parse_response
+
+    with pytest.raises(TypeError, match="non-ChatCompletion"):
+        _parse_response("{\"error\": \"not a chat completion\"}")


### PR DESCRIPTION
## Squash: Daemon/task fixes (#1320 + #1279 + #1248 + #1247 + #1221)

- **#1320** — accept text-only stop as partial finish with inspection reminder
- **#1279** — preserve nested provider_defaults in detached child reconstruction (lingtai#750)
- **#1248** — support Agent Plugins as task plugin paths
- **#1247** — honor explicit per-batch timeout
- **#1221** — proactive task-card nudges for daemon fleets and expired watches

Rebased onto current main `8354960360` (HEAD `2f1d33a1`, 16 files +874/-32, clean).

Telegram: @lingtaidev3bot | Nickname: 澄一
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai

---
**P1 fixes (Jason A, 2026-08-10):** after Fable review REQUEST CHANGES 0P0/2P1/7P2, HEAD advanced `2f1d33a1` -> `f751ce72` (18 files vs base):
- P1-1: inject `task_plugin_catalog` into the final `_combine_oneshot_context` so the `## Parent-selected plugins` section reaches the durable `.prompt` the detached child reads (was overwritten). Regression test `test_handle_emanate_writes_plugin_section_to_prompt_before_detach`.
- P1-2: daemon CONTRACT.md documents `tasks[].plugin` (emanate optional inputs, per-task semantics, anchored claim row).
Focused suites green: tests/test_daemon.py + tests/test_task_card_controller.py = 198 passed; only 3 known pre-existing ceiling-pin failures remain (verified pre-existing on pure main). Fable re-review in flight at f751ce72.
