### PR TITLE
feat(kernel): agent-directory README navigation entry (agent_readme)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,11 @@ exclude = [
 
 [tool.setuptools.package-data]
 "lingtai.kernel" = ["i18n/*.json"]
+# The agent-readme generator is its own subpackage, so its static template and
+# paired architecture documents need their own entry (package-data globs do not
+# recurse into subpackages — same reason as telegram.task_card below). Without
+# this the wheel ships the writer but silently drops the template it renders.
+"lingtai.kernel.agent_readme" = ["README.md.tpl", "ANATOMY.md", "CONTRACT.md"]
 # Consolidated tool packages: i18n catalogs, per-tool JSON policy/data files
 # (e.g. lingtai/tools/bash/bash_policy.json), and every tool manual tree. Without
 # these the wheel installs the tool code but silently drops its data assets.

--- a/src/lingtai/kernel/agent_readme/ANATOMY.md
+++ b/src/lingtai/kernel/agent_readme/ANATOMY.md
@@ -1,0 +1,16 @@
+# agent_readme ANATOMY
+
+## Components
+
+- `README.md.tpl` — packaged static template. Head carries `template_version:`; body is the navigation entry point (Where-to-look table + Notes). No placeholders, no secret values.
+- `ensure_agent_readme(layout_or_root)` — idempotent writer: missing or stale (head `template_version` differs) → atomic rewrite via `_fsutil.atomic_write_text`; version match → no-op. Returns written path or None.
+- `render_readme(template=None)` — pure renderer (identity for static template), testable without touching the filesystem.
+- `template_version(text)` — head-scan regex for `template_version:` (first 2048 bytes).
+- `WorkdirLayout.readme` — `<root>/README.md` path (see `kernel/workdir.py`).
+
+## Connections
+
+- Template loaded via `importlib.resources.files(__package__).joinpath("README.md.tpl")`; package-data ships `.tpl` files (pyproject).
+- Mount points (each fail-soft): `_perform_refresh` (lifecycle), agent molt (`tools/context/_molt.py`), `BaseAgent` construction — README regeneration must never break lifecycle flow.
+- Reciprocal link: `prompts/substrate/substrate.md` frontmatter `related_files` lists `agent_readme/CONTRACT.md` and `agent_readme/README.md.tpl`.
+- Contract: `CONTRACT.md` next to this module fixes README/substrate role split and maintenance boundary.

--- a/src/lingtai/kernel/agent_readme/CONTRACT.md
+++ b/src/lingtai/kernel/agent_readme/CONTRACT.md
@@ -1,0 +1,44 @@
+# agent-readme CONTRACT
+
+> 固定 agent 文件夹 `README.md` 与 `substrate.md` 的角色分工、所有权与维护边界。
+> 替代 #1252 的 agent-manual CONTRACT v1（重生成器 + MANUAL.md）的语义。
+
+## 1. 角色
+
+| 文件 | 位置 | 面向 | 角色 |
+|---|---|---|---|
+| `README.md` | agent 文件夹根 | 外界（人、新接触者、工具） | **入口 + 目录导航**：导航 agent 文件夹的固有结构。**不承载 agent 身份（名字）**，不承载任何动态数据。 |
+| `substrate.md` | agent 的 `system/`（镜像 kernel `prompts/substrate/substrate.md`） | agent/机器 | **机制渐进式披露入口**：身体机制（扩展/生命周期/通信/记忆/空闲/工具分级）的 resident 操作模型 + 深挖指引。 |
+
+## 2. 所有权与生成
+
+- `README.md`：kernel-owned。**运行时生成**：模板位于 kernel repo `agent_readme/` 包；**molt/refresh 时检查 staleness**（文件缺失、模板版本变化 → 重新生成）。全英文；**不含 agent 名占位**（agent 名字不是 README 的责任）。
+- `substrate.md`：kernel-owned。源是 `src/lingtai/prompts/substrate/substrate.md`；agent 文件夹里的副本由 kernel 既有 prompt-source 机制同步。
+
+## 3. 边界
+
+- README **不**复制 substrate 的机制内容；substrate **不**复制 README 的目录导航。二者以链接/指引互相指向。
+- README **不**放 agent 名、live snapshot、身份元数据（provider/model/heartbeat 等动态值）；动态真相由 `init.json` / `.agent.json` / `.status.json` / `system/pad.md` 承载，README 只在 Notes 节以文字提及这些真相文件。
+- README 不是纯目录文件：目录表每行带「是什么 / 何时打开」解释。
+- 无 agent 侧 overlay；无运行时 secret 渲染（模板不含 secret 值）。
+
+## 4. 渐进式披露路径
+
+```
+外界/人 ──► agent 根 README.md（目录导航入口）
+                    │
+                    ▼
+          system/substrate.md（机制入口）
+                    │
+        ┌───────────┼───────────────┐
+        ▼           ▼               ▼
+  system-manual  substrate-manual  各专项 manual
+  (router)       (扩展形态)        (context/soul/notification/...)
+```
+
+## 5. 契约测试（最小）
+
+1. 初始化/refresh/molt 后 agent 根存在 `README.md`，且含指向 `system/substrate.md` 的相对路径。
+2. staleness 检查：README 缺失或模板版本变化时重新生成；文件内容与模板一致。
+3. `README.md` 不含 agent 名与任何 live 动态值（无 provider/model/heartbeat 等运行时替换字段）。
+4. substrate frontmatter `related_files` 含 `agent_readme/CONTRACT.md`（反向链接维护）。

--- a/src/lingtai/kernel/agent_readme/CONTRACT.md
+++ b/src/lingtai/kernel/agent_readme/CONTRACT.md
@@ -12,7 +12,7 @@
 
 ## 2. 所有权与生成
 
-- `README.md`：kernel-owned。**运行时生成**：模板位于 kernel repo `agent_readme/` 包；**molt/refresh 时检查 staleness**（文件缺失、模板版本变化 → 重新生成）。全英文；**不含 agent 名占位**（agent 名字不是 README 的责任）。
+- `README.md`：kernel-owned。**运行时生成**：模板位于 kernel repo `agent_readme/` 包；**refresh / molt / BaseAgent 构造时检查 staleness**（文件缺失、模板版本变化 → 重新生成；构造挂载保证 avatar 首用前即有 README）。全英文；**不含 agent 名占位**（agent 名字不是 README 的责任）。接管无版本头既有文件时先落 `README.md.bak` 并记事件，不静默覆盖。
 - `substrate.md`：kernel-owned。源是 `src/lingtai/prompts/substrate/substrate.md`；agent 文件夹里的副本由 kernel 既有 prompt-source 机制同步。
 
 ## 3. 边界

--- a/src/lingtai/kernel/agent_readme/README.md.tpl
+++ b/src/lingtai/kernel/agent_readme/README.md.tpl
@@ -1,0 +1,37 @@
+---
+template_version: agent-readme/v1
+---
+# LingTai Agent Working Directory
+
+This is the working directory of a LingTai agent. It holds the agent's identity,
+memory, communication, logs, and work products. Use this README to navigate the
+folder; mechanism details live in `system/substrate.md`.
+
+## Where to look
+
+| Path | What it is | Open when |
+|---|---|---|
+| [`system/substrate.md`](system/substrate.md) | How an agent's body works: extensions, lifecycle, communication, memory/molt, idle/soul, tool tiers | You want the mechanism — main entrance |
+| [`system/lingtai.md`](system/lingtai.md) | Who this agent is: specialties, working style, relationships | You want to know the agent |
+| [`system/pad.md`](system/pad.md) | Current state: active tasks, handoff notes | You want to know what it is doing now |
+| [`knowledge/`](knowledge/) | Private long-term memory entries | You want the facts it remembers |
+| [`.library/`](.library/) | Skill catalog (intrinsic + custom) | You want reusable procedures |
+| [`mailbox/`](mailbox/) | Internal email inbox | You want to communicate with it |
+| [`init.json`](init.json) | Config: agent name, LLM, context window, permissions | You want to inspect or change config |
+| [`logs/`](logs/) | Runtime logs | You are troubleshooting |
+| [`history/`](history/) | Chat history and molt archives | You are looking back |
+| [`daemons/`](daemons/) | Ephemeral subagent (神识) artifacts | You want delegated results |
+| [`taskcard/`](taskcard/) | Task Card state | You are tracking a long task |
+| [`scratch/`](scratch/) | Scratch workspace | You are looking for work products |
+| [`.secrets/`](.secrets/) | Credentials (name only — never read contents) | You are configuring credentials |
+
+## Notes
+
+- `.secrets/` contains sensitive credentials: **never** copy its contents into
+  chat, logs, or public documents.
+- This README is a navigation entry point only: it does not carry the agent's
+  identity or any live/dynamic values. Dynamic truth lives in `init.json`
+  (config), `.status.json` (runtime state), `.agent.json` (identity metadata),
+  and `system/pad.md` (current notes).
+- For the contract that fixes these roles, see the kernel repo:
+  `src/lingtai/kernel/agent_readme/CONTRACT.md`.

--- a/src/lingtai/kernel/agent_readme/__init__.py
+++ b/src/lingtai/kernel/agent_readme/__init__.py
@@ -70,6 +70,9 @@ def render_readme(*, template: str | None = None) -> str:
 
 def ensure_agent_readme(
     layout_or_root: WorkdirLayout | Path | str,
+    *,
+    template: str | None = None,
+    _log: callable | None = None,
 ) -> Path | None:
     """Generate ``README.md`` in the agent directory if missing or stale.
 
@@ -78,6 +81,15 @@ def ensure_agent_readme(
     tmp + rename via ``_fsutil.atomic_write_text``) only when the file is
     missing, unreadable, unversioned, or carries a different version. A
     version match is a strict no-op.
+
+    Migration safety (P1-1): a pre-existing file with **no** ``template_version``
+    head is taken over, not clobbered silently \u2014 its content is preserved as
+    ``README.md.bak`` first and the takeover is emitted through ``_log`` when
+    provided, so an upgrade never loses a user-written README without a trace.
+
+    A packaged template that itself lost its version head raises (``ValueError``)
+    instead of silently degrading into a rewrite-every-mount loop; mount call
+    sites wrap fail-soft, so the failure is visible via their logging.
 
     Returns the written path, or None when the existing file is current.
     Raises on I/O failure; mount call sites wrap fail-soft.
@@ -88,16 +100,35 @@ def ensure_agent_readme(
         else workdir_layout(layout_or_root)
     )
     target = layout.readme
-    tpl = _read_template()
+    tpl = render_readme(template=template)
     current_version = template_version(tpl)
+    if current_version is None:
+        raise ValueError("agent_readme packaged template lost its template_version head")
 
     if target.is_file():
         try:
-            existing_head = target.read_text(encoding="utf-8")[:_HEAD_SCAN_BYTES]
-        except OSError:
+            with target.open(encoding="utf-8") as fh:
+                existing_head = fh.read(_HEAD_SCAN_BYTES)
+        except (OSError, UnicodeDecodeError):
             existing_head = ""
-        if current_version is not None and template_version(existing_head) == current_version:
+        existing_version = template_version(existing_head)
+        if existing_version == current_version:
             return None
+        if existing_version is None:
+            # Takeover of a user-authored, unversioned README: preserve a
+            # backup and log the event so the migration is never silent.
+            try:
+                backup = target.with_name("README.md.bak")
+                atomic_write_text(backup, target.read_text(encoding="utf-8"), encoding="utf-8")
+            except Exception:
+                # Backup best-effort; the takeover itself proceeds so the
+                # agent root still gains the navigation entry.
+                pass
+            if _log is not None:
+                try:
+                    _log("agent_readme_takeover", backup=str(backup))
+                except Exception:
+                    pass
 
     atomic_write_text(target, tpl, encoding="utf-8")
     return target

--- a/src/lingtai/kernel/agent_readme/__init__.py
+++ b/src/lingtai/kernel/agent_readme/__init__.py
@@ -1,0 +1,103 @@
+"""Agent-directory README.md \u2014 kernel-owned static navigation entry point.
+
+Every agent working directory carries a static ``README.md`` at its root: a
+navigation entry point for humans and tools reaching the folder. It is **not**
+an operating manual (that role belongs to ``substrate.md`` via the resident
+substrate section and its manuals) and it deliberately does **not** carry the
+agent's identity or any live/dynamic values (see ``CONTRACT.md`` next to this
+module).
+
+The authoritative content lives in the packaged template ``README.md.tpl``;
+there is deliberately **no** overlay or local-append mechanism. Regeneration
+is a mechanical template-version check, not a heartbeat concern:
+:func:`ensure_agent_readme` rewrites the file only when it is missing or its
+head ``template_version`` differs from the packaged template's. The mount
+points are the lifecycle moments \u2014 ``_perform_refresh``, agent molt, and
+``BaseAgent`` construction \u2014 each wrapped fail-soft so a README problem can
+never break lifecycle flow.
+
+Secret discipline: the template contains no secret values and the renderer
+accepts no facts, so credential material cannot reach the rendered file.
+"""
+from __future__ import annotations
+
+import re
+from importlib import resources as importlib_resources
+from pathlib import Path
+
+from .._fsutil import atomic_write_text
+from ..workdir import WorkdirLayout, workdir_layout
+
+__all__ = [
+    "ensure_agent_readme",
+    "render_readme",
+    "template_version",
+]
+
+_TEMPLATE_RESOURCE = "README.md.tpl"
+
+# Matches the `template_version:` field in the YAML-style head of both the
+# packaged template and a rendered README.md. Only the head is scanned (the
+# first _HEAD_SCAN_BYTES bytes) so a stray mention in body prose cannot
+# masquerade as the version marker.
+_TEMPLATE_VERSION_RE = re.compile(r"^template_version:\s*(\S+)\s*$", re.MULTILINE)
+_HEAD_SCAN_BYTES = 2048
+
+
+def _read_template() -> str:
+    return (
+        importlib_resources.files(__package__)
+        .joinpath(_TEMPLATE_RESOURCE)
+        .read_text(encoding="utf-8")
+    )
+
+
+def template_version(text: str) -> str | None:
+    """Return the ``template_version`` declared in *text*'s head, or None."""
+    match = _TEMPLATE_VERSION_RE.search(text[:_HEAD_SCAN_BYTES])
+    return match.group(1) if match else None
+
+
+def render_readme(*, template: str | None = None) -> str:
+    """Render the README template verbatim.
+
+    Pure: no filesystem writes, no agent access, no placeholders \u2014 the
+    template is fully static, so rendering is identity. Kept as a function so
+    callers/tests exercise the packaged template through one path.
+    """
+    return template if template is not None else _read_template()
+
+
+def ensure_agent_readme(
+    layout_or_root: WorkdirLayout | Path | str,
+) -> Path | None:
+    """Generate ``README.md`` in the agent directory if missing or stale.
+
+    The check is mechanical: compare the existing file's head
+    ``template_version`` against the packaged template's; rewrite (atomically,
+    tmp + rename via ``_fsutil.atomic_write_text``) only when the file is
+    missing, unreadable, unversioned, or carries a different version. A
+    version match is a strict no-op.
+
+    Returns the written path, or None when the existing file is current.
+    Raises on I/O failure; mount call sites wrap fail-soft.
+    """
+    layout = (
+        layout_or_root
+        if isinstance(layout_or_root, WorkdirLayout)
+        else workdir_layout(layout_or_root)
+    )
+    target = layout.readme
+    tpl = _read_template()
+    current_version = template_version(tpl)
+
+    if target.is_file():
+        try:
+            existing_head = target.read_text(encoding="utf-8")[:_HEAD_SCAN_BYTES]
+        except OSError:
+            existing_head = ""
+        if current_version is not None and template_version(existing_head) == current_version:
+            return None
+
+    atomic_write_text(target, tpl, encoding="utf-8")
+    return target

--- a/src/lingtai/kernel/base_agent/__init__.py
+++ b/src/lingtai/kernel/base_agent/__init__.py
@@ -554,9 +554,12 @@ class BaseAgent:
         try:
             from ..agent_readme import ensure_agent_readme
 
-            ensure_agent_readme(self._working_dir)
+            ensure_agent_readme(self._working_dir, _log=self._log)
         except Exception:
-            pass
+            try:
+                self._log("agent_readme_ensure_failed", stage="construction")
+            except Exception:
+                pass
 
 
         # Auto-inject identity into system prompt from manifest

--- a/src/lingtai/kernel/base_agent/__init__.py
+++ b/src/lingtai/kernel/base_agent/__init__.py
@@ -547,6 +547,17 @@ class BaseAgent:
         manifest_data = _build_manifest(self)
         self._workdir.write_manifest(manifest_data)
 
+        # Construction is README.md's third mechanical regeneration point
+        # (template-version check only) — the one avatars reach, since they
+        # never pass through refresh or molt before first use. Fail-soft: a
+        # README problem must never break construction.
+        try:
+            from ..agent_readme import ensure_agent_readme
+
+            ensure_agent_readme(self._working_dir)
+        except Exception:
+            pass
+
 
         # Auto-inject identity into system prompt from manifest
         self._prompt_manager.write_section(

--- a/src/lingtai/kernel/base_agent/lifecycle.py
+++ b/src/lingtai/kernel/base_agent/lifecycle.py
@@ -754,7 +754,7 @@ def _perform_refresh(
     try:
         from ..agent_readme import ensure_agent_readme
 
-        ensure_agent_readme(agent._working_dir)
+        ensure_agent_readme(agent._working_dir, _log=agent._log)
     except Exception:
         agent._log("agent_readme_ensure_failed", stage="refresh")
     # Bound-method dispatch — _build_launch_cmd lives on BaseAgent (returns

--- a/src/lingtai/kernel/base_agent/lifecycle.py
+++ b/src/lingtai/kernel/base_agent/lifecycle.py
@@ -747,6 +747,16 @@ def _perform_refresh(
         agent._log("refresh_chat_history_save_skipped", reason=effective_skip_reason)
     else:
         agent._save_chat_history()
+
+    # Refresh is one of README.md's mechanical regeneration points
+    # (template-version check only). Fail-soft: a README problem must never
+    # break a refresh.
+    try:
+        from ..agent_readme import ensure_agent_readme
+
+        ensure_agent_readme(agent._working_dir)
+    except Exception:
+        agent._log("agent_readme_ensure_failed", stage="refresh")
     # Bound-method dispatch — _build_launch_cmd lives on BaseAgent (returns
     # None) and Agent (returns the real `lingtai-agent run` cmd). A prior version
     # called a module-level _build_launch_cmd shadow that always returned

--- a/src/lingtai/kernel/workdir.py
+++ b/src/lingtai/kernel/workdir.py
@@ -20,6 +20,7 @@ _MANIFEST_CORRUPT_FILE = ".agent.json.corrupt"
 _HEARTBEAT_FILE = ".agent.heartbeat"
 _STATUS_FILE = ".status.json"
 _INIT_FILE = "init.json"
+_README_FILE = "README.md"
 _SYSTEM_DIR = "system"
 _LOGS_DIR = "logs"
 _HISTORY_DIR = "history"
@@ -72,6 +73,9 @@ class WorkdirLayout:
     def init_json(self) -> Path:
         return self.root / _INIT_FILE
 
+    @property
+    def readme(self) -> Path:
+        return self.root / _README_FILE
 
     @property
     def system_dir(self) -> Path:

--- a/src/lingtai/prompts/substrate/substrate.md
+++ b/src/lingtai/prompts/substrate/substrate.md
@@ -16,6 +16,8 @@ related_files:
   - "reference/substrate-manual/SKILL.md"
   - "reference/environment-variables/SKILL.md"
   - "src/lingtai/intrinsic_skills/notification-manual/SKILL.md"
+  - "src/lingtai/kernel/agent_readme/CONTRACT.md"
+  - "src/lingtai/kernel/agent_readme/README.md.tpl"
 maintenance: >
   When editing this file, treat related_files as maintained inner links for the prompt/guidance
   source graph. Before changing behavior or prose, crawl the listed files, update any affected
@@ -32,6 +34,11 @@ This section is kernel-owned and cross-app stable. It holds the minimal operatin
 model every LingTai agent must keep resident. The expanded runtime/substrate
 router is `system-manual`; it routes the full substrate expansion to
 `reference/substrate-manual/SKILL.md`.
+
+**This is the progressive-disclosure entrance for how an agent's body works.**
+A human reaching the agent folder starts at `README.md` (the welcome/navigation
+file); this section is where mechanism questions land. Deeper detail on every
+mechanism below is one hop away via `related_files` and `system-manual`.
 
 ## I · Body and extensions
 
@@ -66,12 +73,16 @@ The bundled `runtime-update-checks` manual is only for local read-only diagnosis
 and refresh mechanics. A `source_drift` nudge stays local to those mechanics and
 does not enter release-migration routing.
 
+> deeper: system-manual → substrate-manual §1 (extension decision tree)
+
 ## II · Life states
 
 Agents are ACTIVE, IDLE, STUCK, ASLEEP, or SUSPENDED. The key operational split:
 ASLEEP still has listeners and wakes by mail; SUSPENDED is process-dead and needs
 CPR or external restart. Use sleep/lull for routine rest; suspend only when you
 want process death.
+
+> deeper: substrate-manual §2 (lifecycle states)
 
 ## III · Communication
 
@@ -80,6 +91,8 @@ on the channel where the message arrived. Treat notification previews as hints;
 read the producer channel when the preview is truncated, ambiguous, lacks a clear
 new-message marker, includes media/attachments, or needs exact anchoring. Use
 producer-specific read/dismiss verbs before generic notification dismissals.
+
+> deeper: notification-manual + producer channel manuals
 
 ## IV · Memory and molt
 
@@ -97,11 +110,15 @@ current session) also nudges a molt: when `_meta.agent_meta.agent_state.context.
 says the cache-miss budget is reached, molt to shed the carried context and
 restore cache efficiency.
 
+> deeper: context-manual (molt / summarize / rebuild)
+
 ## V · Idle and soul
 
 When there is nothing concrete to do, go idle. Idle keeps listeners alive and lets
 soul flow reflect. Do not use timed sleep as a default wait. Soul flow is advice,
 not command; verify external-event claims through the relevant channel.
+
+> deeper: soul-manual
 
 ## VI · Nudge policy
 
@@ -114,6 +131,8 @@ complete environment catalogue defines accepted values, invalid-value fallback,
 and read/reload behavior; read `system-manual` →
 `reference/environment-variables/SKILL.md` before changing an environment
 variable.
+
+> deeper: system-manual → environment-variables/SKILL.md
 
 ## VII · Tool tiers and system operations
 
@@ -222,3 +241,5 @@ dedicated `notification` tool (`check`, `dismiss_channel`, `dismiss_event`,
 `nirvana`) and the full operating model, read the `system-manual` router; it
 routes substrate details to `reference/substrate-manual/SKILL.md`. For
 notification details, read the first-level `notification-manual` skill.
+
+> deeper: substrate-manual §11 (preset runtime model)

--- a/src/lingtai/tools/context/_molt.py
+++ b/src/lingtai/tools/context/_molt.py
@@ -531,9 +531,12 @@ def _context_molt(agent, args: dict) -> dict:
     try:
         from lingtai.kernel.agent_readme import ensure_agent_readme
 
-        ensure_agent_readme(agent._working_dir)
+        ensure_agent_readme(agent._working_dir, _log=agent._log)
     except Exception:
-        pass
+        try:
+            agent._log("agent_readme_ensure_failed", stage="molt")
+        except Exception:
+            pass
 
 
     # Post-molt reminder. ToolExecutor strips visible ``reasoning`` and

--- a/src/lingtai/tools/context/_molt.py
+++ b/src/lingtai/tools/context/_molt.py
@@ -526,6 +526,15 @@ def _context_molt(agent, args: dict) -> dict:
         session_journal_path=session_journal_path,
     )
 
+    # Molt is one of README.md's mechanical regeneration points (template-
+    # version check only). Fail-soft: a README problem must never break a molt.
+    try:
+        from lingtai.kernel.agent_readme import ensure_agent_readme
+
+        ensure_agent_readme(agent._working_dir)
+    except Exception:
+        pass
+
 
     # Post-molt reminder. ToolExecutor strips visible ``reasoning`` and
     # injects ``_reasoning``; accept the plain key too so direct callers

--- a/tests/test_agent_readme.py
+++ b/tests/test_agent_readme.py
@@ -6,8 +6,10 @@ from pathlib import Path
 
 import pytest
 
+from lingtai.agent import Agent
 from lingtai.kernel.agent_readme import ensure_agent_readme, render_readme, template_version
 from lingtai.kernel.workdir import WorkdirLayout, workdir_layout
+from tests._service_helpers import make_gemini_mock_service as make_mock_service
 
 
 @pytest.fixture()
@@ -71,6 +73,55 @@ def test_readme_has_no_identity_or_live_values(agent_root: Path) -> None:
     # No live/heartbeat/provider-style dynamic fields.
     for token in ("heartbeat", "provider", "context_limit", "molt_count"):
         assert token not in body
+
+
+def test_unversioned_existing_readme_is_taken_over_with_backup(agent_root: Path) -> None:
+    """CONTRACT/P1-1: a user-authored unversioned README is preserved as .bak before takeover."""
+    user_readme = "# My notes\n\nThis is my own README, not kernel-owned.\n"
+    (agent_root / "README.md").write_text(user_readme, encoding="utf-8")
+    events: list[str] = []
+
+    def _log(name: str, **kwargs: object) -> None:
+        events.append(f"{name}:{kwargs}")
+
+    written = ensure_agent_readme(agent_root, _log=_log)
+    assert written == agent_root / "README.md"
+    # Original content preserved, not silently clobbered.
+    assert (agent_root / "README.md.bak").read_text(encoding="utf-8") == user_readme
+    # Takeover logged.
+    assert any(e.startswith("agent_readme_takeover") for e in events)
+    # Navigation entry now in place.
+    assert "system/substrate.md" in written.read_text(encoding="utf-8")
+
+
+def test_non_utf8_existing_readme_still_rewrites(agent_root: Path) -> None:
+    """P2-1: a non-UTF-8 existing README is treated as unreadable and rewritten."""
+    target = agent_root / "README.md"
+    target.write_bytes(b"\xff\xfe\x00binary\n")
+    written = ensure_agent_readme(agent_root)
+    assert written == target
+    body = target.read_text(encoding="utf-8")
+    assert body.startswith("---\ntemplate_version:")
+    assert "system/substrate.md" in body
+
+
+def test_packaged_template_without_version_head_raises(agent_root: Path) -> None:
+    """P2-5: a broken packaged template (no version head) fails loudly, not silently."""
+    with pytest.raises(ValueError):
+        ensure_agent_readme(agent_root, template="# Broken\n")
+
+
+def test_baseagent_construction_writes_readme(tmp_path: Path) -> None:
+    """P1-2: the construction mount point actually lands README.md in a real agent."""
+    svc = make_mock_service()
+    working_dir = tmp_path / "test"
+    # Construction itself runs ensure_agent_readme (fail-soft mount).
+    Agent(service=svc, agent_name="test", working_dir=working_dir)
+    readme = working_dir / "README.md"
+    assert readme.is_file()
+    body = readme.read_text(encoding="utf-8")
+    assert body.startswith("---\ntemplate_version:")
+    assert "system/substrate.md" in body
 
 
 def test_workdir_layout_names_readme(agent_root: Path) -> None:

--- a/tests/test_agent_readme.py
+++ b/tests/test_agent_readme.py
@@ -1,0 +1,94 @@
+"""Contract tests for the agent-directory README (see agent_readme/CONTRACT.md)."""
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from lingtai.kernel.agent_readme import ensure_agent_readme, render_readme, template_version
+from lingtai.kernel.workdir import WorkdirLayout, workdir_layout
+
+
+@pytest.fixture()
+def agent_root(tmp_path: Path) -> Path:
+    (tmp_path / "system").mkdir()
+    (tmp_path / "knowledge").mkdir()
+    return tmp_path
+
+
+def test_rendered_template_points_at_substrate(agent_root: Path) -> None:
+    """CONTRACT #1: written README exists and carries the substrate relative link."""
+    written = ensure_agent_readme(agent_root)
+    assert written is not None
+    assert written == agent_root / "README.md"
+    body = written.read_text(encoding="utf-8")
+    assert "system/substrate.md" in body
+    # It is a navigation entry point, not a pure listing: rows carry explanation.
+    assert "Where to look" in body
+    assert "Open when" in body
+
+
+def test_missing_file_is_written_and_version_match_is_noop(agent_root: Path) -> None:
+    """CONTRACT #2: missing → write; stale version → rewrite; match → no-op."""
+    layout = workdir_layout(agent_root)
+    assert not layout.readme.exists()
+
+    # Missing: write.
+    written = ensure_agent_readme(agent_root)
+    assert written == layout.readme
+    first = layout.readme.read_text(encoding="utf-8")
+    assert template_version(first) == template_version(render_readme())
+
+    # Version match: strict no-op (returns None, mtime/content unchanged).
+    assert ensure_agent_readme(agent_root) is None
+    assert layout.readme.read_text(encoding="utf-8") == first
+
+    # Stale: rewrite with the packaged template.
+    layout.readme.write_text(
+        textwrap.dedent(
+            """\
+            ---
+            template_version: agent-readme/v0
+            ---
+            # Old README
+            """
+        ),
+        encoding="utf-8",
+    )
+    written = ensure_agent_readme(agent_root)
+    assert written == layout.readme
+    assert layout.readme.read_text(encoding="utf-8") == first
+
+
+def test_readme_has_no_identity_or_live_values(agent_root: Path) -> None:
+    """CONTRACT #3: README carries neither the agent name nor live/dynamic fields."""
+    ensure_agent_readme(agent_root)
+    body = (agent_root / "README.md").read_text(encoding="utf-8")
+    # No placeholder-looking identity slot.
+    assert "{{agent_name}}" not in body
+    assert "<agent_name>" not in body
+    # No live/heartbeat/provider-style dynamic fields.
+    for token in ("heartbeat", "provider", "context_limit", "molt_count"):
+        assert token not in body
+
+
+def test_workdir_layout_names_readme(agent_root: Path) -> None:
+    """WorkdirLayout names the README path."""
+    assert WorkdirLayout(agent_root).readme == agent_root / "README.md"
+
+
+def test_substrate_related_files_links_agent_readme() -> None:
+    """CONTRACT #4: substrate frontmatter related_files links agent_readme docs."""
+    substrate = (
+        Path(__file__).resolve().parents[1]
+        / "src"
+        / "lingtai"
+        / "prompts"
+        / "substrate"
+        / "substrate.md"
+    )
+    assert substrate.is_file()
+    head = substrate.read_text(encoding="utf-8")[:4096]
+    assert "src/lingtai/kernel/agent_readme/CONTRACT.md" in head
+    assert "src/lingtai/kernel/agent_readme/README.md.tpl" in head


### PR DESCRIPTION
## What
Add a static **README.md** at each agent working directory root: a **navigation entry point** for humans/tools reaching the folder. Replaces the #1252 MANUAL.md generator semantics that were removed from the #1329 squash.

## Roles (per design review)
- **README.md** (agent root, for humans/tools): directory navigation only. Carries **no agent identity (name)** and **no live/dynamic values** — those stay in init.json/.status.json/.agent.json/system/pad.md.
- **substrate.md** (agent system/, mirrors kernel prompts/substrate/substrate.md, for agent/machine): the progressive-disclosure entrance for how an agent's body works. Enhanced via frontmatter related_files + opening paragraph + per-section deeper lines.
- **agent_readme/CONTRACT.md** (kernel repo): fixes the role split, ownership, and maintenance boundary.

## Implementation
- New package src/lingtai/kernel/agent_readme/: README.md.tpl (static template with template_version head), ensure_agent_readme (mechanical template-version staleness check; atomic write; no placeholders, no secrets, no live snapshot), CONTRACT.md, ANATOMY.md.
- WorkdirLayout.readme path.
- Mount points (each fail-soft): refresh (_perform_refresh), molt (context/_molt.py), BaseAgent construction — regenerates README only when missing or template version changed.
- substrate.md: related_files links agent_readme docs, entrance paragraph, per-section deeper lines (7 sections, English one-liners).
- pyproject package-data entry; tests/test_agent_readme.py with 5 contract tests.

## Verification
- 5 new contract tests pass; ruff clean.
- Adjacent: test_workdir.py 11 passed; test_context/molt-notification/post-molt 29 passed (1 pre-existing failure test_legacy_psyche_capability_is_tolerated_and_filtered also fails on origin/main — unrelated).
- Diff: 11 files, +354.