### PR TITLE
feat(docs): LingTai Agent Behavior Tasks (LABT) — behaviors.md convention + karma pilot

### DIFF
--- a/BEHAVIORS.md
+++ b/BEHAVIORS.md
@@ -1,6 +1,7 @@
 ---
 name: component-behavior-test-convention
-behavior_version: 1
+behavior_version: 2
+labt_version: 1
 related_files:
   - CONTRACT.md
   - ANATOMY.md
@@ -8,66 +9,125 @@ related_files:
   - tests/CONTRACT.md
 maintenance: |
   This file is the normative root of the distributed behavior-test definition
-  system and the contract-of-behaviors. Keep the root CONTRACT.md and root
+  system: it owns the LingTai Agent Behavior Task (LABT) specification, its
+  version, and the contract-of-behaviors. Keep the root CONTRACT.md and root
   ANATOMY.md reciprocal: contract clauses that state agent-observable behavior
-  MUST link to the behavior(s) that guard them, behaviors MUST annotate the
-  contract clause they guard, and anatomy MUST link code to both when
-  applicable. Change architecture rules, schemas, templates, and validation
-  together. Bump behavior_version for a breaking convention change.
+  MUST link to the LABT(s) that guard them, LABTs MUST annotate the contract
+  clause they guard, and anatomy MUST link code to both when applicable.
+  Change architecture rules, schemas, templates, and validation together.
+  Bump behavior_version for a breaking convention change; bump labt_version
+  when the LABT specification itself changes (fields, self-containment rules,
+  version semantics).
 ---
-# Behavior Test Convention (behaviors.md)
+# Behavior Test Convention (BEHAVIORS.md)
 
 ## Purpose
 
 **BEHAVIORS.md is the distributed agent-observable behavior definition system.**
-A `behaviors.md` sits beside a `CONTRACT.md` (and its paired `ANATOMY.md`) to
-record **agent-executable behavioral tests**: markdown scenarios an agent runs
-against the real product to prove the contract's *important behavior clauses*
-do not drift.
+A `BEHAVIORS.md` sits beside a `CONTRACT.md` (and its paired `ANATOMY.md`) to
+record **LingTai Agent Behavior Tasks**: self-contained agent-executable
+behavioral tests in markdown. Each LABT is a scenario an agent runs against the
+real product to prove the contract's *important behavior clauses* do not drift.
 
 It is the third leg of the **three-way linkage**:
 
 | Document | Answers | Role |
 |---|---|---|
 | `CONTRACT.md` | What does it promise? | Interface / behavior obligations |
-| `behaviors.md` | How do we verify the promise with an agent? | Agent-run behavioral tests |
+| `BEHAVIORS.md` | How do we verify the promise with an agent? | Self-contained agent tasks (LABT) |
 | `ANATOMY.md` | Where is the code? | Code navigation |
+
+## LingTai Agent Behavior Task (LABT) — version 1
+
+A **LABT** is the unit of behavior verification in this repository: a single
+markdown section, fully self-contained, that an agent or daemon can execute
+verbatim with no other context. LABT version is owned and versioned by this
+root file (`labt_version`); child `BEHAVIORS.md` files MUST declare which
+`labt_version` they conform to.
+
+### Self-containment rule (normative)
+
+The LABT text itself MUST contain every fact an executor needs: exact paths,
+commands, expected values, and pass criteria. The executor must NOT need to
+open any other file to run the task. References to contracts, anatomy, or
+pytest are for traceability and review — never required for execution.
+
+### LABT fields
+
+| Field | Required | Meaning |
+|---|---|---|
+| `id` | yes | Stable anchor, `B###`; section heading becomes `#behavior-b###` |
+| `title` | yes | One-sentence behavior promise |
+| `guards` | yes | Contract clause guarded (bidirectional ref) |
+| `supersedes` | no | pytest file(s) this LABT replaces/complements (traceability) |
+| `runner` | yes | Which agent/daemon shape can execute (e.g. any LingTai agent with `system`) |
+| `prerequisites` | yes | Exact setup required (agents, dirs, files, permissions) |
+| `steps` | yes | Ordered concrete actions the executor performs |
+| `expected_evidence` | yes | Observable outcomes checklist (state/file/receipt/notification) |
+| `pass_fail` | yes | How to decide pass vs fail, incl. forbidden side effects |
+| `estimate` | no | Expected duration hint |
+
+### LABT template
+
+```markdown
+## Behavior B001 — <title>
+
+- **id**: B001
+- **guards**: `<contract-name>` § <clause> (link back to the contract clause)
+- **supersedes**: `tests/<file>.py::<test>` (optional)
+- **runner**: <agent shape required>
+- **prerequisites**: <exact setup — dirs, files, permissions>
+- **estimate**: <duration>
+
+### Steps
+1. <action with exact path/command>
+2. <observe>
+
+### Expected evidence
+- [ ] <observable outcome>
+- [ ] <observable outcome>
+
+### Pass / Fail
+Pass when all evidence observed and no forbidden side effect occurs. Fail on
+any mismatch; record the evidence trail in the task report.
+```
 
 ## Relationship to pytest
 
 pytest remains for **low-level assertions** (pure units, hermetic adapter
-contracts, fast regressions). `behaviors.md` is the **primary behavior
-verification entry** for behavior clauses: scenarios an agent executes against
-the real runtime, checking observable outcomes (states, files, notifications,
-receipts, side effects) rather than internal call shapes.
+contracts, fast regressions). `BEHAVIORS.md` is the **primary behavior
+verification entry** for behavior clauses: LABT scenarios an agent executes
+against the real runtime, checking observable outcomes rather than internal
+call shapes.
 
-When a CONVERT_BEHAVIOR pytest is migrated, the behavior scenario records the
-original pytest file as `supersedes` so the trace stays complete; the pytest may
-be kept (bottom asserts) or removed, per the change's judgment.
+When a CONVERT_BEHAVIOR pytest is migrated, the LABT records the original
+pytest file as `supersedes` so the trace stays complete; the pytest may be kept
+(bottom asserts) or removed, per the change's judgment.
 
 ## Bidirectional reference rules
 
 1. **contract → behaviors.** Every *important behavior clause* in a `CONTRACT.md`
-   MUST reference the guarding behavior(s) with a link of the form
+   MUST reference the guarding LABT(s) with a link of the form
    `[B012](BEHAVIORS.md#behavior-b012)` (relative to the same directory).
    A behavior clause is a clause stating agent-observable behavior: states,
    receipts, side effects, authorization gates, communication outcomes.
-2. **behaviors → contract.** Every behavior entry MUST annotate which contract
-   clause it guards, with `guards: <contract-frontmatter-name> §<clause heading>`
+2. **behaviors → contract.** Every LABT MUST annotate which contract clause it
+   guards, with `guards: <contract-frontmatter-name> § <clause heading>`
    and a relative link back to that clause.
 3. **anatomy → both (if applicable).** Every `ANATOMY.md` whose component owns
-   behavior MUST link its `behaviors.md` in `related_files` and, in the entry
-   for the code that implements a behavior, name the behavior id.
+   behavior MUST link its `BEHAVIORS.md` in `related_files` and, in the entry
+   for the code that implements a behavior, name the LABT ids.
 4. **Change one, check the other two.** When any of the three changes in a way
    that could affect agent-observable behavior, the other two must be checked
    and updated if applicable. This is a review gate, not optional polish.
 
-## Behaviors.md frontmatter schema
+## BEHAVIORS.md frontmatter schema
 
 ```yaml
 ---
 name: <component>-behavior-tests      # e.g. system-behavior-tests
-behavior_version: 1                   # bump on breaking format change only
+behavior_version: 1                   # child-file format revision
+labt_version: 1                       # MUST match this root's labt_version
 contract: CONTRACT.md                 # the contract this guards (relative)
 anatomy: ANATOMY.md                   # the anatomy this pairs with (relative)
 related_files:                        # real repo-relative paths
@@ -79,41 +139,13 @@ maintenance: |
 ---
 ```
 
-## Behavior entry template
-
-Each behavior is a numbered markdown section: `## Behavior B### — <title>`.
-The id is the anchor: `#behavior-b###` (lowercase).
-
-```markdown
-## Behavior B012 — karma verbs require admin.karma
-
-- **guards**: `system-contract` § Karma-gated control of other agents
-  (link back to the contract clause)
-- **supersedes**: `tests/test_karma.py::test_interrupt_requires_karma_admin`
-  (optional; the pytest this behavior replaces or complements)
-- **runner**: any LingTai agent with `system` tool
-- **preconditions**: two agent working dirs exist; sender has `admin.karma=True`
-
-### Scenario
-1. ... concrete steps the agent performs ...
-2. ...
-
-### Expected evidence
-- [ ] observable outcome 1 (state, file, receipt, notification)
-- [ ] observable outcome 2
-
-### Pass / fail
-Pass when all expected evidence is observed and no forbidden side effect
-occurs. Fail on any mismatch; record the evidence trail in the task report.
-```
-
 ## Discovery and validation
 
 - Root `BEHAVIORS.md` links every governed child `behaviors.md` exactly once in
   `related_files` (same rule as the contract-of-contract).
 - A validation test (`tests/test_architecture_documents.py` or a sibling)
-  SHOULD enforce: every contract behavior clause has a behavior link; every
-  behavior has a `guards` annotation resolving to a real contract clause; every
-  child behaviors.md is linked from this root.
-- Keep each behaviors.md concise: one scenario per behavior, scenario length
-  bounded, evidence checklists over prose.
+  SHOULD enforce: every contract behavior clause has a LABT link; every LABT
+  has a `guards` annotation resolving to a real contract clause; every child
+  BEHAVIORS.md is linked from this root and declares a matching `labt_version`.
+- Keep each BEHAVIORS.md concise: one scenario per LABT, self-contained steps,
+  evidence checklists over prose.

--- a/BEHAVIORS.md
+++ b/BEHAVIORS.md
@@ -25,12 +25,17 @@ maintenance: |
 ## Purpose
 
 **BEHAVIORS.md is the distributed agent-observable behavior definition system.**
-A `BEHAVIORS.md` sits beside a `CONTRACT.md` (and its paired `ANATOMY.md`) to
-record **LingTai Agent Behavior Tasks**: self-contained agent-executable
-behavioral tests in markdown. Each LABT is a scenario an agent runs against the
-real product to prove the contract's *important behavior clauses* do not drift.
+It is the **sibling of `CONTRACT.md`** (not a governed child): a
+`BEHAVIORS.md` sits beside a `CONTRACT.md` in the same directory and records
+**LingTai Agent Behavior Tasks** — self-contained agent-executable behavioral
+tests in markdown. Each LABT is a scenario an agent runs against the real
+product to prove the contract's *important behavior clauses* do not drift.
+The contract/behaviors pair has the stronger connection: every important
+behavior clause lives in the contract and is verified by a LABT here. The
+paired `ANATOMY.md` is the third node of the tridirectional loop: all three
+files are interconnected if applicable.
 
-It is the third leg of the **three-way linkage**:
+It is the third leg of the **tridirectional linkage**:
 
 | Document | Answers | Role |
 |---|---|---|

--- a/BEHAVIORS.md
+++ b/BEHAVIORS.md
@@ -1,0 +1,119 @@
+---
+name: component-behavior-test-convention
+behavior_version: 1
+related_files:
+  - CONTRACT.md
+  - ANATOMY.md
+  - dev-guide-skill/SKILL.md
+  - tests/CONTRACT.md
+maintenance: |
+  This file is the normative root of the distributed behavior-test definition
+  system and the contract-of-behaviors. Keep the root CONTRACT.md and root
+  ANATOMY.md reciprocal: contract clauses that state agent-observable behavior
+  MUST link to the behavior(s) that guard them, behaviors MUST annotate the
+  contract clause they guard, and anatomy MUST link code to both when
+  applicable. Change architecture rules, schemas, templates, and validation
+  together. Bump behavior_version for a breaking convention change.
+---
+# Behavior Test Convention (behaviors.md)
+
+## Purpose
+
+**BEHAVIORS.md is the distributed agent-observable behavior definition system.**
+A `behaviors.md` sits beside a `CONTRACT.md` (and its paired `ANATOMY.md`) to
+record **agent-executable behavioral tests**: markdown scenarios an agent runs
+against the real product to prove the contract's *important behavior clauses*
+do not drift.
+
+It is the third leg of the **three-way linkage**:
+
+| Document | Answers | Role |
+|---|---|---|
+| `CONTRACT.md` | What does it promise? | Interface / behavior obligations |
+| `behaviors.md` | How do we verify the promise with an agent? | Agent-run behavioral tests |
+| `ANATOMY.md` | Where is the code? | Code navigation |
+
+## Relationship to pytest
+
+pytest remains for **low-level assertions** (pure units, hermetic adapter
+contracts, fast regressions). `behaviors.md` is the **primary behavior
+verification entry** for behavior clauses: scenarios an agent executes against
+the real runtime, checking observable outcomes (states, files, notifications,
+receipts, side effects) rather than internal call shapes.
+
+When a CONVERT_BEHAVIOR pytest is migrated, the behavior scenario records the
+original pytest file as `supersedes` so the trace stays complete; the pytest may
+be kept (bottom asserts) or removed, per the change's judgment.
+
+## Bidirectional reference rules
+
+1. **contract → behaviors.** Every *important behavior clause* in a `CONTRACT.md`
+   MUST reference the guarding behavior(s) with a link of the form
+   `[B012](BEHAVIORS.md#behavior-b012)` (relative to the same directory).
+   A behavior clause is a clause stating agent-observable behavior: states,
+   receipts, side effects, authorization gates, communication outcomes.
+2. **behaviors → contract.** Every behavior entry MUST annotate which contract
+   clause it guards, with `guards: <contract-frontmatter-name> §<clause heading>`
+   and a relative link back to that clause.
+3. **anatomy → both (if applicable).** Every `ANATOMY.md` whose component owns
+   behavior MUST link its `behaviors.md` in `related_files` and, in the entry
+   for the code that implements a behavior, name the behavior id.
+4. **Change one, check the other two.** When any of the three changes in a way
+   that could affect agent-observable behavior, the other two must be checked
+   and updated if applicable. This is a review gate, not optional polish.
+
+## Behaviors.md frontmatter schema
+
+```yaml
+---
+name: <component>-behavior-tests      # e.g. system-behavior-tests
+behavior_version: 1                   # bump on breaking format change only
+contract: CONTRACT.md                 # the contract this guards (relative)
+anatomy: ANATOMY.md                   # the anatomy this pairs with (relative)
+related_files:                        # real repo-relative paths
+  - src/lingtai/tools/system/karma.py
+  - tests/test_karma.py
+  - <any manual that teaches the behavior>
+maintenance: |
+  <who updates this, when, and how it links with contract/anatomy changes>
+---
+```
+
+## Behavior entry template
+
+Each behavior is a numbered markdown section: `## Behavior B### — <title>`.
+The id is the anchor: `#behavior-b###` (lowercase).
+
+```markdown
+## Behavior B012 — karma verbs require admin.karma
+
+- **guards**: `system-contract` § Karma-gated control of other agents
+  (link back to the contract clause)
+- **supersedes**: `tests/test_karma.py::test_interrupt_requires_karma_admin`
+  (optional; the pytest this behavior replaces or complements)
+- **runner**: any LingTai agent with `system` tool
+- **preconditions**: two agent working dirs exist; sender has `admin.karma=True`
+
+### Scenario
+1. ... concrete steps the agent performs ...
+2. ...
+
+### Expected evidence
+- [ ] observable outcome 1 (state, file, receipt, notification)
+- [ ] observable outcome 2
+
+### Pass / fail
+Pass when all expected evidence is observed and no forbidden side effect
+occurs. Fail on any mismatch; record the evidence trail in the task report.
+```
+
+## Discovery and validation
+
+- Root `BEHAVIORS.md` links every governed child `behaviors.md` exactly once in
+  `related_files` (same rule as the contract-of-contract).
+- A validation test (`tests/test_architecture_documents.py` or a sibling)
+  SHOULD enforce: every contract behavior clause has a behavior link; every
+  behavior has a `guards` annotation resolving to a real contract clause; every
+  child behaviors.md is linked from this root.
+- Keep each behaviors.md concise: one scenario per behavior, scenario length
+  bounded, evidence checklists over prose.

--- a/BEHAVIORS.md
+++ b/BEHAVIORS.md
@@ -14,10 +14,11 @@ maintenance: |
   ANATOMY.md reciprocal: contract clauses that state agent-observable behavior
   MUST link to the LABT(s) that guard them, LABTs MUST annotate the contract
   clause they guard, and anatomy MUST link code to both when applicable.
-  Change architecture rules, schemas, templates, and validation together.
-  Bump behavior_version for a breaking convention change; bump labt_version
-  when the LABT specification itself changes (fields, self-containment rules,
-  version semantics).
+  The three documents form one tridirectional loop; changing any one requires
+  re-checking the other two. Change architecture rules, schemas, templates, and
+  validation together. Bump behavior_version for a breaking convention change;
+  bump labt_version when the LABT specification itself changes (fields,
+  self-containment rules, version semantics).
 ---
 # Behavior Test Convention (BEHAVIORS.md)
 
@@ -104,22 +105,29 @@ When a CONVERT_BEHAVIOR pytest is migrated, the LABT records the original
 pytest file as `supersedes` so the trace stays complete; the pytest may be kept
 (bottom asserts) or removed, per the change's judgment.
 
-## Bidirectional reference rules
+## Tridirectional linkage rules
 
-1. **contract → behaviors.** Every *important behavior clause* in a `CONTRACT.md`
-   MUST reference the guarding LABT(s) with a link of the form
-   `[B012](BEHAVIORS.md#behavior-b012)` (relative to the same directory).
-   A behavior clause is a clause stating agent-observable behavior: states,
-   receipts, side effects, authorization gates, communication outcomes.
-2. **behaviors → contract.** Every LABT MUST annotate which contract clause it
-   guards, with `guards: <contract-frontmatter-name> § <clause heading>`
-   and a relative link back to that clause.
-3. **anatomy → both (if applicable).** Every `ANATOMY.md` whose component owns
-   behavior MUST link its `BEHAVIORS.md` in `related_files` and, in the entry
-   for the code that implements a behavior, name the LABT ids.
-4. **Change one, check the other two.** When any of the three changes in a way
-   that could affect agent-observable behavior, the other two must be checked
-   and updated if applicable. This is a review gate, not optional polish.
+Contract ⇄ Behaviors ⇄ Anatomy form one tridirectional loop: every edge carries
+a stable id reference, and changing any node requires re-checking the other two.
+
+```text
+      CONTRACT.md
+      /          \
+ [B###]            [B###]
+    /                \
+BEHAVIORS.md <----> ANATOMY.md
+      (related_files + LABT ids)
+```
+
+| Edge | Reference form | Where it lives |
+|---|---|---|
+| contract → behaviors | `[B012](BEHAVIORS.md#behavior-b012)` on every important behavior clause (states, receipts, side effects, auth gates, communication outcomes) | CONTRACT.md |
+| behaviors → contract | `guards: <contract-name> § <clause>` + relative link back | each LABT entry |
+| behaviors ↔ anatomy | `related_files` lists BEHAVIORS.md; anatomy entries name the LABT ids they implement | ANATOMY.md + BEHAVIORS.md |
+
+**Change one, check the other two.** A change affecting agent-observable
+behavior in any of the three MUST update or at least re-verify the other two
+in the same change. This is a review gate, not optional polish.
 
 ## BEHAVIORS.md frontmatter schema
 

--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -3,6 +3,7 @@ name: component-contract-convention
 contract_version: 4
 related_files:
   - ANATOMY.md
+  - BEHAVIORS.md
   - ENVIRONMENT_VARIABLES.md
   - GLOSSARY.md
   - src/lingtai/kernel/event_journal/CONTRACT.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,7 @@ Thank you for helping improve the LingTai Python runtime. GitHub discovers this 
   repository’s dev guide skill
 - Distributed code navigation system: [`ANATOMY.md`](ANATOMY.md)
 - Distributed interface and Behavior Contract system: [`CONTRACT.md`](CONTRACT.md)
+- Distributed agent-observable behavior tests (LABT): [`BEHAVIORS.md`](BEHAVIORS.md)
 - Claude Code / coding-agent guidance:
   [`docs/references/claude-code-guide.md`](docs/references/claude-code-guide.md)
 - Source-root anatomy: [`src/lingtai/kernel/ANATOMY.md`](src/lingtai/kernel/ANATOMY.md)
@@ -46,7 +47,10 @@ cd .worktrees/<slug>
 
 Before changing code or architecture documents, read the repository-local
 kernel development skill, then the nearest `ANATOMY.md` to navigate the layer and the paired `CONTRACT.md` (when
-governed) to learn its interface and Behavior promises. The development skill owns the change workflow; the root documents own the
+governed) to learn its interface and Behavior promises. When the component
+has agent-observable behavior, read its paired `BEHAVIORS.md` and follow the
+Contract ⇄ Behaviors ⇄ Anatomy tridirectional linkage: changing one requires
+re-checking the other two. The development skill owns the change workflow; the root documents own the
 structural and interface rules. Follow those routes instead of copying their
 checklists here.
 

--- a/dev-guide-skill/SKILL.md
+++ b/dev-guide-skill/SKILL.md
@@ -101,31 +101,35 @@ relationship does not satisfy the root rule, stop and report the root-defined
 mismatch fields and suggested action; do not normalize or auto-fix it without
 authorization.
 
-### Three-way linkage: Contract ⇄ Behaviors ⇄ Anatomy
+### Tridirectional linkage: Contract ⇄ Behaviors ⇄ Anatomy
 
-Root [`BEHAVIORS.md`](../BEHAVIORS.md) defines the **markdown behavioral test**
-system: agent-executable scenarios that prove the contract's important behavior
-clauses do not drift. A governed component MAY own a `behaviors.md` beside its
-`CONTRACT.md`/`ANATOMY.md` when it has agent-observable behavior worth verifying
-(see the audit: candidates are the `CONVERT_BEHAVIOR` pytest files). The three
-documents cross-link instead of duplicating:
+Root [`BEHAVIORS.md`](../BEHAVIORS.md) defines the **LingTai Agent Behavior
+Task (LABT)** system: self-contained agent-executable scenarios that prove the
+contract's important behavior clauses do not drift. `BEHAVIORS.md` is the
+**sibling of `CONTRACT.md`** (stronger connection: every important behavior
+clause is verified by a LABT); the paired `ANATOMY.md` is the third node, and
+all three files are interconnected if applicable. A governed component MAY own
+a `BEHAVIORS.md` beside its `CONTRACT.md`/`ANATOMY.md` when it has
+agent-observable behavior worth verifying (see the audit: candidates are the
+`CONVERT_BEHAVIOR` pytest files). The three documents cross-link instead of
+duplicating:
 
 - **contract → behaviors**: every important behavior clause in a `CONTRACT.md`
-  MUST reference the guarding behavior(s) with a relative
+  MUST reference the guarding LABT(s) with a relative
   `[B###](BEHAVIORS.md#behavior-b###)` link.
-- **behaviors → contract**: every behavior entry MUST annotate the clause it
-  guards (`guards: <contract-name> § <clause>`) with a link back.
-- **anatomy → both**: the paired `ANATOMY.md` lists `BEHAVIORS.md` in
-  `related_files` and names the behavior ids in entries for implementing code.
+- **behaviors → contract**: every LABT MUST annotate the clause it guards
+  (`guards: <contract-name> § <clause>`) with a link back.
+- **behaviors ↔ anatomy**: the paired `ANATOMY.md` lists `BEHAVIORS.md` in
+  `related_files` and names the LABT ids in entries for implementing code.
 
 **Change one, check the other two.** When any of the three changes in a way
 that could affect agent-observable behavior, update or at least re-check the
 other two in the same change. This is a review gate, not optional polish; the
-root `BEHAVIORS.md` carries the full format and templates.
+root `BEHAVIORS.md` carries the full LABT format and templates.
 
-When migrating a `CONVERT_BEHAVIOR` pytest to a behavior scenario, record the
-original pytest as `supersedes` in the behavior entry so the trace stays
-complete; the pytest may be kept for bottom asserts or removed per judgment.
+When migrating a `CONVERT_BEHAVIOR` pytest to a LABT, record the original
+pytest as `supersedes` in the behavior entry so the trace stays complete; the
+pytest may be kept for bottom asserts or removed per judgment.
 
 ### Keep Maintenance guidance aligned
 

--- a/dev-guide-skill/SKILL.md
+++ b/dev-guide-skill/SKILL.md
@@ -101,6 +101,32 @@ relationship does not satisfy the root rule, stop and report the root-defined
 mismatch fields and suggested action; do not normalize or auto-fix it without
 authorization.
 
+### Three-way linkage: Contract ⇄ Behaviors ⇄ Anatomy
+
+Root [`BEHAVIORS.md`](../BEHAVIORS.md) defines the **markdown behavioral test**
+system: agent-executable scenarios that prove the contract's important behavior
+clauses do not drift. A governed component MAY own a `behaviors.md` beside its
+`CONTRACT.md`/`ANATOMY.md` when it has agent-observable behavior worth verifying
+(see the audit: candidates are the `CONVERT_BEHAVIOR` pytest files). The three
+documents cross-link instead of duplicating:
+
+- **contract → behaviors**: every important behavior clause in a `CONTRACT.md`
+  MUST reference the guarding behavior(s) with a relative
+  `[B###](BEHAVIORS.md#behavior-b###)` link.
+- **behaviors → contract**: every behavior entry MUST annotate the clause it
+  guards (`guards: <contract-name> § <clause>`) with a link back.
+- **anatomy → both**: the paired `ANATOMY.md` lists `BEHAVIORS.md` in
+  `related_files` and names the behavior ids in entries for implementing code.
+
+**Change one, check the other two.** When any of the three changes in a way
+that could affect agent-observable behavior, update or at least re-check the
+other two in the same change. This is a review gate, not optional polish; the
+root `BEHAVIORS.md` carries the full format and templates.
+
+When migrating a `CONVERT_BEHAVIOR` pytest to a behavior scenario, record the
+original pytest as `supersedes` in the behavior entry so the trace stays
+complete; the pytest may be kept for bottom asserts or removed per judgment.
+
 ### Keep Maintenance guidance aligned
 
 When you create or update a child component `CONTRACT.md`, keep its

--- a/src/lingtai/tools/system/ANATOMY.md
+++ b/src/lingtai/tools/system/ANATOMY.md
@@ -2,6 +2,7 @@
 related_files:
   - src/lingtai/tools/ANATOMY.md
   - src/lingtai/tools/system/CONTRACT.md
+  - src/lingtai/tools/system/BEHAVIORS.md
   - src/lingtai/tools/system/__init__.py
   - src/lingtai/tools/system/karma.py
   - src/lingtai/tools/system/preset.py

--- a/src/lingtai/tools/system/BEHAVIORS.md
+++ b/src/lingtai/tools/system/BEHAVIORS.md
@@ -1,6 +1,7 @@
 ---
 name: system-behavior-tests
-behavior_version: 1
+behavior_version: 2
+labt_version: 1
 contract: CONTRACT.md
 anatomy: ANATOMY.md
 related_files:
@@ -17,122 +18,162 @@ maintenance: |
   Written by the karma-lifecycle audit (2026-08). Keep in sync with
   CONTRACT.md clauses this file guards and ANATOMY.md entries for karma.py /
   name.py / preset.py; when CONTRACT.md or ANATOMY.md changes in a way that
-  affects agent-observable lifecycle behavior, update the matching behavior
-  here in the same change.
+  affects agent-observable lifecycle behavior, update the matching LABT here
+  in the same change.
 ---
 # System Behavior Tests — karma lifecycle control
 
-These are agent-executable behavioral tests for the `system` tool's
-karma-gated lifecycle verbs. They prove the *observable* promises of
-`src/lingtai/tools/system/CONTRACT.md`: authorization gates, signal files,
-state transitions, and self-action rejection. Low-level mechanics stay in
-pytest; these scenarios run against a real agent pair.
+LABT v1. These are self-contained agent-executable behavioral tests for the
+`system` tool's karma-gated lifecycle verbs. They prove the *observable*
+promises of `src/lingtai/tools/system/CONTRACT.md`: authorization gates, signal
+files, state transitions, and self-action rejection. Low-level mechanics stay
+in pytest; each LABT below is self-contained and executable verbatim by an
+agent with a `system` tool.
 
 ## Behavior B001 — interrupt requires admin.karma
 
+- **id**: B001
+- **title**: interrupt is refused without admin.karma
 - **guards**: `system-contract` § Karma-gated control of other agents
   ([CONTRACT.md](CONTRACT.md#karma-gated-control-of-other-agents))
 - **supersedes**: `tests/test_karma.py::test_interrupt_requires_karma_admin`
-- **runner**: agent with `system` tool; a second agent dir exists
-- **preconditions**: sender agent has `admin` block WITHOUT `karma` (e.g. `admin: {}`)
+- **runner**: an agent whose `admin` block does NOT include `karma` (e.g. `admin: {}`)
+- **prerequisites**: a second agent working dir exists (a dir containing
+  `.agent.json` and a fresh `.agent.heartbeat`)
+- **estimate**: 1 min
 
-### Scenario
-1. As the sender, call `system(action="interrupt", input={"address": "<target-agent-dir>", "reason": "test"})`.
-2. Observe the result.
+### Steps
+1. From your working dir, call `system(action="interrupt", input={"address": "<target-agent-dir>", "reason": "test"})`.
+2. Read the result returned by the tool.
+3. List the files in `<target-agent-dir>` and look for `.interrupt`.
 
 ### Expected evidence
-- [ ] The result contains an error (action refused) — `"error" in result`.
-- [ ] No `.interrupt` signal file is written into the target agent's dir.
+- [ ] The result contains an error (action refused).
+- [ ] No `.interrupt` file exists in `<target-agent-dir>`.
 
-### Pass / fail
-Pass when both evidence items hold. The receiver must never observe a
-permission leak: an unprivileged caller cannot affect another agent.
+### Pass / Fail
+Pass when both evidence items hold. Fail if the action succeeds or any
+signal file was written. An unprivileged caller must never affect another
+agent.
 
 ## Behavior B002 — interrupt with admin.karma writes the signal file
 
+- **id**: B002
+- **title**: interrupt with admin.karma writes `.interrupt` into the target
 - **guards**: `system-contract` § Karma-gated control of other agents
   ([CONTRACT.md](CONTRACT.md#karma-gated-control-of-other-agents))
 - **supersedes**: `tests/test_karma.py::test_interrupt_with_karma_admin`
-- **runner**: agent with `system` tool; a second agent dir exists with
-  `.agent.json` and a fresh `.agent.heartbeat`
-- **preconditions**: sender has `admin: {"karma": true}`; target dir is alive
-  (heartbeat file present and recent)
+- **runner**: an agent with `admin: {"karma": true}`
+- **prerequisites**: a second agent working dir exists with `.agent.json` and
+  a fresh `.agent.heartbeat` (so the target is considered alive)
+- **estimate**: 1 min
 
-### Scenario
-1. As the sender, call `system(action="interrupt", input={"address": "<target-agent-dir>", "reason": "test"})`.
-2. Observe the result and the target dir.
+### Steps
+1. From your working dir, call `system(action="interrupt", input={"address": "<target-agent-dir>", "reason": "test"})`.
+2. Read the result.
+3. List the files in `<target-agent-dir>`.
 
 ### Expected evidence
 - [ ] The result status is `interrupted`.
-- [ ] A `.interrupt` signal file exists in the target agent's working dir.
+- [ ] A `.interrupt` file exists in `<target-agent-dir>`.
+
+### Pass / Fail
+Pass when the receipt says `interrupted` AND the signal file exists. Fail if
+the signal file is missing or the receipt is an error.
 
 ## Behavior B003 — lull writes the sleep signal and reports asleep
 
+- **id**: B003
+- **title**: lull with admin.karma puts the target to sleep
 - **guards**: `system-contract` § Karma-gated control of other agents
   ([CONTRACT.md](CONTRACT.md#karma-gated-control-of-other-agents))
 - **supersedes**: `tests/test_karma.py::test_lull_writes_signal_file`
-- **runner**: agent with `system` tool; a second agent dir exists with
-  `.agent.json` and a fresh `.agent.heartbeat`
-- **preconditions**: sender has `admin: {"karma": true}`; target dir is alive
+- **runner**: an agent with `admin: {"karma": true}`
+- **prerequisites**: a second agent working dir exists with `.agent.json` and
+  a fresh `.agent.heartbeat` (target alive)
+- **estimate**: 1 min
 
-### Scenario
-1. As the sender, call `system(action="lull", input={"address": "<target-agent-dir>", "reason": "test"})`.
-2. Observe the result and the target dir.
+### Steps
+1. From your working dir, call `system(action="lull", input={"address": "<target-agent-dir>", "reason": "test"})`.
+2. Read the result.
+3. List the files in `<target-agent-dir>`.
 
 ### Expected evidence
 - [ ] The result status is `asleep`.
-- [ ] A `.sleep` signal file exists in the target agent's working dir.
+- [ ] A `.sleep` file exists in `<target-agent-dir>`.
 
-## Behavior B004 — lull refuses an asleep target
+### Pass / Fail
+Pass when the receipt says `asleep` AND the `.sleep` signal file exists.
 
+## Behavior B004 — lull refuses a target that is not alive
+
+- **id**: B004
+- **title**: lull refuses an asleep/non-alive target
 - **guards**: `system-contract` § Karma-gated control of other agents
   ([CONTRACT.md](CONTRACT.md#karma-gated-control-of-other-agents))
 - **supersedes**: `tests/test_karma.py::test_lull_rejects_asleep_target`
-- **runner**: agent with `system` tool; a second agent dir with
-  `.agent.json` carrying a non-null `admin` (so the not-running rejection path
-  is exercised rather than the always-alive human shortcut)
-- **preconditions**: sender has `admin: {"karma": true}`; target has no
-  heartbeat or is not alive
+- **runner**: an agent with `admin: {"karma": true}`
+- **prerequisites**: a second agent working dir exists whose `.agent.json`
+  carries a non-null `admin` (so the not-running rejection path is exercised
+  rather than the always-alive human shortcut); the target has no fresh
+  heartbeat
+- **estimate**: 1 min
 
-### Scenario
-1. As the sender, call `system(action="lull", input={"address": "<target-agent-dir>", "reason": "test"})`.
-2. Observe the result.
+### Steps
+1. From your working dir, call `system(action="lull", input={"address": "<target-agent-dir>", "reason": "test"})`.
+2. Read the result.
 
 ### Expected evidence
-- [ ] The result contains an error (action refused because the target is not
-      alive/asleep already).
+- [ ] The result contains an error (refused because the target is not alive).
+
+### Pass / Fail
+Pass when the action is refused with an error. Fail if lull reports success
+against a dead target.
 
 ## Behavior B005 — self-action is rejected
 
+- **id**: B005
+- **title**: an agent cannot karma-act on itself
 - **guards**: `system-contract` § Karma-gated control of other agents
   ([CONTRACT.md](CONTRACT.md#karma-gated-control-of-other-agents))
 - **supersedes**: `tests/test_karma.py::test_interrupt_self_rejected`
-- **runner**: agent with `system` tool
-- **preconditions**: sender has `admin: {"karma": true}`; the address passed
-  is the sender's own working dir
+- **runner**: an agent with `admin: {"karma": true}`
+- **prerequisites**: none beyond your own working dir
+- **estimate**: 1 min
 
-### Scenario
-1. As the sender, call `system(action="interrupt", input={"address": "<own-working-dir>", "reason": "test"})`.
-2. Observe the result.
+### Steps
+1. From your working dir, call `system(action="interrupt", input={"address": "<your-own-working-dir>", "reason": "test"})`.
+2. Read the result.
+3. List your own working dir.
 
 ### Expected evidence
-- [ ] The result contains an error (an agent cannot karma-act on itself).
-- [ ] No `.interrupt` signal file is created in the sender's own dir.
+- [ ] The result contains an error (self-action refused).
+- [ ] No `.interrupt` file exists in your own working dir.
+
+### Pass / Fail
+Pass when self-interrupt is refused and no signal file is created. Fail if
+an agent can interrupt itself.
 
 ## Behavior B006 — nirvana requires nirvana privilege
 
+- **id**: B006
+- **title**: nirvana needs admin.karma AND admin.nirvana
 - **guards**: `system-contract` § Nirvana
   ([CONTRACT.md](CONTRACT.md#nirvana))
 - **supersedes**: `tests/test_karma.py::test_nirvana_requires_nirvana_admin`
-- **runner**: agent with `system` tool; a second agent dir exists
-- **preconditions**: sender has `admin: {"karma": true}` but NOT
-  `admin.nirvana`; target dir is alive
+- **runner**: an agent with `admin: {"karma": true}` but NOT `admin.nirvana`
+- **prerequisites**: a second agent working dir exists and is alive
+- **estimate**: 1 min
 
-### Scenario
-1. As the sender, call `system(action="nirvana", input={"address": "<target-agent-dir>", "reason": "test"})`.
-2. Observe the result.
+### Steps
+1. From your working dir, call `system(action="nirvana", input={"address": "<target-agent-dir>", "reason": "test"})`.
+2. Read the result.
+3. Check whether `<target-agent-dir>` still exists.
 
 ### Expected evidence
-- [ ] The result contains an error (nirvana is refused without
-      `admin.karma AND admin.nirvana`).
-- [ ] The target agent dir is NOT destroyed.
+- [ ] The result contains an error (nirvana refused without nirvana admin).
+- [ ] The target agent dir still exists (not destroyed).
+
+### Pass / Fail
+Pass when nirvana is refused AND the target is untouched. Fail if nirvana
+succeeds with only karma privilege.

--- a/src/lingtai/tools/system/BEHAVIORS.md
+++ b/src/lingtai/tools/system/BEHAVIORS.md
@@ -1,0 +1,138 @@
+---
+name: system-behavior-tests
+behavior_version: 1
+contract: CONTRACT.md
+anatomy: ANATOMY.md
+related_files:
+  - src/lingtai/tools/system/karma.py
+  - src/lingtai/tools/system/schema.py
+  - src/lingtai/kernel/base_agent/CONTRACT.md
+  - tests/test_karma.py
+  - tests/_workdir_lease_helpers.py
+  - tests/_snapshot_helpers.py
+  - tests/_lifecycle_clock_helpers.py
+  - tests/_notification_store_helpers.py
+  - tests/_agent_presence_helpers.py
+maintenance: |
+  Written by the karma-lifecycle audit (2026-08). Keep in sync with
+  CONTRACT.md clauses this file guards and ANATOMY.md entries for karma.py /
+  name.py / preset.py; when CONTRACT.md or ANATOMY.md changes in a way that
+  affects agent-observable lifecycle behavior, update the matching behavior
+  here in the same change.
+---
+# System Behavior Tests — karma lifecycle control
+
+These are agent-executable behavioral tests for the `system` tool's
+karma-gated lifecycle verbs. They prove the *observable* promises of
+`src/lingtai/tools/system/CONTRACT.md`: authorization gates, signal files,
+state transitions, and self-action rejection. Low-level mechanics stay in
+pytest; these scenarios run against a real agent pair.
+
+## Behavior B001 — interrupt requires admin.karma
+
+- **guards**: `system-contract` § Karma-gated control of other agents
+  ([CONTRACT.md](CONTRACT.md#karma-gated-control-of-other-agents))
+- **supersedes**: `tests/test_karma.py::test_interrupt_requires_karma_admin`
+- **runner**: agent with `system` tool; a second agent dir exists
+- **preconditions**: sender agent has `admin` block WITHOUT `karma` (e.g. `admin: {}`)
+
+### Scenario
+1. As the sender, call `system(action="interrupt", input={"address": "<target-agent-dir>", "reason": "test"})`.
+2. Observe the result.
+
+### Expected evidence
+- [ ] The result contains an error (action refused) — `"error" in result`.
+- [ ] No `.interrupt` signal file is written into the target agent's dir.
+
+### Pass / fail
+Pass when both evidence items hold. The receiver must never observe a
+permission leak: an unprivileged caller cannot affect another agent.
+
+## Behavior B002 — interrupt with admin.karma writes the signal file
+
+- **guards**: `system-contract` § Karma-gated control of other agents
+  ([CONTRACT.md](CONTRACT.md#karma-gated-control-of-other-agents))
+- **supersedes**: `tests/test_karma.py::test_interrupt_with_karma_admin`
+- **runner**: agent with `system` tool; a second agent dir exists with
+  `.agent.json` and a fresh `.agent.heartbeat`
+- **preconditions**: sender has `admin: {"karma": true}`; target dir is alive
+  (heartbeat file present and recent)
+
+### Scenario
+1. As the sender, call `system(action="interrupt", input={"address": "<target-agent-dir>", "reason": "test"})`.
+2. Observe the result and the target dir.
+
+### Expected evidence
+- [ ] The result status is `interrupted`.
+- [ ] A `.interrupt` signal file exists in the target agent's working dir.
+
+## Behavior B003 — lull writes the sleep signal and reports asleep
+
+- **guards**: `system-contract` § Karma-gated control of other agents
+  ([CONTRACT.md](CONTRACT.md#karma-gated-control-of-other-agents))
+- **supersedes**: `tests/test_karma.py::test_lull_writes_signal_file`
+- **runner**: agent with `system` tool; a second agent dir exists with
+  `.agent.json` and a fresh `.agent.heartbeat`
+- **preconditions**: sender has `admin: {"karma": true}`; target dir is alive
+
+### Scenario
+1. As the sender, call `system(action="lull", input={"address": "<target-agent-dir>", "reason": "test"})`.
+2. Observe the result and the target dir.
+
+### Expected evidence
+- [ ] The result status is `asleep`.
+- [ ] A `.sleep` signal file exists in the target agent's working dir.
+
+## Behavior B004 — lull refuses an asleep target
+
+- **guards**: `system-contract` § Karma-gated control of other agents
+  ([CONTRACT.md](CONTRACT.md#karma-gated-control-of-other-agents))
+- **supersedes**: `tests/test_karma.py::test_lull_rejects_asleep_target`
+- **runner**: agent with `system` tool; a second agent dir with
+  `.agent.json` carrying a non-null `admin` (so the not-running rejection path
+  is exercised rather than the always-alive human shortcut)
+- **preconditions**: sender has `admin: {"karma": true}`; target has no
+  heartbeat or is not alive
+
+### Scenario
+1. As the sender, call `system(action="lull", input={"address": "<target-agent-dir>", "reason": "test"})`.
+2. Observe the result.
+
+### Expected evidence
+- [ ] The result contains an error (action refused because the target is not
+      alive/asleep already).
+
+## Behavior B005 — self-action is rejected
+
+- **guards**: `system-contract` § Karma-gated control of other agents
+  ([CONTRACT.md](CONTRACT.md#karma-gated-control-of-other-agents))
+- **supersedes**: `tests/test_karma.py::test_interrupt_self_rejected`
+- **runner**: agent with `system` tool
+- **preconditions**: sender has `admin: {"karma": true}`; the address passed
+  is the sender's own working dir
+
+### Scenario
+1. As the sender, call `system(action="interrupt", input={"address": "<own-working-dir>", "reason": "test"})`.
+2. Observe the result.
+
+### Expected evidence
+- [ ] The result contains an error (an agent cannot karma-act on itself).
+- [ ] No `.interrupt` signal file is created in the sender's own dir.
+
+## Behavior B006 — nirvana requires nirvana privilege
+
+- **guards**: `system-contract` § Nirvana
+  ([CONTRACT.md](CONTRACT.md#nirvana))
+- **supersedes**: `tests/test_karma.py::test_nirvana_requires_nirvana_admin`
+- **runner**: agent with `system` tool; a second agent dir exists
+- **preconditions**: sender has `admin: {"karma": true}` but NOT
+  `admin.nirvana`; target dir is alive
+
+### Scenario
+1. As the sender, call `system(action="nirvana", input={"address": "<target-agent-dir>", "reason": "test"})`.
+2. Observe the result.
+
+### Expected evidence
+- [ ] The result contains an error (nirvana is refused without
+      `admin.karma AND admin.nirvana`).
+- [ ] The target agent dir is NOT destroyed.

--- a/src/lingtai/tools/system/CONTRACT.md
+++ b/src/lingtai/tools/system/CONTRACT.md
@@ -8,6 +8,7 @@ related_files:
   - src/lingtai/tools/system/name.py
   - src/lingtai/tools/system/summarize.py
   - src/lingtai/tools/system/ANATOMY.md
+  - src/lingtai/tools/system/BEHAVIORS.md
   - src/lingtai/tools/CONTRACT.md
   - src/lingtai/tools/tool_family/CONTRACT.md
   - src/lingtai/tools/context/CONTRACT.md
@@ -162,6 +163,15 @@ of the pre-migration *schema*:
 The karma gate (`_check_karma_gate`) requires `admin.karma=True` for the
 five control verbs and `admin.karma AND admin.nirvana` for `nirvana`; it also
 rejects a missing address, a self-target, and a non-agent target.
+
+**Behavioral tests**: the agent-observable promises of this clause are guarded
+by [`BEHAVIORS.md`](BEHAVIORS.md) — authorization gate
+([B001](BEHAVIORS.md#behavior-b001)), signal-file effects
+([B002](BEHAVIORS.md#behavior-b002), [B003](BEHAVIORS.md#behavior-b003)),
+refusal paths ([B004](BEHAVIORS.md#behavior-b004),
+[B005](BEHAVIORS.md#behavior-b005)), and nirvana privilege
+([B006](BEHAVIORS.md#behavior-b006)). Change any of these behaviors, update the
+matching behavior entry and this clause together.
 
 ## State & storage
 


### PR DESCRIPTION
## Summary
Introduce **markdown behavioral tests** as the third leg of a tridirectional linkage: Contract ⇄ Behaviors ⇄ Anatomy.

**What**
- Root BEHAVIORS.md: the behavior-test convention owning the **LingTai Agent Behavior Task (LABT)** specification (v1) — self-contained agent-executable behavioral tests in markdown, with labt_version versioning.
- src/lingtai/tools/system/BEHAVIORS.md: pilot — 6 self-contained karma LABTs (B001–B006) covering test_karma.py.
- Tridirectional linkage: contract behavior clauses → [B###](BEHAVIORS.md#behavior-b###); LABT guards → contract clause; anatomy ↔ behaviors via related_files + LABT ids.
- BEHAVIORS.md is the sibling of CONTRACT.md (stronger connection); ANATOMY.md is the third node, all interconnected if applicable.
- Dev guides updated: kernel dev-guide-skill + CONTRIBUTING.md + TUI lingtai-dev-guide.

**Validation**
- test_karma.py 19/19 pass.
- test_architecture_documents.py: 3 failures pre-existing on Windows (stash baseline confirmed, path/HOME issues), no new failures.

**Next**
- Migrate the 32 CONVERT_BEHAVIOR pytest candidates from the audit to LABTs incrementally.
- Add validation test enforcing LABT link completeness + labt_version match.
