### PR TITLE
feat(behaviors): LABT v1 files for 6 module families

### DIFF
--- a/BEHAVIORS.md
+++ b/BEHAVIORS.md
@@ -1,7 +1,7 @@
 ---
 name: component-behavior-test-convention
 behavior_version: 2
-labt_version: 1
+labt_version: 2
 related_files:
   - CONTRACT.md
   - ANATOMY.md
@@ -11,9 +11,12 @@ related_files:
   - src/lingtai/tools/system/BEHAVIORS.md
   - src/lingtai/tools/context/BEHAVIORS.md
   - src/lingtai/tools/daemon/BEHAVIORS.md
-  - src/lingtai/tools/shell/BEHAVIORS.md
+  - src/lingtai/tools/bash/BEHAVIORS.md
   - src/lingtai/tools/telegram/BEHAVIORS.md
   - src/lingtai/tools/tool_family/BEHAVIORS.md
+  - src/lingtai/tools/file/BEHAVIORS.md
+  - src/lingtai/tools/feishu/BEHAVIORS.md
+  - src/lingtai/tools/web_search/BEHAVIORS.md
 maintenance: |
   This file is the normative root of the distributed behavior-test definition
   system: it owns the LingTai Agent Behavior Task (LABT) specification, its
@@ -50,7 +53,7 @@ It is the third leg of the **tridirectional linkage**:
 | `BEHAVIORS.md` | How do we verify the promise with an agent? | Self-contained agent tasks (LABT) |
 | `ANATOMY.md` | Where is the code? | Code navigation |
 
-## LingTai Agent Behavior Task (LABT) — version 1
+## LingTai Agent Behavior Task (LABT) — version 2
 
 A **LABT** is the unit of behavior verification in this repository: a single
 markdown section, fully self-contained, that an agent or daemon can execute
@@ -69,11 +72,11 @@ pytest are for traceability and review — never required for execution.
 
 | Field | Required | Meaning |
 |---|---|---|
-| `id` | yes | Stable anchor, `B###`; section heading becomes `#behavior-b###` |
+| `id` | yes | Stable anchor. Default scheme is `B###`; section heading becomes `#behavior-b###`. Per-family files MAY use a family prefix (e.g. `D###` daemon, `L###` lifecycle, `T###` tool-family, `C###` comms, `K###` kernel, `S###` shell) — prefix IDs are globally unique, collision-free across files, and readably self-describing in cross-refs; anchor becomes `#behavior-<prefix>###` (e.g. `#behavior-d003`). A validation test MUST NOT hardcode one scheme; it must accept the per-family scheme a child file declares. |
 | `title` | yes | One-sentence behavior promise |
-| `guards` | yes | Contract clause guarded (bidirectional ref) |
+| `guards` | yes | Contract clause guarded (bidirectional ref). Format: `<contract-frontmatter-name> § <clause heading>`; the `name:` MUST match the target contract's frontmatter exactly |
 | `supersedes` | no | pytest file(s) this LABT replaces/complements (traceability) |
-| `runner` | yes | Which agent/daemon shape can execute (e.g. any LingTai agent with `system`) |
+| `runner` | yes | Which agent/daemon shape can execute (e.g. any LingTai agent with `system`) — an agent shape, NOT a pytest command |
 | `prerequisites` | yes | Exact setup required (agents, dirs, files, permissions) |
 | `steps` | yes | Ordered concrete actions the executor performs |
 | `expected_evidence` | yes | Observable outcomes checklist (state/file/receipt/notification) |
@@ -147,8 +150,8 @@ in the same change. This is a review gate, not optional polish.
 ---
 name: <component>-behavior-tests      # e.g. system-behavior-tests
 behavior_version: 1                   # child-file format revision
-labt_version: 1                       # MUST match this root's labt_version
-contract: CONTRACT.md                 # the contract this guards (relative)
+labt_version: 2                       # MUST match this root's labt_version
+contract: CONTRACT.md                 # the contract(s) this guards (relative); may be a list
 anatomy: ANATOMY.md                   # the anatomy this pairs with (relative)
 related_files:                        # real repo-relative paths
   - src/lingtai/tools/system/karma.py

--- a/BEHAVIORS.md
+++ b/BEHAVIORS.md
@@ -7,6 +7,13 @@ related_files:
   - ANATOMY.md
   - dev-guide-skill/SKILL.md
   - tests/CONTRACT.md
+  - src/lingtai/kernel/BEHAVIORS.md
+  - src/lingtai/tools/system/BEHAVIORS.md
+  - src/lingtai/tools/context/BEHAVIORS.md
+  - src/lingtai/tools/daemon/BEHAVIORS.md
+  - src/lingtai/tools/shell/BEHAVIORS.md
+  - src/lingtai/tools/telegram/BEHAVIORS.md
+  - src/lingtai/tools/tool_family/BEHAVIORS.md
 maintenance: |
   This file is the normative root of the distributed behavior-test definition
   system: it owns the LingTai Agent Behavior Task (LABT) specification, its

--- a/src/lingtai/CONTRACT.md
+++ b/src/lingtai/CONTRACT.md
@@ -95,6 +95,8 @@ constructs a migration workspace, or performs a second notification path.
 
 ## Contract rules
 
+Guarded by: [K001](kernel/BEHAVIORS.md#behavior-k001), [K002](kernel/BEHAVIORS.md#behavior-k002), [K007](kernel/BEHAVIORS.md#behavior-k007)
+
 1. `src/lingtai/init.jsonc` is the sole kernel semantic source. New writers must
    use its canonical/normal shape; compatibility is read-only.
 2. Boot and refresh must call the same `read_init` path and use the same parser,

--- a/src/lingtai/kernel/ANATOMY.md
+++ b/src/lingtai/kernel/ANATOMY.md
@@ -1,5 +1,6 @@
 ---
 related_files:
+  - BEHAVIORS.md
   - src/lingtai/services/LICC_NOTIFICATION_CONTRACT.md
   - ANATOMY.md
   - MANIFEST.in

--- a/src/lingtai/kernel/BEHAVIORS.md
+++ b/src/lingtai/kernel/BEHAVIORS.md
@@ -1,0 +1,618 @@
+---
+name: kernel-behavior-tests
+behavior_version: 1
+labt_version: 1
+contract: ../tools/notification/CONTRACT.md
+anatomy: ANATOMY.md
+related_files:
+  - src/lingtai/kernel/nudge/__init__.py
+  - src/lingtai/kernel/nudge/kernel_version.py
+  - src/lingtai/kernel/nudge/source_drift.py
+  - src/lingtai/kernel/nudge/prompts.py
+  - src/lingtai/kernel/meta_block.py
+  - src/lingtai/kernel/tool_executor.py
+  - src/lingtai/kernel/tool_result_artifacts.py
+  - src/lingtai/kernel/notifications.py
+  - src/lingtai/tools/context/CONTRACT.md
+  - src/lingtai/tools/notification/CONTRACT.md
+  - src/lingtai/CONTRACT.md
+  - tests/test_kernel_version_nudge.py
+  - tests/test_eigen.py
+  - tests/test_large_result_no_notification.py
+  - tests/test_tool_meta_comment_overflow.py
+maintenance: |
+  Written by the kernel nudge/notification CONVERT_BEHAVIOR migration (2026-08).
+  Keep in sync with the contracts this file guards — `src/lingtai/CONTRACT.md`
+  (Contract rules 6–7, Nudge transport and inline cap), `src/lingtai/tools/notification/CONTRACT.md`
+  (large-result routing, no large_tool_result source), `src/lingtai/tools/context/CONTRACT.md`
+  (eigen retirement, molt input) — and with `src/lingtai/kernel/ANATOMY.md`
+  entries for nudge, notifications, and meta_block. When any of those change
+  agent-observable behavior, update the matching LABT here in the same change.
+---
+# Kernel Behavior Tests — nudge / notification family
+
+LABT v1. These are self-contained agent-executable behavioral tests for the
+kernel nudge/notification family: the kernel-version nudge (`kernel_version`,
+including its source-drift/dev-runtime detection), the source-drift nudge
+(`source_drift`), the retired `eigen` identity surface, the promise that a
+large tool result never becomes a notification (it is ranked in
+`_meta.agent_meta.current_tool_result_chars` instead), and the per-result
+`_meta.tool_meta.comment.overflow` hint. Low-level mechanics stay in pytest;
+each LABT below is self-contained — the full harness script is inlined — and
+executable verbatim by an agent with `shell` and `file` tools at a checkout of
+this repository. Replace `<repo-root>` with the checkout path and `<scratch>`
+with any empty working directory the executor owns.
+
+All harness scripts set the package path themselves (`sys.path.insert(0,
+<repo-root>/src)`) and write into a fresh temp working dir, so they never touch
+the executing agent's own `.notification/` or session state.
+
+## Behavior K001 — kernel version nudge emits the local refresh finding on the `release_version` channel
+
+- **id**: K001
+- **title**: an installed distribution newer than the running kernel produces a
+  `kernel_version` nudge entry (`nudge_channel: release_version`) with a
+  safe-refresh suggested action, without any remote probe
+- **guards**: `src/lingtai/CONTRACT.md` § Contract rules rule 6 — every declared
+  Nudge kind uses the ordinary `.notification/nudge.json` transport and the
+  shared global Nudge policy
+  ([CONTRACT.md](../CONTRACT.md#contract-rules))
+- **supersedes**: `tests/test_kernel_version_nudge.py::test_installed_runtime_refresh_nudge_does_not_hit_remote`
+- **runner**: any LingTai agent with `shell` and `file` tools at a checkout of
+  this repository (Python 3.10+)
+- **prerequisites**: a checkout of this repo at `<repo-root>`; an empty scratch
+  dir `<scratch>`; python on PATH
+- **estimate**: 2 min
+
+### Steps
+1. Write `<scratch>/k001.py` with the following content (self-contained
+   harness; `REPO` is the only value to substitute):
+
+```python
+import sys, os, json, pathlib, tempfile
+REPO = r"<repo-root>"
+sys.path.insert(0, os.path.join(REPO, "src"))
+os.chdir(REPO)
+
+from lingtai.adapters.posix.notification_store import PosixNotificationStoreAdapter
+from lingtai.kernel.nudge import kernel_version as kv
+
+class Agent:
+    def __init__(self, workdir):
+        self._working_dir = str(workdir)
+        self._notification_store = PosixNotificationStoreAdapter(pathlib.Path(workdir))
+        self.logs = []
+        self._nudge_kernel_version_state = {"last_probe_ts": 0.0}
+    def _log(self, event, **fields):
+        self.logs.append((event, fields))
+
+def entries(workdir):
+    snap = PosixNotificationStoreAdapter(pathlib.Path(workdir)).snapshot(lambda ch: True)
+    data = (snap.get("nudge") or {}).get("data") or {}
+    return data.get("nudges") or []
+
+d = pathlib.Path(tempfile.mkdtemp(prefix="k001"))
+a = Agent(d)
+# installed (0.14.2) is newer than running (0.14.1): local refresh, no remote.
+kv._runtime_info = lambda: kv._RuntimeInfo(
+    running_version="0.14.1", installed_version="0.14.2", dev_reason=None)
+kv._fetch_latest_version = lambda: (_ for _ in ()).throw(
+    AssertionError("remote must not be queried for a local refresh mismatch"))
+kv._today_utc = lambda: "2026-06-30"
+kv.check(a)
+e = entries(d)
+assert len(e) == 1, e
+entry = e[0]
+assert entry["kind"] == "kernel_version"
+assert entry["nudge_channel"] == "release_version"
+assert entry["source"] == "installed-distribution"
+assert entry["running"] == "0.14.1" and entry["installed"] == "0.14.2"
+assert entry["latest"] is None
+assert entry["suggested_action"] == "refresh-installed-runtime-if-authorized-and-safe"
+assert "already on disk" in entry["detail"]
+assert "system(action='refresh')" in entry["detail"]
+print("K001 ENTRY:", json.dumps({
+    k: entry.get(k) for k in ("kind", "nudge_channel", "source",
+                               "running", "installed", "suggested_action")}, ensure_ascii=False))
+print("workdir:", d)
+```
+
+2. Run `python <scratch>/k001.py` from `<repo-root>`; the script exits 0 and
+   prints the entry fields and the workdir path.
+3. Read the notification file the script created: `<printed workdir>/.notification/nudge.json`
+   and the state file `<printed workdir>/.notification/.nudge_state.json`.
+
+### Expected evidence
+- [ ] The script exits 0 (all assertions pass) and prints
+      `K001 ENTRY:` with `kind: kernel_version`, `nudge_channel: release_version`,
+      `source: installed-distribution`, `suggested_action:
+      refresh-installed-runtime-if-authorized-and-safe`.
+- [ ] `<workdir>/.notification/nudge.json` exists and its `data.nudges` contains
+      exactly one entry whose `title` is `LingTai kernel refresh available:
+      0.14.1 -> 0.14.2` and whose `detail` contains `already on disk` and
+      `system(action='refresh')`.
+- [ ] The remote probe was never invoked (the harness proves it by raising
+      inside `_fetch_latest_version`).
+
+### Pass / Fail
+Pass when all evidence items hold and no network call occurred. Fail if the
+entry is missing, has a different `nudge_channel`/`source`, or the remote fetch
+was attempted.
+
+## Behavior K002 — kernel version nudge is fail-safe: diagnostic direction, dev/source-drift runtimes, malformed versions
+
+- **id**: K002
+- **title**: running-newer/unparseable runtimes emit a read-only diagnostic
+  (`installed-distribution-diagnostic`), dev/editable/source-checkout runtimes
+  skip and clear the nudge with a recorded reason, and malformed remote
+  versions can never be promoted
+- **guards**: `src/lingtai/CONTRACT.md` § Contract rules rule 6 — Nudge
+  findings stay on the ordinary `.notification/nudge.json` transport under the
+  shared policy
+  ([CONTRACT.md](../CONTRACT.md#contract-rules))
+- **supersedes**: `tests/test_kernel_version_nudge.py::test_runtime_version_direction_is_fail_safe_and_equal_pairs_probe_remote`,
+  `tests/test_kernel_version_nudge.py::test_dev_or_editable_runtime_skips_and_clears_kernel_nudge`,
+  `tests/test_kernel_version_nudge.py::test_runtime_info_detects_source_checkout_from_wrapper_file`,
+  `tests/test_kernel_version_nudge.py::test_malformed_remote_version_cannot_be_promoted_by_numeric_substrings`
+- **runner**: any LingTai agent with `shell` and `file` tools at a checkout of
+  this repository
+- **prerequisites**: a checkout of this repo at `<repo-root>`; an empty scratch
+  dir `<scratch>`; python on PATH
+- **estimate**: 3 min
+
+### Steps
+1. Write `<scratch>/k002.py` with the following content:
+
+```python
+import sys, os, json, pathlib, tempfile
+REPO = r"<repo-root>"
+sys.path.insert(0, os.path.join(REPO, "src"))
+os.chdir(REPO)
+
+from lingtai.adapters.posix.notification_store import PosixNotificationStoreAdapter
+from lingtai.kernel.nudge import kernel_version as kv
+
+class Agent:
+    def __init__(self, workdir):
+        self._working_dir = str(workdir)
+        self._notification_store = PosixNotificationStoreAdapter(pathlib.Path(workdir))
+        self.logs = []
+        self._nudge_kernel_version_state = {"last_probe_ts": 0.0}
+    def _log(self, event, **fields):
+        self.logs.append((event, fields))
+
+def entries(workdir):
+    snap = PosixNotificationStoreAdapter(pathlib.Path(workdir)).snapshot(lambda ch: True)
+    data = (snap.get("nudge") or {}).get("data") or {}
+    return data.get("nudges") or []
+
+def run_case(prefix, running, installed, dev_reason):
+    d = pathlib.Path(tempfile.mkdtemp(prefix=prefix))
+    a = Agent(d)
+    kv._runtime_info = lambda: kv._RuntimeInfo(
+        running_version=running, installed_version=installed, dev_reason=dev_reason)
+    kv._fetch_latest_version = lambda: (_ for _ in ()).throw(
+        AssertionError("no remote probe expected"))
+    kv._today_utc = lambda: "2026-06-24"
+    kv.check(a)
+    return d, entries(d)
+
+# (a) running newer than installed -> read-only diagnostic, never refresh
+_, ea = run_case("k002a", "0.17.0", "0.16.5", None)
+assert len(ea) == 1
+assert ea[0]["source"] == "installed-distribution-diagnostic"
+assert ea[0]["suggested_action"] == "inspect-runtime-interpreter-and-import-paths"
+assert "Do not refresh" in ea[0]["detail"]
+
+# (b) unparseable running version -> same diagnostic
+_, eb = run_case("k002b", "not-a-version", "0.17.0", None)
+assert len(eb) == 1 and eb[0]["source"] == "installed-distribution-diagnostic"
+
+# (c) dev/editable runtime -> nudge skipped AND cleared, reason recorded
+d, ec = run_case("k002c", "0.14.1.dev0", "0.14.1.dev0", "editable-install")
+assert ec == []
+state = json.loads((d / ".notification" / ".nudge_state.json").read_text())
+assert state["kernel_version"]["last_skip_date"] == "2026-06-24"
+assert state["kernel_version"]["skip_reason"] == "editable-install"
+
+# (d) source checkout (source drift) -> skipped, reason recorded
+_, ed = run_case("k002d", "0.14.1", "0.14.1", "source-checkout")
+assert ed == []
+
+# (e) malformed remote candidates are never promoted by numeric substrings
+assert kv._is_newer("999-not-a-release", "0.16.5") is False
+assert kv._is_newer("release-999", "0.16.5") is False
+assert kv._is_newer("not-a-version", "0.16.5") is False
+
+print("K002 OK: diagnostic(a,b), dev-skip(c), source-checkout-skip(d), no-promote(e)")
+```
+
+2. Run `python <scratch>/k002.py` from `<repo-root>`; it must exit 0.
+
+### Expected evidence
+- [ ] The script exits 0 and prints `K002 OK: ...`.
+- [ ] Case (a)/(b) entries carry `source: installed-distribution-diagnostic`,
+      `suggested_action: inspect-runtime-interpreter-and-import-paths`, and
+      `Do not refresh` in `detail` — an ambiguous direction never recommends
+      refresh.
+- [ ] Case (c) leaves `data.nudges` empty and `kernel_version.skip_reason` is
+      `editable-install` (source drift/dev detection recorded). Case (d) leaves
+      it empty for `source-checkout`.
+- [ ] `kv._is_newer` returns `False` for every malformed candidate.
+
+### Pass / Fail
+Pass when all evidence holds. Fail if a diagnostic case recommends refresh, a
+dev runtime still emits a nudge, or a malformed remote version is treated as
+newer.
+
+## Behavior K003 — `eigen` is retired: LingTai identity lives in `context` + `psyche`, name changes are `system.name_set`
+
+- **id**: K003
+- **title**: the `eigen` intrinsic no longer exists; the identity/soul surface
+  is `context` (molt owns the identity summary in `input`) plus the
+  manual-only `psyche` family, and the true name is set once via
+  `system.name_set` / `system.name_nickname`
+- **guards**: `context-tool` § Purpose and public ownership — no OLD `psyche`
+  action is reachable, `eigen` is gone, name changes remain
+  `system.name_set | system.name_nickname`, and `molt` requires `summary` in
+  its own strict input branch
+  ([CONTRACT.md](../tools/context/CONTRACT.md#purpose-and-public-ownership))
+- **supersedes**: `tests/test_eigen.py::test_eigen_is_gone_and_psyche_is_the_durable_domain_root`,
+  `tests/test_eigen.py::test_eigen_schema_has_molt`,
+  `tests/test_eigen.py::test_eigen_name_sets_agent_name`
+- **runner**: any LingTai agent with `shell` tool at a checkout of this
+  repository
+- **prerequisites**: a checkout of this repo at `<repo-root>`; python on PATH
+- **estimate**: 1 min
+
+### Steps
+1. Run the following from `<repo-root>` (single command, quoted):
+
+```
+python -c "import sys,os,json; sys.path.insert(0, os.path.join(r'<repo-root>','src')); from lingtai.tools.registry import INTRINSICS; from lingtai.tools.context import get_schema; from lingtai.tools.system import get_schema as sys_schema; i=sorted(INTRINSICS); print('intrinsics:', [k for k in i if k in ('context','psyche','eigen','pad','lingtai')]); s=get_schema('en'); print('context actions:', s['properties']['action']['enum']); print('summary-not-root:', 'summary' not in s['properties']); print('summarize-type:', s['properties']['summarize']['type']); print('required:', sorted(s['required'])); ss=sys_schema('en'); print('system name actions:', [a for a in ss['properties']['action']['enum'] if a in ('name_set','name_nickname')])"
+```
+
+2. Read the printed values against the checklist below.
+
+### Expected evidence
+- [ ] `intrinsics:` prints exactly `['context', 'psyche']` — `eigen`, `pad`,
+      and `lingtai` are NOT registered intrinsics.
+- [ ] `context actions:` is `['molt', 'summarize', 'rebuild', 'manual']` — no
+      `context_molt`/`pad_edit`/`lingtai_update`/`name_set` old spellings.
+- [ ] `summary-not-root:` is `True` (the molt summary lives in the `molt`
+      action's `input` branch, not on the root), `summarize-type:` is
+      `boolean` (the unrelated root post-processing control), and `required:`
+      is `['action', 'input', 'reasoning']`.
+- [ ] `system name actions:` prints `['name_set', 'name_nickname']` — identity
+      naming is owned by the `system` tool.
+
+### Pass / Fail
+Pass when every printed value matches. Fail if `eigen` (or `pad`/`lingtai`)
+appears as an intrinsic, or `name_set` is absent from the `system` schema.
+
+## Behavior K004 — `context.molt` refuses an empty or missing summary before any context mutation
+
+- **id**: K004
+- **title**: `context(action="molt", input={...})` without a non-empty
+  `summary` returns the pinned refusal error and sheds nothing
+- **guards**: `context-tool` § Molt safety invariants — agent-initiated molt
+  requires a nonempty retrospective; validation occurs before snapshot/
+  archive/wipe or count mutation
+  ([CONTRACT.md](../tools/context/CONTRACT.md#molt-safety-invariants))
+- **supersedes**: `tests/test_eigen.py::test_context_molt_rejects_empty_summary`,
+  `tests/test_eigen.py::test_context_molt_rejects_missing_summary`
+- **runner**: any LingTai agent with `shell` tool at a checkout of this
+  repository
+- **prerequisites**: a checkout of this repo at `<repo-root>`; python on PATH
+- **estimate**: 1 min
+
+### Steps
+1. Run the following from `<repo-root>` (single command, quoted):
+
+```
+python -c "import sys,os,json,types; sys.path.insert(0, os.path.join(r'<repo-root>','src')); from lingtai.tools.context import handle; stub=types.SimpleNamespace(); empty=handle(stub, {'action':'molt','input':{'summary':''},'reasoning':'t'}); missing=handle(stub, {'action':'molt','input':{},'reasoning':'t'}); print('empty:', json.dumps(empty, ensure_ascii=False)); print('missing:', json.dumps(missing, ensure_ascii=False))"
+```
+
+2. Read the printed errors.
+
+### Expected evidence
+- [ ] `empty:` prints `{"error": "summary cannot be empty — write what you need to remember."}`.
+- [ ] `missing:` prints `{"error": "summary is required — write a briefing to your future self."}`.
+- [ ] The refusal happens before any session wipe/snapshot/molt-count mutation
+      (the stub has no session at all, yet the error returns cleanly).
+
+### Pass / Fail
+Pass when both pinned error strings are returned verbatim. Fail if an empty
+summary is accepted or a non-error result is returned.
+
+## Behavior K005 — a large tool result never becomes a notification; `_meta.agent_meta.current_tool_result_chars` ranks it instead
+
+- **id**: K005
+- **title**: large tool results produce no `large_tool_result` system
+  notification (neither per-result nor at the turn boundary); the same result
+  is reported through `_meta.agent_meta.current_tool_result_chars` with
+  `total_chars`, `threshold`, `over_threshold_count`, and `top_results`
+- **guards**: `notification-tool` § Behavior — agents MUST NOT route
+  large-result compaction through the notification tool, and the kernel no
+  longer publishes a `large_tool_result` source
+  ([CONTRACT.md](../tools/notification/CONTRACT.md#behavior))
+- **supersedes**: `tests/test_large_result_no_notification.py::test_rescan_never_publishes_for_huge_result`,
+  `tests/test_large_result_no_notification.py::test_large_result_still_reported_by_current_tool_result_chars`,
+  `tests/test_large_result_no_notification.py::test_current_tool_result_chars_reports_threshold_and_over_count`
+- **runner**: any LingTai agent with `shell` tool at a checkout of this
+  repository
+- **prerequisites**: a checkout of this repo at `<repo-root>`; python on PATH
+- **estimate**: 2 min
+
+### Steps
+1. Write `<scratch>/k005.py` with the following content:
+
+```python
+import sys, os, json, types
+from unittest.mock import MagicMock
+REPO = r"<repo-root>"
+sys.path.insert(0, os.path.join(REPO, "src"))
+os.chdir(REPO)
+
+from lingtai.kernel.llm.interface import ChatInterface, ToolCallBlock, ToolResultBlock
+from lingtai.kernel import meta_block
+from lingtai.kernel.base_agent.messaging import _rescan_large_tool_results
+
+iface = ChatInterface()
+iface.add_assistant_message([ToolCallBlock(id="tc-rank", name="bash", args={})])
+iface.add_tool_results([ToolResultBlock(
+    id="tc-rank", name="bash", content={"output": "Q" * 40000, "status": "ok"})])
+
+agent = types.SimpleNamespace()
+agent._session = types.SimpleNamespace(chat=types.SimpleNamespace(interface=iface))
+
+# Default threshold (no attribute configured) is 3000 chars.
+s = meta_block.current_tool_result_chars(agent)
+print("summary:", json.dumps({k: s[k] for k in ("total_chars", "threshold",
+                                                "over_threshold_count")}))
+assert s["total_chars"] >= 40000
+assert s["threshold"] == 3000
+assert "tc-rank" in [r["id"] for r in s["top_results"]]
+assert s["top_results"][0]["tool_name"] == "bash"
+
+# Configured threshold: only results over it are counted.
+agent._summarize_notification_threshold = 5000
+s2 = meta_block.current_tool_result_chars(agent)
+assert s2["threshold"] == 5000 and s2["over_threshold_count"] == 1
+
+# Turn-boundary rescan: never publishes, always returns 0.
+class StubChat:
+    interface = iface
+stub = MagicMock()
+stub._chat = StubChat()
+stub._log = MagicMock()
+stub._summarize_notification_threshold = 5000
+published = []
+stub._enqueue_system_notification = lambda *, source, ref_id, body, \
+    skip_if_ref_id_exists=False, **kw: published.append(source) or "evt001"
+count = _rescan_large_tool_results(stub)
+print("rescan_count:", count, "published:", published)
+assert count == 0 and published == []
+print("K005 OK")
+```
+
+2. Run `python <scratch>/k005.py` from `<repo-root>`; it must exit 0.
+
+### Expected evidence
+- [ ] The script exits 0 and prints `summary:` with `total_chars >= 40000`,
+      `threshold: 3000` (default), and `over_threshold_count: 1` (the single
+      40000-char result already exceeds the default 3000-char threshold).
+- [ ] With `_summarize_notification_threshold = 5000`, the same ranking
+      reports `threshold: 5000` and `over_threshold_count: 1`, and
+      `top_results` lists `id: tc-rank` with `tool_name: bash`.
+- [ ] `rescan_count: 0` and `published: []` — the turn-boundary rescan never
+      emits a `large_tool_result` (or any) notification.
+
+### Pass / Fail
+Pass when all evidence holds. Fail if any `large_tool_result` notification is
+published, the rescan returns a nonzero count, or the ranked summary lacks
+`total_chars`/`threshold`/`over_threshold_count`/`top_results`.
+
+## Behavior K006 — capped/large results carry `_meta.tool_meta.comment.overflow`
+
+- **id**: K006
+- **title**: spilled and large-but-inline tool results carry exactly one
+  machine-generated guidance topic `_meta.tool_meta.comment.overflow` pointing
+  at `logs/events.jsonl` by `tool_call_id` (never a sidecar `saved_path`),
+  while ordinary small results carry no comment and the `tool_meta` identity
+  fields (`id`, `char_count`, `elapsed_ms`) stay intact
+- **guards**: `notification-tool` § Behavior — large-result compaction is
+  guidance, not notification; the digest action is `system(action="summarize")`
+  ([CONTRACT.md](../tools/notification/CONTRACT.md#behavior))
+- **supersedes**: `tests/test_tool_meta_comment_overflow.py::test_spilled_result_carries_overflow_comment`,
+  `tests/test_tool_meta_comment_overflow.py::test_large_inline_result_carries_overflow_comment`,
+  `tests/test_tool_meta_comment_overflow.py::test_small_result_has_no_overflow_comment`
+- **runner**: any LingTai agent with `shell` tool at a checkout of this
+  repository
+- **prerequisites**: a checkout of this repo at `<repo-root>`; python on PATH
+- **estimate**: 2 min
+
+### Steps
+1. Write `<scratch>/k006.py` with the following content:
+
+```python
+import sys, os, json, pathlib, tempfile
+from unittest.mock import MagicMock
+REPO = r"<repo-root>"
+sys.path.insert(0, os.path.join(REPO, "src"))
+os.chdir(REPO)
+
+from lingtai.kernel.llm.base import ToolCall
+from lingtai.kernel.llm.interface import ToolResultBlock
+from lingtai.kernel.loop_guard import LoopGuard
+from lingtai.kernel.meta_block import build_tool_meta_overflow_comment
+from lingtai.kernel.tool_executor import ToolExecutor, _DEFAULT_MAX_RESULT_CHARS
+
+# The spill hard ceiling (PREVENTIVE_MAX_CHARS, src/lingtai/kernel/tool_result_artifacts.py).
+assert _DEFAULT_MAX_RESULT_CHARS == 200_000
+
+# Builder shape: one topic, four subkeys, references the durable log by call id.
+c = build_tool_meta_overflow_comment("tc-abc")
+blob = json.dumps(c)
+assert set(c) == {"summary", "full_original", "how_to_retrieve", "after_consuming"}
+assert "logs/events.jsonl" in blob and "tool_call_id=tc-abc" in blob
+assert "saved_path" not in blob
+assert "grep" in c["how_to_retrieve"] and "lingtai-agent log query" in c["how_to_retrieve"]
+assert ("daemon" in c["how_to_retrieve"] or "subagent" in c["how_to_retrieve"])
+assert "summarize" in c["after_consuming"]
+
+# Spilled result (payload over the configured 500-char cap) -> status spilled
+# + overflow comment + spilled_char_count.
+def make_executor(dispatch_fn, workdir, max_result_chars, threshold):
+    captured = MagicMock(side_effect=lambda name, result, **kw: ToolResultBlock(
+        kw.get("tool_call_id", ""), name, result))
+    ex = ToolExecutor(dispatch_fn=dispatch_fn, make_tool_result_fn=captured,
+                      guard=LoopGuard(max_total_calls=50), working_dir=workdir,
+                      max_result_chars=max_result_chars,
+                      summarize_notification_threshold=threshold)
+    return ex
+
+ex = make_executor(lambda tc: {"data": "Z" * 1200}, str(tempfile.mkdtemp()),
+                   500, None)
+block = ex.execute([ToolCall(name="read", args={}, id="tc-spill")])[0][0]
+assert block.content["status"] == "spilled"
+tm = block.metadata.get("tool_meta", {})
+assert set(tm["comment"].keys()) == {"overflow"}
+assert tm["id"] == "tc-spill"
+assert isinstance(tm["char_count"], int) and isinstance(tm["elapsed_ms"], int)
+assert "spilled_char_count" in tm
+
+# Large but inline (over the 100-char hint threshold, under the spill cap)
+# -> overflow comment, not spilled.
+ex2 = make_executor(lambda tc: {"data": "Q" * 400}, str(tempfile.mkdtemp()),
+                   _DEFAULT_MAX_RESULT_CHARS, 100)
+block2 = ex2.execute([ToolCall(name="read", args={}, id="tc-large")])[0][0]
+assert block2.content.get("status") != "spilled"
+tm2 = block2.metadata.get("tool_meta", {})
+assert tm2["char_count"] > 100
+assert "overflow" in tm2.get("comment", {})
+assert "logs/events.jsonl" in tm2["comment"]["overflow"]["full_original"]
+
+# Small result -> no comment at all; identity fields still present.
+ex3 = make_executor(lambda tc: {"ok": True}, str(tempfile.mkdtemp()),
+                   _DEFAULT_MAX_RESULT_CHARS, 100)
+block3 = ex3.execute([ToolCall(name="read", args={}, id="tc-small")])[0][0]
+tm3 = block3.metadata.get("tool_meta", {})
+assert "comment" not in tm3
+assert tm3["id"] == "tc-small"
+assert isinstance(tm3["char_count"], int) and isinstance(tm3["elapsed_ms"], int)
+
+print("K006 OK: builder-shape, spilled, large-inline, small-no-comment")
+```
+
+2. Run `python <scratch>/k006.py` from `<repo-root>`; it must exit 0.
+
+### Expected evidence
+- [ ] The script exits 0 and prints `K006 OK: ...`.
+- [ ] `_DEFAULT_MAX_RESULT_CHARS` is `200000` (the preventive spill ceiling).
+- [ ] The builder returns exactly `{summary, full_original, how_to_retrieve,
+      after_consuming}`; `full_original` names `logs/events.jsonl` and
+      `tool_call_id=<id>`; no `saved_path`; `how_to_retrieve` offers `grep`
+      and `lingtai-agent log query`; `after_consuming` recommends
+      `system(action="summarize")`.
+- [ ] A spilled result reports `status: spilled` with
+      `tool_meta.comment.overflow` and `spilled_char_count`; a large inline
+      result (over the hint threshold) also carries the comment; a small
+      result carries no `comment`. Identity fields `id`/`char_count`/
+      `elapsed_ms` remain intact in all three.
+
+### Pass / Fail
+Pass when all evidence holds. Fail if the comment is split into multiple
+headings, references a `saved_path`, appears on a small result, or drops the
+identity fields.
+
+## Behavior K007 — source-drift nudge: startup vs on-disk fingerprint mismatch emits the `source_integrity` finding
+
+- **id**: K007
+- **title**: when the current on-disk source fingerprint (git rev / source
+  digest) differs from the startup fingerprint, the `source_drift` nudge entry
+  is emitted on the `source_integrity` channel; when they match again the
+  entry is cleared
+- **guards**: `src/lingtai/CONTRACT.md` § Contract rules rule 6 — every
+  declared Nudge kind uses the ordinary `.notification/nudge.json` transport
+  and the shared global policy
+  ([CONTRACT.md](../CONTRACT.md#contract-rules))
+- **supersedes**: `tests/test_source_drift.py` (emit/clear scenarios)
+- **runner**: any LingTai agent with `shell` and `file` tools at a checkout of
+  this repository
+- **prerequisites**: a checkout of this repo at `<repo-root>`; an empty scratch
+  dir `<scratch>`; python on PATH
+- **estimate**: 2 min
+
+### Steps
+1. Write `<scratch>/k007.py` with the following content:
+
+```python
+import sys, os, json, pathlib, tempfile
+REPO = r"<repo-root>"
+sys.path.insert(0, os.path.join(REPO, "src"))
+os.chdir(REPO)
+
+from lingtai.adapters.posix.notification_store import PosixNotificationStoreAdapter
+from lingtai.kernel.nudge import source_drift as sd
+from lingtai.kernel.base_agent import lifecycle as lc
+
+class Agent:
+    def __init__(self, workdir):
+        self._working_dir = str(workdir)
+        self._notification_store = PosixNotificationStoreAdapter(pathlib.Path(workdir))
+        self.logs = []
+        self._nudge_source_drift_state = {"last_probe_ts": 0.0}
+        self._source_revision_port = None
+    def _log(self, event, **fields):
+        self.logs.append((event, fields))
+
+def entries(workdir):
+    snap = PosixNotificationStoreAdapter(pathlib.Path(workdir)).snapshot(lambda ch: True)
+    data = (snap.get("nudge") or {}).get("data") or {}
+    return data.get("nudges") or []
+
+d = pathlib.Path(tempfile.mkdtemp(prefix="k007"))
+a = Agent(d)
+startup = {"git_rev": "abc1234", "source_digest": "digestAAAA",
+           "captured_at": "2026-07-01T00:00:00Z"}
+a._runtime_fingerprint = startup
+# On-disk source changed since startup -> drift.
+lc._capture_runtime_fingerprint = lambda port: {
+    "git_rev": "def5678", "source_digest": "digestBBBB",
+    "captured_at": "2026-07-02T00:00:00Z"}
+sd.check(a)
+e = entries(d)
+assert len(e) == 1, e
+entry = e[0]
+assert entry["kind"] == "source_drift"
+assert entry["nudge_channel"] == "source_integrity"
+assert entry["title"] == "Source drift detected \u2014 running code is stale"
+assert entry["suggested_action"] == "system(action='refresh')"
+assert "git_rev: abc1234 \u2192 def5678" in entry["detail"]
+assert "source_digest: digestAAAA \u2192 digestBBBB" in entry["detail"]
+
+# On-disk source matches startup again -> the finding is cleared.
+lc._capture_runtime_fingerprint = lambda port: startup
+a._nudge_source_drift_state = {"last_probe_ts": 0.0, "emitted": True}
+sd.check(a)
+assert entries(d) == [], entries(d)
+print("K007 OK: source_integrity emit + clear")
+```
+
+2. Run `python <scratch>/k007.py` from `<repo-root>`; it must exit 0.
+
+### Expected evidence
+- [ ] The script exits 0 and prints `K007 OK: source_integrity emit + clear`.
+- [ ] The drift entry has `kind: source_drift`, `nudge_channel:
+      source_integrity`, `title: Source drift detected — running code is
+      stale`, `suggested_action: system(action='refresh')`, and a `detail`
+      listing `git_rev: abc1234 → def5678` and `source_digest: digestAAAA →
+      digestBBBB`.
+- [ ] After the fingerprints match again, `data.nudges` is empty (the stale
+      finding is cleared, not left visible).
+
+### Pass / Fail
+Pass when all evidence holds. Fail if no entry is emitted on drift, the
+channel/title/action differ, or a matching fingerprint does not clear the
+finding.

--- a/src/lingtai/kernel/BEHAVIORS.md
+++ b/src/lingtai/kernel/BEHAVIORS.md
@@ -1,18 +1,25 @@
 ---
 name: kernel-behavior-tests
 behavior_version: 1
-labt_version: 1
-contract: ../tools/notification/CONTRACT.md
+labt_version: 2
+contract:
+  - ../CONTRACT.md
+  - ../tools/notification/CONTRACT.md
+  - ../tools/context/CONTRACT.md
 anatomy: ANATOMY.md
 related_files:
   - src/lingtai/kernel/nudge/__init__.py
   - src/lingtai/kernel/nudge/kernel_version.py
   - src/lingtai/kernel/nudge/source_drift.py
   - src/lingtai/kernel/nudge/prompts.py
+  - src/lingtai/kernel/base_agent/lifecycle.py
+  - src/lingtai/kernel/base_agent/messaging.py
   - src/lingtai/kernel/meta_block.py
   - src/lingtai/kernel/tool_executor.py
   - src/lingtai/kernel/tool_result_artifacts.py
   - src/lingtai/kernel/notifications.py
+  - src/lingtai/kernel/snapshot/__init__.py
+  - src/lingtai/adapters/posix/git_cli.py
   - src/lingtai/tools/context/CONTRACT.md
   - src/lingtai/tools/notification/CONTRACT.md
   - src/lingtai/CONTRACT.md
@@ -20,32 +27,51 @@ related_files:
   - tests/test_eigen.py
   - tests/test_large_result_no_notification.py
   - tests/test_tool_meta_comment_overflow.py
+  - tests/test_source_drift.py
 maintenance: |
-  Written by the kernel nudge/notification CONVERT_BEHAVIOR migration (2026-08).
-  Keep in sync with the contracts this file guards — `src/lingtai/CONTRACT.md`
-  (Contract rules 6–7, Nudge transport and inline cap), `src/lingtai/tools/notification/CONTRACT.md`
-  (large-result routing, no large_tool_result source), `src/lingtai/tools/context/CONTRACT.md`
-  (eigen retirement, molt input) — and with `src/lingtai/kernel/ANATOMY.md`
-  entries for nudge, notifications, and meta_block. When any of those change
+  Written by the kernel nudge/notification CONVERT_BEHAVIOR migration (2026-08)
+  and trimmed per the fable PR review: K001/K002/K005/K006/K007 are now
+  observable-outcome LABTs (real artifacts written by the real runtime into a
+  scratch working dir: `.notification/nudge.json`, `.nudge_state.json`,
+  `.notification/system.json`, `ToolResultBlock` metadata, real git revisions).
+  No mocks, no private monkeypatching, no internal-call-shape assertions. The
+  pytest files in `supersedes` REMAIN the bottom-level assertions for the parts
+  that are not agent-observable without mocks: the strict "remote is never
+  queried" proof (its fake `_fetch_latest_version` raises), release-mirror
+  agreement/transport, malformed-remote-version non-promotion
+  (`kv._is_newer`), source-digest drift via a synthetic package, and private
+  helper units. Keep the pytest when you touch those paths; change this file
+  only when agent-observable behavior changes.
+  This file guards three contracts: `src/lingtai/CONTRACT.md` (Contract rules
+  rule 6, Nudge transport/policy) for K001/K002/K007; `notification-tool`
+  (large-result routing, no `large_tool_result` source, overflow guidance) for
+  K005/K006; `context-contract` (eigen retirement, molt summary guard) for
+  K003/K004. The frontmatter `contract:` list names all three (kernel/ has no
+  CONTRACT.md of its own). Keep the guards names in sync with each target's
+  frontmatter `name:` and with `src/lingtai/kernel/ANATOMY.md` entries for
+  nudge, notifications, and meta_block. When any of those change
   agent-observable behavior, update the matching LABT here in the same change.
 ---
 # Kernel Behavior Tests — nudge / notification family
 
-LABT v1. These are self-contained agent-executable behavioral tests for the
+LABT v2. These are self-contained agent-executable behavioral tests for the
 kernel nudge/notification family: the kernel-version nudge (`kernel_version`,
-including its source-drift/dev-runtime detection), the source-drift nudge
-(`source_drift`), the retired `eigen` identity surface, the promise that a
-large tool result never becomes a notification (it is ranked in
+including its source-drift/dev-runtime detection and fail-safe diagnostic
+direction), the source-drift nudge (`source_drift`), the retired `eigen`
+identity surface (K003), the `context.molt` summary guard (K004), the promise
+that a large tool result never becomes a notification (it is ranked in
 `_meta.agent_meta.current_tool_result_chars` instead), and the per-result
-`_meta.tool_meta.comment.overflow` hint. Low-level mechanics stay in pytest;
-each LABT below is self-contained — the full harness script is inlined — and
-executable verbatim by an agent with `shell` and `file` tools at a checkout of
-this repository. Replace `<repo-root>` with the checkout path and `<scratch>`
-with any empty working directory the executor owns.
-
-All harness scripts set the package path themselves (`sys.path.insert(0,
-<repo-root>/src)`) and write into a fresh temp working dir, so they never touch
-the executing agent's own `.notification/` or session state.
+`_meta.tool_meta.comment.overflow` hint. Every LABT below observes real
+artifacts written by the real runtime into a scratch working dir
+(`.notification/*.json`, `.nudge_state.json`, `ToolResultBlock` metadata, real
+git revisions) — no mocks, no private monkeypatching, no internal-call-shape
+assertions. Low-level mechanics that are not agent-observable without mocks
+(remote-mirror agreement, malformed-version promotion, digest-drift capture)
+stay in the pytest files named in `supersedes`; they remain the bottom-level
+assertions. Replace `<repo-root>` with the checkout path and `<scratch>` with
+any empty working directory the executor owns. Harness scripts set the package
+path themselves and write only into their own temp dirs, so they never touch
+the executing agent's `.notification/` or session state.
 
 ## Behavior K001 — kernel version nudge emits the local refresh finding on the `release_version` channel
 
@@ -66,86 +92,114 @@ the executing agent's own `.notification/` or session state.
 
 ### Steps
 1. Write `<scratch>/k001.py` with the following content (self-contained
-   harness; `REPO` is the only value to substitute):
+   harness; `REPO` is the only value to substitute). It stages a real
+   "stale install" — a wrapper module at v0.14.1 plus installed distribution
+   metadata v0.14.2 — on disk and boots the interpreter against it, so the
+   real `_runtime_info` observes running 0.14.1 / installed 0.14.2 without any
+   mocking:
 
 ```python
-import sys, os, json, pathlib, tempfile
+import sys, os, json, pathlib, tempfile, importlib.util
 REPO = r"<repo-root>"
 sys.path.insert(0, os.path.join(REPO, "src"))
 os.chdir(REPO)
 
 from lingtai.adapters.posix.notification_store import PosixNotificationStoreAdapter
+
+# Stage a real "stale install": wrapper at v0.14.1, installed dist v0.14.2.
+root = pathlib.Path(tempfile.mkdtemp(prefix="k001"))
+site = root / "site"
+wrapper_dir = site / "lingtai"
+wrapper_dir.mkdir(parents=True)
+(wrapper_dir / "__init__.py").write_text('__version__ = "0.14.1"\n', encoding="utf-8")
+dist_dir = site / "lingtai-0.14.2.dist-info"
+dist_dir.mkdir(parents=True)
+(dist_dir / "METADATA").write_text("Name: lingtai\nVersion: 0.14.2\n", encoding="utf-8")
+
+# Import the real kernel nudge module from the checkout first.
 from lingtai.kernel.nudge import kernel_version as kv
+
+# Boot the interpreter against the staged install: load the wrapper from the
+# real file; importlib.metadata then reads the staged dist-info from sys.path.
+spec = importlib.util.spec_from_file_location("lingtai", str(wrapper_dir / "__init__.py"))
+wrapper = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(wrapper)
+sys.modules["lingtai"] = wrapper
+sys.path.insert(0, str(site))
 
 class Agent:
     def __init__(self, workdir):
         self._working_dir = str(workdir)
         self._notification_store = PosixNotificationStoreAdapter(pathlib.Path(workdir))
         self.logs = []
-        self._nudge_kernel_version_state = {"last_probe_ts": 0.0}
     def _log(self, event, **fields):
         self.logs.append((event, fields))
 
-def entries(workdir):
-    snap = PosixNotificationStoreAdapter(pathlib.Path(workdir)).snapshot(lambda ch: True)
-    data = (snap.get("nudge") or {}).get("data") or {}
-    return data.get("nudges") or []
-
-d = pathlib.Path(tempfile.mkdtemp(prefix="k001"))
-a = Agent(d)
-# installed (0.14.2) is newer than running (0.14.1): local refresh, no remote.
-kv._runtime_info = lambda: kv._RuntimeInfo(
-    running_version="0.14.1", installed_version="0.14.2", dev_reason=None)
-kv._fetch_latest_version = lambda: (_ for _ in ()).throw(
-    AssertionError("remote must not be queried for a local refresh mismatch"))
-kv._today_utc = lambda: "2026-06-30"
+workdir = root / "agent"
+workdir.mkdir()
+a = Agent(workdir)
 kv.check(a)
-e = entries(d)
-assert len(e) == 1, e
-entry = e[0]
-assert entry["kind"] == "kernel_version"
-assert entry["nudge_channel"] == "release_version"
-assert entry["source"] == "installed-distribution"
-assert entry["running"] == "0.14.1" and entry["installed"] == "0.14.2"
-assert entry["latest"] is None
-assert entry["suggested_action"] == "refresh-installed-runtime-if-authorized-and-safe"
-assert "already on disk" in entry["detail"]
-assert "system(action='refresh')" in entry["detail"]
+
+nudge_path = workdir / ".notification" / "nudge.json"
+assert nudge_path.is_file(), f"nudge.json missing: {nudge_path}"
+data = json.loads(nudge_path.read_text(encoding="utf-8"))
+entries = data["data"]["nudges"]
+assert len(entries) == 1, entries
+e = entries[0]
+assert e["kind"] == "kernel_version", e
+assert e["nudge_channel"] == "release_version", e
+assert e["source"] == "installed-distribution", e
+assert e["running"] == "0.14.1" and e["installed"] == "0.14.2", e
+assert e.get("latest") is None, e
+assert e["suggested_action"] == "refresh-installed-runtime-if-authorized-and-safe", e
+assert "already on disk" in e["detail"], e
+assert "system(action='refresh')" in e["detail"], e
+assert e["title"] == "LingTai kernel refresh available: 0.14.1 -> 0.14.2", e
+
+# No remote probe was initiated: the persistent state carries no remote fields.
+state_path = workdir / ".notification" / ".nudge_state.json"
+if state_path.is_file():
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    kv_state = state.get("kernel_version", {})
+    assert "last_remote_check_date" not in kv_state, kv_state
+    assert "latest_seen" not in kv_state, kv_state
+
 print("K001 ENTRY:", json.dumps({
-    k: entry.get(k) for k in ("kind", "nudge_channel", "source",
-                               "running", "installed", "suggested_action")}, ensure_ascii=False))
-print("workdir:", d)
+    k: e.get(k) for k in ("kind", "nudge_channel", "source", "running",
+                           "installed", "suggested_action")}, ensure_ascii=False))
+print("workdir:", workdir)
 ```
 
 2. Run `python <scratch>/k001.py` from `<repo-root>`; the script exits 0 and
-   prints the entry fields and the workdir path.
-3. Read the notification file the script created: `<printed workdir>/.notification/nudge.json`
-   and the state file `<printed workdir>/.notification/.nudge_state.json`.
+   prints `K001 ENTRY:` and the workdir path.
+3. Read the notification file the script created: `<printed workdir>/.notification/nudge.json`.
 
 ### Expected evidence
-- [ ] The script exits 0 (all assertions pass) and prints
-      `K001 ENTRY:` with `kind: kernel_version`, `nudge_channel: release_version`,
-      `source: installed-distribution`, `suggested_action:
+- [ ] The script exits 0 and prints `K001 ENTRY:` with `kind: kernel_version`,
+      `nudge_channel: release_version`, `source: installed-distribution`,
+      `running: 0.14.1`, `installed: 0.14.2`, `suggested_action:
       refresh-installed-runtime-if-authorized-and-safe`.
 - [ ] `<workdir>/.notification/nudge.json` exists and its `data.nudges` contains
       exactly one entry whose `title` is `LingTai kernel refresh available:
-      0.14.1 -> 0.14.2` and whose `detail` contains `already on disk` and
-      `system(action='refresh')`.
-- [ ] The remote probe was never invoked (the harness proves it by raising
-      inside `_fetch_latest_version`).
+      0.14.1 -> 0.14.2`, whose `latest` is `null`, and whose `detail` contains
+      `already on disk` and `system(action='refresh')`.
+- [ ] The local-mismatch branch never initiates a remote probe: if
+      `<workdir>/.notification/.nudge_state.json` exists, its
+      `kernel_version` block has no `last_remote_check_date` or `latest_seen`
+      keys (the harness asserts this). The strict "the remote fetch is never
+      invoked" proof stays in the pytest, whose fake remote probe raises.
 
 ### Pass / Fail
-Pass when all evidence items hold and no network call occurred. Fail if the
-entry is missing, has a different `nudge_channel`/`source`, or the remote fetch
-was attempted.
+Pass when all evidence items hold. Fail if the entry is missing, has a
+different `nudge_channel`/`source`/`suggested_action`, or the state file shows a
+remote probe was started (`last_remote_check_date`/`latest_seen` present).
 
-## Behavior K002 — kernel version nudge is fail-safe: diagnostic direction, dev/source-drift runtimes, malformed versions
+## Behavior K002 — kernel version nudge is fail-safe: diagnostic direction and dev/source-drift runtimes
 
 - **id**: K002
 - **title**: running-newer/unparseable runtimes emit a read-only diagnostic
   (`installed-distribution-diagnostic`), dev/editable/source-checkout runtimes
-  skip and clear the nudge with a recorded reason, and malformed remote
-  versions can never be promoted
+  skip and clear the nudge with a recorded reason
 - **guards**: `src/lingtai/CONTRACT.md` § Contract rules rule 6 — Nudge
   findings stay on the ordinary `.notification/nudge.json` transport under the
   shared policy
@@ -161,89 +215,136 @@ was attempted.
 - **estimate**: 3 min
 
 ### Steps
-1. Write `<scratch>/k002.py` with the following content:
+1. Write `<scratch>/k002.py` with the following content (`REPO` is the only
+   value to substitute). Each case stages a real on-disk installation and
+   boots the interpreter against it — the same real `_runtime_info` path the
+   agent uses:
 
 ```python
-import sys, os, json, pathlib, tempfile
+import sys, os, json, pathlib, tempfile, importlib.util
+from datetime import datetime, timezone
 REPO = r"<repo-root>"
 sys.path.insert(0, os.path.join(REPO, "src"))
 os.chdir(REPO)
 
 from lingtai.adapters.posix.notification_store import PosixNotificationStoreAdapter
-from lingtai.kernel.nudge import kernel_version as kv
+from lingtai.kernel.nudge import kernel_version as kv, upsert
+
+root = pathlib.Path(tempfile.mkdtemp(prefix="k002"))
 
 class Agent:
     def __init__(self, workdir):
         self._working_dir = str(workdir)
         self._notification_store = PosixNotificationStoreAdapter(pathlib.Path(workdir))
         self.logs = []
-        self._nudge_kernel_version_state = {"last_probe_ts": 0.0}
     def _log(self, event, **fields):
         self.logs.append((event, fields))
 
-def entries(workdir):
-    snap = PosixNotificationStoreAdapter(pathlib.Path(workdir)).snapshot(lambda ch: True)
-    data = (snap.get("nudge") or {}).get("data") or {}
-    return data.get("nudges") or []
+def load_wrapper(wrapper_path, site):
+    spec = importlib.util.spec_from_file_location("lingtai", str(wrapper_path))
+    w = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(w)
+    sys.modules["lingtai"] = w
+    sys.path.insert(0, str(site))
 
-def run_case(prefix, running, installed, dev_reason):
-    d = pathlib.Path(tempfile.mkdtemp(prefix=prefix))
-    a = Agent(d)
-    kv._runtime_info = lambda: kv._RuntimeInfo(
-        running_version=running, installed_version=installed, dev_reason=dev_reason)
-    kv._fetch_latest_version = lambda: (_ for _ in ()).throw(
-        AssertionError("no remote probe expected"))
-    kv._today_utc = lambda: "2026-06-24"
-    kv.check(a)
-    return d, entries(d)
+def make_site(running, installed, *, editable=False, source_checkout=False, name="site"):
+    site = root / name
+    site.mkdir(parents=True, exist_ok=True)
+    if source_checkout:
+        base = root / "srccheck"
+        (base / ".git").mkdir(parents=True, exist_ok=True)
+        (base / "pyproject.toml").write_text("", encoding="utf-8")
+        wdir = base / "src" / "lingtai"
+        wdir.mkdir(parents=True, exist_ok=True)
+    else:
+        wdir = site / "lingtai"
+        wdir.mkdir(parents=True, exist_ok=True)
+    wrapper_file = wdir / "__init__.py"
+    wrapper_file.write_text(f'__version__ = "{running}"\n', encoding="utf-8")
+    dist_dir = site / f"lingtai-{installed}.dist-info"
+    dist_dir.mkdir(parents=True, exist_ok=True)
+    (dist_dir / "METADATA").write_text(f"Name: lingtai\nVersion: {installed}\n", encoding="utf-8")
+    if editable:
+        (dist_dir / "direct_url.json").write_text(
+            json.dumps({"dir_info": {"editable": True}}), encoding="utf-8")
+    return site, wrapper_file
+
+def nudge_entries(d):
+    p = d / ".notification" / "nudge.json"
+    if not p.is_file():
+        return []
+    return json.loads(p.read_text(encoding="utf-8"))["data"]["nudges"]
 
 # (a) running newer than installed -> read-only diagnostic, never refresh
-_, ea = run_case("k002a", "0.17.0", "0.16.5", None)
-assert len(ea) == 1
-assert ea[0]["source"] == "installed-distribution-diagnostic"
-assert ea[0]["suggested_action"] == "inspect-runtime-interpreter-and-import-paths"
-assert "Do not refresh" in ea[0]["detail"]
+site, wrapper = make_site("0.17.0", "0.16.5", name="site_a")
+load_wrapper(wrapper, site)
+a = root / "a"; a.mkdir(exist_ok=True)
+aa = Agent(a)
+kv.check(aa)
+ea = nudge_entries(a)[0]
+assert ea["source"] == "installed-distribution-diagnostic", ea
+assert ea["suggested_action"] == "inspect-runtime-interpreter-and-import-paths", ea
+assert "Do not refresh" in ea["detail"], ea
 
 # (b) unparseable running version -> same diagnostic
-_, eb = run_case("k002b", "not-a-version", "0.17.0", None)
-assert len(eb) == 1 and eb[0]["source"] == "installed-distribution-diagnostic"
+site, wrapper = make_site("not-a-version", "0.17.0", name="site_b")
+load_wrapper(wrapper, site)
+b = root / "b"; b.mkdir(exist_ok=True)
+ab = Agent(b)
+kv.check(ab)
+eb = nudge_entries(b)[0]
+assert eb["source"] == "installed-distribution-diagnostic", eb
 
-# (c) dev/editable runtime -> nudge skipped AND cleared, reason recorded
-d, ec = run_case("k002c", "0.14.1.dev0", "0.14.1.dev0", "editable-install")
-assert ec == []
-state = json.loads((d / ".notification" / ".nudge_state.json").read_text())
-assert state["kernel_version"]["last_skip_date"] == "2026-06-24"
-assert state["kernel_version"]["skip_reason"] == "editable-install"
+# (c) editable install -> nudge skipped AND cleared, reason recorded
+site, wrapper = make_site("0.14.1", "0.14.1", editable=True, name="site_c")
+load_wrapper(wrapper, site)
+c = root / "c"; c.mkdir(exist_ok=True)
+ac = Agent(c)
+upsert(ac, "kernel_version", {"title": "stale", "source": "release-manifest"})
+assert nudge_entries(c), "pre-seeded nudge should exist"
+kv.check(ac)
+assert nudge_entries(c) == [], "stale nudge must be cleared"
+state = json.loads((c / ".notification" / ".nudge_state.json").read_text(encoding="utf-8"))
+assert state["kernel_version"]["skip_reason"] == "editable-install", state
+assert state["kernel_version"]["last_skip_date"] == datetime.now(timezone.utc).date().isoformat(), state
 
-# (d) source checkout (source drift) -> skipped, reason recorded
-_, ed = run_case("k002d", "0.14.1", "0.14.1", "source-checkout")
-assert ed == []
+# (d) source checkout -> skipped, reason recorded
+site, wrapper = make_site("0.14.1", "0.14.1", source_checkout=True, name="site_d")
+load_wrapper(wrapper, site)
+d2 = root / "d"; d2.mkdir(exist_ok=True)
+ad = Agent(d2)
+upsert(ad, "kernel_version", {"title": "stale", "source": "release-manifest"})
+kv.check(ad)
+assert nudge_entries(d2) == []
+state = json.loads((d2 / ".notification" / ".nudge_state.json").read_text(encoding="utf-8"))
+assert state["kernel_version"]["skip_reason"] == "source-checkout", state
 
-# (e) malformed remote candidates are never promoted by numeric substrings
-assert kv._is_newer("999-not-a-release", "0.16.5") is False
-assert kv._is_newer("release-999", "0.16.5") is False
-assert kv._is_newer("not-a-version", "0.16.5") is False
-
-print("K002 OK: diagnostic(a,b), dev-skip(c), source-checkout-skip(d), no-promote(e)")
+print("K002 OK: diagnostic(a,b), editable-skip+clear(c), source-checkout-skip+clear(d)")
 ```
 
 2. Run `python <scratch>/k002.py` from `<repo-root>`; it must exit 0.
 
 ### Expected evidence
 - [ ] The script exits 0 and prints `K002 OK: ...`.
-- [ ] Case (a)/(b) entries carry `source: installed-distribution-diagnostic`,
+- [ ] Case (a) and (b) entries carry `source: installed-distribution-diagnostic`,
       `suggested_action: inspect-runtime-interpreter-and-import-paths`, and
       `Do not refresh` in `detail` — an ambiguous direction never recommends
       refresh.
-- [ ] Case (c) leaves `data.nudges` empty and `kernel_version.skip_reason` is
-      `editable-install` (source drift/dev detection recorded). Case (d) leaves
-      it empty for `source-checkout`.
-- [ ] `kv._is_newer` returns `False` for every malformed candidate.
+- [ ] Case (c) leaves `data.nudges` empty (a pre-seeded stale nudge is cleared)
+      and `.nudge_state.json` records `kernel_version.skip_reason` =
+      `editable-install` with `last_skip_date` equal to today's UTC date.
+      Case (d) likewise leaves the channel empty and records `skip_reason` =
+      `source-checkout`.
+- [ ] Malformed remote candidates (`999-not-a-release`, `release-999`,
+      `not-a-version`) are never promoted: that scenario is NOT part of this
+      LABT — it requires a stubbed remote probe and stays in
+      `tests/test_kernel_version_nudge.py::test_malformed_remote_version_cannot_be_promoted_by_numeric_substrings`
+      as the bottom-level assertion.
 
 ### Pass / Fail
 Pass when all evidence holds. Fail if a diagnostic case recommends refresh, a
-dev runtime still emits a nudge, or a malformed remote version is treated as
-newer.
+dev/editable/source-checkout runtime still emits or keeps a nudge, or the skip
+reason is not recorded.
 
 ## Behavior K003 — `eigen` is retired: LingTai identity lives in `context` + `psyche`, name changes are `system.name_set`
 
@@ -252,7 +353,7 @@ newer.
   is `context` (molt owns the identity summary in `input`) plus the
   manual-only `psyche` family, and the true name is set once via
   `system.name_set` / `system.name_nickname`
-- **guards**: `context-tool` § Purpose and public ownership — no OLD `psyche`
+- **guards**: `context-contract` § Purpose and public ownership — no OLD `psyche`
   action is reachable, `eigen` is gone, name changes remain
   `system.name_set | system.name_nickname`, and `molt` requires `summary` in
   its own strict input branch
@@ -295,7 +396,7 @@ appears as an intrinsic, or `name_set` is absent from the `system` schema.
 - **id**: K004
 - **title**: `context(action="molt", input={...})` without a non-empty
   `summary` returns the pinned refusal error and sheds nothing
-- **guards**: `context-tool` § Molt safety invariants — agent-initiated molt
+- **guards**: `context-contract` § Molt safety invariants — agent-initiated molt
   requires a nonempty retrospective; validation occurs before snapshot/
   archive/wipe or count mutation
   ([CONTRACT.md](../tools/context/CONTRACT.md#molt-safety-invariants))
@@ -339,79 +440,108 @@ summary is accepted or a non-error result is returned.
 - **supersedes**: `tests/test_large_result_no_notification.py::test_rescan_never_publishes_for_huge_result`,
   `tests/test_large_result_no_notification.py::test_large_result_still_reported_by_current_tool_result_chars`,
   `tests/test_large_result_no_notification.py::test_current_tool_result_chars_reports_threshold_and_over_count`
-- **runner**: any LingTai agent with `shell` tool at a checkout of this
-  repository
+- **runner**: any LingTai agent with `shell` and `file` tools at a checkout of
+  this repository
 - **prerequisites**: a checkout of this repo at `<repo-root>`; python on PATH
 - **estimate**: 2 min
 
 ### Steps
-1. Write `<scratch>/k005.py` with the following content:
+1. Write `<scratch>/k005.py` with the following content (`REPO` is the only
+   value to substitute). It drives the real `ChatInterface`, the real
+   `meta_block.current_tool_result_chars`, the real retained no-op hooks, and
+   a real notification store — no mocks:
 
 ```python
-import sys, os, json, types
-from unittest.mock import MagicMock
+import sys, os, json, pathlib, tempfile
 REPO = r"<repo-root>"
 sys.path.insert(0, os.path.join(REPO, "src"))
 os.chdir(REPO)
 
 from lingtai.kernel.llm.interface import ChatInterface, ToolCallBlock, ToolResultBlock
 from lingtai.kernel import meta_block
-from lingtai.kernel.base_agent.messaging import _rescan_large_tool_results
+from lingtai.kernel.base_agent.messaging import _rescan_large_tool_results, _enqueue_system_notification
+from lingtai.kernel.base_agent import BaseAgent
+from lingtai.adapters.posix.notification_store import PosixNotificationStoreAdapter
+
+class Agent:
+    def __init__(self, workdir):
+        self._working_dir = str(workdir)
+        self._notification_store = PosixNotificationStoreAdapter(pathlib.Path(workdir))
+        self.logs = []
+    def _log(self, event, **fields):
+        self.logs.append((event, fields))
+    def _wake_nap(self, reason):
+        self.logs.append(("wake_nap", {"reason": reason}))
+
+workdir = pathlib.Path(tempfile.mkdtemp(prefix="k005"))
+a = Agent(workdir)
 
 iface = ChatInterface()
 iface.add_assistant_message([ToolCallBlock(id="tc-rank", name="bash", args={})])
-iface.add_tool_results([ToolResultBlock(
-    id="tc-rank", name="bash", content={"output": "Q" * 40000, "status": "ok"})])
+iface.add_tool_results([ToolResultBlock(id="tc-rank", name="bash",
+                                        content={"output": "Q" * 40000, "status": "ok"})])
+chat = type("Chat", (), {"interface": iface})()
+session = type("Session", (), {"chat": chat})()
+a._session = session
 
-agent = types.SimpleNamespace()
-agent._session = types.SimpleNamespace(chat=types.SimpleNamespace(interface=iface))
-
-# Default threshold (no attribute configured) is 3000 chars.
-s = meta_block.current_tool_result_chars(agent)
-print("summary:", json.dumps({k: s[k] for k in ("total_chars", "threshold",
-                                                "over_threshold_count")}))
-assert s["total_chars"] >= 40000
-assert s["threshold"] == 3000
-assert "tc-rank" in [r["id"] for r in s["top_results"]]
-assert s["top_results"][0]["tool_name"] == "bash"
+# The large result is ranked, not notified: default threshold is 3000 chars.
+s = meta_block.current_tool_result_chars(a)
+assert s["total_chars"] >= 40000, s
+assert s["threshold"] == 3000, s
+assert "tc-rank" in [r["id"] for r in s["top_results"]], s
+assert s["top_results"][0]["tool_name"] == "bash", s
 
 # Configured threshold: only results over it are counted.
-agent._summarize_notification_threshold = 5000
-s2 = meta_block.current_tool_result_chars(agent)
-assert s2["threshold"] == 5000 and s2["over_threshold_count"] == 1
+a._summarize_notification_threshold = 5000
+s2 = meta_block.current_tool_result_chars(a)
+assert s2["threshold"] == 5000 and s2["over_threshold_count"] == 1, s2
 
-# Turn-boundary rescan: never publishes, always returns 0.
-class StubChat:
-    interface = iface
-stub = MagicMock()
-stub._chat = StubChat()
-stub._log = MagicMock()
-stub._summarize_notification_threshold = 5000
-published = []
-stub._enqueue_system_notification = lambda *, source, ref_id, body, \
-    skip_if_ref_id_exists=False, **kw: published.append(source) or "evt001"
-count = _rescan_large_tool_results(stub)
-print("rescan_count:", count, "published:", published)
-assert count == 0 and published == []
-print("K005 OK")
+# Retained no-ops: the turn-boundary rescan and the per-result hook publish
+# nothing.
+assert _rescan_large_tool_results(a) == 0
+assert BaseAgent._maybe_notify_large_tool_result(
+    a, "bash", {"output": "X" * 80000, "status": "ok"}, tool_call_id="tc-huge") is None
+
+# No system notification was published: .notification/system.json does not exist.
+sys_json = workdir / ".notification" / "system.json"
+assert not sys_json.is_file(), f"system.json must not exist yet: {sys_json}"
+
+# Positive control: the store channel works; a real publish creates system.json.
+ev = _enqueue_system_notification(a, source="labt-control", ref_id="ctrl-1", body="control")
+assert ev, "control publish should return an event id"
+assert sys_json.is_file(), "control publish should create system.json"
+payload = json.loads(sys_json.read_text(encoding="utf-8"))
+events = payload["data"]["events"]
+assert len(events) == 1 and events[0]["source"] == "labt-control", events
+assert all(evt["source"] != "large_tool_result" for evt in events)
+
+print("K005 OK: ranked, no large_tool_result notification, control published")
 ```
 
 2. Run `python <scratch>/k005.py` from `<repo-root>`; it must exit 0.
 
 ### Expected evidence
-- [ ] The script exits 0 and prints `summary:` with `total_chars >= 40000`,
-      `threshold: 3000` (default), and `over_threshold_count: 1` (the single
-      40000-char result already exceeds the default 3000-char threshold).
-- [ ] With `_summarize_notification_threshold = 5000`, the same ranking
-      reports `threshold: 5000` and `over_threshold_count: 1`, and
-      `top_results` lists `id: tc-rank` with `tool_name: bash`.
-- [ ] `rescan_count: 0` and `published: []` — the turn-boundary rescan never
-      emits a `large_tool_result` (or any) notification.
+- [ ] The script exits 0 and prints `K005 OK: ...`.
+- [ ] `current_tool_result_chars` reports `total_chars >= 40000`, the default
+      `threshold: 3000`, and `over_threshold_count: 1`; with
+      `_summarize_notification_threshold = 5000` it reports `threshold: 5000`
+      and `over_threshold_count: 1`, and `top_results` lists `id: tc-rank`
+      with `tool_name: bash`.
+- [ ] The turn-boundary rescan returns `0` and the per-result hook returns
+      `None` — retained no-ops. Before the control publish,
+      `<workdir>/.notification/system.json` does NOT exist: no
+      `large_tool_result` (or any) system notification was produced for the
+      40000-char result.
+- [ ] The positive control proves the channel works: after publishing one
+      `labt-control` event through the real `_enqueue_system_notification`,
+      `system.json` exists with exactly one event, and no event carries
+      `source: large_tool_result`.
 
 ### Pass / Fail
 Pass when all evidence holds. Fail if any `large_tool_result` notification is
-published, the rescan returns a nonzero count, or the ranked summary lacks
-`total_chars`/`threshold`/`over_threshold_count`/`top_results`.
+published, the rescan returns a nonzero count, the ranked summary lacks
+`total_chars`/`threshold`/`over_threshold_count`/`top_results`, or the control
+publish does not land in `system.json`.
 
 ## Behavior K006 — capped/large results carry `_meta.tool_meta.comment.overflow`
 
@@ -427,17 +557,20 @@ published, the rescan returns a nonzero count, or the ranked summary lacks
 - **supersedes**: `tests/test_tool_meta_comment_overflow.py::test_spilled_result_carries_overflow_comment`,
   `tests/test_tool_meta_comment_overflow.py::test_large_inline_result_carries_overflow_comment`,
   `tests/test_tool_meta_comment_overflow.py::test_small_result_has_no_overflow_comment`
-- **runner**: any LingTai agent with `shell` tool at a checkout of this
-  repository
+- **runner**: any LingTai agent with `shell` and `file` tools at a checkout of
+  this repository
 - **prerequisites**: a checkout of this repo at `<repo-root>`; python on PATH
 - **estimate**: 2 min
 
 ### Steps
-1. Write `<scratch>/k006.py` with the following content:
+1. Write `<scratch>/k006.py` with the following content (`REPO` is the only
+   value to substitute). It drives the real `ToolExecutor` (the same executor
+   the agent's turn loop builds) against real payload files on disk and
+   inspects the resulting model-visible `ToolResultBlock` metadata — no
+   mocks:
 
 ```python
 import sys, os, json, pathlib, tempfile
-from unittest.mock import MagicMock
 REPO = r"<repo-root>"
 sys.path.insert(0, os.path.join(REPO, "src"))
 os.chdir(REPO)
@@ -451,7 +584,26 @@ from lingtai.kernel.tool_executor import ToolExecutor, _DEFAULT_MAX_RESULT_CHARS
 # The spill hard ceiling (PREVENTIVE_MAX_CHARS, src/lingtai/kernel/tool_result_artifacts.py).
 assert _DEFAULT_MAX_RESULT_CHARS == 200_000
 
-# Builder shape: one topic, four subkeys, references the durable log by call id.
+root = pathlib.Path(tempfile.mkdtemp(prefix="k006"))
+big = root / "big.txt"; big.write_text("Z" * 1200, encoding="utf-8")
+med = root / "med.txt"; med.write_text("Q" * 400, encoding="utf-8")
+
+# Wire-format builder: the same shape BaseAgent.turn passes to ToolExecutor
+# (turn.py: make_tool_result_fn=lambda name, result, **kw: agent.service.make_tool_result(...)).
+def make_tool_result(name, result, **kw):
+    return ToolResultBlock(kw.get("tool_call_id", ""), name, result)
+
+def make_executor(dispatch, workdir, max_result_chars, threshold):
+    return ToolExecutor(
+        dispatch_fn=dispatch,
+        make_tool_result_fn=make_tool_result,
+        guard=LoopGuard(max_total_calls=50),
+        working_dir=workdir,
+        max_result_chars=max_result_chars,
+        summarize_notification_threshold=threshold,
+    )
+
+# Builder shape: exactly one guidance topic, four subkeys, references the durable log.
 c = build_tool_meta_overflow_comment("tc-abc")
 blob = json.dumps(c)
 assert set(c) == {"summary", "full_original", "how_to_retrieve", "after_consuming"}
@@ -461,31 +613,21 @@ assert "grep" in c["how_to_retrieve"] and "lingtai-agent log query" in c["how_to
 assert ("daemon" in c["how_to_retrieve"] or "subagent" in c["how_to_retrieve"])
 assert "summarize" in c["after_consuming"]
 
-# Spilled result (payload over the configured 500-char cap) -> status spilled
-# + overflow comment + spilled_char_count.
-def make_executor(dispatch_fn, workdir, max_result_chars, threshold):
-    captured = MagicMock(side_effect=lambda name, result, **kw: ToolResultBlock(
-        kw.get("tool_call_id", ""), name, result))
-    ex = ToolExecutor(dispatch_fn=dispatch_fn, make_tool_result_fn=captured,
-                      guard=LoopGuard(max_total_calls=50), working_dir=workdir,
-                      max_result_chars=max_result_chars,
-                      summarize_notification_threshold=threshold)
-    return ex
-
-ex = make_executor(lambda tc: {"data": "Z" * 1200}, str(tempfile.mkdtemp()),
-                   500, None)
+# Spilled result (payload over the 500-char cap) -> status spilled + comment.
+ex = make_executor(lambda tc: {"data": big.read_text(encoding="utf-8")}, root / "wd1", 500, None)
 block = ex.execute([ToolCall(name="read", args={}, id="tc-spill")])[0][0]
-assert block.content["status"] == "spilled"
+assert block.content["status"] == "spilled", block.content
+assert (root / "wd1" / "tmp" / "tool-results").is_dir(), "spill artifact dir missing"
 tm = block.metadata.get("tool_meta", {})
-assert set(tm["comment"].keys()) == {"overflow"}
+assert set(tm["comment"].keys()) == {"overflow"}, tm
 assert tm["id"] == "tc-spill"
 assert isinstance(tm["char_count"], int) and isinstance(tm["elapsed_ms"], int)
 assert "spilled_char_count" in tm
+assert "logs/events.jsonl" in json.dumps(tm["comment"])
+assert "saved_path" not in json.dumps(tm["comment"])
 
-# Large but inline (over the 100-char hint threshold, under the spill cap)
-# -> overflow comment, not spilled.
-ex2 = make_executor(lambda tc: {"data": "Q" * 400}, str(tempfile.mkdtemp()),
-                   _DEFAULT_MAX_RESULT_CHARS, 100)
+# Large but inline (over the 100-char hint threshold, under the spill cap).
+ex2 = make_executor(lambda tc: {"data": med.read_text(encoding="utf-8")}, root / "wd2", _DEFAULT_MAX_RESULT_CHARS, 100)
 block2 = ex2.execute([ToolCall(name="read", args={}, id="tc-large")])[0][0]
 assert block2.content.get("status") != "spilled"
 tm2 = block2.metadata.get("tool_meta", {})
@@ -493,12 +635,11 @@ assert tm2["char_count"] > 100
 assert "overflow" in tm2.get("comment", {})
 assert "logs/events.jsonl" in tm2["comment"]["overflow"]["full_original"]
 
-# Small result -> no comment at all; identity fields still present.
-ex3 = make_executor(lambda tc: {"ok": True}, str(tempfile.mkdtemp()),
-                   _DEFAULT_MAX_RESULT_CHARS, 100)
+# Small result -> no comment; identity fields intact.
+ex3 = make_executor(lambda tc: {"ok": True}, root / "wd3", _DEFAULT_MAX_RESULT_CHARS, 100)
 block3 = ex3.execute([ToolCall(name="read", args={}, id="tc-small")])[0][0]
 tm3 = block3.metadata.get("tool_meta", {})
-assert "comment" not in tm3
+assert "comment" not in tm3, tm3
 assert tm3["id"] == "tc-small"
 assert isinstance(tm3["char_count"], int) and isinstance(tm3["elapsed_ms"], int)
 
@@ -516,7 +657,8 @@ print("K006 OK: builder-shape, spilled, large-inline, small-no-comment")
       and `lingtai-agent log query`; `after_consuming` recommends
       `system(action="summarize")`.
 - [ ] A spilled result reports `status: spilled` with
-      `tool_meta.comment.overflow` and `spilled_char_count`; a large inline
+      `tool_meta.comment.overflow`, `spilled_char_count`, and a preserved
+      spill artifact under `<workdir>/tmp/tool-results/`; a large inline
       result (over the hint threshold) also carries the comment; a small
       result carries no `comment`. Identity fields `id`/`char_count`/
       `elapsed_ms` remain intact in all three.
@@ -541,76 +683,115 @@ identity fields.
 - **runner**: any LingTai agent with `shell` and `file` tools at a checkout of
   this repository
 - **prerequisites**: a checkout of this repo at `<repo-root>`; an empty scratch
-  dir `<scratch>`; python on PATH
+  dir `<scratch>`; python and `git` on PATH
 - **estimate**: 2 min
 
 ### Steps
-1. Write `<scratch>/k007.py` with the following content:
+1. Write `<scratch>/k007.py` with the following content (`REPO` is the only
+   value to substitute). It creates a real throwaway git repo, captures the
+   real runtime fingerprint through the real `_capture_runtime_fingerprint`
+   and the real `PosixGitCliAdapter` revision port, then drives the real
+   `source_drift.check` against real `.notification/nudge.json` artifacts —
+   no mocks:
 
 ```python
-import sys, os, json, pathlib, tempfile
+import sys, os, json, pathlib, tempfile, subprocess
 REPO = r"<repo-root>"
 sys.path.insert(0, os.path.join(REPO, "src"))
 os.chdir(REPO)
 
+from lingtai.adapters.posix.git_cli import PosixGitCliAdapter
 from lingtai.adapters.posix.notification_store import PosixNotificationStoreAdapter
+from lingtai.kernel.base_agent.lifecycle import _capture_runtime_fingerprint
 from lingtai.kernel.nudge import source_drift as sd
-from lingtai.kernel.base_agent import lifecycle as lc
 
 class Agent:
     def __init__(self, workdir):
         self._working_dir = str(workdir)
         self._notification_store = PosixNotificationStoreAdapter(pathlib.Path(workdir))
         self.logs = []
-        self._nudge_source_drift_state = {"last_probe_ts": 0.0}
-        self._source_revision_port = None
     def _log(self, event, **fields):
         self.logs.append((event, fields))
 
-def entries(workdir):
-    snap = PosixNotificationStoreAdapter(pathlib.Path(workdir)).snapshot(lambda ch: True)
-    data = (snap.get("nudge") or {}).get("data") or {}
-    return data.get("nudges") or []
+def git(*args, cwd):
+    return subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True, check=True)
 
-d = pathlib.Path(tempfile.mkdtemp(prefix="k007"))
-a = Agent(d)
-startup = {"git_rev": "abc1234", "source_digest": "digestAAAA",
-           "captured_at": "2026-07-01T00:00:00Z"}
+root = pathlib.Path(tempfile.mkdtemp(prefix="k007"))
+repo = root / "src_repo"
+repo.mkdir()
+git("init", cwd=repo)
+git("config", "user.email", "agent@lingtai", cwd=repo)
+git("config", "user.name", "agent", cwd=repo)
+# Seed commits so the short-revision abbreviation is stable across the test.
+(repo / "seed.txt").write_text("seed 1\n", encoding="utf-8")
+git("add", "-A", cwd=repo)
+git("commit", "-m", "seed 1", cwd=repo)
+(repo / "seed.txt").write_text("seed 2\n", encoding="utf-8")
+git("add", "-A", cwd=repo)
+git("commit", "-m", "seed 2", cwd=repo)
+
+# Startup fingerprint: the real capture at the current HEAD (call it rev A).
+port = PosixGitCliAdapter(repo)
+startup = _capture_runtime_fingerprint(port)
+revA = startup["git_rev"]
+assert revA and startup["source_digest"] and len(startup["source_digest"]) == 12, startup
+revA_full = git("rev-parse", "HEAD", cwd=repo).stdout.strip()
+
+# On-disk source moves to a new commit (rev B) -> drift.
+(repo / "code.txt").write_text("v2\n", encoding="utf-8")
+git("add", "-A", cwd=repo)
+git("commit", "-m", "rev B", cwd=repo)
+revB = port.current_revision(None, 2.0)
+assert revA != revB, (revA, revB)
+
+workdir = root / "agent"
+workdir.mkdir()
+a = Agent(workdir)
 a._runtime_fingerprint = startup
-# On-disk source changed since startup -> drift.
-lc._capture_runtime_fingerprint = lambda port: {
-    "git_rev": "def5678", "source_digest": "digestBBBB",
-    "captured_at": "2026-07-02T00:00:00Z"}
-sd.check(a)
-e = entries(d)
-assert len(e) == 1, e
-entry = e[0]
-assert entry["kind"] == "source_drift"
-assert entry["nudge_channel"] == "source_integrity"
-assert entry["title"] == "Source drift detected \u2014 running code is stale"
-assert entry["suggested_action"] == "system(action='refresh')"
-assert "git_rev: abc1234 \u2192 def5678" in entry["detail"]
-assert "source_digest: digestAAAA \u2192 digestBBBB" in entry["detail"]
+a._source_revision_port = port  # on-disk repo is now at rev B
 
-# On-disk source matches startup again -> the finding is cleared.
-lc._capture_runtime_fingerprint = lambda port: startup
-a._nudge_source_drift_state = {"last_probe_ts": 0.0, "emitted": True}
 sd.check(a)
-assert entries(d) == [], entries(d)
-print("K007 OK: source_integrity emit + clear")
+nudge_path = workdir / ".notification" / "nudge.json"
+assert nudge_path.is_file(), nudge_path
+data = json.loads(nudge_path.read_text(encoding="utf-8"))
+entries = data["data"]["nudges"]
+assert len(entries) == 1, entries
+e = entries[0]
+assert e["kind"] == "source_drift", e
+assert e["nudge_channel"] == "source_integrity", e
+assert e["title"] == "Source drift detected \u2014 running code is stale", e
+assert e["suggested_action"] == "system(action='refresh')", e
+assert f"git_rev: {revA} \u2192 {revB}" in e["detail"], e["detail"]
+assert e["startup_fingerprint"]["git_rev"] == revA, e
+assert e["disk_fingerprint"]["git_rev"] == revB, e
+
+# On-disk source returns to the startup commit -> the finding is cleared.
+git("reset", "--hard", revA_full, cwd=repo)
+assert port.current_revision(None, 2.0) == revA, "on-disk source must match startup again"
+a._nudge_source_drift_state["last_probe_ts"] = 0.0  # advance past the 60s throttle
+sd.check(a)
+assert not nudge_path.exists(), "stale source_drift finding must be cleared"
+
+print("K007 OK: source_integrity emit + clear (git_rev %s -> %s)" % (revA, revB))
 ```
 
 2. Run `python <scratch>/k007.py` from `<repo-root>`; it must exit 0.
 
 ### Expected evidence
-- [ ] The script exits 0 and prints `K007 OK: source_integrity emit + clear`.
+- [ ] The script exits 0 and prints `K007 OK: source_integrity emit + clear
+      (git_rev <revA> -> <revB>)`.
 - [ ] The drift entry has `kind: source_drift`, `nudge_channel:
       source_integrity`, `title: Source drift detected — running code is
       stale`, `suggested_action: system(action='refresh')`, and a `detail`
-      listing `git_rev: abc1234 → def5678` and `source_digest: digestAAAA →
-      digestBBBB`.
-- [ ] After the fingerprints match again, `data.nudges` is empty (the stale
-      finding is cleared, not left visible).
+      listing `git_rev: <revA> → <revB>`, plus `startup_fingerprint`/
+      `disk_fingerprint` blocks whose `git_rev` values match the two commits.
+- [ ] After `git reset --hard <revA>` the port again reports `<revA>` (on-disk
+      source matches startup), and the second `check` clears the finding:
+      `data.nudges` is empty and `.notification/nudge.json` is gone.
+- [ ] Source-digest drift (a changed kernel package file) is not exercised
+      here — it needs a synthetic package and stays in
+      `tests/test_source_drift.py::TestCaptureRuntimeFingerprint` as the
+      bottom-level assertion.
 
 ### Pass / Fail
 Pass when all evidence holds. Fail if no entry is emitted on drift, the

--- a/src/lingtai/tools/bash/BEHAVIORS.md
+++ b/src/lingtai/tools/bash/BEHAVIORS.md
@@ -1,9 +1,9 @@
 ---
-name: shell-behavior-tests
+name: bash-behavior-tests
 behavior_version: 1
-labt_version: 1
-contract: ../bash/CONTRACT.md
-anatomy: ../bash/ANATOMY.md
+labt_version: 2
+contract: CONTRACT.md
+anatomy: ANATOMY.md
 related_files:
   - src/lingtai/tools/bash/__init__.py
   - src/lingtai/tools/bash/_tool_family.py
@@ -23,13 +23,14 @@ related_files:
   - src/lingtai/tools/daemon/BEHAVIORS.md
 maintenance: |
   Written by the shell/sandbox CONVERT_BEHAVIOR migration (2026-08). The
-  canonical shell implementation lives in src/lingtai/tools/bash/ (the public
-  tool is `shell`; see bash-contract), so this file's contract/anatomy links
-  point at ../bash/. Keep in sync with every contract this file guards:
-  bash-contract, the LTP v2 family convention (src/lingtai/tools/CONTRACT.md
-  + tool_family), the context/psyche contracts, the email contract, and the
-  base-agent runtime contract. When any of those changes in a way that affects
-  agent-observable behavior, update the matching LABT here in the same change.
+  canonical shell implementation lives in this directory (src/lingtai/tools/bash/;
+  the public tool is `shell`; see bash-contract), so this file's contract/anatomy
+  links are local (CONTRACT.md, ANATOMY.md). Keep in sync with every contract
+  this file guards: bash-contract, the LTP v2 family convention
+  (src/lingtai/tools/CONTRACT.md + tool_family), the context/psyche contracts,
+  the email contract, and the base-agent runtime contract (agent-runtime). When
+  any of those changes in a way that affects agent-observable behavior, update
+  the matching LABT here in the same change.
 ---
 # Shell / Sandbox Behavior Tests
 
@@ -49,10 +50,12 @@ executable verbatim by an agent with the listed tools.
 to historical run dirs), so it is NOT duplicated here.
 
 Pinned pytest commands below must run from the repo root `<repo>` with the
-project venv interpreter that resolves `lingtai` from `<repo>/src` (an
-editable install), e.g. `C:\Users\zhuang\.lingtai-tui\runtime\venv\Scripts\python.exe`
-on the original host. Substitute your own venv `python`; the expected pass
-counts are pinned and platform notes are given per LABT.
+project's Python: any interpreter that resolves `lingtai` from `<repo>/src`
+(an editable install) and has pytest installed. Prefer the project's configured
+python, e.g. `python -m pytest ...` from an activated project environment, or
+the interpreter named by the `LINGTAI_RUNTIME_PYTHON` environment variable if
+your environment provides it. Do not hardcode a machine-specific venv path; the
+expected pass counts are pinned and platform notes are given per LABT.
 
 ## Behavior S001 — shell run stays inside the agent sandbox
 
@@ -81,7 +84,7 @@ counts are pinned and platform notes are given per LABT.
    "working_dir": "<outside>"}, reasoning="check")` where `<outside>` is any
    absolute directory NOT under `<agent>` (e.g. the parent of `<agent>`, `/tmp`
    on POSIX, or `C:\Windows` on Windows).
-6. (Pinned check) From `<repo>`, run
+6. (POSIX-only pinned check — skip on native Windows) From `<repo>`, run
    `python -m pytest tests/test_shell_sandbox_containment.py -q`.
 
 ### Expected evidence
@@ -95,18 +98,18 @@ counts are pinned and platform notes are given per LABT.
       `under agent working directory` (outside path refused).
 - [ ] Steps 4–5 ran no command: no `stdout`/`stderr` payload, and nothing was
       created or modified outside `<agent>`.
-- [ ] Step 6: on POSIX hosts the summary is `5 passed`; on native Windows the
-      two `@posix_paths` end-to-end tests are skipped and the un-marked
-      POSIX-path unit assertions fail by design (the file proves the Windows
-      separator path via monkeypatch on POSIX CI and is not in the Windows CI
-      set) — run it on POSIX, or rely on steps 1–5 as the cross-platform
-      evidence.
+- [ ] Step 6 (POSIX only): summary reads `5 passed`. This step is not part of
+      the LABT on native Windows — the two `@posix_paths` end-to-end tests are
+      skipped there and the un-marked POSIX-path unit assertions fail by design
+      (the file proves the Windows separator path via monkeypatch on POSIX CI
+      and is not in the Windows CI set); on Windows, steps 1–5 are the
+      cross-platform evidence and the pinned check is omitted.
 
 ### Pass / Fail
 Pass when nested `working_dir` runs succeed, every out-of-bounds path is
-refused with an error containing `under agent working directory`, and no
-command escaped the sandbox. Fail if any outside or sibling-prefix path
-executes, or if the error message shape changes.
+refused with an error containing `under agent working directory`, no command
+escaped the sandbox, and (on POSIX) the pinned suite passes. Fail if any
+outside or sibling-prefix path executes, or if the error message shape changes.
 
 ## Behavior S002 — shell exposes the strict LTP v2 family envelope
 
@@ -116,8 +119,9 @@ executes, or if the error message shape changes.
   any dispatch
 - **guards**: `bash-contract` § Tool surface (closed LTP v2 root,
   `ACTION_REQUIRED` / `INVALID_ARGUMENT` rejections)
-  ([CONTRACT.md](../bash/CONTRACT.md#tool-surface)); tools contract § LTP v2
-  family convention ([CONTRACT.md](../CONTRACT.md))
+  ([CONTRACT.md](../bash/CONTRACT.md#tool-surface)); `lingtai-tool-protocol`
+  § Envelope (closed LTP v2 root)
+  ([CONTRACT.md](../CONTRACT.md#envelope))
 - **runner**: any LingTai agent with the `shell` tool
 - **prerequisites**: none beyond your working dir
 - **estimate**: 2 min
@@ -160,9 +164,7 @@ cross-action input key dispatches, or if the closed root gains a field.
 - **title**: a plain user-text turn (`send(str)`) is serialized into the
   provider wire for every conforming production session regime, and `send`
   returns a real `LLMResponse` with concrete `UsageMetadata`
-- **guards**: `llm-conversation-input` characterization suite § `send(str)`
-  input shape
-  ([__init__.py](../../../../tests/contracts/llm_conversation_input/__init__.py));
+- **guards**: `agent-runtime` § Behavior
   kernel `ChatSession` ABC § `send` ([base.py](../../kernel/llm/base.py))
 - **supersedes**: `tests/contracts/llm_conversation_input/test_send_str.py`
 - **runner**: any LingTai agent with shell access to a checkout of `<repo>`
@@ -212,8 +214,8 @@ conforming regime drops or rewrites the user text, returns no concrete
 - **guards**: `context-contract` § Full reconstruction ordering
   ([CONTRACT.md](../context/CONTRACT.md#full-reconstruction-ordering)) and §
   LTP v2 port ([CONTRACT.md](../context/CONTRACT.md#ltp-v2-port));
-  `psyche-contract` § Behavior / Root reuse is not action compatibility
-  ([CONTRACT.md](../psyche/CONTRACT.md#behavior))
+  `psyche-tool-contract` § Root reuse is not action compatibility
+  ([CONTRACT.md](../psyche/CONTRACT.md#root-reuse-is-not-action-compatibility))
 - **supersedes**: `tests/test_context_ownership_redesign.py`
 - **runner**: any LingTai agent with the `file`, `context`, and `psyche` tools
 - **prerequisites**: your working dir `<agent>`; the `system/` dir may need
@@ -273,7 +275,7 @@ sources.
 - **title**: identical tool errors keep flowing as ordinary tool-result
   payloads; there is no repeated-error hard-stop continuation and no
   `repeated_tool_error` notification
-- **guards**: `base-agent-contract` § Behavior (main turn loop)
+- **guards**: `agent-runtime` § Behavior (main turn loop)
   ([CONTRACT.md](../../kernel/base_agent/CONTRACT.md#behavior)); incident
   regression 2026-06-12 (mimo-1) documented in the superseded test
 - **supersedes**: `tests/test_repeated_tool_error_continue.py`

--- a/src/lingtai/tools/bash/CONTRACT.md
+++ b/src/lingtai/tools/bash/CONTRACT.md
@@ -75,6 +75,8 @@ does not stream output incrementally (async jobs are polled, not streamed).
 
 ## Tool surface
 
+Guarded by: [S002](BEHAVIORS.md#behavior-s002)
+
 `shell` is a migrated LingTai Tool Protocol v2 family (see
 `src/lingtai/tools/CONTRACT.md`). Its public/model-facing root is exactly
 `action`, `input`, `reasoning`, and `summarize`; `action`, `input`, and
@@ -326,6 +328,8 @@ with neither dialect nor invocation remains readable evidence but is explicitly
 unrecoverable on a non-POSIX host rather than being reinterpreted as PowerShell.
 
 ## Cross-platform invariants
+
+Guarded by: [S001](BEHAVIORS.md#behavior-s001)
 
 POSIX and PowerShell 7 are the production dialect adapters. Platform-specific
 process and lock mechanisms stay outside the retained Bash-local Ports; adapters

--- a/src/lingtai/tools/context/ANATOMY.md
+++ b/src/lingtai/tools/context/ANATOMY.md
@@ -1,5 +1,6 @@
 ---
 related_files:
+  - BEHAVIORS.md
   - src/lingtai/intrinsic_skills/context-manual/SKILL.md
   - src/lingtai/intrinsic_skills/context-manual/assets/session-journal-entry-template.md
   - src/lingtai/tools/ANATOMY.md

--- a/src/lingtai/tools/context/BEHAVIORS.md
+++ b/src/lingtai/tools/context/BEHAVIORS.md
@@ -1,0 +1,523 @@
+---
+name: context-behavior-tests
+behavior_version: 1
+labt_version: 1
+contract: CONTRACT.md
+anatomy: ANATOMY.md
+related_files:
+  - src/lingtai/tools/context/_molt.py
+  - src/lingtai/tools/context/_session_journal.py
+  - src/lingtai/tools/context/_snapshots.py
+  - src/lingtai/tools/system/karma.py
+  - src/lingtai/tools/system/name.py
+  - src/lingtai/tools/system/preset.py
+  - src/lingtai/kernel/state.py
+  - src/lingtai/kernel/base_agent/lifecycle.py
+  - src/lingtai/kernel/nudge/goal.py
+  - src/lingtai/intrinsic_skills/system-manual/reference/how-to-change-name/SKILL.md
+  - src/lingtai/intrinsic_skills/system-manual/reference/how-to-change-name/scripts/change_name.py
+  - tests/test_cli_integration.py
+  - tests/test_molt_notification_persistence.py
+  - tests/test_post_molt_notification.py
+  - tests/test_preset_context_guard.py
+  - tests/test_how_to_change_name_e2e.py
+  - tests/test_goal_notification.py
+maintenance: |
+  Written by the lifecycle/state behavior audit. Keep in sync with the clauses
+  these LABTs guard and with the paired ANATOMY.md files: when CONTRACT.md
+  (context or system) or ANATOMY.md changes agent-observable lifecycle behavior
+  (signal-file transitions, molt persistence, post-molt channel, preset guard,
+  naming semantics, goal reminders), update the matching LABT here in the same
+  change and re-verify the tridirectional loop.
+---
+# Context Behavior Tests — lifecycle and state
+
+LABT v1. These are self-contained agent-executable behavioral tests for the
+lifecycle/state family: the 5-state machine driven by signal files
+(`src/lingtai/kernel/state.py`, `src/lingtai/kernel/base_agent/lifecycle.py`),
+molt persistence and the post-molt continuation channel
+(`src/lingtai/tools/context/_molt.py`), the preset context-limit guard
+(`src/lingtai/tools/system/preset.py`), identity naming
+(`src/lingtai/tools/system/name.py`), and the protected goal reminder
+(`src/lingtai/kernel/nudge/goal.py`). The family spans two contracts: the
+`context` contract ([CONTRACT.md](CONTRACT.md)) owns molt and its side effects;
+the `system` contract ([CONTRACT.md](../system/CONTRACT.md)) owns refresh,
+sleep/suspend signal files, and the name actions. Every LABT below is
+self-contained and executable verbatim by an agent with the tools listed in its
+`runner` field; low-level mechanics stay in pytest.
+
+## Behavior L001 — .sleep signal transitions the agent to ASLEEP (process stays alive)
+
+- **id**: L001
+- **title**: touching `.sleep` in a running agent's workdir puts it to sleep without killing the process
+- **guards**: `system-contract` § State & storage
+  ([CONTRACT.md](../system/CONTRACT.md#state--storage)) — `.sleep` = agent goes
+  ASLEEP, process keeps running; state machine
+  `ACTIVE/IDLE --(sleep)--> ASLEEP` (`src/lingtai/kernel/state.py`)
+- **supersedes**: `tests/test_cli_integration.py::test_sleep_signal_triggers_asleep`
+- **runner**: any LingTai agent with a `shell` and `file` tool on POSIX
+  (Linux/macOS), with `lingtai` importable (installed, or
+  `PYTHONPATH=<repo>/src`)
+- **prerequisites**: a scratch agent workdir `<WD>` (empty directory);
+  `init.json` inside it (exact content in step 1); the lifecycle loop needs no
+  reachable LLM — the agent boots and idles without any turn
+- **estimate**: 2 min
+
+### Steps
+1. Write `<WD>/init.json` with exactly:
+   ```json
+   {
+     "manifest": {
+       "agent_name": "integration-test", "language": "en",
+       "llm": {"provider": "gemini", "model": "test-model", "api_key": "fake-key", "base_url": null},
+       "capabilities": {}, "soul": {"delay": 5}, "stamina": 10,
+       "context_limit": null, "molt_pressure": 0.8, "molt_prompt": "", "max_turns": 5,
+       "admin": {}, "streaming": false
+     },
+     "principle": "", "covenant": "You are a test agent.", "pad": "", "lingtai": ""
+   }
+   ```
+2. Start the agent in the background (capture output to `<WD>/boot.log`):
+   `python -m lingtai run <WD>` (from a checkout: `PYTHONPATH=<repo>/src python -m lingtai run <WD>`).
+   Record the process pid.
+3. Wait (poll up to 30 s) until `<WD>/.agent.heartbeat`, `<WD>/.agent.lock`,
+   and `<WD>/.agent.json` all exist.
+4. Create the sleep signal: `touch <WD>/.sleep`.
+5. Poll `<WD>/logs/events.jsonl` (up to 10 s) for a JSON line whose `type` is
+   `sleep_received`.
+6. Check that `<WD>/.sleep` no longer exists (the agent consumed it).
+7. Check the agent process is still alive: `kill -0 <pid>` returns 0.
+8. Cleanup: `touch <WD>/.suspend`, wait up to 20 s for the process to exit,
+   then `kill -TERM <pid>` if it still runs.
+
+### Expected evidence
+- [ ] `<WD>/logs/events.jsonl` contains a `sleep_received` event.
+- [ ] `<WD>/.sleep` was consumed (deleted by the agent).
+- [ ] The agent process is still running after the transition (`kill -0` succeeds).
+
+### Pass / Fail
+Pass when all three evidence items hold: the event fired, the signal file was
+consumed, and the process stayed alive — ASLEEP is a sleep, not a shutdown. Fail
+if the process exits on `.sleep` (that would be suspend semantics) or no
+`sleep_received` event is logged. Forbidden side effects: `.suspend` must not be
+touched by this LABT, and `<WD>` must not be deleted.
+
+## Behavior L002 — .suspend signal shuts the agent down to SUSPENDED
+
+- **id**: L002
+- **title**: touching `.suspend` in a running agent's workdir terminates the process (SUSPENDED)
+- **guards**: `system-contract` § State & storage
+  ([CONTRACT.md](../system/CONTRACT.md#state--storage)) — `.suspend` = process
+  shuts down; state machine `ASLEEP --(.suspend/SIGINT)--> SUSPENDED`
+  (`src/lingtai/kernel/state.py`)
+- **supersedes**: `tests/test_cli_integration.py::test_suspend_triggers_shutdown`
+- **runner**: any LingTai agent with a `shell` and `file` tool on POSIX, with
+  `lingtai` importable (same environment as L001)
+- **prerequisites**: same scratch workdir `<WD>` and `init.json` as L001 (step 1)
+- **estimate**: 2 min
+
+### Steps
+1. Boot the agent exactly as in L001 steps 1–3 (background `python -m lingtai run <WD>`,
+   wait for `.agent.heartbeat`, `.agent.lock`, `.agent.json`). Record the pid.
+2. Create the suspend signal: `touch <WD>/.suspend`.
+3. Wait (up to 15 s) for the process to exit (`kill -0 <pid>` fails).
+4. Check that `<WD>/.suspend` no longer exists (consumed).
+5. Check `<WD>/logs/events.jsonl` for a `suspend_received` event (best effort —
+   the process may exit before the flush; the file-deletion + exit evidence below
+   is sufficient on its own).
+6. Verify `<WD>` still exists and `.agent.json` is intact (SUSPENDED preserves
+   the workdir — this is not nirvana).
+
+### Expected evidence
+- [ ] The agent process exited after `.suspend` was touched.
+- [ ] `<WD>/.suspend` was consumed (deleted).
+- [ ] `<WD>` still exists with `.agent.json` present.
+
+### Pass / Fail
+Pass when the process exits and the signal file is consumed. Fail if the process
+stays alive (that would be sleep semantics) or the workdir is destroyed (that
+would be nirvana). A missing `suspend_received` log line does NOT fail the LABT
+if process exit + file consumption are observed.
+
+## Behavior L003 — agent-initiated molt preserves durable stores and notification files
+
+- **id**: L003
+- **title**: a successful `context(action="molt")` preserves `.notification/` files, the durable stores, and the session journal, and persists the summary
+- **guards**: `context-contract` § Molt safety invariants
+  ([CONTRACT.md](CONTRACT.md#molt-safety-invariants)) — durable history and
+  summary paths remain under `history/` and `system/summaries/`; notification
+  files survive the shed
+- **supersedes**: `tests/test_molt_notification_persistence.py::test_notification_files_survive_agent_molt`
+- **runner**: any LingTai agent with `context`, `file`, and `shell` tools
+- **prerequisites**: a **disposable executor agent** — this LABT performs a real
+  molt on the executing agent's own context. The session-journal sub-entry must
+  exist BEFORE the molt call (the kernel refuses a molt without it)
+- **estimate**: 3 min
+
+### Steps
+1. Create the session-journal sub-entry
+   `<WD>/knowledge/session-journal/2026-06-19-molt-1-test/KNOWLEDGE.md` with exactly:
+   ```markdown
+   ---
+   name: 2026-06-19-molt-1-test
+   description: A test session journal entry for the molt gate.
+   date: 2026-06-19
+   molt_count: 1
+   type: session-journal
+   ---
+
+   ## What this segment was about
+   Testing.
+
+   ## Accomplishments
+   Wrote a valid session journal.
+   ```
+2. Create `<WD>/system/pad.md` containing exactly the line `pad sentinel`.
+3. Create `<WD>/.notification/email.json` with exactly:
+   `{"header": "test notification", "icon": "📧", "priority": "normal", "data": {"test": true}}`.
+4. Call:
+   ```
+   context(action="molt", input={"summary": "LABT L003: verify durable persistence", "session_journal_path": "knowledge/session-journal/2026-06-19-molt-1-test/KNOWLEDGE.md", "keep_tool_calls": null, "keep_last": null}, reasoning="LABT: prove durable state survives molt")
+   ```
+5. Read the result; record `molt_count` and `summary_path` (a relative path under
+   `system/summaries/`).
+6. Verify `<WD>/.notification/` still exists and `email.json` still exists with
+   `header == "test notification"` unchanged.
+7. Verify `<WD>/system/pad.md` still exists and its content is unchanged.
+8. Verify the journal entry
+   `<WD>/knowledge/session-journal/2026-06-19-molt-1-test/KNOWLEDGE.md` still exists.
+9. Resolve `<summary_path>` from step 5 under `<WD>`; verify the file exists and
+   its content mentions `session_journal_path`.
+
+### Expected evidence
+- [ ] Molt result `status == "ok"` and `molt_count` is an integer ≥ 1.
+- [ ] `.notification/email.json` survived with unchanged content.
+- [ ] `system/pad.md` survived with unchanged content.
+- [ ] The session-journal sub-entry survived.
+- [ ] The summary file exists at `<WD>/system/summaries/molt_<count>_<ts>.md` and
+      records `session_journal_path`.
+
+### Pass / Fail
+Pass when all evidence holds. Fail if the molt was refused, if any notification
+file, durable store, or journal entry disappeared, or if `summary_path` does not
+resolve. Forbidden side effects: the molt must not delete `.notification/`,
+`system/pad.md`, or the journal entry.
+
+## Behavior L004 — post-molt continuation channel
+
+- **id**: L004
+- **title**: every molt publishes `.notification/post-molt.json` with continuation identity and a reason-required ack
+- **guards**: `context-contract` § Passive lifecycle scenarios
+  ([CONTRACT.md](CONTRACT.md#passive-lifecycle-scenarios)) — "updates
+  `molt_count`, writes its summary, and publishes the post-molt reminder"
+- **supersedes**: `tests/test_post_molt_notification.py`
+  (`test_agent_molt_publishes_post_molt_with_reasoning`,
+  `test_agent_molt_carries_continuation_fields`,
+  `test_instructions_spell_out_reconstruct_then_ack`)
+- **runner**: any LingTai agent with `context`, `notification`, and `file` tools
+- **prerequisites**: a disposable executor agent; stage the same journal entry
+  and pad file as L003 steps 1–2 before molting
+- **estimate**: 3 min
+
+### Steps
+1. Stage the journal entry and `<WD>/system/pad.md` exactly as in L003 steps 1–2.
+2. Call:
+   ```
+   context(action="molt", input={"summary": "LABT L004: continuation channel", "session_journal_path": "knowledge/session-journal/2026-06-19-molt-1-test/KNOWLEDGE.md", "keep_tool_calls": null, "keep_last": null}, reasoning="LABT: verify post-molt continuation")
+   ```
+   Record `molt_count` from the result.
+3. Read `<WD>/.notification/post-molt.json` (UTF-8 JSON) and verify:
+   - `header` contains `post-molt`; `priority == "high"`;
+   - `data.initiator == "agent"`; `data.molt_count` equals the result's `molt_count`;
+   - `data.molt_id` starts with `molt-<molt_count>-`;
+   - `data.molt_at` is a non-empty ISO-8601 UTC timestamp (`YYYY-MM-DDTHH:MM:SSZ`);
+   - `data.source_agent` equals the agent's true name;
+   - `data.ack_options == ["continue", "defer", "obsolete"]`;
+   - `data.reminder` is non-empty; `data.summary_path` is present;
+     `data.session_journal_path` is present; `data.reasoning` equals
+     `"LABT: verify post-molt continuation"`.
+4. Verify `data` does NOT contain a `next_action` key (no heuristic extraction).
+5. Verify `instructions` is non-empty and mentions `pad`, `summary`,
+   `human-channel`, the labels `continue`/`defer`/`obsolete`, and the taught
+   dismiss call `notification(action='dismiss_channel', input={'channel': 'post-molt', 'force': null, 'reason': 'continue: ...'}, reasoning='...')`.
+6. Attempt dismissal WITHOUT a reason:
+   ```
+   notification(action="dismiss_channel", input={"channel": "post-molt"}, reasoning="LABT")
+   ```
+   Expect an error result with `reason == "missing_ack_reason"`.
+7. Dismiss WITH a reason:
+   ```
+   notification(action="dismiss_channel", input={"channel": "post-molt", "force": null, "reason": "continue: LABT L004 complete"}, reasoning="LABT")
+   ```
+   Expect `status == "ok"`; verify `<WD>/.notification/post-molt.json` is gone.
+
+### Expected evidence
+- [ ] `post-molt.json` exists with every field and value from step 3.
+- [ ] No `next_action` key in `data`.
+- [ ] Dismiss without a reason is refused with `missing_ack_reason`.
+- [ ] Dismiss with `reason: 'continue: ...'` succeeds and clears the channel.
+
+### Pass / Fail
+Pass when all evidence holds. Fail if fields are missing/mismatched, a
+`next_action` heuristic field appears, or the ack gate is bypassed (dismiss
+succeeds without a reason). Forbidden side effects: legacy `molt` channel
+cleanup must never remove `post-molt.json`.
+
+## Behavior L005 — preset context guard: refresh refused when context exceeds the target preset
+
+- **id**: L005
+- **title**: `system(action="refresh", input={"preset": ...})` is refused with a molt-first error when the target preset's `context_limit` is below current usage
+- **guards**: `system-contract` § Tool surface
+  ([CONTRACT.md](../system/CONTRACT.md#tool-surface)) — `refresh` returns
+  `{status: "error", message}` on oversize context; event
+  `preset_swap_refused_oversize`
+- **supersedes**: `tests/test_preset_context_guard.py`
+  (`test_swap_refused_when_current_context_exceeds_target_limit`,
+  `test_guard_reads_context_limit_from_llm_block`,
+  `test_revert_refused_when_current_context_exceeds_default_limit`)
+- **runner**: any LingTai agent with `system` and `file` tools
+- **prerequisites**: a **disposable agent** whose `<WD>/init.json` you may edit
+  (this LABT mutates the `manifest.preset` block and may persist
+  `manifest.preset.default`); the preset library and `.env` file created in the
+  steps; your current context usage must exceed 1000 tokens (see step 4)
+- **estimate**: 3 min
+
+### Steps
+1. Create a preset library `<PLIB>/` with four files. Use your own working
+   provider values (api key/base_url from your environment) but keep the
+   `context_limit` values exactly:
+   - `big.json`: `{"name": "big", "manifest": {"llm": {"provider": "<yours>", "model": "<yours>", "api_key": "<yours>", "context_limit": 200000}, "capabilities": {"file": {}}}}`
+   - `small.json`: same shape with `"name": "small"` and `"context_limit": 1000`
+     at the **manifest root** (sibling of `llm`)
+   - `tight.json`: same shape with `"name": "tight"` and `"context_limit": 1000`
+     **inside** `manifest.llm` (nested layout — the guard must find it there too)
+   - `no_limit.json`: `{"name": "no_limit", "manifest": {"llm": {"provider": "<yours>", "model": "<yours>", "api_key": "<yours>"}, "capabilities": {"file": {}}}}` — no `context_limit` field at all
+2. Write `<WD>/.env` containing `P1KEY=sk-test` (or any value your provider
+   reads) and set `manifest.env_file` in `<WD>/init.json` to `"<WD>/.env"`.
+3. Edit `<WD>/init.json` so `manifest.preset` is:
+   ```json
+   {"path": "<PLIB>", "active": "<PLIB>/big.json", "default": "<PLIB>/big.json",
+    "allowed": ["<PLIB>/big.json", "<PLIB>/small.json", "<PLIB>/tight.json", "<PLIB>/no_limit.json"]}
+   ```
+4. Read your current context usage (`ctx_total_tokens`) from your
+   `_meta.agent_meta.agent_state`; if it is ≤ 1000, perform a few tool calls
+   (any tool results add tokens) and re-read until it exceeds 1000.
+5. Call `system(action="refresh", input={"preset": "<PLIB>/small.json"}, reasoning="LABT L005")`.
+   Expect `status == "error"`; the message must contain `molt` and the target
+   limit `1000` (and may quote the current usage).
+6. Verify `<WD>/init.json` → `manifest.preset.active` is unchanged
+   (`"<PLIB>/big.json"`): the swap was NOT applied.
+7. Repeat step 5 with `<PLIB>/tight.json`; expect the same refusal (limit read
+   from the nested `manifest.llm.context_limit`).
+8. Verify `<WD>/logs/events.jsonl` contains a `preset_swap_refused_oversize` event.
+9. Positive control: call
+   `system(action="refresh", input={"preset": "<PLIB>/no_limit.json"}, reasoning="LABT L005")`
+   — a preset without `context_limit` skips the guard; expect `status == "ok"`
+   (or an activation error that does NOT mention molt/context limit).
+10. Revert control: edit `manifest.preset.default` to `"<PLIB>/small.json"`, then
+    call `system(action="refresh", input={"revert_preset": true}, reasoning="LABT L005")`.
+    Expect `status == "error"` mentioning `molt`; `manifest.preset.active` stays
+    `"<PLIB>/big.json"`.
+
+### Expected evidence
+- [ ] Swap to `small.json` refused; error mentions `molt` and `1000`.
+- [ ] `manifest.preset.active` unchanged after the refusal.
+- [ ] Swap to `tight.json` refused (nested-limit layout respected).
+- [ ] `preset_swap_refused_oversize` event logged.
+- [ ] `no_limit.json` swap is NOT refused by the guard.
+- [ ] `revert_preset` to a too-narrow default is refused and `active` unchanged.
+
+### Pass / Fail
+Pass when all evidence holds. Fail if a too-narrow swap (or revert) succeeds,
+if the swap is applied despite refusal, or if a preset without `context_limit`
+is refused by the guard. Forbidden side effects: an unauthorized preset must
+still fail with the not-found/unauthorized error (the guard must not mask it).
+
+## Behavior L006 — physical rename of a live POSIX agent (address/workdir)
+
+- **id**: L006
+- **title**: `change_name.py` renames a live agent's workdir/address via suspend → no-replace rename → resume, without changing `agent_name` or `agent_id`
+- **guards**: `system-contract` § Routing Card
+  ([CONTRACT.md](../system/CONTRACT.md#routing-card)) — name actions "mutate
+  neither address nor working directory — that is the operator migration
+  workflow in `system-manual`"; V1 contract of
+  `reference/how-to-change-name/SKILL.md`
+- **supersedes**: `tests/test_how_to_change_name_e2e.py::test_real_agent_suspend_rename_rebase_and_resume`
+- **runner**: an agent with `shell` and `file` tools on POSIX (Linux/macOS);
+  Windows and network filesystems are out of scope
+- **prerequisites**: POSIX host; Python ≥ 3.10 that can import `lingtai`;
+  `<REPO>` = the lingtai-kernel checkout; a scratch root `<ROOT>` (empty); the
+  helper source at
+  `<REPO>/src/lingtai/intrinsic_skills/system-manual/reference/how-to-change-name/scripts/change_name.py`
+- **estimate**: 5 min
+
+### Steps
+1. Create scratch dirs `<ROOT>/old` and `<ROOT>/new` (new must NOT exist at
+   rename time). Create a venv inside the old workdir:
+   `python -m venv --copies --without-pip --system-site-packages <ROOT>/old/runtime/venv`.
+2. Write `<ROOT>/old/init.json` with exactly:
+   ```json
+   {
+     "manifest": {
+       "agent_name": "temporary-true-name", "language": "en",
+       "llm": {"provider": "gemini", "model": "test", "api_key": "fake", "base_url": null},
+       "capabilities": {}, "soul": {"delay": 60}, "stamina": 10,
+       "context_limit": null, "molt_pressure": 0.8, "molt_prompt": "", "max_turns": 5,
+       "admin": {}, "streaming": false
+     },
+     "principle": "", "covenant": "No network.", "pad": "", "lingtai": "",
+     "venv_path": "<ROOT>/old/runtime/venv"
+   }
+   ```
+3. Copy the helper and make it executable:
+   `cp <REPO>/src/lingtai/intrinsic_skills/system-manual/reference/how-to-change-name/scripts/change_name.py <ROOT>/old/change_name.py && chmod 755 <ROOT>/old/change_name.py`.
+4. Boot the agent in the background:
+   `cd <ROOT>/old && PYTHONPATH=<REPO>/src <ROOT>/old/runtime/venv/bin/python -m lingtai run <ROOT>/old`.
+   Wait (up to 25 s) for `<ROOT>/old/.agent.heartbeat`, `.agent.lock`, and
+   `.agent.json`.
+5. Read `<ROOT>/old/.agent.json`; record `agent_id`, `agent_name`
+   (must be `temporary-true-name`), and `address` (must be `old`).
+6. Run the helper in the foreground (must return exit code 0):
+   `PYTHONPATH=<REPO>/src <ROOT>/old/runtime/venv/bin/python <ROOT>/old/change_name.py <ROOT>/old new --timeout 20`.
+7. Wait (up to 25 s) for `<ROOT>/new/.agent.heartbeat` to reappear.
+8. Verify: `<ROOT>/old` no longer exists; `<ROOT>/new` exists; read
+   `<ROOT>/new/.agent.json`: `agent_id` unchanged from step 5, `agent_name` still
+   `temporary-true-name`, `address == "new"`; read `<ROOT>/new/init.json`:
+   `venv_path == "<ROOT>/new/runtime/venv"` (rebased).
+9. Cleanup: `touch <ROOT>/new/.suspend`; wait up to 20 s for the process to
+   exit; `kill -TERM` any surviving `python -m lingtai run <ROOT>/new` pid.
+
+### Expected evidence
+- [ ] The helper exits 0.
+- [ ] `<ROOT>/old` is gone; `<ROOT>/new` exists with a fresh `.agent.heartbeat`.
+- [ ] `agent_id` and `agent_name` are identical before/after; `address` changed to `new`.
+- [ ] `venv_path` in the new `init.json` points into `<ROOT>/new/runtime/venv`.
+
+### Pass / Fail
+Pass when all evidence holds. Fail if `agent_id`/`agent_name` changed, if the
+old directory was replaced instead of renamed (RENAME_NOREPLACE violation), or
+if the resumed agent does not come back up under the new path.
+
+## Behavior L007 — name_set immutable / name_nickname mutable
+
+- **id**: L007
+- **title**: `system(action="name_set")` sets the true name once and refuses thereafter; `system(action="name_nickname")` stays mutable and clears on empty; neither renames the workdir
+- **guards**: `system-contract` § Tool surface
+  ([CONTRACT.md](../system/CONTRACT.md#tool-surface)) — `name_set` errors when
+  a true name is already set (immutable); § Anchored claims
+  ([CONTRACT.md](../system/CONTRACT.md#anchored-claims)) — "A true name stays
+  immutable and neither name action renames the workdir"
+- **supersedes**: `tests/test_tool_family_system_migration.py::test_name_actions_preserve_identity_semantics`
+- **runner**: any LingTai agent with a `shell` tool; the subject is a fresh
+  in-process agent created by an embedded script (a newborn has no true name,
+  which is the only state in which `name_set` succeeds)
+- **prerequisites**: `lingtai` importable from `<REPO>/src`; `python` available
+- **estimate**: 2 min
+
+### Steps
+1. Write the script `<TMP>/labt_name.py` with exactly:
+   ```python
+   import json, sys, tempfile
+   from pathlib import Path
+   from unittest.mock import MagicMock
+   sys.path.insert(0, "<REPO>/src")
+   from lingtai.agent import Agent
+   from lingtai.tools.system import handle as system_handle
+
+   svc = MagicMock()
+   svc.get_adapter.return_value = MagicMock()
+   svc.provider = "gemini"
+   svc.model = "gemini-test"
+   workdir = Path(tempfile.mkdtemp()) / "named"
+   agent = Agent(service=svc, working_dir=workdir)
+   before_dir = agent._working_dir
+
+   r1 = system_handle(agent, {"action": "name_set", "input": {"content": "wukong"}})
+   assert r1.get("name") == "wukong", r1
+   r2 = system_handle(agent, {"action": "name_set", "input": {"content": "bajie"}})
+   assert "error" in r2 and "name_nickname" in r2["error"], r2
+   r3 = system_handle(agent, {"action": "name_set", "input": {"content": ""}})
+   assert "error" in r3, r3
+   for value, expected in (("monkey", "monkey"), ("king", "king"), ("", None)):
+       got = system_handle(agent, {"action": "name_nickname", "input": {"content": value}})
+       assert got["nickname"] == expected, (value, got)
+   manifest = json.loads((workdir / ".agent.json").read_text())
+   assert manifest["agent_name"] == "wukong", manifest
+   assert manifest["nickname"] is None, manifest
+   assert "wukong" in agent._prompt_manager.read_section("identity")
+   assert agent._working_dir == before_dir
+   assert manifest["address"] == before_dir.name
+   print("LABT L007 PASS")
+   ```
+2. Run it: `python <TMP>/labt_name.py`. Exit code must be 0.
+
+### Expected evidence
+- [ ] First `name_set` returns `{status: "ok", name: "wukong"}`.
+- [ ] Second `name_set` returns an error whose text mentions `name_nickname`.
+- [ ] Empty `name_set` is refused.
+- [ ] `name_nickname` accepts successive values and returns `nickname: null` on empty.
+- [ ] `.agent.json` persists `agent_name == "wukong"`, `nickname == null`; the
+      protected prompt `identity` section contains `wukong`.
+- [ ] The workdir and `address` are unchanged by any name action.
+- [ ] Script prints `LABT L007 PASS` and exits 0.
+
+### Pass / Fail
+Pass when the script exits 0 and prints `LABT L007 PASS`. Fail if a second
+`name_set` overwrites the true name, an empty `name_set` clears it, or any name
+action renames the workdir/address.
+
+## Behavior L008 — goal notification: active goal reminder after idle delay
+
+- **id**: L008
+- **title**: an active `.notification/goal.json` with a due idle delay publishes one `goal.reminder` event into `.notification/system.json`
+- **guards**: `src/lingtai/CONTRACT.md` § Contract rules rule 6
+  ([CONTRACT.md](../../CONTRACT.md#contract-rules)) — "The goal reminder is
+  explicitly a separate protected-goal system notification"
+- **supersedes**: `tests/test_goal_notification.py`
+  (`test_goal_reminder_publishes_short_system_event_after_idle_delay`,
+  `test_goal_reminder_does_not_duplicate_existing_event`,
+  `test_goal_reminder_clears_when_goal_becomes_done`)
+- **runner**: any LingTai agent with `shell` and `file` tools on POSIX, with
+  `lingtai` importable (the target agent must be IDLE — the goal check runs in
+  the target's own idle loop, never while it is ACTIVE)
+- **prerequisites**: a scratch agent workdir `<WD>` booted as in L001 steps 1–3
+  (a freshly booted agent with no messages is IDLE); the goal reminder delay is
+  set per-goal via `data.reminder_delay_seconds`
+- **estimate**: 4 min
+
+### Steps
+1. Boot the target agent exactly as in L001 steps 1–3 (background
+   `python -m lingtai run <WD>`, wait for heartbeat files).
+2. Write `<WD>/.notification/goal.json` with exactly:
+   ```json
+   {
+     "header": "Active goal", "icon": "🎯", "priority": "normal",
+     "instructions": "Current active goal. Details live here; see the goal manual under system-manual.",
+     "data": {"id": "demo", "status": "active", "reminder_delay_seconds": 1}
+   }
+   ```
+3. Poll `<WD>/.notification/system.json` (up to 90 s — the check cadence is
+   10 s) until `data.events` contains an event with
+   `source == "goal.reminder"` and `ref_id == "goal:demo"`.
+4. Verify the event `body` equals exactly:
+   `Goal reminder: read .notification/goal.json and follow its instructions; see the goal manual under system-manual.`
+5. Verify there is exactly ONE `goal.reminder` event for `goal:demo` (dedup by
+   ref_id) — poll two more check cycles and confirm the count stays 1.
+6. Rewrite `<WD>/.notification/goal.json` with `"status": "done"` (same id),
+   wait up to 30 s, and verify `goal:demo` is no longer in `data.events`.
+7. Delete `<WD>/.notification/goal.json`, wait up to 30 s, and verify the
+   `system` channel is clear of `goal.reminder` events.
+8. Write a new goal with `"id": "replacement"` (active, delay 1), wait up to
+   60 s, and verify a fresh event with `ref_id == "goal:replacement"` appears.
+
+### Expected evidence
+- [ ] `goal.reminder` event with `ref_id == "goal:demo"` and the exact body text.
+- [ ] Exactly one event per goal id (no duplicates across check cycles).
+- [ ] Event cleared when the goal becomes `done` and when `goal.json` is deleted.
+- [ ] A new goal id produces a new `goal:replacement` event.
+
+### Pass / Fail
+Pass when all evidence holds. Fail if no reminder publishes while IDLE, if
+duplicates accumulate, if a `done`/deleted goal keeps its reminder, or if a
+reminder publishes while the agent is not IDLE. Forbidden side effects: the
+reminder must never modify `goal.json` itself.

--- a/src/lingtai/tools/context/BEHAVIORS.md
+++ b/src/lingtai/tools/context/BEHAVIORS.md
@@ -1,7 +1,7 @@
 ---
 name: context-behavior-tests
 behavior_version: 1
-labt_version: 1
+labt_version: 2
 contract: CONTRACT.md
 anatomy: ANATOMY.md
 related_files:

--- a/src/lingtai/tools/context/CONTRACT.md
+++ b/src/lingtai/tools/context/CONTRACT.md
@@ -3,6 +3,7 @@ name: context-contract
 tool: context
 contract_version: 5
 related_files:
+  - BEHAVIORS.md
   - src/lingtai/tools/context/__init__.py
   - src/lingtai/tools/context/_molt.py
   - src/lingtai/tools/context/_session_journal.py

--- a/src/lingtai/tools/context/CONTRACT.md
+++ b/src/lingtai/tools/context/CONTRACT.md
@@ -33,6 +33,8 @@ maintenance: |
 
 ## Purpose and public ownership
 
+Guarded by: [K003](../../kernel/BEHAVIORS.md#behavior-k003)
+
 `context` owns the agent's context lifecycle. Its exact public actions are:
 
 - `molt` — shed conversation history while preserving durable stores;
@@ -100,6 +102,8 @@ applying summaries or requesting provider replay.
 
 ## Passive lifecycle scenarios
 
+Guarded by: [L004](BEHAVIORS.md#behavior-l004)
+
 Refresh and molt are passive scenarios invoking the same internal
 `Agent._reconstruct_context` contract:
 
@@ -116,6 +120,8 @@ journal and keep sets, snapshots/archives, sheds/replays selected history,
 updates `molt_count`, writes its summary, and publishes the post-molt reminder.
 
 ## Molt safety invariants
+
+Guarded by: [L003](BEHAVIORS.md#behavior-l003), [K004](../../kernel/BEHAVIORS.md#behavior-k004)
 
 Agent-initiated molt requires a nonempty retrospective and a valid
 `knowledge/session-journal/<entry>/KNOWLEDGE.md` with session-journal

--- a/src/lingtai/tools/daemon/ANATOMY.md
+++ b/src/lingtai/tools/daemon/ANATOMY.md
@@ -1,5 +1,6 @@
 ---
 related_files:
+  - BEHAVIORS.md
   - src/lingtai/ANATOMY.md
   - src/lingtai/tools/daemon/CONTRACT.md
   - src/lingtai/tools/daemon/__init__.py

--- a/src/lingtai/tools/daemon/BEHAVIORS.md
+++ b/src/lingtai/tools/daemon/BEHAVIORS.md
@@ -1,0 +1,379 @@
+---
+name: daemon-behavior-tests
+behavior_version: 1
+labt_version: 1
+contract: CONTRACT.md
+anatomy: ANATOMY.md
+related_files:
+  - src/lingtai/tools/daemon/__init__.py
+  - src/lingtai/tools/daemon/run_dir.py
+  - src/lingtai/tools/daemon/_tool_family.py
+  - src/lingtai/tools/daemon/manual/SKILL.md
+  - src/lingtai/tools/daemon/manual/reference/cli-backends/SKILL.md
+  - src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/claude-p/SKILL.md
+  - src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/qwen-code/SKILL.md
+  - tests/test_daemon_check.py
+  - tests/test_daemon_check_historical.py
+  - tests/test_daemon_claude_p_submanual.py
+  - tests/test_daemon_qwen_code_submanual.py
+  - tests/test_daemon_per_batch_limits.py
+maintenance: |
+  Written by the daemon CONVERT_BEHAVIOR migration (2026-08). Keep in sync
+  with CONTRACT.md clauses this file guards and ANATOMY.md entries for the
+  daemon tool family; when CONTRACT.md or the daemon manual changes in a way
+  that affects agent-observable behavior (check JSON contract, per-batch
+  emanate limits, CLI-backend submanual routing), update the matching LABT
+  here in the same change.
+---
+# Daemon Behavior Tests
+
+LABT v1. These are self-contained agent-executable behavioral tests for the
+`daemon` tool family. They prove the *observable* promises of
+`src/lingtai/tools/daemon/CONTRACT.md`: the `check` JSON contract, historical
+run-dir fallback, per-batch `emanate` limits, and the CLI-backend submanual
+routing contracts. Low-level mechanics stay in pytest; each LABT below is
+self-contained and executable verbatim by an agent with the `daemon` and
+`file` tools.
+
+## Behavior D001 — daemon.check returns the canonical JSON contract
+
+- **id**: D001
+- **title**: `check` returns state, events, result-file fields, and honors
+  `last` / `truncate`
+- **guards**: `daemon-contract` § Tool Surface (check success output)
+  ([CONTRACT.md](CONTRACT.md#tool-surface))
+- **supersedes**: `tests/test_daemon_check.py` (JSON-shape and truncation tests)
+- **runner**: any LingTai agent with the `daemon` and `file` tools
+- **prerequisites**: a working dir; the ability to emanate one trivial task
+  and wait for its `source="daemon"` terminal notification
+- **estimate**: 3 min
+
+### Steps
+1. From your working dir, call
+   `daemon(action="emanate", input={"tasks": [{"task": "Create the file
+   scratch/check-evidence.txt containing the word evidence, then read it back
+   with the file tool. Reply with exactly: DONE", "tools": ["file"]}]},
+   reasoning="...")`. Record the returned `ids[0]` as `<id>`.
+2. Wait for the terminal notification for `<id>` (status `done`). Then call
+   `daemon(action="check", input={"id": "<id>"}, reasoning="...")` with no
+   other fields.
+3. Call `daemon(action="check", input={"id": "<id>", "last": 3,
+   "truncate": 0}, reasoning="...")`.
+4. Call `daemon(action="check", input={"id": "<id>", "truncate": 1},
+   reasoning="...")`.
+5. Read the file at the `result_path` returned in step 2 and compare it with
+   the `result_preview` field.
+6. Call `daemon(action="check", input={"id": "<id>"}, reasoning="...")` a
+   second time and compare `events_total` with the first call.
+
+### Expected evidence
+- [ ] Step 2 returns a success object (no `status` key) containing `id`,
+      `run_id`, `state: "done"`, `backend`, `path`, `turn`,
+      `finished_at` (non-null), `result_preview` (non-empty), `result_path`
+      (a real path ending in `result.txt`), `error: null`, `events` (a list),
+      `events_returned`, and `events_total`.
+- [ ] The `events` list contains a `daemon_done` event plus `tool_call` /
+      `tool_result` events (from the file calls) whose `tool_call` entries
+      carry an `args_preview` string.
+- [ ] `events_returned == min(events_total, 20)` (default `last` is 20).
+- [ ] Step 3: `events_returned == 3` and `events_total >= 3`.
+- [ ] Step 3 (`truncate: 0`): no event string field carries the
+      `[truncated]` marker.
+- [ ] Step 4 (`truncate: 1`): the last `tool_call` event's `args_preview`
+      contains `[truncated]` and its length is `<= 1 + len("…[truncated]")`.
+- [ ] Step 5: the file at `result_path` contains the same text as
+      `result_preview`.
+- [ ] Step 6: `events_total` did not grow (checking is read-only for a
+      finished run).
+
+### Pass / Fail
+Pass when every evidence item holds. Fail on any missing field, a wrong
+`state`, a `{status: "error"}` response for a known id, a non-null `error` on
+a `done` run, or evidence that a check call mutated the run dir.
+
+## Behavior D002 — daemon.check validates inputs and bounds last
+
+- **id**: D002
+- **title**: `check` refuses unknown ids and invalid `last` / `truncate`, and
+  bounds `last` at the engine maximum
+- **guards**: `daemon-contract` § Tool Surface (check error shape)
+  ([CONTRACT.md](CONTRACT.md#tool-surface))
+- **supersedes**: `tests/test_daemon_check.py` (input-validation tests)
+- **runner**: any LingTai agent with the `daemon` tool
+- **prerequisites**: none beyond your working dir
+- **estimate**: 2 min
+
+### Steps
+1. Call `daemon(action="check", input={"id": "em-999"}, reasoning="...")`
+   with an id that has never existed in your session.
+2. Call `daemon(action="check", input={"id": "em-x", "last": "twenty"},
+   reasoning="...")`.
+3. Call `daemon(action="check", input={"id": "em-x", "truncate": "tons"},
+   reasoning="...")`.
+4. Call `daemon(action="check", input={"id": "em-x", "last": 0},
+   reasoning="...")`, then the same with `last: -1`.
+5. Call `daemon(action="check", input={"id": "em-x", "truncate": -10},
+   reasoning="...")`.
+6. Call `daemon(action="check", input={"id": "em-x", "last": 1000000000},
+   reasoning="...")`.
+
+### Expected evidence
+- [ ] Step 1: `{status: "error", message}` and the message contains the
+      requested id `em-999`; no events blob is returned.
+- [ ] Step 2: refused with an error that names `last`.
+- [ ] Step 3: refused with an error that names `truncate`.
+- [ ] Step 4: both calls refused with errors that name `last`.
+- [ ] Step 5: refused with an error that names `truncate`.
+- [ ] Step 6: the call is refused cleanly (the `check.last` schema bound is
+      `maximum: 1000`) or, if your host permits it through, returns a success
+      shape with `events_returned <= 1000` (the engine's `_CHECK_LAST_MAX`)
+      — never an unbounded event list or an exception.
+
+### Pass / Fail
+Pass when every invalid input returns a clean error naming the offending
+field and the oversized `last` is refused or capped without error. Fail if any
+invalid call raises, succeeds, or returns an unbounded list.
+
+## Behavior D003 — daemon.check falls back to historical run dirs
+
+- **id**: D003
+- **title**: `check` resolves completed run dirs on disk when the in-memory
+  registry misses, and rejects ambiguous legacy handles
+- **guards**: `daemon-contract` § Tool Surface (check accepts historical run
+  ids) ([CONTRACT.md](CONTRACT.md#tool-surface)); see also `daemon-manual`
+  "check still resolves a daemon after refresh/molt"
+  ([manual/SKILL.md](manual/SKILL.md))
+- **supersedes**: `tests/test_daemon_check_historical.py`
+- **runner**: any LingTai agent with the `daemon` and `file` tools
+- **prerequisites**: a `<parent>/daemons/` directory (created by any
+  emanation); file write access to it; the synthetic dirs created in the
+  steps are removed at the end
+- **estimate**: 3 min
+
+### Steps
+1. If you have no completed run dir on disk, emanate a trivial task and wait
+   for its `done` notification; record its exact `run_id` (from the
+   notification or `daemon(action="list", input={})`).
+2. Create two synthetic completed run dirs sharing the legacy short handle
+   `em-7`, under `<parent>/daemons/`:
+   - `<parent>/daemons/em-7-20260623-100000-aaaaaa/` with
+     `daemon.json` = `{"handle": "em-7", "run_id": "em-7-20260623-100000-aaaaaa", "state": "done", "backend": "lingtai", "data_version": 1, "result_path": "<dir>/result.txt", "result_preview": "older run", "finished_at": "2026-06-23T00:00:00Z"}`, `result.txt` containing `older run`, and `logs/events.jsonl` containing one line `{"event": "daemon_done", "run_id": "em-7-20260623-100000-aaaaaa"}`.
+   - `<parent>/daemons/em-7-20260623-110000-bbbbbb/` with the same shape,
+     `run_id` / `result_preview` = `em-7-20260623-110000-bbbbbb` / `newer run`.
+   (`data_version` is `DaemonRunDir.DATA_VERSION`, currently 1.)
+3. Create one compact-id run dir `<parent>/daemons/em-abcd/` with
+   `daemon.json` = `{"handle": "em-abcd", "run_id": "em-abcd", "state": "done", "backend": "lingtai", "data_version": 1, "result_path": "<dir>/result.txt", "result_preview": "compact daemon work", "finished_at": "2026-06-23T00:00:00Z"}`, `result.txt` containing `compact daemon work`, and `logs/events.jsonl` containing one line `{"event": "daemon_done", "run_id": "em-abcd"}`.
+4. Call `daemon(action="check", input={"id": "em-7-20260623-110000-bbbbbb"},
+   reasoning="...")`.
+5. Call `daemon(action="check", input={"id": "em-7"}, reasoning="...")`.
+6. Call `daemon(action="check", input={"id": "em-abcd"}, reasoning="...")`.
+7. Call `daemon(action="check", input={"id": "em-999"}, reasoning="...")`.
+8. Delete the three synthetic dirs you created in steps 2–3.
+
+### Expected evidence
+- [ ] Step 4: success (no `status: "error"`), `run_id == "em-7-20260623-110000-bbbbbb"`, `state == "done"`, `path` is that dir, `result_preview == "newer run"`, `source == "history"`, and `events` (tailed from the on-disk `logs/events.jsonl`) contains `daemon_done`.
+- [ ] Step 5: `{status: "error", ambiguous: true, match_count: 2,
+      latest_run_id: "em-7-20260623-110000-bbbbbb"}`; the message contains
+      `use the exact run_id`; no `other_run_dirs` key is present.
+- [ ] Step 6: success with `run_id == "em-abcd"` and `source == "history"`;
+      no `other_run_dirs` key.
+- [ ] Step 7: `{status: "error", message}` containing `em-999`.
+- [ ] Step 8: the synthetic dirs are gone and no other files were touched.
+
+### Pass / Fail
+Pass when a registry-miss `check` resolves on-disk run dirs with
+`source: "history"`, rejects an ambiguous legacy handle with
+`match_count` / `latest_run_id` instead of an unbounded path list, and still
+errors on a truly unknown id. Fail if a completed on-disk run is reported
+unknown, an ambiguous handle returns a path list, or a synthetic dir is left
+behind.
+
+## Behavior D004 — emanate per-batch max_turns ceiling is 1000
+
+- **id**: D004
+- **title**: `emanate` defaults `max_turns` to the 1000 ceiling, honors a
+  smaller per-batch value, caps larger values, and rejects non-positive ones
+- **guards**: `daemon-contract` § Tool Surface (emanate row: optional
+  `max_turns`) ([CONTRACT.md](CONTRACT.md#tool-surface))
+- **supersedes**: `tests/test_daemon_per_batch_limits.py` (max_turns tests)
+- **runner**: any LingTai agent with the `daemon` and `file` tools
+- **prerequisites**: a working dir; each dispatched run is allowed to reach a
+  terminal state (or is reclaimed at the end)
+- **estimate**: 4 min
+
+### Steps
+1. Call `daemon(action="emanate", input={"tasks": [{"task": "Reply with
+   exactly: done", "tools": []}]}, reasoning="...")` with no `max_turns`.
+   Record `<id>`; immediately call
+   `daemon(action="check", input={"id": "<id>"}, reasoning="...")` to get
+   `<path>`, then read `<path>/daemon.json` and note its `max_turns` value.
+2. Repeat step 1 with `"max_turns": 50` and note the recorded `max_turns`.
+3. Repeat step 1 with `"max_turns": 9999` and note the recorded `max_turns`.
+4. Repeat step 1 with `"max_turns": 1000` and note the recorded `max_turns`.
+5. Call `daemon(action="emanate", input={"tasks": [{"task": "x",
+   "tools": []}], "max_turns": 0}, reasoning="...")` and then the same with
+   `"max_turns": -5`; read both results.
+6. Wait for each run's terminal notification (or reclaim at the end) so no
+   run is left running.
+
+### Expected evidence
+- [ ] Step 1: dispatched; `<path>/daemon.json` records `max_turns == 1000`
+      (the default is the ceiling).
+- [ ] Step 2: `max_turns == 50` (per-batch override respected).
+- [ ] Step 3: `max_turns == 1000` (9999 capped at the ceiling).
+- [ ] Step 4: `max_turns == 1000` (the ceiling itself is allowed).
+- [ ] Step 5: both calls return `{status: "error", message}` and the message
+      mentions `max_turns`.
+- [ ] The emanate branch of the public `daemon` schema advertises `max_turns`
+      with `minimum: 1`, `maximum: 1000`, and a description containing `1000`
+      (pinned by the CONVERT_BEHAVIOR contract).
+- [ ] No emanation is left running at the end of step 6.
+
+### Pass / Fail
+Pass when the recorded values match exactly and invalid values are refused
+before dispatch. Fail if the default exceeds 1000, an override above 1000 is
+recorded uncapped, zero/negative values are accepted, or a run is left
+running.
+
+## Behavior D005 — emanate per-batch timeout contract
+
+- **id**: D005
+- **title**: `emanate` honors a per-batch `timeout`, caps it at the manager
+  ceiling, and rejects zero, negative, and sub-5s values
+- **guards**: `daemon-contract` § Tool Surface (emanate row: optional
+  `timeout`) ([CONTRACT.md](CONTRACT.md#tool-surface))
+- **supersedes**: `tests/test_daemon_per_batch_limits.py` (timeout tests)
+- **runner**: any LingTai agent with the `daemon` and `file` tools
+- **prerequisites**: a working dir; each dispatched run is allowed to reach a
+  terminal state (or is reclaimed at the end)
+- **estimate**: 4 min
+
+### Steps
+1. Call `daemon(action="emanate", input={"tasks": [{"task": "Reply with
+   exactly: done", "tools": []}], "timeout": 600}, reasoning="...")`.
+   Record `<id>`; call
+   `daemon(action="check", input={"id": "<id>"}, reasoning="...")` to get
+   `<path>`, then read `<path>/daemon.json` and note its `timeout_s` value.
+2. Repeat with `"timeout": 99999` and note the recorded `timeout_s`.
+3. Call with `"timeout": 0`, then `"timeout": -1`, then `"timeout": 2`;
+   read all three results.
+4. Wait for each run's terminal notification (or reclaim at the end) so no
+   run is left running.
+
+### Expected evidence
+- [ ] Step 1: dispatched; `<path>/daemon.json` records `timeout_s == 600.0`.
+- [ ] Step 2: dispatched; `timeout_s` equals the manager's ceiling — `3600.0`
+      seconds in default configuration (the same value the schema describes
+      as "Default: parent max (3600s)").
+- [ ] Step 3: `timeout: 0` and `timeout: -1` each return
+      `{status: "error", message}` mentioning `timeout`; `timeout: 2` returns
+      `{status: "error", message}` mentioning both `timeout` and `5` (sub-5s
+      timeouts are refused because the watchdog could fire before the run
+      starts).
+- [ ] The emanate branch of the public `daemon` schema advertises `timeout`
+      with `minimum: 5`.
+- [ ] No emanation is left running at the end of step 4.
+
+### Pass / Fail
+Pass when the recorded values match exactly and invalid values are refused.
+Fail if a per-batch timeout is not recorded, an oversized timeout is recorded
+uncapped, or a zero/negative/sub-5s timeout is accepted.
+
+## Behavior D006 — claude-p backend submanual routing contract
+
+- **id**: D006
+- **title**: the daemon CLI-backends router catalogs and routes to the
+  claude-p submanual, which stays a tiny live-help entrypoint
+- **guards**: `daemon-contract` § Backend Support Matrix (claude-p row)
+  ([CONTRACT.md](CONTRACT.md#backend-support-matrix)); daemon-manual nested
+  reference catalog ([manual/SKILL.md](manual/SKILL.md))
+- **supersedes**: `tests/test_daemon_claude_p_submanual.py`
+- **runner**: any LingTai agent with file read/grep access to the repo root
+- **prerequisites**: the repo root; the three files listed below exist
+- **estimate**: 2 min
+
+### Steps
+1. Read `src/lingtai/tools/daemon/manual/reference/cli-backends/SKILL.md`.
+   Locate the `## Nested reference catalog` section and its fenced YAML block;
+   confirm exactly one entry has `location: reference/backends/claude-p/SKILL.md`,
+   `name: daemon-backend-claude-p`, and a non-empty `description`.
+2. In the same file, locate the `## Routing table` section; confirm at least
+   one table row contains `reference/backends/claude-p/SKILL.md`.
+3. Read `src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/claude-p/SKILL.md`.
+   Check its YAML frontmatter: `name: daemon-backend-claude-p`, non-empty
+   `description`, and a present `last_changed_at`.
+4. Confirm the child body contains each exact string: `claude --version`,
+   `claude --help`, `backend_options`, `"fallback_model"`, `--fallback-model`,
+   `not validate, enumerate, or simulate`, `claude-code`, `compatibility alias`,
+   `--settings`, `--print`, `--output-format`, `--mcp-config`,
+   `--strict-mcp-config`, `claude_session_id`, `ANTHROPIC_API_KEY`,
+   `ANTHROPIC_AUTH_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`.
+5. Count the lines of the child file (shell `wc -l` or your file read tool's
+   line count); record the number.
+
+### Expected evidence
+- [ ] Exactly one catalog entry resolves to the claude-p child, named
+      `daemon-backend-claude-p`, with a non-empty description.
+- [ ] The routing table contains a row pointing at
+      `reference/backends/claude-p/SKILL.md`.
+- [ ] Child frontmatter has the pinned `name`, non-empty `description`, and
+      `last_changed_at`.
+- [ ] Every phrase in step 4 is present in the child body.
+- [ ] The child file has `<= 230` lines.
+
+### Pass / Fail
+Pass when all evidence holds. Fail on any missing phrase, a missing or
+duplicate catalog entry, a missing routing-table row, wrong frontmatter, or a
+child grown past 230 lines — the submanual must route agents to the installed
+CLI's live help (`claude --version`, `claude --help`), never become a
+maintained flag catalog.
+
+## Behavior D007 — qwen-code backend submanual static-content contract
+
+- **id**: D007
+- **title**: the daemon CLI-backends router catalogs and routes to the
+  qwen-code submanual, which stays a tiny live-help entrypoint
+- **guards**: `daemon-contract` § Backend Support Matrix (qwen-code row)
+  ([CONTRACT.md](CONTRACT.md#backend-support-matrix)); daemon-manual nested
+  reference catalog ([manual/SKILL.md](manual/SKILL.md))
+- **supersedes**: `tests/test_daemon_qwen_code_submanual.py`
+- **runner**: any LingTai agent with file read/grep access to the repo root
+- **prerequisites**: the repo root; the three files listed below exist
+- **estimate**: 2 min
+
+### Steps
+1. Read `src/lingtai/tools/daemon/manual/reference/cli-backends/SKILL.md`.
+   Locate the `## Nested reference catalog` section and its fenced YAML block;
+   confirm exactly one entry has `location: reference/backends/qwen-code/SKILL.md`,
+   `name: daemon-backend-qwen-code`, and a non-empty `description`.
+2. In the same file, locate the `## Routing table` section; confirm at least
+   one table row contains `reference/backends/qwen-code/SKILL.md`.
+3. Read `src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/qwen-code/SKILL.md`.
+   Check its YAML frontmatter: `name: daemon-backend-qwen-code`, non-empty
+   `description`, and a present `last_changed_at`.
+4. Confirm the child body contains each exact string: `qwen --version`,
+   `qwen --help`, `no subcommand`, `backend_options`, `qwen3-coder-plus`,
+   `qwen --yolo --model qwen3-coder-plus -p <prompt>`,
+   `not validate, enumerate, or simulate`, `--prompt`, `--yolo`,
+   `--approval-mode`, `QWEN_CODE_SYSTEM_SETTINGS_PATH`,
+   `qwen-daemon-settings.json`, and
+   `daemon(action='ask', input={'id': ..., 'message': ...})`.
+5. Count the lines of the child file (shell `wc -l` or your file read tool's
+   line count); record the number.
+
+### Expected evidence
+- [ ] Exactly one catalog entry resolves to the qwen-code child, named
+      `daemon-backend-qwen-code`, with a non-empty description.
+- [ ] The routing table contains a row pointing at
+      `reference/backends/qwen-code/SKILL.md`.
+- [ ] Child frontmatter has the pinned `name`, non-empty `description`, and
+      `last_changed_at`.
+- [ ] Every phrase in step 4 is present in the child body.
+- [ ] The child file has `<= 90` lines.
+
+### Pass / Fail
+Pass when all evidence holds. Fail on any missing phrase, a missing or
+duplicate catalog entry, a missing routing-table row, wrong frontmatter, or a
+child grown past 90 lines — the submanual must route agents to the installed
+CLI's live help (`qwen --version`, `qwen --help`, no subcommand), never become
+a maintained flag catalog.

--- a/src/lingtai/tools/daemon/BEHAVIORS.md
+++ b/src/lingtai/tools/daemon/BEHAVIORS.md
@@ -1,7 +1,7 @@
 ---
 name: daemon-behavior-tests
 behavior_version: 1
-labt_version: 1
+labt_version: 2
 contract: CONTRACT.md
 anatomy: ANATOMY.md
 related_files:

--- a/src/lingtai/tools/daemon/CONTRACT.md
+++ b/src/lingtai/tools/daemon/CONTRACT.md
@@ -150,6 +150,8 @@ where those changes affect the invariants here.
 
 ## Tool Surface
 
+Guarded by: [D001](BEHAVIORS.md#behavior-d001), [D002](BEHAVIORS.md#behavior-d002), [D003](BEHAVIORS.md#behavior-d003), [D004](BEHAVIORS.md#behavior-d004), [D005](BEHAVIORS.md#behavior-d005)
+
 `daemon` is migrated to the LingTai Tool Protocol v2 action-separated envelope
 (`../CONTRACT.md`, `../tool_family/CONTRACT.md`) using the generic
 `tool_family` infrastructure. The public root is exactly `action`, `input`,
@@ -539,6 +541,8 @@ run-local `logs/events.jsonl` / `daemon_tool_result` recovery locator. The closu
 is inert unless a tool explicitly requests `summary=true`.
 
 ## Backend Support Matrix
+
+Guarded by: [D006](BEHAVIORS.md#behavior-d006), [D007](BEHAVIORS.md#behavior-d007)
 
 Current source-backed status:
 

--- a/src/lingtai/tools/daemon/CONTRACT.md
+++ b/src/lingtai/tools/daemon/CONTRACT.md
@@ -10,6 +10,7 @@ status: active
 contract_version: 8
 last_changed_at: "2026-08-09"
 related_files:
+  - BEHAVIORS.md
   - src/lingtai/tools/daemon/ANATOMY.md
   - src/lingtai/tools/daemon/__init__.py
   - src/lingtai/tools/daemon/_tool_family.py

--- a/src/lingtai/tools/feishu/BEHAVIORS.md
+++ b/src/lingtai/tools/feishu/BEHAVIORS.md
@@ -1,0 +1,68 @@
+---
+name: feishu-behavior-tests
+behavior_version: 1
+labt_version: 2
+contract: ../../mcp_servers/feishu/SKILL.md
+anatomy: ../../mcp_servers/ANATOMY.md
+related_files:
+  - src/lingtai/mcp_servers/feishu/SKILL.md
+  - src/lingtai/mcp_servers/feishu/_family.py
+  - src/lingtai/mcp_servers/feishu/manager.py
+  - src/lingtai/mcp_servers/ANATOMY.md
+  - src/lingtai/tools/CONTRACT.md
+  - tests/test_feishu_toolfamily_ltpv2.py
+maintenance: |
+  LABT v2, migrated 2026-08 from tests/test_feishu_toolfamily_ltpv2.py
+  (previously filed as C006 under src/lingtai/tools/telegram/BEHAVIORS.md;
+  re-homed here). Feishu has no CONTRACT.md as of 2026-08 — neither
+  src/lingtai/tools/feishu/CONTRACT.md nor
+  src/lingtai/mcp_servers/feishu/CONTRACT.md exists — so the contract-ish
+  source is the feishu-mcp-manual SKILL.md
+  (src/lingtai/mcp_servers/feishu/SKILL.md, § PUBLIC TOOL FAMILY: strict
+  LTP-v2) plus the shared LTP v2 envelope in src/lingtai/tools/CONTRACT.md
+  (§ Envelope), with code under src/lingtai/mcp_servers/feishu (_family.py,
+  manager.py). When a feishu CONTRACT.md lands, repoint contract:/guards at it
+  and close the loop here and in the root BEHAVIORS.md related_files.
+---
+# Feishu Behavior Tests
+
+LABT v2. FE001 is a self-contained agent-executable behavioral test for the
+`feishu` tool family's LTP v2 envelope: envelope validation short-circuits
+before manager I/O, `accounts` identity handling, child-schema scrub rules, and
+flat-vs-ltpv2 dispatch parity. The closest contract-ish source is the
+feishu-mcp-manual SKILL.md § PUBLIC TOOL FAMILY: strict LTP-v2
+(`src/lingtai/mcp_servers/feishu/SKILL.md`) plus the shared LTP v2 envelope in
+`src/lingtai/tools/CONTRACT.md` — feishu has no CONTRACT.md yet (see
+maintenance).
+
+## Behavior FE001 — Feishu tool family LTP v2 envelope
+
+- **id**: FE001
+- **title**: feishu LTP v2 envelope validation, child schemas, and flat dispatch
+- **guards**: `feishu-mcp-manual` § PUBLIC TOOL FAMILY: strict LTP-v2 ([SKILL.md](../../mcp_servers/feishu/SKILL.md#public-tool-family-strict-ltp-v2))
+- **supersedes**: tests/test_feishu_toolfamily_ltpv2.py (CONVERT_BEHAVIOR)
+- **runner**: any LingTai agent with the feishu capability (recording manager, no network)
+- **prerequisites**: repo checkout with src/lingtai/mcp_servers/feishu; the feishu manager is a recording stub — no network; identity path is `/tmp/identities.json`; envelope rules per `src/lingtai/tools/CONTRACT.md` § Envelope.
+- **estimate**: 30 minutes
+
+### Steps
+
+1. Call the feishu tool with 9 invalid envelope shapes (missing/unknown `action`, wrong `payload` type, etc.).
+2. Call `feishu(action="accounts")` on a cold identity path.
+3. Exercise `send` (receive_id/text/body combinations), `remove_contact`, `manual`, and each empty-input action.
+4. Inspect the generated child tool schemas for the family.
+
+### Expected evidence
+
+- [ ] **Actions**: `FEISHU_ACTIONS` is exactly `("send", "check", "read", "reply", "react", "search", "delete", "edit", "contacts", "add_contact", "remove_contact", "accounts", "manual")` — 13 actions.
+- [ ] **Envelope validation**: each of the 9 invalid shapes returns a `failed`-status result **before** any manager I/O (the stub records zero calls for those inputs).
+- [ ] **accounts**: the valid call makes the manager receive exactly `{"action": "accounts"}` and returns `{status: ok, accounts: [main], details, ...}` with `identity_path == "/tmp/identities.json"`; the ltpv2 flat result equals the family handle result.
+- [ ] **send**: requires `receive_id` with **text XOR content** (body); a payload with both or neither is rejected.
+- [ ] **remove_contact**: accepts **exactly one** of `alias` / `open_id`; both or neither is rejected.
+- [ ] **manual**: echoes the input verbatim or returns `{status: ok, skill: "feishu-mcp-manual", manual: <str>}`.
+- [ ] **Child schemas**: `input` uses `anyOf` (not `oneOf`); `reasoning`/`summarize` never appear in child schemas or handlers; scrub preserves `required`, the `action` enum, `anyOf`/`allOf`, an `allOf` length of 13, and `additionalProperties: false`.
+- [ ] **Empty-input branches**: exactly `{check, contacts, accounts, manual}` succeed with an empty payload.
+
+### Pass / Fail
+
+PASS when validation short-circuits before manager I/O, flat==ltpv2 for accounts, and child schemas match the scrub rules; FAIL on any manager call for invalid input, any schema drift (`oneOf`, leaked `reasoning`/`summarize`), or a wrong action count.

--- a/src/lingtai/tools/file/BEHAVIORS.md
+++ b/src/lingtai/tools/file/BEHAVIORS.md
@@ -1,0 +1,58 @@
+---
+name: file-behavior-tests
+behavior_version: 1
+labt_version: 2
+contract: CONTRACT.md
+anatomy: ANATOMY.md
+related_files:
+  - src/lingtai/tools/file/CONTRACT.md
+  - src/lingtai/tools/file/ANATOMY.md
+  - src/lingtai/tools/file/__init__.py
+  - src/lingtai/tools/file/_read.py
+  - tests/test_read_continuation.py
+  - tests/test_file_tool_family.py
+maintenance: |
+  LABT v2, migrated 2026-08 from tests/test_read_continuation.py (previously
+  filed as C005 under src/lingtai/tools/telegram/BEHAVIORS.md; re-homed here so
+  file owns its own behavior tests). Guards `file-contract` § read
+  (`_read.py`) — read-only. Keep this LABT in sync with the read
+  caps/continuation clause in CONTRACT.md; update both in the same change when
+  `_read.py` caps or next_offset semantics change, and keep ANATOMY.md
+  reciprocal.
+---
+# File Behavior Tests
+
+LABT v2. F001 is a self-contained agent-executable behavioral test for the
+`file` tool's read continuation: pagination via `next_offset`, truncation caps,
+and long-line truncation. It guards the `read` clause of
+`src/lingtai/tools/file/CONTRACT.md` (frontmatter name `file-contract`).
+
+## Behavior F001 — File read continuation via next_offset pagination
+
+- **id**: F001
+- **title**: `file` read-only continuation, truncation caps, and next_offset semantics
+- **guards**: `file-contract` § read (`_read.py`) — read-only (caps, `next_offset` continuation, `line_truncated` skip) ([CONTRACT.md](CONTRACT.md#read-_readpy--read-only))
+- **supersedes**: tests/test_read_continuation.py (CONVERT_BEHAVIOR)
+- **runner**: any LingTai agent with the `file` tool
+- **prerequisites**: repo checkout with src/lingtai/tools/file; a fixture file larger than one page and a file containing one very long line (or scratch copies the executor creates in a temp dir); operates on fixture files under tests/fixtures — never writes (read-only action only).
+- **estimate**: 20 minutes
+
+### Steps
+
+1. Read a file larger than one page: `file(action=read, file_path=<fixture>, offset=1, limit=null, max_chars=null)`.
+2. Take `next_offset` from the result and call read again with `offset=<next_offset>, limit=null, max_chars=null`.
+3. Repeat with explicit `offset`/`limit` and with `max_chars` smaller than the page.
+4. Read a file containing one very long line.
+
+### Expected evidence
+
+- [ ] **Caps**: `DEFAULT_READ_CAP_CHARS == 100_000`, `READ_HARD_CAP_CHARS == 200_000`, `PREVENTIVE_MAX_CHARS == 200_000`.
+- [ ] **First page**: when the file exceeds the cap, the result is truncated and reports `next_offset == last_returned_line + 1`, plus `remaining_lines_estimate`, `total_lines`, and `lines_shown`.
+- [ ] **Continuation**: reading with `offset == next_offset` starts exactly at that line (no overlap, no gap) and again returns its own `next_offset` for the next page.
+- [ ] **Offset/limit**: explicit `offset` and `limit` are honored; a per-call `max_chars` returns `cap_chars == <requested>` and `returned_chars <= cap_chars`.
+- [ ] **Single long line**: the line is truncated with `line_truncated: true`, `last_returned_line == 1`, and `next_offset == 2`.
+- [ ] **Schema/description**: the read result schema mentions `max_chars`, `read-manual`, `truncated`, `next_offset`, and `line_truncated`, and the limits are documented as `100 000` and `200 000` (spaced thousands) in the tool description.
+
+### Pass / Fail
+
+PASS when pagination is gap-free and overlap-free, caps hold, and the long-line case reports exactly `last_returned_line == 1` / `next_offset == 2`; FAIL on any skipped or repeated line.

--- a/src/lingtai/tools/file/CONTRACT.md
+++ b/src/lingtai/tools/file/CONTRACT.md
@@ -126,6 +126,8 @@ catches every one of them.
 
 ### read (`_read.py`) — read-only
 
+Guarded by: [F001](BEHAVIORS.md#behavior-f001)
+
 Returns `{content, total_lines, lines_shown}`. `content` is `cat -n`-style:
 each kept line is `"{lineno}\t{line}"`, preserving the file's own newline style
 (`splitlines(keepends=True)`).

--- a/src/lingtai/tools/notification/CONTRACT.md
+++ b/src/lingtai/tools/notification/CONTRACT.md
@@ -49,6 +49,8 @@ operation.
 
 ## Behavior
 
+Guarded by: [K005](../../kernel/BEHAVIORS.md#behavior-k005), [K006](../../kernel/BEHAVIORS.md#behavior-k006)
+
 LingTai agents MUST use `manual` only to retrieve installed guidance, `check` to
 request current notification state, and the narrowest producer-specific or
 atomic dismiss action after handling a notification. They MUST NOT treat generic

--- a/src/lingtai/tools/shell/BEHAVIORS.md
+++ b/src/lingtai/tools/shell/BEHAVIORS.md
@@ -1,0 +1,370 @@
+---
+name: shell-behavior-tests
+behavior_version: 1
+labt_version: 1
+contract: ../bash/CONTRACT.md
+anatomy: ../bash/ANATOMY.md
+related_files:
+  - src/lingtai/tools/bash/__init__.py
+  - src/lingtai/tools/bash/_tool_family.py
+  - src/lingtai/tools/bash/CONTRACT.md
+  - src/lingtai/tools/bash/ANATOMY.md
+  - src/lingtai/tools/tool_family/__init__.py
+  - src/lingtai/tools/email/__init__.py
+  - src/lingtai/tools/context/__init__.py
+  - src/lingtai/tools/psyche/__init__.py
+  - src/lingtai/kernel/base_agent/turn.py
+  - src/lingtai/kernel/llm/base.py
+  - tests/test_shell_sandbox_containment.py
+  - tests/contracts/llm_conversation_input/test_send_str.py
+  - tests/test_context_ownership_redesign.py
+  - tests/test_repeated_tool_error_continue.py
+  - tests/test_daemon_check_historical.py
+  - src/lingtai/tools/daemon/BEHAVIORS.md
+maintenance: |
+  Written by the shell/sandbox CONVERT_BEHAVIOR migration (2026-08). The
+  canonical shell implementation lives in src/lingtai/tools/bash/ (the public
+  tool is `shell`; see bash-contract), so this file's contract/anatomy links
+  point at ../bash/. Keep in sync with every contract this file guards:
+  bash-contract, the LTP v2 family convention (src/lingtai/tools/CONTRACT.md
+  + tool_family), the context/psyche contracts, the email contract, and the
+  base-agent runtime contract. When any of those changes in a way that affects
+  agent-observable behavior, update the matching LABT here in the same change.
+---
+# Shell / Sandbox Behavior Tests
+
+LABT v1. These are self-contained agent-executable behavioral tests for the
+shell/sandbox family: the `shell` tool's working-dir containment and strict
+LTP v2 envelope, the agent conversation-input `send(str)` wire, the context
+ownership redesign (durable prompt sources), and the turn engine's repeated-
+tool-error continuation. They prove the *observable* promises of
+`src/lingtai/tools/bash/CONTRACT.md` (the `shell` capability contract),
+`src/lingtai/tools/context/CONTRACT.md`, `src/lingtai/tools/psyche/CONTRACT.md`,
+`src/lingtai/tools/email/CONTRACT.md`, and the base-agent runtime contract.
+Low-level mechanics stay in pytest; each LABT below is self-contained and
+executable verbatim by an agent with the listed tools.
+
+`tests/test_daemon_check_historical.py` is already converted: it is covered by
+`src/lingtai/tools/daemon/BEHAVIORS.md` Behavior D003 (daemon.check falls back
+to historical run dirs), so it is NOT duplicated here.
+
+Pinned pytest commands below must run from the repo root `<repo>` with the
+project venv interpreter that resolves `lingtai` from `<repo>/src` (an
+editable install), e.g. `C:\Users\zhuang\.lingtai-tui\runtime\venv\Scripts\python.exe`
+on the original host. Substitute your own venv `python`; the expected pass
+counts are pinned and platform notes are given per LABT.
+
+## Behavior S001 — shell run stays inside the agent sandbox
+
+- **id**: S001
+- **title**: shell `working_dir` must equal the agent sandbox or be nested
+  under it; sibling-prefix and outside paths are refused
+- **guards**: `bash-contract` § Cross-platform invariants
+  ([CONTRACT.md](../bash/CONTRACT.md#cross-platform-invariants)) and § Tool
+  surface run error shape ([CONTRACT.md](../bash/CONTRACT.md#tool-surface))
+- **supersedes**: `tests/test_shell_sandbox_containment.py`
+- **runner**: any LingTai agent with the `shell` tool
+- **prerequisites**: your working dir `<agent>`; nothing else
+- **estimate**: 2 min
+
+### Steps
+1. Call `shell(action="run", input={"command": "pwd"}, reasoning="check")`
+   with no `working_dir`.
+2. Create `<agent>/sub/deep/` (write `<agent>/sub/deep/.keep` with the file
+   tool or `mkdir` it from a shell run inside the sandbox).
+3. Call `shell(action="run", input={"command": "pwd",
+   "working_dir": "<agent>/sub/deep"}, reasoning="check")`.
+4. Call `shell(action="run", input={"command": "pwd",
+   "working_dir": "<agent>-sibling"}, reasoning="check")` — a name sharing
+   the sandbox string as a prefix but not nested under it.
+5. Call `shell(action="run", input={"command": "pwd",
+   "working_dir": "<outside>"}, reasoning="check")` where `<outside>` is any
+   absolute directory NOT under `<agent>` (e.g. the parent of `<agent>`, `/tmp`
+   on POSIX, or `C:\Windows` on Windows).
+6. (Pinned check) From `<repo>`, run
+   `python -m pytest tests/test_shell_sandbox_containment.py -q`.
+
+### Expected evidence
+- [ ] Step 1: `{status: "ok", ...}` and `stdout` contains your working dir
+      (the sandbox itself is accepted as `working_dir`).
+- [ ] Step 3: `{status: "ok", ...}` and `stdout` contains the resolved
+      `<agent>/sub/deep` path (a nested cwd is accepted).
+- [ ] Step 4: `{status: "error", message}` and the message contains
+      `under agent working directory` (sibling-prefix escape refused).
+- [ ] Step 5: `{status: "error", message}` containing
+      `under agent working directory` (outside path refused).
+- [ ] Steps 4–5 ran no command: no `stdout`/`stderr` payload, and nothing was
+      created or modified outside `<agent>`.
+- [ ] Step 6: on POSIX hosts the summary is `5 passed`; on native Windows the
+      two `@posix_paths` end-to-end tests are skipped and the un-marked
+      POSIX-path unit assertions fail by design (the file proves the Windows
+      separator path via monkeypatch on POSIX CI and is not in the Windows CI
+      set) — run it on POSIX, or rely on steps 1–5 as the cross-platform
+      evidence.
+
+### Pass / Fail
+Pass when nested `working_dir` runs succeed, every out-of-bounds path is
+refused with an error containing `under agent working directory`, and no
+command escaped the sandbox. Fail if any outside or sibling-prefix path
+executes, or if the error message shape changes.
+
+## Behavior S002 — shell exposes the strict LTP v2 family envelope
+
+- **id**: S002
+- **title**: the `shell` tool root is exactly `{action, input, reasoning,
+  summarize}`; unknown actions and cross-action input keys are refused before
+  any dispatch
+- **guards**: `bash-contract` § Tool surface (closed LTP v2 root,
+  `ACTION_REQUIRED` / `INVALID_ARGUMENT` rejections)
+  ([CONTRACT.md](../bash/CONTRACT.md#tool-surface)); tools contract § LTP v2
+  family convention ([CONTRACT.md](../CONTRACT.md))
+- **runner**: any LingTai agent with the `shell` tool
+- **prerequisites**: none beyond your working dir
+- **estimate**: 2 min
+
+### Steps
+1. Inspect the `shell` tool definition in your own environment (the composed
+   schema the host exposes to you). Record its root `properties`, `required`,
+   and `additionalProperties`.
+2. Call `shell(action="run", input={"command": "pwd"}, reasoning="ok")`.
+3. Call `shell(action="frobnicate", input={}, reasoning="x")` — an action
+   that is not one of the four children.
+4. Call `shell(action="poll", input={"command": "pwd"}, reasoning="x")` — a
+   `run`-only field smuggled into `poll`'s input.
+5. Call `shell(action="manual", input={}, reasoning="x")`.
+6. Call `shell(action="manual", input={"page": 2}, reasoning="x")`.
+
+### Expected evidence
+- [ ] Step 1: `properties == {action, input, reasoning, summarize}`,
+      `required == [action, input, reasoning]`, and
+      `additionalProperties == false` (the strict LTP v2 root).
+- [ ] Step 2: `{status: "ok", ...}` — the valid envelope dispatches.
+- [ ] Step 3: `{status: "failed", error_code: "ACTION_REQUIRED", message:
+      "action must be one of run, poll, cancel, or manual"}`.
+- [ ] Step 4: `{status: "failed", error_code: "INVALID_ARGUMENT", message:
+      "unsupported shell input field"}` — rejected before any job lookup.
+- [ ] Step 5: `{status: "ok", content: [{type: "text", text: <shell-manual
+      body>}], structuredContent: {manual_path}}`.
+- [ ] Step 6: `{status: "failed", error_code: "INVALID_ARGUMENT", message:
+      "unsupported shell input field"}` — `manual` input is strict empty.
+- [ ] Steps 3, 4, 6 spawned no process and touched no job state.
+
+### Pass / Fail
+Pass when the root schema matches exactly and every invalid call is refused
+with the exact `error_code`/`message` above. Fail if an unknown action or a
+cross-action input key dispatches, or if the closed root gains a field.
+
+## Behavior S003 — send(str) reaches the provider transport as provider text
+
+- **id**: S003
+- **title**: a plain user-text turn (`send(str)`) is serialized into the
+  provider wire for every conforming production session regime, and `send`
+  returns a real `LLMResponse` with concrete `UsageMetadata`
+- **guards**: `llm-conversation-input` characterization suite § `send(str)`
+  input shape
+  ([__init__.py](../../../../tests/contracts/llm_conversation_input/__init__.py));
+  kernel `ChatSession` ABC § `send` ([base.py](../../kernel/llm/base.py))
+- **supersedes**: `tests/contracts/llm_conversation_input/test_send_str.py`
+- **runner**: any LingTai agent with shell access to a checkout of `<repo>`
+  and the project venv `python` (resolving `lingtai` from `<repo>/src`)
+- **prerequisites**: the repo checkout; pytest installed in that venv
+- **estimate**: 3 min
+
+### Steps
+1. From `<repo>`, run
+   `python -m pytest tests/contracts/llm_conversation_input/test_send_str.py -q`.
+2. Read the summary line and, if any failure, the failing regime name.
+3. (Optional live check) In your own session, submit a plain user-text turn
+   (a bare string, no tool call) to a real provider and confirm the reply
+   responds to that text — the text reached the provider, not a tool result.
+
+### Expected evidence
+- [ ] Exit code 0 and the summary line reads `10 passed`.
+- [ ] The ten conforming regime rows all ran and passed: `openai_chat`,
+      `deepseek_chat`, `mimo_chat`, `zhipu_chat`, `anthropic`, `claude_code`,
+      `gemini_interactions`, `openai_responses`, `codex_responses`,
+      `gated_openai_chat`.
+- [ ] Each row proves, for `USER_TEXT = "characterization text turn"`: the
+      text appears in the captured provider wire in that regime's shape — the
+      OpenAI-family dict `{"role": "user", "content": "characterization text
+      turn"}` (openai_chat, deepseek_chat, mimo_chat, zhipu_chat,
+      openai_responses, codex_responses, gated_openai_chat), the Anthropic
+      messages array (anthropic), the rendered CLI prompt string
+      (claude_code), or the Gemini Interactions `input` array
+      (gemini_interactions) — and `send` returns an `LLMResponse` whose
+      `UsageMetadata` carries the concrete mocked counts `input_tokens=10`,
+      `output_tokens=5` (never zeroed).
+- [ ] Step 3: the provider reply engages with your plain text (no error, no
+      dropped turn).
+
+### Pass / Fail
+Pass when `10 passed` and the wire/envelope facts above hold. Fail if any
+conforming regime drops or rewrites the user text, returns no concrete
+`UsageMetadata`, or the suite reports a failure.
+
+## Behavior S004 — context ownership: durable sources change disk, never the live prompt
+
+- **id**: S004
+- **title**: durable prompt sources (`<agent>/system/*.md`, pinned references)
+  are plain files; `file` writes/edits never hot-load the running prompt, only
+  an explicit `context(action="rebuild")` recomposes, and retired
+  domain-mutation actions are rejected
+- **guards**: `context-contract` § Full reconstruction ordering
+  ([CONTRACT.md](../context/CONTRACT.md#full-reconstruction-ordering)) and §
+  LTP v2 port ([CONTRACT.md](../context/CONTRACT.md#ltp-v2-port));
+  `psyche-contract` § Behavior / Root reuse is not action compatibility
+  ([CONTRACT.md](../psyche/CONTRACT.md#behavior))
+- **supersedes**: `tests/test_context_ownership_redesign.py`
+- **runner**: any LingTai agent with the `file`, `context`, and `psyche` tools
+- **prerequisites**: your working dir `<agent>`; the `system/` dir may need
+  creating
+- **estimate**: 4 min
+
+### Steps
+1. Inspect the `psyche` and `context` tool definitions in your environment;
+   record each `action` enum.
+2. Call each retired domain-mutation action and record the results:
+   `psyche(action="update", input={}, reasoning="x")`, `"load"`, `"edit"`,
+   `"append"`, `"info"`, and `context(action="load", input={},
+   reasoning="x")`.
+3. Call `psyche(action="lingtai", input={}, reasoning="inspect")`; record the
+   status.
+4. Call `psyche(action="lingtai", input={"content": "not allowed"},
+   reasoning="x")`; record the result.
+5. Create `<agent>/system/` and write `<agent>/system/pad.md` containing
+   `DURABLE-ONE` via `file(action="write", ...)`. Read `<agent>/system/system.md`
+   (it may not exist yet) and record whether it contains `DURABLE-ONE`.
+6. Call `context(action="rebuild", input={}, reasoning="x")`; record the
+   result fields. Read `<agent>/system/system.md` again and record whether it
+   now contains `DURABLE-ONE`.
+7. (Pinned check) From `<repo>`, run
+   `python -m pytest tests/test_context_ownership_redesign.py -q`.
+
+### Expected evidence
+- [ ] Step 1: `psyche` action enum == `["pad", "lingtai", "knowledge",
+      "skills", "manual"]`; `context` action enum == `["molt",
+      "summarize", "rebuild", "manual"]` (the locked inventories).
+- [ ] Step 2: every retired call returns an error whose message contains
+      `Unknown psyche action` (for the psyche calls) or `Unknown context
+      action` (for the context call).
+- [ ] Step 3: status is `ok` or `degraded` — the 灵台 signpost survives as
+      `psyche(action="lingtai")`.
+- [ ] Step 4: `{status: "failed", error_code: "INVALID_ARGUMENT", ...}` — the
+      lingtai input branch is strict empty.
+- [ ] Step 5: `pad.md` on disk reads `DURABLE-ONE`, and
+      `<agent>/system/system.md` does NOT contain `DURABLE-ONE` (no hot-load
+      from a plain file write).
+- [ ] Step 6: rebuild returns `status: "ok"` with `prompt_reconstructed` true
+      and a `prompt_reconstruction` field containing `All canonical prompt
+      sources`; `<agent>/system/system.md` now contains `DURABLE-ONE`
+      (recomposition, not overlay — a removed source also disappears on the
+      next full rebuild).
+- [ ] Step 7: summary reads `12 passed`.
+
+### Pass / Fail
+Pass when all evidence holds. Fail if a retired action dispatches, the lingtai
+envelope accepts extra input, a plain file write changes the running prompt
+before `rebuild`, or rebuild does not recompose `system.md` from the durable
+sources.
+
+## Behavior S005 — repeated identical tool errors stay normal tool results
+
+- **id**: S005
+- **title**: identical tool errors keep flowing as ordinary tool-result
+  payloads; there is no repeated-error hard-stop continuation and no
+  `repeated_tool_error` notification
+- **guards**: `base-agent-contract` § Behavior (main turn loop)
+  ([CONTRACT.md](../../kernel/base_agent/CONTRACT.md#behavior)); incident
+  regression 2026-06-12 (mimo-1) documented in the superseded test
+- **supersedes**: `tests/test_repeated_tool_error_continue.py`
+- **runner**: any LingTai agent with the `file` and `shell` tools (live
+  check), plus shell access to `<repo>` (pinned check)
+- **prerequisites**: your working dir `<agent>`; repo checkout for step 4
+- **estimate**: 3 min
+
+### Steps
+1. Deliberately trigger the same tool error at least three times in a row,
+   e.g. `file(action="read", input={"file_path":
+   "<agent>/does-not-exist.txt"}, reasoning="x")` three times (or
+   `shell(action="run", input={"command": "definitely-not-a-command-xyz"},
+   reasoning="x")` three times).
+2. After the third identical error, make one more ordinary tool call (e.g.
+   glob `<agent>`) and finish the turn; record that the runtime continued
+   normally — you were not dropped to IDLE and needed no continuation/
+   notification workaround.
+3. Check whether `<agent>/.notification/repeated_tool_error.json` exists.
+4. (Pinned check) From `<repo>`, run
+   `python -m pytest tests/test_repeated_tool_error_continue.py -q`.
+
+### Expected evidence
+- [ ] Steps 1–2: each failure came back as an ordinary tool result with its
+      error payload; the follow-up tool call and your final reply completed
+      within the same turn (no hard-stop path, no string continuation
+      synthesized by the engine).
+- [ ] Step 3: no `repeated_tool_error.json` exists in
+      `<agent>/.notification/`.
+- [ ] Step 4: summary reads `3 passed`. The pinned tests additionally assert:
+      every payload the session received was a list of tool results (never a
+      `str`), committed ids `call_1`..`call_3` (and, in the second test,
+      through `call_4`), no pending tool calls remain, no log event starts
+      with `repeated_tool_error`, and no notification file is written.
+
+### Pass / Fail
+Pass when repeated identical errors keep the normal tool loop going with no
+notification file and the pinned suite passes. Fail if the engine hard-stops
+on identical errors, synthesizes a text continuation, writes a
+`repeated_tool_error.json`, or logs a `repeated_tool_error` event.
+
+## Behavior S006 — email send works through the strict LTP v2 envelope
+
+- **id**: S006
+- **title**: `email(action="send", input={"address": ..., "message": ...})`
+  writes exactly one sent record, and cross-action input keys / unknown root
+  fields are refused before any mailbox I/O
+- **guards**: `email-contract` § Tool surface (send row; cross-action key
+  rejection before any mailbox I/O or delivery)
+  ([CONTRACT.md](../email/CONTRACT.md#tool-surface))
+- **supersedes**: `tests/test_tool_family_email_migration.py::test_cross_action_key_is_rejected_before_any_mailbox_io`,
+  `::test_send_fields_cannot_be_smuggled_through_a_read_call`,
+  `::test_unknown_root_field_is_rejected`
+- **runner**: any LingTai agent with the `email` tool
+- **prerequisites**: your working dir `<agent>` (the mailbox is
+  `<agent>/mailbox/`); a recipient address string for your own mailbox
+  (peer mode, e.g. your agent name)
+- **estimate**: 2 min
+
+### Steps
+1. Record the current `sent/` dirs: glob `<agent>/mailbox/sent/*/` and note
+   the count.
+2. Call `email(action="send", input={"address": "<recipient>",
+   "message": "hello"}, reasoning="x")`; record the result.
+3. Glob `<agent>/mailbox/sent/*/message.json` again; read the newest file and
+   record its `address` and `message` fields.
+4. Call `email(action="read", input={"email_id": ["x"], "address":
+   "peer", "message": "leak"}, reasoning="x")` — `send` fields smuggled
+   into a `read` call; record the result.
+5. Call `email(action="contacts", input={}, not_a_field=1, reasoning="x")`
+   — an unknown root field; record the result.
+6. Re-glob `<agent>/mailbox/sent/` and `<agent>/mailbox/inbox/`; record
+   whether steps 4–5 created or changed any mailbox record.
+
+### Expected evidence
+- [ ] Step 2: `{status: "sent", to, cc, bcc, delay}` with `to` containing
+      `<recipient>` and no error.
+- [ ] Step 3: exactly one new `sent/<uuid>/message.json` exists; its JSON
+      carries `"message": "hello"` and the recipient address (a single
+      record per send call).
+- [ ] Step 4: `{status: "failed", error_code: "INVALID_ARGUMENT", message:
+      "unsupported email input field"}` — the smuggle is refused before any
+      mailbox I/O or delivery.
+- [ ] Step 5: `{status: "failed", error_code: "INVALID_ARGUMENT", message:
+      "unsupported email argument"}`.
+- [ ] Step 6: the `sent/` and `inbox/` inventories are unchanged by steps 4–5
+      (no delivery, no read-state change).
+
+### Pass / Fail
+Pass when a string-message send produces exactly one `sent/` record with the
+canonical receipt, and both envelope violations are refused with the exact
+`error_code`/`message` above without touching the mailbox. Fail if a smuggled
+key dispatches, mail leaves via a read-shaped call, or the send writes more
+than one record.

--- a/src/lingtai/tools/system/BEHAVIORS.md
+++ b/src/lingtai/tools/system/BEHAVIORS.md
@@ -1,7 +1,7 @@
 ---
 name: system-behavior-tests
 behavior_version: 2
-labt_version: 1
+labt_version: 2
 contract: CONTRACT.md
 anatomy: ANATOMY.md
 related_files:

--- a/src/lingtai/tools/telegram/BEHAVIORS.md
+++ b/src/lingtai/tools/telegram/BEHAVIORS.md
@@ -1,297 +1,102 @@
 ---
 name: telegram-behavior-tests
 behavior_version: 1
-labt_version: 1
----
-
+labt_version: 2
+contract:
+  - ../../mcp_servers/telegram/task_card/CONTRACT.md
+  - ../../mcp_servers/telegram/SKILL.md
+anatomy: ../../mcp_servers/telegram/task_card/ANATOMY.md
 related_files:
-  - src/lingtai/tools/telegram/manager.py
-  - src/lingtai/tools/telegram/SKILL.md
   - src/lingtai/mcp_servers/telegram/task_card/CONTRACT.md
   - src/lingtai/mcp_servers/telegram/task_card/ANATOMY.md
-  - src/lingtai/tools/feishu/_family.py
-  - src/lingtai/tools/feishu/manager.py
-  - src/lingtai/tools/web_search/CONTRACT.md
-  - src/lingtai/tools/web_search/__init__.py
-  - src/lingtai/tools/file/CONTRACT.md
-  - src/lingtai/tools/file/_read.py
-  - src/lingtai/tools/CONTRACT.md
+  - src/lingtai/mcp_servers/telegram/task_card/resident.py
+  - src/lingtai/mcp_servers/telegram/SKILL.md
+  - src/lingtai/mcp_servers/telegram/manager.py
   - tests/test_telegram_task_card_last_message.py
   - tests/test_telegram_reaction_states.py
-  - tests/test_web_canonical_provider_routing.py
-  - tests/test_read_continuation.py
-  - tests/test_feishu_toolfamily_ltpv2.py
-maintenance:
-  migrated: 2026-08
-  migration: CONVERT_BEHAVIOR from the five legacy test files listed above
-  note: src/lingtai/tools/telegram has no sibling CONTRACT.md yet; the Telegram
-    task-card contract lives at src/lingtai/mcp_servers/telegram/task_card/CONTRACT.md
-    and Telegram reaction semantics are guarded by src/lingtai/tools/telegram/SKILL.md
+maintenance: |
+  LABT v2, migrated 2026-08 (CONVERT_BEHAVIOR) from
+  tests/test_telegram_task_card_last_message.py (C001) and
+  tests/test_telegram_reaction_states.py (C002). This file now covers only the
+  Telegram task-card projection and Telegram reaction states. The former
+  C003/C004 (web_search), C005 (file read continuation), and C006 (feishu LTP
+  v2) LABTs were re-homed to src/lingtai/tools/web_search/BEHAVIORS.md,
+  src/lingtai/tools/file/BEHAVIORS.md, and src/lingtai/tools/feishu/BEHAVIORS.md
+  respectively (all three are listed in the root BEHAVIORS.md related_files).
+  There is no root CONTRACT.md beside this file; the task-card contract lives
+  at src/lingtai/mcp_servers/telegram/task_card/CONTRACT.md (frontmatter name
+  `telegram-task-card-projection`) and Telegram reaction semantics are guarded
+  by src/lingtai/mcp_servers/telegram/SKILL.md (`telegram-mcp-manual` § REPLY
+  vs SEND) until a Telegram root contract exists. Keep guards pointed at real
+  clauses when the contract or manual changes; update the paired ANATOMY.md
+  entries in the same change.
 ---
+# Telegram Behavior Tests
 
-# LABT v1 behaviors — comms/channels family
-
-This file captures agent-observable behaviors for the comms/channels tool family in
-lingtai-kernel, converted from the five CONVERT_BEHAVIOR test files listed in the
-frontmatter. Every behavior below pins exact paths, tool names, commands, and expected
-values so a test harness can reproduce it verbatim. C001 covers the
-Telegram task-card projection, C002 covers Telegram reaction states, C003–C004 cover web
-canonical provider routing (search→browse), C005 covers file read continuation, and
-C006 covers the Feishu tool family LTP v2 envelope.
+LABT v2. Self-contained agent-executable behavioral tests for the Telegram
+channel: C001 proves the task-card projection's last-message semantics
+(edit-in-place, rotation, failure paths) against the resident-core contract
+(`src/lingtai/mcp_servers/telegram/task_card/CONTRACT.md`), and C002 proves the
+reaction state machine (received → seen → replied). The web_search, file
+read, and feishu LTP v2 LABTs that previously lived here were re-homed to their
+own module BEHAVIORS.md files (see related_files and the root BEHAVIORS.md).
 
 ## Behavior C001 — Telegram task card: edit-in-place vs supersede by last message
 
-- **LABT id**: C001
-- **Title**: Telegram task-card last-message semantics (edit-in-place, rotation, failure paths)
-- **Guards**: test only runs with the telegram task-card fake transport; no network.
-- **Supersedes**: tests/test_telegram_task_card_last_message.py (CONVERT_BEHAVIOR)
-- **Runner**: pytest tests/test_telegram_task_card_last_message.py
-- **Prerequisites**: repo checkout with src/lingtai/mcp_servers/telegram/task_card.
-- **Estimate**: 20 minutes.
+- **id**: C001
+- **title**: Telegram task-card last-message semantics (edit-in-place, rotation, failure paths)
+- **guards**: `telegram-task-card-projection` § Behavior (items 7–8: commit-after-success, edit-first delivery, conservative old-first rotation, failure-state projection) ([CONTRACT.md](../../mcp_servers/telegram/task_card/CONTRACT.md#behavior))
+- **supersedes**: tests/test_telegram_task_card_last_message.py (CONVERT_BEHAVIOR)
+- **runner**: any LingTai agent with the telegram capability (task-card projection against a recording transport)
+- **prerequisites**: repo checkout with src/lingtai/mcp_servers/telegram/task_card; the task-card resident core exercised through a recording (fake) transport — all transport I/O is recorded locally, never sent to the network; start from a cold state with no resident task-card message for the tracked account+chat.
+- **estimate**: 20 minutes
 
 ### Steps
 
-1. Start from a cold state (no resident task-card message).
-2. Update the task card with `taskcard_update(draft="old text")`; note the resulting
-   resident message id (compound id `mybot:55:100`).
-3. Update again with `taskcard_update(draft="new text")` while the previous message is
-   still the last one the bot sent.
-4. Send a user message (user msg id `200`), then update the card again.
-5. Force the bot to send an unrelated message (bot reply id `101`), then update again.
-6. Rotate the resident card to a fresh message id (`mybot:55:201`), then update again.
-7. Run the cold-state and failure-path scenarios below.
+1. Start from a cold state (no resident task-card message for the tracked account+chat).
+2. Produce a task-card update with draft text `"old text"`; note the resulting resident message id (compound id `mybot:55:100`).
+3. Produce a second update with draft text `"new text"` while the previous message is still the last message the bot sent.
+4. Deliver a user message (user msg id `200`), then produce a third update.
+5. Force the bot to send an unrelated message (bot reply id `101`), then produce a fourth update.
+6. Rotate the resident card to a fresh message id (`mybot:55:201`), then produce a fifth update.
+7. Exercise the rotation failure paths: old resident already gone; delete raises; send raises after rotation; persist of the new resident fails; suppressed updates; malformed send ids.
 
 ### Expected evidence
 
-- **Edit-in-place**: when the resident task-card message is still the last message, the
-  update result is `{status: ok, message_id: <same id>}` and exactly **1 send, 0 delete**
-  transport calls occur.
-- **Supersede by user message**: a user message after the resident card means the card is
-  no longer "last"; the update rotates the card — the old resident message (`mybot:55:100`)
-  is deleted and a new card is sent.
-
-- **Rotation call order** (user msg id `200` case): transport sees exactly
-  `edit(55, 100, <committed old text>)` → `delete(55, 100)` → `send(55, 201, <new text>)`
-  with compound ids `mybot:55:100` / `mybot:55:201`; the rotation happens **before** the
-  new send, so the card is never duplicated.
-- **Supersede by bot message**: a bot reply (`mybot:55:101`) between the card and the
-  update also rotates: `delete(55, 100)` → `send(55, 301, <new text>)`.
-- **Rotation failure paths** (each returns `{status: ok, taskcard: false}` and a distinct
-  marker): old resident already gone → `old_resident_deleted`; delete raises →
-  `stale_delete_failed`; send raises after rotation → `indeterminate_send`; persist of
-  the new resident fails → `resident_persist_failed`. Suppressed updates return
-  `{status: ok, suppressed: true, taskcard: false}`.
-- **Malformed send ids** (e.g. `no-colon-id`, `just:one`) are never adopted as the new
-  resident; the update is suppressed.
-- **Concurrency**: the task-card manager serializes rotation; only one in-flight rotation
-  is allowed (`max_active == 1`).
+- [ ] **Edit-in-place**: when the resident task-card message is still the last message, the update result is `{status: ok, message_id: <same id>}` and exactly **1 send, 0 delete** transport calls occur.
+- [ ] **Supersede by user message**: a user message after the resident card means the card is no longer "last"; the update rotates the card — the old resident message (`mybot:55:100`) is deleted and a new card is sent.
+- [ ] **Rotation call order** (user msg id `200` case): transport sees exactly `edit(55, 100, <committed old text>)` → `delete(55, 100)` → `send(55, 201, <new text>)` with compound ids `mybot:55:100` / `mybot:55:201`; the rotation happens **before** the new send, so the card is never duplicated.
+- [ ] **Supersede by bot message**: a bot reply (`mybot:55:101`) between the card and the update also rotates: `delete(55, 100)` → `send(55, 301, <new text>)`.
+- [ ] **Rotation failure paths** (each returns `{status: ok, taskcard: false}` and a distinct marker): old resident already gone → `old_resident_deleted`; delete raises → `stale_delete_failed`; send raises after rotation → `indeterminate_send`; persist of the new resident fails → `resident_persist_failed`. Suppressed updates return `{status: ok, suppressed: true, taskcard: false}`.
+- [ ] **Malformed send ids** (e.g. `no-colon-id`, `just:one`) are never adopted as the new resident; the update is suppressed.
+- [ ] **Concurrency**: the task-card manager serializes rotation; only one in-flight rotation is allowed (`max_active == 1`).
 
 ### Pass / Fail
 
-PASS when all evidence above holds; FAIL on any extra send/delete, any wrong id, or any
-missing failure marker.
+PASS when all evidence above holds; FAIL on any extra send/delete, any wrong id, or any missing failure marker.
 
 ## Behavior C002 — Telegram reaction states (received → seen → replied)
 
-- **LABT id**: C002
-- **Title**: Telegram reaction state transitions and reply-vs-send semantics
-- **Guards**: fake telegram transport; reactions never hit the network.
-- **Supersedes**: tests/test_telegram_reaction_states.py (CONVERT_BEHAVIOR)
-- **Runner**: pytest tests/test_telegram_reaction_states.py
-- **Prerequisites**: src/lingtai/tools/telegram/SKILL.md section `#reply-vs-send`
-  (the guard for reply-vs-send until a telegram root contract exists).
-- **Estimate**: 15 minutes.
+- **id**: C002
+- **title**: Telegram reaction state transitions and reply-vs-send semantics
+- **guards**: `telegram-mcp-manual` § REPLY vs SEND (a reply threads the response to a specific message and adds a ✅ reaction to it; reactions never hit the network in this LABT) ([SKILL.md](../../mcp_servers/telegram/SKILL.md#reply-vs-send))
+- **supersedes**: tests/test_telegram_reaction_states.py (CONVERT_BEHAVIOR)
+- **runner**: any LingTai agent with the telegram capability (reaction state machine against a recording transport)
+- **prerequisites**: repo checkout with src/lingtai/mcp_servers/telegram; the reaction state machine exercised through a recording (fake) telegram transport — reactions are recorded locally, never sent to the network; the reply-vs-send rule is the manual clause `telegram-mcp-manual` § REPLY vs SEND (`src/lingtai/mcp_servers/telegram/SKILL.md`) — the guard for reply-vs-send until a telegram root contract exists.
+- **estimate**: 15 minutes
 
 ### Steps
 
-1. Deliver a user message with `message_id=12345` that mentions a tool call with
-   `reply_to_message_id=8`.
+1. Deliver a user message with `message_id=12345` that mentions a tool call with `reply_to_message_id=8`.
 2. Let the handler run the received → seen → replied state machine.
 
 ### Expected evidence
 
-- `REACTION_RECEIVED` is `[{type: "emoji", emoji: "👍"}]`; `REACTION_SEEN` is `"👀"`;
-  `REACTION_REPLIED` is `"✍️"`; `REACTION_DONE` equals `REACTION_REPLIED`.
-- The transport receives exactly the reaction sequence
-  `[(12345, 8, "👍"), (12345, 8, "👀")]` — received and seen both react to
-  `message_id=12345`, `reply_to_message_id=8`.
-- If seen-reaction delivery fails, the seen step is **skipped** (no retry, no crash)
-  and the sequence stays `[(12345, 8, "👍")]`.
-- On reply, the state machine reacts `(12345, 8, "✍️")` — it reacts to the message
-  whose id is `_reply_to_message_id` (8), not to a separately sent message.
+- [ ] `REACTION_RECEIVED` is `[{type: "emoji", emoji: "👍"}]`; `REACTION_SEEN` is `"👀"`; `REACTION_REPLIED` is `"✍️"`; `REACTION_DONE` equals `REACTION_REPLIED`.
+- [ ] The transport receives exactly the reaction sequence `[(12345, 8, "👍"), (12345, 8, "👀")]` — received and seen both react to `message_id=12345`, `reply_to_message_id=8`.
+- [ ] If seen-reaction delivery fails, the seen step is **skipped** (no retry, no crash) and the sequence stays `[(12345, 8, "👍")]`.
+- [ ] On reply, the state machine reacts `(12345, 8, "✍️")` — it reacts to the message whose id is `_reply_to_message_id` (8), not to a separately sent message.
 
 ### Pass / Fail
 
-PASS when the reaction sequence and skip-on-delivery-failure match exactly; FAIL on any
-missing reaction, extra reaction, or a reply that sends instead of reacting.
-
-## Behavior C003 — Web canonical provider routing: default selection and hot config
-
-- **LABT id**: C003
-- **Title**: web search→browse canonical provider selection and hot-read settings
-- **Guards**: provider factories are stubbed; no network; env vars are managed per-case.
-- **Supersedes**: tests/test_web_canonical_provider_routing.py (CONVERT_BEHAVIOR)
-- **Runner**: pytest tests/test_web_canonical_provider_routing.py
-- **Prerequisites**: src/lingtai/tools/web_search/CONTRACT.md section
-  `#provider-ownership-and-routing`; tool name `web` per web_search CONTRACT.md.
-- **Estimate**: 30 minutes.
-
-### Steps
-
-1. Clear all provider env vars, then set `OPENAI_API_KEY` and call the `web` tool's
-   search provider selection.
-2. Clear `OPENAI_API_KEY` too, so no keys exist; select again.
-3. Set only `ANTHROPIC_API_KEY` (or `GEMINI_API_KEY`); select again.
-4. Write `settings/web.search.json` with `{"schema_version": 1, "engine": ...}` and
-   select again without restarting.
-
-### Expected evidence
-
-- With `OPENAI_API_KEY` set and nothing else: `engine == "openai"`,
-  `source == "built_in_default"`, and the factory tuple is
-  `("openai", api_key=<env value>, model=None)`.
-- With **no** keys: `engine == "duckduckgo"` (built-in default fallback).
-- With only anthropic/gemini keys: the corresponding engine is **available but
-  unselected**; `PROVIDERS["providers"]` is exactly
-  `{"duckduckgo", "gemini", "anthropic", "openai"}`.
-- Settings file present: selection re-reads it hot — `engine` matches the file, and
-  `source == "settings/web.search.json"` (relative to the working dir).
-- `minimax` and `zhipu` are retired: composing either raises `RetiredProviderError`
-  before any factory runs.
-
-## Behavior C004 — Web routing constraints, typed errors, and fallback
-
-- **LABT id**: C004
-- **Title**: settings-only/backend-gated providers, typed failures, DDG fallback,
-  link_ref extraction, browse independence
-- **Guards**: same as C003 (stubbed factories, managed env).
-- **Supersedes**: tests/test_web_canonical_provider_routing.py (CONVERT_BEHAVIOR)
-- **Runner**: pytest tests/test_web_canonical_provider_routing.py
-- **Prerequisites**: web_search CONTRACT.md `#provider-ownership-and-routing`.
-- **Estimate**: 30 minutes.
-
-### Steps
-
-1. Select anthropic/gemini via `settings/web.search.json` while the active backend is a
-   non-canonical one (`claude-code`, `openai`, `openrouter`, `custom`, or `codex`).
-2. Force each typed failure below and inspect the error envelope.
-3. Make OpenAI-only search fail, then fall back; inspect the fallback result.
-4. Call `web` browse with a URL and with an empty URL.
-
-### Expected evidence
-
-- **Backend-gated**: settings-selected anthropic/gemini on the non-canonical backends
-  listed above is refused with `error_code == "PROVIDER_BACKEND_INELIGIBLE"` (distinct
-  from `SettingsOnlyProviderError`).
-- **Typed errors**: provider failures surface as `error_code == "SEARCH_FAILED"` with a
-  `provider_failure_class` field carrying the provider's exception class; a non-provider
-  `TypeError` is **not** classified as `SEARCH_FAILED` and triggers **no** fallback.
-- **OpenAI-only DDG fallback**: when the sole configured provider (openai) fails, the
-  result is `actual_engine == "duckduckgo"` with `openai_failure_class` set; the result
-  contains no API keys or secrets.
-- **link_ref**: an item's `link_ref` is truthy iff its `url` is non-empty; items with an
-  empty URL are discarded, not returned with empty link_ref.
-- **manual**: `web` manual reports `current_setting.source == "not_applicable"` and an
-  `error_code` that is not `PROVIDER_BACKEND_INELIGIBLE`.
-- **Browse independence**: `web` browse does its own fetch and succeeds regardless of
-  provider selection or provider state.
-
-### Pass / Fail
-
-PASS when error codes, fallback engine, secrets-free results, link_ref, and browse
-independence all hold; FAIL on any wrong error code, secret leakage, or browse that
-inherits provider state.
-
-## Behavior C005 — File read continuation via next_offset pagination
-
-- **LABT id**: C005
-- **Title**: `file` read-only continuation, truncation caps, and next_offset semantics
-- **Guards**: operates on fixture files under tests/fixtures; never writes.
-- **Supersedes**: tests/test_read_continuation.py (CONVERT_BEHAVIOR)
-- **Runner**: pytest tests/test_read_continuation.py
-- **Prerequisites**: src/lingtai/tools/file/CONTRACT.md section
-  `#read-_readpy--read-only`; tool name `file-contract` per file CONTRACT.md.
-- **Estimate**: 20 minutes.
-
-### Steps
-
-1. Read a file larger than one page: `file(action=read, file_path=<fixture>,
-   offset=1, limit=null, max_chars=null)`.
-2. Take `next_offset` from the result and call read again with
-   `offset=<next_offset>, limit=null, max_chars=null`.
-3. Repeat with explicit `offset`/`limit` and with `max_chars` smaller than the page.
-4. Read a file containing one very long line.
-
-### Expected evidence
-
-- **Caps**: `DEFAULT_READ_CAP_CHARS == 100_000`, `READ_HARD_CAP_CHARS == 200_000`,
-  `PREVENTIVE_MAX_CHARS == 200_000`.
-- **First page**: when the file exceeds the cap, the result is truncated and reports
-  `next_offset == last_returned_line + 1`, plus `remaining_lines_estimate`,
-  `total_lines`, and `lines_shown`.
-- **Continuation**: reading with `offset == next_offset` starts exactly at that line
-  (no overlap, no gap) and again returns its own `next_offset` for the next page.
-- **Offset/limit**: explicit `offset` and `limit` are honored; a per-call `max_chars`
-  returns `cap_chars == <requested>` and `returned_chars <= cap_chars`.
-- **Single long line**: the line is truncated with `line_truncated: true`,
-  `last_returned_line == 1`, and `next_offset == 2`.
-- **Schema/description**: the read result schema mentions `max_chars`, `read-manual`,
-  `truncated`, `next_offset`, and `line_truncated`, and the limits are documented as
-  `100 000` and `200 000` (spaced thousands) in the tool description.
-
-### Pass / Fail
-
-PASS when pagination is gap-free and overlap-free, caps hold, and the long-line case
-reports exactly `last_returned_line == 1` / `next_offset == 2`; FAIL on any skipped or
-repeated line.
-
-## Behavior C006 — Feishu tool family LTP v2 envelope
-
-- **LABT id**: C006
-- **Title**: feishu LTP v2 envelope validation, child schemas, and flat dispatch
-- **Guards**: the feishu manager is a recording stub; no network; identity path is
-  `/tmp/identities.json`.
-- **Supersedes**: tests/test_feishu_toolfamily_ltpv2.py (CONVERT_BEHAVIOR)
-- **Runner**: pytest tests/test_feishu_toolfamily_ltpv2.py
-- **Prerequisites**: src/lingtai/tools/CONTRACT.md section `#envelope`;
-  src/lingtai/tools/feishu/_family.py and src/lingtai/tools/feishu/manager.py.
-- **Estimate**: 30 minutes.
-
-### Steps
-
-1. Call the feishu tool with 9 invalid envelope shapes (missing/unknown `action`,
-   wrong `payload` type, etc.).
-2. Call `feishu(action="accounts")` on a cold identity path.
-3. Exercise `send` (receive_id/text/body combinations), `remove_contact`, `manual`,
-   and each empty-input action.
-4. Inspect the generated child tool schemas for the family.
-
-### Expected evidence
-
-- **Actions**: `FEISHU_ACTIONS` is exactly
-  `("send", "check", "read", "reply", "react", "search", "delete", "edit",
-  "contacts", "add_contact", "remove_contact", "accounts", "manual")` — 13 actions.
-- **Envelope validation**: each of the 9 invalid shapes returns a `failed`-status result
-  **before** any manager I/O (the stub records zero calls for those inputs).
-- **accounts**: the valid call makes the manager receive exactly
-  `{"action": "accounts"}` and returns `{status: ok, accounts: [main], details, ...}`
-  with `identity_path == "/tmp/identities.json"`; the ltpv2 flat result equals the
-  family handle result.
-- **send**: requires `receive_id` with **text XOR content** (body); a payload with both
-  or neither is rejected.
-- **remove_contact**: accepts **exactly one** of `alias` / `open_id`; both or neither
-  is rejected.
-- **manual**: echoes the input verbatim or returns
-  `{status: ok, skill: "feishu-mcp-manual", manual: <str>}`.
-- **Child schemas**: `input` uses `anyOf` (not `oneOf`); `reasoning`/`summarize` never
-  appear in child schemas or handlers; scrub preserves `required`, the `action` enum,
-  `anyOf`/`allOf`, an `allOf` length of 13, and `additionalProperties: false`.
-- **Empty-input branches**: exactly `{check, contacts, accounts, manual}` succeed with
-  an empty payload.
-
-### Pass / Fail
-
-PASS when validation short-circuits before manager I/O, flat==ltpv2 for accounts, and
-child schemas match the scrub rules; FAIL on any manager call for invalid input, any
-schema drift (`oneOf`, leaked `reasoning`/`summarize`), or a wrong action count.
-
+PASS when the reaction sequence and skip-on-delivery-failure match exactly; FAIL on any missing reaction, extra reaction, or a reply that sends instead of reacting.

--- a/src/lingtai/tools/telegram/BEHAVIORS.md
+++ b/src/lingtai/tools/telegram/BEHAVIORS.md
@@ -1,0 +1,297 @@
+---
+name: telegram-behavior-tests
+behavior_version: 1
+labt_version: 1
+---
+
+related_files:
+  - src/lingtai/tools/telegram/manager.py
+  - src/lingtai/tools/telegram/SKILL.md
+  - src/lingtai/mcp_servers/telegram/task_card/CONTRACT.md
+  - src/lingtai/mcp_servers/telegram/task_card/ANATOMY.md
+  - src/lingtai/tools/feishu/_family.py
+  - src/lingtai/tools/feishu/manager.py
+  - src/lingtai/tools/web_search/CONTRACT.md
+  - src/lingtai/tools/web_search/__init__.py
+  - src/lingtai/tools/file/CONTRACT.md
+  - src/lingtai/tools/file/_read.py
+  - src/lingtai/tools/CONTRACT.md
+  - tests/test_telegram_task_card_last_message.py
+  - tests/test_telegram_reaction_states.py
+  - tests/test_web_canonical_provider_routing.py
+  - tests/test_read_continuation.py
+  - tests/test_feishu_toolfamily_ltpv2.py
+maintenance:
+  migrated: 2026-08
+  migration: CONVERT_BEHAVIOR from the five legacy test files listed above
+  note: src/lingtai/tools/telegram has no sibling CONTRACT.md yet; the Telegram
+    task-card contract lives at src/lingtai/mcp_servers/telegram/task_card/CONTRACT.md
+    and Telegram reaction semantics are guarded by src/lingtai/tools/telegram/SKILL.md
+---
+
+# LABT v1 behaviors — comms/channels family
+
+This file captures agent-observable behaviors for the comms/channels tool family in
+lingtai-kernel, converted from the five CONVERT_BEHAVIOR test files listed in the
+frontmatter. Every behavior below pins exact paths, tool names, commands, and expected
+values so a test harness can reproduce it verbatim. C001 covers the
+Telegram task-card projection, C002 covers Telegram reaction states, C003–C004 cover web
+canonical provider routing (search→browse), C005 covers file read continuation, and
+C006 covers the Feishu tool family LTP v2 envelope.
+
+## Behavior C001 — Telegram task card: edit-in-place vs supersede by last message
+
+- **LABT id**: C001
+- **Title**: Telegram task-card last-message semantics (edit-in-place, rotation, failure paths)
+- **Guards**: test only runs with the telegram task-card fake transport; no network.
+- **Supersedes**: tests/test_telegram_task_card_last_message.py (CONVERT_BEHAVIOR)
+- **Runner**: pytest tests/test_telegram_task_card_last_message.py
+- **Prerequisites**: repo checkout with src/lingtai/mcp_servers/telegram/task_card.
+- **Estimate**: 20 minutes.
+
+### Steps
+
+1. Start from a cold state (no resident task-card message).
+2. Update the task card with `taskcard_update(draft="old text")`; note the resulting
+   resident message id (compound id `mybot:55:100`).
+3. Update again with `taskcard_update(draft="new text")` while the previous message is
+   still the last one the bot sent.
+4. Send a user message (user msg id `200`), then update the card again.
+5. Force the bot to send an unrelated message (bot reply id `101`), then update again.
+6. Rotate the resident card to a fresh message id (`mybot:55:201`), then update again.
+7. Run the cold-state and failure-path scenarios below.
+
+### Expected evidence
+
+- **Edit-in-place**: when the resident task-card message is still the last message, the
+  update result is `{status: ok, message_id: <same id>}` and exactly **1 send, 0 delete**
+  transport calls occur.
+- **Supersede by user message**: a user message after the resident card means the card is
+  no longer "last"; the update rotates the card — the old resident message (`mybot:55:100`)
+  is deleted and a new card is sent.
+
+- **Rotation call order** (user msg id `200` case): transport sees exactly
+  `edit(55, 100, <committed old text>)` → `delete(55, 100)` → `send(55, 201, <new text>)`
+  with compound ids `mybot:55:100` / `mybot:55:201`; the rotation happens **before** the
+  new send, so the card is never duplicated.
+- **Supersede by bot message**: a bot reply (`mybot:55:101`) between the card and the
+  update also rotates: `delete(55, 100)` → `send(55, 301, <new text>)`.
+- **Rotation failure paths** (each returns `{status: ok, taskcard: false}` and a distinct
+  marker): old resident already gone → `old_resident_deleted`; delete raises →
+  `stale_delete_failed`; send raises after rotation → `indeterminate_send`; persist of
+  the new resident fails → `resident_persist_failed`. Suppressed updates return
+  `{status: ok, suppressed: true, taskcard: false}`.
+- **Malformed send ids** (e.g. `no-colon-id`, `just:one`) are never adopted as the new
+  resident; the update is suppressed.
+- **Concurrency**: the task-card manager serializes rotation; only one in-flight rotation
+  is allowed (`max_active == 1`).
+
+### Pass / Fail
+
+PASS when all evidence above holds; FAIL on any extra send/delete, any wrong id, or any
+missing failure marker.
+
+## Behavior C002 — Telegram reaction states (received → seen → replied)
+
+- **LABT id**: C002
+- **Title**: Telegram reaction state transitions and reply-vs-send semantics
+- **Guards**: fake telegram transport; reactions never hit the network.
+- **Supersedes**: tests/test_telegram_reaction_states.py (CONVERT_BEHAVIOR)
+- **Runner**: pytest tests/test_telegram_reaction_states.py
+- **Prerequisites**: src/lingtai/tools/telegram/SKILL.md section `#reply-vs-send`
+  (the guard for reply-vs-send until a telegram root contract exists).
+- **Estimate**: 15 minutes.
+
+### Steps
+
+1. Deliver a user message with `message_id=12345` that mentions a tool call with
+   `reply_to_message_id=8`.
+2. Let the handler run the received → seen → replied state machine.
+
+### Expected evidence
+
+- `REACTION_RECEIVED` is `[{type: "emoji", emoji: "👍"}]`; `REACTION_SEEN` is `"👀"`;
+  `REACTION_REPLIED` is `"✍️"`; `REACTION_DONE` equals `REACTION_REPLIED`.
+- The transport receives exactly the reaction sequence
+  `[(12345, 8, "👍"), (12345, 8, "👀")]` — received and seen both react to
+  `message_id=12345`, `reply_to_message_id=8`.
+- If seen-reaction delivery fails, the seen step is **skipped** (no retry, no crash)
+  and the sequence stays `[(12345, 8, "👍")]`.
+- On reply, the state machine reacts `(12345, 8, "✍️")` — it reacts to the message
+  whose id is `_reply_to_message_id` (8), not to a separately sent message.
+
+### Pass / Fail
+
+PASS when the reaction sequence and skip-on-delivery-failure match exactly; FAIL on any
+missing reaction, extra reaction, or a reply that sends instead of reacting.
+
+## Behavior C003 — Web canonical provider routing: default selection and hot config
+
+- **LABT id**: C003
+- **Title**: web search→browse canonical provider selection and hot-read settings
+- **Guards**: provider factories are stubbed; no network; env vars are managed per-case.
+- **Supersedes**: tests/test_web_canonical_provider_routing.py (CONVERT_BEHAVIOR)
+- **Runner**: pytest tests/test_web_canonical_provider_routing.py
+- **Prerequisites**: src/lingtai/tools/web_search/CONTRACT.md section
+  `#provider-ownership-and-routing`; tool name `web` per web_search CONTRACT.md.
+- **Estimate**: 30 minutes.
+
+### Steps
+
+1. Clear all provider env vars, then set `OPENAI_API_KEY` and call the `web` tool's
+   search provider selection.
+2. Clear `OPENAI_API_KEY` too, so no keys exist; select again.
+3. Set only `ANTHROPIC_API_KEY` (or `GEMINI_API_KEY`); select again.
+4. Write `settings/web.search.json` with `{"schema_version": 1, "engine": ...}` and
+   select again without restarting.
+
+### Expected evidence
+
+- With `OPENAI_API_KEY` set and nothing else: `engine == "openai"`,
+  `source == "built_in_default"`, and the factory tuple is
+  `("openai", api_key=<env value>, model=None)`.
+- With **no** keys: `engine == "duckduckgo"` (built-in default fallback).
+- With only anthropic/gemini keys: the corresponding engine is **available but
+  unselected**; `PROVIDERS["providers"]` is exactly
+  `{"duckduckgo", "gemini", "anthropic", "openai"}`.
+- Settings file present: selection re-reads it hot — `engine` matches the file, and
+  `source == "settings/web.search.json"` (relative to the working dir).
+- `minimax` and `zhipu` are retired: composing either raises `RetiredProviderError`
+  before any factory runs.
+
+## Behavior C004 — Web routing constraints, typed errors, and fallback
+
+- **LABT id**: C004
+- **Title**: settings-only/backend-gated providers, typed failures, DDG fallback,
+  link_ref extraction, browse independence
+- **Guards**: same as C003 (stubbed factories, managed env).
+- **Supersedes**: tests/test_web_canonical_provider_routing.py (CONVERT_BEHAVIOR)
+- **Runner**: pytest tests/test_web_canonical_provider_routing.py
+- **Prerequisites**: web_search CONTRACT.md `#provider-ownership-and-routing`.
+- **Estimate**: 30 minutes.
+
+### Steps
+
+1. Select anthropic/gemini via `settings/web.search.json` while the active backend is a
+   non-canonical one (`claude-code`, `openai`, `openrouter`, `custom`, or `codex`).
+2. Force each typed failure below and inspect the error envelope.
+3. Make OpenAI-only search fail, then fall back; inspect the fallback result.
+4. Call `web` browse with a URL and with an empty URL.
+
+### Expected evidence
+
+- **Backend-gated**: settings-selected anthropic/gemini on the non-canonical backends
+  listed above is refused with `error_code == "PROVIDER_BACKEND_INELIGIBLE"` (distinct
+  from `SettingsOnlyProviderError`).
+- **Typed errors**: provider failures surface as `error_code == "SEARCH_FAILED"` with a
+  `provider_failure_class` field carrying the provider's exception class; a non-provider
+  `TypeError` is **not** classified as `SEARCH_FAILED` and triggers **no** fallback.
+- **OpenAI-only DDG fallback**: when the sole configured provider (openai) fails, the
+  result is `actual_engine == "duckduckgo"` with `openai_failure_class` set; the result
+  contains no API keys or secrets.
+- **link_ref**: an item's `link_ref` is truthy iff its `url` is non-empty; items with an
+  empty URL are discarded, not returned with empty link_ref.
+- **manual**: `web` manual reports `current_setting.source == "not_applicable"` and an
+  `error_code` that is not `PROVIDER_BACKEND_INELIGIBLE`.
+- **Browse independence**: `web` browse does its own fetch and succeeds regardless of
+  provider selection or provider state.
+
+### Pass / Fail
+
+PASS when error codes, fallback engine, secrets-free results, link_ref, and browse
+independence all hold; FAIL on any wrong error code, secret leakage, or browse that
+inherits provider state.
+
+## Behavior C005 — File read continuation via next_offset pagination
+
+- **LABT id**: C005
+- **Title**: `file` read-only continuation, truncation caps, and next_offset semantics
+- **Guards**: operates on fixture files under tests/fixtures; never writes.
+- **Supersedes**: tests/test_read_continuation.py (CONVERT_BEHAVIOR)
+- **Runner**: pytest tests/test_read_continuation.py
+- **Prerequisites**: src/lingtai/tools/file/CONTRACT.md section
+  `#read-_readpy--read-only`; tool name `file-contract` per file CONTRACT.md.
+- **Estimate**: 20 minutes.
+
+### Steps
+
+1. Read a file larger than one page: `file(action=read, file_path=<fixture>,
+   offset=1, limit=null, max_chars=null)`.
+2. Take `next_offset` from the result and call read again with
+   `offset=<next_offset>, limit=null, max_chars=null`.
+3. Repeat with explicit `offset`/`limit` and with `max_chars` smaller than the page.
+4. Read a file containing one very long line.
+
+### Expected evidence
+
+- **Caps**: `DEFAULT_READ_CAP_CHARS == 100_000`, `READ_HARD_CAP_CHARS == 200_000`,
+  `PREVENTIVE_MAX_CHARS == 200_000`.
+- **First page**: when the file exceeds the cap, the result is truncated and reports
+  `next_offset == last_returned_line + 1`, plus `remaining_lines_estimate`,
+  `total_lines`, and `lines_shown`.
+- **Continuation**: reading with `offset == next_offset` starts exactly at that line
+  (no overlap, no gap) and again returns its own `next_offset` for the next page.
+- **Offset/limit**: explicit `offset` and `limit` are honored; a per-call `max_chars`
+  returns `cap_chars == <requested>` and `returned_chars <= cap_chars`.
+- **Single long line**: the line is truncated with `line_truncated: true`,
+  `last_returned_line == 1`, and `next_offset == 2`.
+- **Schema/description**: the read result schema mentions `max_chars`, `read-manual`,
+  `truncated`, `next_offset`, and `line_truncated`, and the limits are documented as
+  `100 000` and `200 000` (spaced thousands) in the tool description.
+
+### Pass / Fail
+
+PASS when pagination is gap-free and overlap-free, caps hold, and the long-line case
+reports exactly `last_returned_line == 1` / `next_offset == 2`; FAIL on any skipped or
+repeated line.
+
+## Behavior C006 — Feishu tool family LTP v2 envelope
+
+- **LABT id**: C006
+- **Title**: feishu LTP v2 envelope validation, child schemas, and flat dispatch
+- **Guards**: the feishu manager is a recording stub; no network; identity path is
+  `/tmp/identities.json`.
+- **Supersedes**: tests/test_feishu_toolfamily_ltpv2.py (CONVERT_BEHAVIOR)
+- **Runner**: pytest tests/test_feishu_toolfamily_ltpv2.py
+- **Prerequisites**: src/lingtai/tools/CONTRACT.md section `#envelope`;
+  src/lingtai/tools/feishu/_family.py and src/lingtai/tools/feishu/manager.py.
+- **Estimate**: 30 minutes.
+
+### Steps
+
+1. Call the feishu tool with 9 invalid envelope shapes (missing/unknown `action`,
+   wrong `payload` type, etc.).
+2. Call `feishu(action="accounts")` on a cold identity path.
+3. Exercise `send` (receive_id/text/body combinations), `remove_contact`, `manual`,
+   and each empty-input action.
+4. Inspect the generated child tool schemas for the family.
+
+### Expected evidence
+
+- **Actions**: `FEISHU_ACTIONS` is exactly
+  `("send", "check", "read", "reply", "react", "search", "delete", "edit",
+  "contacts", "add_contact", "remove_contact", "accounts", "manual")` — 13 actions.
+- **Envelope validation**: each of the 9 invalid shapes returns a `failed`-status result
+  **before** any manager I/O (the stub records zero calls for those inputs).
+- **accounts**: the valid call makes the manager receive exactly
+  `{"action": "accounts"}` and returns `{status: ok, accounts: [main], details, ...}`
+  with `identity_path == "/tmp/identities.json"`; the ltpv2 flat result equals the
+  family handle result.
+- **send**: requires `receive_id` with **text XOR content** (body); a payload with both
+  or neither is rejected.
+- **remove_contact**: accepts **exactly one** of `alias` / `open_id`; both or neither
+  is rejected.
+- **manual**: echoes the input verbatim or returns
+  `{status: ok, skill: "feishu-mcp-manual", manual: <str>}`.
+- **Child schemas**: `input` uses `anyOf` (not `oneOf`); `reasoning`/`summarize` never
+  appear in child schemas or handlers; scrub preserves `required`, the `action` enum,
+  `anyOf`/`allOf`, an `allOf` length of 13, and `additionalProperties: false`.
+- **Empty-input branches**: exactly `{check, contacts, accounts, manual}` succeed with
+  an empty payload.
+
+### Pass / Fail
+
+PASS when validation short-circuits before manager I/O, flat==ltpv2 for accounts, and
+child schemas match the scrub rules; FAIL on any manager call for invalid input, any
+schema drift (`oneOf`, leaked `reasoning`/`summarize`), or a wrong action count.
+

--- a/src/lingtai/tools/tool_family/ANATOMY.md
+++ b/src/lingtai/tools/tool_family/ANATOMY.md
@@ -1,5 +1,6 @@
 ---
 related_files:
+  - BEHAVIORS.md
   - src/lingtai/tools/tool_family/CONTRACT.md
   - src/lingtai/tools/ANATOMY.md
   - src/lingtai/tools/CONTRACT.md

--- a/src/lingtai/tools/tool_family/BEHAVIORS.md
+++ b/src/lingtai/tools/tool_family/BEHAVIORS.md
@@ -1,7 +1,7 @@
 ---
 name: tool-family-behavior-tests
 behavior_version: 1
-labt_version: 1
+labt_version: 2
 contract: CONTRACT.md
 anatomy: ANATOMY.md
 related_files:
@@ -331,7 +331,7 @@ no `.rules` file and no ledger record.
   empty input, and the canonical `content[0].text` /
   `structuredContent.manual_path` result — returned verbatim by dispatch, with
   any family-specific flat shape adapted only in that family's Host layer
-- **guards**: `tool-family-contract` § Contract rules — `build_manual_child`
+- **guards**: `tool-family` § Contract rules — `build_manual_child`
   ([CONTRACT.md](CONTRACT.md#contract-rules))
 - **supersedes**: `tests/test_tool_family_manual_contract.py`
 - **runner**: any LingTai agent with the `file` and `avatar` tools
@@ -378,7 +378,7 @@ second time, or a manual call performs any target I/O.
 - **title**: `psyche` routes `pad | lingtai | knowledge | skills | manual` to
   five distinct installed manuals, performs no mutation or catalog scan, and
   rejects every retired action and every `input` key
-- **guards**: `psyche-contract` § Port (action inventory) / § Behavior
+- **guards**: `psyche-tool-contract` § Port (action inventory) / § Behavior
   ([CONTRACT.md](../psyche/CONTRACT.md#port))
 - **supersedes**: `tests/test_psyche_family.py` (inventory, routing,
   read-only, and retired-root tests)

--- a/src/lingtai/tools/tool_family/BEHAVIORS.md
+++ b/src/lingtai/tools/tool_family/BEHAVIORS.md
@@ -1,0 +1,560 @@
+---
+name: tool-family-behavior-tests
+behavior_version: 1
+labt_version: 1
+contract: CONTRACT.md
+anatomy: ANATOMY.md
+related_files:
+  - src/lingtai/tools/tool_family/__init__.py
+  - src/lingtai/tools/tool_family/manual.py
+  - src/lingtai/tools/file/CONTRACT.md
+  - src/lingtai/tools/avatar/CONTRACT.md
+  - src/lingtai/tools/psyche/CONTRACT.md
+  - src/lingtai/tools/mcp/CONTRACT.md
+  - src/lingtai/tools/email/CONTRACT.md
+  - tests/test_file_tool_family.py
+  - tests/test_tool_family_avatar_migration.py
+  - tests/test_tool_family_manual_contract.py
+  - tests/test_psyche_family.py
+  - tests/test_mcp_identity_discovery.py
+  - tests/test_email_abs_reply_route.py
+maintenance: |
+  Written by the tool-family CONVERT_BEHAVIOR migration (2026-08). Keep in
+  sync with the CONTRACT.md clauses this file guards and the ANATOMY.md entries
+  for the generic ChildTool/ToolFamily infrastructure and the migrating
+  families (file, avatar, psyche, mcp, email). When a guarded contract changes
+  in a way that affects agent-observable behavior (envelope errors, receipts,
+  manual result shape, identity projection, reply routing), update the matching
+  LABT here in the same change. Each LABT is self-contained: an agent executes
+  it verbatim with only the tools it names, never by opening another file.
+---
+# ToolFamily Behavior Tests
+
+LABT v1. These are self-contained agent-executable behavioral tests for the
+families built on the generic `src/lingtai/tools/tool_family/` infrastructure.
+They prove the *observable* promises of the family contracts this package
+serves: the `file` read/write/edit surface and its fail-closed envelope, the
+`avatar` spawn/rules/manual migration envelope, the reserved `manual` child's
+canonical result contract (no double wrap), the `psyche` five-domain manual
+router (pad + lingtai + knowledge + skills = psyche), `mcp` identity
+discovery with secret-safe projection, and `email` abs-mode reply routing with
+the #145 ambiguity guard. Low-level mechanics stay in pytest; each LABT below
+is executable verbatim by an agent with the tools it names.
+
+## Behavior T001 — file write/edit receipts are verbatim and mutating
+
+- **id**: T001
+- **title**: `file` write and edit return their own canonical receipts, apply
+  real mutations, and refuse ambiguous or absent edits without touching the file
+- **guards**: `file-contract` § Per-action behavior — write/edit
+  ([CONTRACT.md](../file/CONTRACT.md#per-action-behavior))
+- **supersedes**: `tests/test_file_tool_family.py` (write/edit receipt,
+  replace_all, and per-action error tests)
+- **runner**: any LingTai agent with the `file` tool
+- **prerequisites**: a scratch dir under your working dir (`<wd>`); no other
+  setup needed
+- **estimate**: 2 min
+
+### Steps
+1. Call `file(action="write", input={"file_path": "<wd>/scratch/a.txt",
+   "content": "one\ntwo\n"}, reasoning="...")`. Record the returned receipt.
+2. Call `file(action="read", input={"file_path": "<wd>/scratch/a.txt"},
+   reasoning="...")` and compare the file content with the written text.
+3. Call `file(action="edit", input={"file_path": "<wd>/scratch/a.txt",
+   "old_string": "two", "new_string": "2", "replace_all": null},
+   reasoning="...")`, then read the file back.
+4. Write `"x x x\n"` to `<wd>/scratch/many.txt`, then edit with
+   `old_string: "x"`, `new_string: "y"`, `replace_all: true`, and read back.
+5. Write `"dup dup\n"` to `<wd>/scratch/ambig.txt`, then edit
+   `old_string: "dup"`, `new_string: "x"` WITHOUT `replace_all`. Read the
+   returned result and then read the file back.
+6. On the same file, edit `old_string: "absent"`, `new_string: "x"` and read
+   the result.
+
+### Expected evidence
+- [ ] Step 1 returns exactly `{"status": "ok", "path": "<abs path of
+      scratch/a.txt>", "bytes": 8}` (bytes = UTF-8 length of `"one\ntwo\n"`).
+- [ ] Step 2 shows the file content is exactly `one\ntwo\n` (parent dirs were
+      created by write; the write mutated the tree).
+- [ ] Step 3 returns `{"status": "ok", "replacements": 1}` and the file now
+      reads `one\n2\n`.
+- [ ] Step 4 returns `{"status": "ok", "replacements": 3}` and the file now
+      reads `y y y\n` (replace_all counts every replacement).
+- [ ] Step 5 returns `{"status": "error", "message": "old_string found 2
+      times — use replace_all=true or provide more context"}` and the file
+      still reads `dup dup\n` (ambiguous edit mutates nothing).
+- [ ] Step 6 returns `{"status": "error", "message": "old_string not found in
+      <wd>/scratch/ambig.txt"}` and the file is still unchanged.
+- [ ] `file(action="read", input={})` and `file(action="write",
+      input={"file_path": "x"})` report `file_path is required` / `content is
+      required`; reading a missing path reports `File not found: <path>`.
+
+### Pass / Fail
+Pass when every evidence item holds. Fail if a receipt is wrapped in an extra
+envelope, a mutating call reports ok without changing the file, or an
+ambiguous/zero-match edit modifies the file. Forbidden side effect: a failed
+edit must never partially apply.
+
+## Behavior T002 — file read returns a numbered window with truthful truncation
+
+- **id**: T002
+- **title**: `file` read returns `cat -n`-style numbered lines and honest
+  continuation/line-truncation facts so a caller can page to the end
+- **guards**: `file-contract` § Per-action behavior — read
+  ([CONTRACT.md](../file/CONTRACT.md#per-action-behavior))
+- **supersedes**: `tests/test_file_tool_family.py` (read continuation and
+  line-truncation tests)
+- **runner**: any LingTai agent with the `file` tool
+- **prerequisites**: a scratch dir under `<wd>`
+- **estimate**: 2 min
+
+### Steps
+1. Write `<wd>/scratch/n.txt` with content `alpha\nbeta\n`, then call
+   `file(action="read", input={"file_path": "<wd>/scratch/n.txt"},
+   reasoning="...")`.
+2. Write `<wd>/scratch/big.txt` containing 20 lines `line0\n` .. `line19\n`,
+   then call read with `input={"file_path": "<wd>/scratch/big.txt",
+   "max_chars": 30}`. Record `next_offset` from the result, then call read
+   again with `input={"file_path": "<wd>/scratch/big.txt", "offset":
+   <next_offset>}`.
+3. Write `<wd>/scratch/long.txt` with content `"z" * 500 + "\nnext\n"`, then
+   call read with `max_chars: 50`.
+4. Write `<wd>/scratch/win.txt` with `L0\n` .. `L9\n`, then call read with
+   `input={"file_path": "<wd>/scratch/win.txt", "offset": 3, "limit": 2}`.
+
+### Expected evidence
+- [ ] Step 1: `content == "1\talpha\n2\tbeta\n"`, `total_lines == 2`,
+      `lines_shown == 2`, and no `truncated` key (defaults: offset 1, limit
+      2000, max_chars 100 000).
+- [ ] Step 2 first call: `truncated == true`, `cap_chars == 30`,
+      `requested_offset == 1`, `remaining_lines_estimate > 0`, no
+      `line_truncated`, and `next_offset` present; the resumed call's `content`
+      starts with `"<next_offset>\t"` and carries no `truncated` key.
+- [ ] Step 3: `truncated == true`, `line_truncated == true`, the returned
+      `content` is exactly 50 chars (a bounded prefix), and `next_offset == 2`
+      (the hidden tail of the over-cap line is NOT recoverable; the next page
+      starts at the next physical line).
+- [ ] Step 4: `content == "3\tL2\n4\tL3\n"` and `total_lines == 10` (offset
+      and limit select the window).
+
+### Pass / Fail
+Pass when every evidence item holds. Fail if line numbers are wrong, a
+mid-file cap omits the continuation fields, or a page falsely claims to be
+complete when it is truncated. Forbidden side effect: read must never mutate
+the file or any state.
+
+## Behavior T003 — file envelope is fail-closed before I/O; manual is no-I/O
+
+- **id**: T003
+- **title**: `file` rejects unknown actions, cross-action input, malformed
+  envelope fields, and non-empty manual input before any handler I/O, and
+  `manual` returns the canonical body+path with no side effects
+- **guards**: `file-contract` § Tool surface / § Manual / § Risk posture
+  ([CONTRACT.md](../file/CONTRACT.md#tool-surface))
+- **supersedes**: `tests/test_file_tool_family.py` (envelope, rejection, and
+  manual tests)
+- **runner**: any LingTai agent with the `file` tool
+- **prerequisites**: a scratch dir under `<wd>`
+- **estimate**: 2 min
+
+### Steps
+1. List every file under `<wd>` with `file(action="glob", input={"pattern":
+   "**/*", "path": "<wd>"}, reasoning="...")` and record the match set.
+2. Call `file(action="delete", input={}, reasoning="...")` (unknown action).
+3. Call `file(action="read", input={"file_path": "x", "offset": null,
+   "limit": null, "max_chars": null, "content": "smuggled"},
+   reasoning="...")` (a key from another action's branch).
+4. Call `file(action="read", input="not-an-object", reasoning="...")`, then
+   `file(action="manual", input={}, reasoning="...", parameters={})`, then
+   `file(action="manual", input={}, reasoning="...", summarize="yes")`.
+5. Call `file(action="manual", input={}, reasoning="...")`. From the result,
+   record `structuredContent.manual_path`, then read that exact path with the
+   `file` tool and compare it with `content[0].text`.
+6. Call `file(action="manual", input={"file_path": "/etc/passwd"},
+   reasoning="...")`, then list every file under `<wd>` again.
+
+### Expected evidence
+- [ ] Step 2 returns `{"status": "failed", "error_code": "ACTION_REQUIRED",
+      "message": "action must be one of read, write, edit, glob, grep,
+      manual"}`.
+- [ ] Step 3 returns `{"status": "failed", "error_code": "INVALID_ARGUMENT",
+      "message": "unsupported file input field"}` and no read/write/glob/grep
+      I/O ran (the smuggled `content` never reached a handler).
+- [ ] Step 4: non-object `input` and the unknown root field `parameters` fail
+      with `error_code: "INVALID_ARGUMENT"`; `summarize: "yes"` fails with
+      `error_code: "INVALID_ARGUMENT"` and `message: "summarize must be a
+      boolean"`.
+- [ ] Step 5: the manual result has exactly the keys `status`, `content`,
+      `structuredContent`; `status == "ok"`; `content[0].text` is the full
+      body and starts with `name: file-manual`; `structuredContent.manual_path`
+      ends with `capabilities/file-manual/SKILL.md`; the file at that path
+      equals the body (the dispatched result is the canonical child result,
+      verbatim, no double wrap).
+- [ ] Step 6: any non-empty manual `input` fails with
+      `error_code: "INVALID_ARGUMENT"` (strict empty input), and the glob
+      match set is identical to step 1 (manual performed no target I/O).
+
+### Pass / Fail
+Pass when every evidence item holds. Fail if an envelope error is missing, a
+cross-action key reaches a handler, or `manual` reads/writes any file other
+than its own manual. Forbidden side effect: any rejected call must leave the
+tree untouched.
+
+## Behavior T004 — avatar spawn envelope: dry-run, mission gate, receipts
+
+- **id**: T004
+- **title**: `avatar` spawn exposes dry-run, the mission-quality gate, name
+  validation, a verbatim `ok` receipt plus ledger, never requires admin, and
+  preserves the exact unknown/omitted-action error envelope
+- **guards**: `avatar-contract` § Tool surface / § Invalid or missing
+  `action` / § State & storage
+  ([CONTRACT.md](../avatar/CONTRACT.md#tool-surface))
+- **supersedes**: `tests/test_tool_family_avatar_migration.py` (schema,
+  dispatch, spawn-envelope, and manual tests)
+- **runner**: any LingTai agent with the `avatar` capability (no admin needed
+  — spawning never checks admin)
+- **prerequisites**: a parent agent working dir (`<wd>`) whose parent
+  `<network-root>` is writable (avatars are siblings of the parent: the avatar
+  dir is `<network-root>/<avatar-name>`); `init.json` exists in `<wd>`; a
+  fresh avatar name `helper` must not already exist
+- **estimate**: 3 min (includes one real spawn; boot may report `slow`)
+
+### Steps
+1. Call `avatar(action="spawn", input={"name": "helper", "dry_run": true},
+   reasoning="Investigate the heartbeat regression and report back")`.
+2. Call `avatar(action="spawn", input={"name": "helper"}, reasoning="test")`
+   (a 4-char mission) and read the result.
+3. Call `avatar(action="spawn", input={"name": "helper", "confirm": true},
+   reasoning="test")`. Record the receipt, then check
+   `<network-root>/helper/init.json`, `<network-root>/helper/.prompt`, and
+   `<wd>/delegates/ledger.jsonl`.
+4. Call `avatar(action="spawn", input={"name": "../evil", "confirm": true},
+   reasoning="a genuine mission brief, long enough to pass")` and repeat with
+   `name: "a" * 65`.
+5. Call `avatar(action="bogus", input={}, reasoning="...")` and then
+   `avatar(input={"name": "x", "confirm": true}, reasoning="...")` with the
+   `action` key omitted entirely.
+6. Call `avatar(action="spawn", input={"name": "x", "rules_content": "no"},
+   reasoning="a genuine mission brief, long enough to pass")` (a key from the
+   `rules` branch smuggled into spawn input) and then
+   `avatar(action="spawn", input={"name": "x", "confirm": true},
+   reasoning="...", summarize="yes")`.
+7. Call `avatar(action="manual", input={}, reasoning="...")`; record
+   `manual_path` and compare `manual` with the packaged file
+   `src/lingtai/tools/avatar/manual/SKILL.md`.
+
+### Expected evidence
+- [ ] Step 1 returns `{"status": "dry_run", "preview": {...}}` with
+      `preview.name == "helper"`, `preview.type == "shallow"`, and
+      `preview.mission` containing the reasoning; no `<network-root>/helper`
+      dir and no `<wd>/delegates/ledger.jsonl` were created.
+- [ ] Step 2 returns `{"status": "confirmation_needed", ...}` whose `warning`
+      contains `confirm=true`; nothing was launched and no avatar dir exists.
+- [ ] Step 3 returns `{"status": "ok", "address": "helper", "agent_name":
+      "helper", "type": "shallow", "pid": <int>, ...}` (a `warning` key is
+      allowed when boot is slow); `<network-root>/helper/init.json` exists;
+      `<network-root>/helper/.prompt` contains the reasoning text; the ledger
+      contains a record with `event: "avatar"`, `name: "helper"`, and
+      `boot_status: "ok"`.
+- [ ] Step 4: both unsafe names return an `error` and no avatar dir was
+      created (names must match `^[\w-]+$`, be ≤64 chars, with no dot, slash,
+      or leading `.`).
+- [ ] Step 5 returns exactly `{"error": "unknown action: 'bogus', only
+      'spawn', 'rules', or 'manual' is supported"}` and `{"error": "unknown
+      action: '', only 'spawn', 'rules', or 'manual' is supported"}` for the
+      omitted case — no spawn, no ledger, no process.
+- [ ] Step 6: the cross-action key fails with `{"status": "failed",
+      "error_code": "INVALID_ARGUMENT", "message": "unsupported avatar input
+      field"}` before any I/O, and `summarize: "yes"` fails with
+      `INVALID_ARGUMENT` before any spawn.
+- [ ] Step 7 returns `{"status": "ok", "action": "manual", "manual":
+      "<exact body>", "manual_path": "<host path>"}`; `manual` equals the
+      packaged SKILL.md body; the result has no `content`/`structuredContent`
+      keys (avatar owns its own manual child; nothing is double-wrapped).
+
+### Pass / Fail
+Pass when every evidence item holds. Fail if a dry-run or guarded call
+launches a process, a guarded mission spawns without `confirm`, an unsafe
+name is accepted, `action`-less payload is inferred as `spawn`, or the
+manual result is wrapped. Forbidden side effect: any failed spawn must leave
+no avatar dir, no ledger record, and no live process.
+
+## Behavior T005 — avatar rules gate: authorization and distribution
+
+- **id**: T005
+- **title**: `avatar` rules requires admin.karma, writes the `.rules` signal,
+  and distributes to the caller — with cross-action keys rejected before
+  authorization
+- **guards**: `avatar-contract` § Tool surface — rules
+  ([CONTRACT.md](../avatar/CONTRACT.md#tool-surface))
+- **supersedes**: `tests/test_tool_family_avatar_migration.py` (rules tests);
+  the no-admin refusal path stays covered by
+  `tests/test_avatar_rules.py::test_rules_requires_admin`
+- **runner**: an agent with the `avatar` capability whose `admin` block
+  includes at least one truthy privilege (e.g. `admin: {"karma": true}`)
+- **prerequisites**: `<wd>` writable; no `<wd>/.rules` file before the run
+- **estimate**: 1 min
+
+### Steps
+1. Call `avatar(action="rules", input={"rules_content": "   "},
+   reasoning="...")` (whitespace-only content) and check whether
+   `<wd>/.rules` exists.
+2. Call `avatar(action="rules", input={"rules_content": "Be concise.",
+   "name": "helper"}, reasoning="...")` (a spawn-branch key smuggled into
+   rules input), then check `<wd>/.rules` again.
+3. Call `avatar(action="rules", input={"rules_content": "Be concise."},
+   reasoning="...")`; read `<wd>/.rules` and the returned `distributed_to`.
+4. Call `avatar(action="manual", input={}, reasoning="...")` once more and
+   list `<wd>` before/after to confirm no spawn or rules side effect.
+
+### Expected evidence
+- [ ] Step 1 returns an `error` (empty `rules_content`) and no `.rules` file
+      was written.
+- [ ] Step 2 returns `{"status": "failed", "error_code": "INVALID_ARGUMENT",
+      "message": "unsupported avatar input field"}` and no `.rules` file was
+      written (rejected before the authorization check and before any write).
+- [ ] Step 3 returns `{"status": "ok", "message": ..., "distributed_to":
+      [<your agent name>]}` and `<wd>/.rules` contains exactly `Be concise.`
+- [ ] Step 4: the manual result is the same no-I/O flat shape as T004 step 7
+      and the file listing is unchanged.
+
+### Pass / Fail
+Pass when every evidence item holds. Fail if rules are written without
+content, a cross-action key passes dispatch, or the `.rules` self signal is
+missing on success. Forbidden side effect: a rejected rules call must write
+no `.rules` file and no ledger record.
+
+## Behavior T006 — manual action contract: canonical result, no double wrap
+
+- **id**: T006
+- **title**: the family-owned `manual` child uses the reserved name, strict
+  empty input, and the canonical `content[0].text` /
+  `structuredContent.manual_path` result — returned verbatim by dispatch, with
+  any family-specific flat shape adapted only in that family's Host layer
+- **guards**: `tool-family-contract` § Contract rules — `build_manual_child`
+  ([CONTRACT.md](CONTRACT.md#contract-rules))
+- **supersedes**: `tests/test_tool_family_manual_contract.py`
+- **runner**: any LingTai agent with the `file` and `avatar` tools
+- **prerequisites**: `<wd>` and the `file`/`avatar` capabilities; no other
+  setup (the generic manual child is exercised through `file`, the
+  self-owned manual child through `avatar`)
+- **estimate**: 1 min
+
+### Steps
+1. Call `file(action="manual", input={}, reasoning="...")`; record `status`,
+   `content[0].text`, and `structuredContent.manual_path`; read the path with
+   `file(action="read", ...)`.
+2. Call `file(action="manual", input={"file_path": "/etc/passwd"},
+   reasoning="...")` and `avatar(action="manual", input={"name": "x"},
+   reasoning="...")`.
+3. Call `avatar(action="manual", input={}, reasoning="...")` and compare its
+   `manual` field with the packaged `src/lingtai/tools/avatar/manual/SKILL.md`.
+
+### Expected evidence
+- [ ] Step 1: `status == "ok"`; the result keys are exactly `status`,
+      `content`, `structuredContent`; `content[0].text` is the full
+      `file-manual` body (`name: file-manual` frontmatter) and equals the file
+      read from `structuredContent.manual_path`; the path ends with
+      `capabilities/file-manual/SKILL.md`.
+- [ ] Step 2: every non-empty `input` on a strict-empty manual child fails
+      with `error_code: "INVALID_ARGUMENT"` before the manual is loaded.
+- [ ] Step 3: avatar's manual returns its own flat shape `{status, action,
+      manual, manual_path}` — `manual` equals the packaged SKILL.md body and
+      `manual_path` is that packaged file — with no `content` or
+      `structuredContent` keys.
+- [ ] The contrast between steps 1 and 3 holds: the generic child's canonical
+      `content`/`structuredContent` shape is what `ToolFamily.handle()`
+      returns verbatim (no double wrap), while avatar's own child defines its
+      own canonical flat shape; neither family wraps the other's result.
+
+### Pass / Fail
+Pass when every evidence item holds. Fail if a manual body is missing or
+summarized, the path is absent or not model-visible, the result is wrapped a
+second time, or a manual call performs any target I/O.
+
+## Behavior T007 — psyche: five-domain manual routing, read-only
+
+- **id**: T007
+- **title**: `psyche` routes `pad | lingtai | knowledge | skills | manual` to
+  five distinct installed manuals, performs no mutation or catalog scan, and
+  rejects every retired action and every `input` key
+- **guards**: `psyche-contract` § Port (action inventory) / § Behavior
+  ([CONTRACT.md](../psyche/CONTRACT.md#port))
+- **supersedes**: `tests/test_psyche_family.py` (inventory, routing,
+  read-only, and retired-root tests)
+- **runner**: any LingTai agent (the `psyche` intrinsic is mandatory)
+- **prerequisites**: a fresh `<wd>` whose `.library/intrinsic/capabilities/`
+  holds the installed manuals `pad-manual`, `lingtai-manual`, `knowledge`,
+  `skills`, and `psyche-manual` (installed by the agent initializer)
+- **estimate**: 2 min
+
+### Steps
+1. Record a baseline listing of every file under `<wd>` with
+   `file(action="glob", input={"pattern": "**/*", "path": "<wd>"},
+   reasoning="...")`.
+2. For each action `a` in `["pad", "lingtai", "knowledge", "skills",
+   "manual"]`, call `psyche(action="<a>", input={}, reasoning="...")` and
+   record `status`, `manual`, and `manual_path`. Call `pad` and `manual` a
+   second time and compare bodies.
+3. Inspect the `manual` action's returned body for the four domain spellings
+   and the shared mutation/rebuild model.
+4. Inspect the `knowledge` and `skills` bodies for current-route call shapes.
+5. Call `psyche(action="pad_edit", input={}, reasoning="...")`, then
+   `psyche(action="", input={}, reasoning="...")`, then `psyche(action=
+   "manual", input={"files": ["x"]}, reasoning="...")`.
+6. Glob `<wd>` again and compare with the step 1 baseline.
+
+### Expected evidence
+- [ ] Step 2: every action returns `{"status": "ok", "manual": <non-empty
+      body>, "manual_path": <path>}` with `manual_path` ending in
+      `.library/intrinsic/capabilities/pad-manual/SKILL.md`,
+      `lingtai-manual/SKILL.md`, `knowledge/SKILL.md`, `skills/SKILL.md`, and
+      `psyche-manual/SKILL.md` respectively; the five bodies are all distinct;
+      repeated calls return byte-identical bodies (no stateful side effect).
+- [ ] Step 3: the `manual` body is the routing table — it contains
+      `action="pad"`, `action="lingtai"`, `action="knowledge"`,
+      `action="skills"`, plus `file.write`, `file.edit`, and
+      `context(action="rebuild"`.
+- [ ] Step 4: the `knowledge` body contains `psyche(action="knowledge"`,
+      `file(action="write"`, and `context(action="rebuild"`; the `skills`
+      body contains `psyche(action="skills"`, `context(action="rebuild"`,
+      `shell(action="run"`, `file(action="read"`, `system(action="refresh"`,
+      and `"revert_preset": null`. Neither body teaches a retired public root
+      (`pad(action=`, `lingtai(action=`, `knowledge(action=`, `skills(action=`,
+      `substrate(action=`) nor `pad.append` / `knowledge.info` / `skills.info`.
+- [ ] Step 5: `pad_edit` returns `{"error": "Unknown psyche action:
+      pad_edit. Must be one of: pad, lingtai, knowledge, skills, manual."}`;
+      the omitted/empty and other retired spellings (`lingtai_update`,
+      `lingtai_load`, `pad_load`, `pad_append`, `context_molt`, `name_set`,
+      `name_nickname`, `molt`, `summarize`, `rebuild`) fail with the same
+      `Unknown psyche action: ...` shape; any `input` key fails with
+      `{"error_code": "INVALID_ARGUMENT", "message": "unsupported psyche
+      input field"}` before the manual is read.
+- [ ] Step 6: the glob match set is identical to the baseline — no `psyche`
+      action created, edited, or deleted any file (every action is read-only).
+
+### Pass / Fail
+Pass when every evidence item holds. Fail if an action returns the wrong
+manual, a body teaches a retired root or an undispatchable call, any action
+mutates the tree, or a retired action is accepted. Forbidden side effect: no
+`psyche` action may scan a catalog, write a prompt or source file, or reload
+prompt state.
+
+## Behavior T008 — mcp: identity discovery surfaces safe fields only
+
+- **id**: T008
+- **title**: `mcp` info surfaces per-server identity from
+  `system/mcp_identities/<name>.json` projected to the non-secret allowlist,
+  and keeps secrets and volatile timestamps out of the model-facing prompt XML
+- **guards**: `mcp-contract` § Tool surface (info) / § Anchored claims
+  (identity attached only when present; secrets stripped)
+  ([CONTRACT.md](../mcp/CONTRACT.md#tool-surface))
+- **supersedes**: `tests/test_mcp_identity_discovery.py`
+- **runner**: any LingTai agent with the `mcp` capability and the `file` tool
+- **prerequisites**: `<wd>` is the agent working dir; the per-agent registry
+  `<wd>/mcp_registry.jsonl` already contains a server named `telegram` (e.g.
+  via `init.json` `addons: ["telegram"]` boot-time decompression, or an
+  existing registry entry); the `file` tool for writing identity files
+- **estimate**: 2 min
+
+### Steps
+1. Write `<wd>/system/mcp_identities/telegram.json` with
+   `file(action="write", input={"file_path": "<wd>/system/mcp_identities/
+   telegram.json", "content": "<identity JSON>"}, reasoning="...")` where the
+   JSON is `{"schema": "lingtai.mcp.identity.v1", "mcp": "telegram",
+   "generated_at": "2026-06-24T10:00:00+00:00", "accounts": [{"alias":
+   "main", "bot_username": "my_agent_bot", "bot_id": 123456789,
+   "bot_display_name": "My Agent", "is_bot": true, "allowed_users_count":
+   2, "contact_count": 5, "last_verified_at": "2026-06-24T09:59:00+00:00",
+   "bot_token": "123:SUPERSECRET"}]}` — deliberately including a
+   secret-shaped key.
+2. Call `mcp(action="info", input={}, reasoning="...")` and inspect the
+   `registered` list and `registry_path`.
+3. Read the `<mcp>` section of your own current system prompt (the protected
+   section the tool maintains) and look for `<registered_mcp>`, `<identity>`,
+   `my_agent_bot`, `last_verified_at`, and `SUPERSECRET`.
+4. Write `<wd>/system/mcp_identities/ghost.json` (same schema, `mcp`:
+   `"ghost"`, one account) and `<wd>/system/mcp_identities/bad.json` with
+   `schema: "something.else.v9"`; call `mcp(action="info", ...)` again. Then
+   delete `<wd>/system/mcp_identities/telegram.json` and call `info` again.
+
+### Expected evidence
+- [ ] Step 2: `status == "ok"`, `registry_path == "<wd>/mcp_registry.jsonl"`,
+      and the `registered` entry for `telegram` carries `identity` with
+      `account_count == 1` and `accounts[0].bot_username == "my_agent_bot"`;
+      the serialized `registered` payload contains none of `bot_token`,
+      `SUPERSECRET`, `password`, `token`, `secret`, or any secret-shaped key.
+- [ ] Step 3: the `<mcp>` prompt section contains `<registered_mcp>` and
+      `<identity>` and `my_agent_bot`, but contains no `last_verified_at` (the
+      volatile re-verification timestamp is excluded from the prompt XML) and
+      no secret value.
+- [ ] Step 4: `ghost` is NOT listed in `registered` (an identity without a
+      registry match invents no entry); the malformed-schema `bad.json` is
+      skipped without an error; after deleting the telegram identity, the
+      `telegram` registered entry has no `identity` key.
+
+### Pass / Fail
+Pass when every evidence item holds. Fail if a secret-shaped key or value
+appears anywhere in `info` output or the prompt XML, an identity for an
+unregistered server appears, or a malformed identity file crashes `info`.
+Forbidden side effect: `mcp` must never write or modify
+`mcp_registry.jsonl` or any identity file (it is signpost-only).
+
+## Behavior T009 — email abs reply routing and the ambiguity guard
+
+- **id**: T009
+- **title**: `email` abs-mode sends embed a `_return_route` so replies cross
+  `.lingtai/` networks to the original sender's absolute path, and an
+  ambiguous self-route is refused loudly instead of self-delivering
+- **guards**: `email-contract` § Anchored claims — abs-mode replies / §
+  Cross-platform invariants (`mode='abs'` return route)
+  ([CONTRACT.md](../email/CONTRACT.md#anchored-claims))
+- **supersedes**: `tests/test_email_abs_reply_route.py`
+- **runner**: any LingTai agent with the `email` and `file` tools
+- **prerequisites**: `<wd>` is the agent working dir; the mailbox dirs
+  `mailbox/inbox/`, `mailbox/sent/`, `mailbox/archive/` exist (created by the
+  email capability); an original-sender absolute path `<abs-sender>` (e.g. a
+  second network's agent dir) for the crafted inbound messages
+- **estimate**: 2 min
+
+### Steps
+1. Call `email(action="send", input={"address": "peer-2", "subject":
+   "hi", "message": "ping"}, reasoning="...")` (default peer mode), then
+   call `email(action="send", input={"address": "<abs-sender>", "mode":
+   "abs", "subject": "hi", "message": "ping"}, reasoning="...")` (abs
+   mode). For each call, find the newest record under `<wd>/mailbox/sent/` and
+   read its `message.json`.
+2. Craft an inbound message: `file(action="write", input={"file_path":
+   "<wd>/mailbox/inbox/<uuid>/message.json", "content": <JSON>},
+   reasoning="...")` where `<uuid>` is a fresh id and the JSON is `{
+   "from": "mimo-1", "to": ["mimo-1"], "subject": "cross-project ping",
+   "message": "please reply", "received_at": "2026-06-24T10:00:00Z",
+   "identity": {"agent_name": "mimo-1", "agent_id": "AGENT-DEV-1",
+   "admin": {}}}` (bare `from` equal to your own name, a different agent_id,
+   and NO `_return_route`). Then call `email(action="reply",
+   input={"email_id": ["<uuid>"], "message": "should be refused"},
+   reasoning="...")` and list `<wd>/mailbox/sent/` before/after.
+3. Craft a second inbound message with the same fields PLUS `"_return_route":
+   {"mode": "abs", "address": "<abs-sender>", "sender_agent_id":
+   "AGENT-DEV-1"}` (new `<uuid2>`), then call `email(action="reply",
+   input={"email_id": ["<uuid2>"], "message": "reply body"},
+   reasoning="...")` and read the newest `<wd>/mailbox/sent/` record.
+
+### Expected evidence
+- [ ] Step 1: the peer-mode sent record has no `_return_route` key; the abs
+      sent record carries `from` = your absolute working dir and
+      `_return_route` = `{"mode": "abs", "address": "<your working dir>",
+      "sender_agent_id": "<your agent id>"}`.
+- [ ] Step 2: the reply returns an `error` starting `Reply target is
+      ambiguous:` that contains `email(action='send', input={'mode': 'abs',`
+      and `reasoning=`, and no new record appears under `<wd>/mailbox/sent/`
+      (no outbound dispatch; the bare alias could have self-delivered).
+- [ ] Step 3: the reply returns `{"status": "sent", ...}` and the newest
+      sent record's `to` contains `<abs-sender>` with `mode: "abs"` (the
+      `_return_route` address won over the bare `from` alias).
+
+### Pass / Fail
+Pass when every evidence item holds. Fail if an abs send omits
+`_return_route`, a reply self-delivers to the responder's own inbox, or the
+ambiguity guard silently sends instead of refusing. Forbidden side effect: an
+ambiguous reply must create no sent record and dispatch no mail.

--- a/src/lingtai/tools/tool_family/CONTRACT.md
+++ b/src/lingtai/tools/tool_family/CONTRACT.md
@@ -366,6 +366,8 @@ its own scoped migration.
 
 ## Contract rules
 
+Guarded by: [T006](BEHAVIORS.md#behavior-t006)
+
 - A `ToolFamily`'s child registry MUST be validated at construction: duplicate
   child names and more than one child named the reserved `manual` MUST raise
   `ToolFamilyError`, not register silently or resolve by precedence.

--- a/src/lingtai/tools/tool_family/CONTRACT.md
+++ b/src/lingtai/tools/tool_family/CONTRACT.md
@@ -3,6 +3,7 @@ name: tool-family
 contract_version: 2
 root_contract: CONTRACT.md
 related_files:
+  - BEHAVIORS.md
   - src/lingtai/tools/tool_family/ANATOMY.md
   - src/lingtai/tools/tool_family/__init__.py
   - src/lingtai/tools/tool_family/manual.py

--- a/src/lingtai/tools/web_search/BEHAVIORS.md
+++ b/src/lingtai/tools/web_search/BEHAVIORS.md
@@ -1,0 +1,90 @@
+---
+name: web-search-behavior-tests
+behavior_version: 1
+labt_version: 2
+contract: CONTRACT.md
+anatomy: ANATOMY.md
+related_files:
+  - src/lingtai/tools/web_search/CONTRACT.md
+  - src/lingtai/tools/web_search/ANATOMY.md
+  - src/lingtai/tools/web_search/__init__.py
+  - src/lingtai/tools/web_search/settings.py
+  - src/lingtai/tools/web_search/manual/SKILL.md
+  - src/lingtai/tools/CONTRACT.md
+  - tests/test_web_canonical_provider_routing.py
+maintenance: |
+  LABT v2, migrated 2026-08 from tests/test_web_canonical_provider_routing.py
+  (previously filed as C003/C004 under src/lingtai/tools/telegram/BEHAVIORS.md;
+  re-homed here so web_search owns its own behavior tests). Keep guards pointed
+  at real `web` contract clauses (frontmatter name `web`): § Provider ownership
+  and routing for default selection / backend eligibility / error hierarchy /
+  DDG fallback, and § Contract rules for link_ref and browse independence.
+  Update the matching LABT here in the same change as the contract clause; keep
+  the paired ANATOMY.md reciprocal.
+---
+# Web Search Behavior Tests
+
+LABT v2. Self-contained agent-executable behavioral tests for the `web`
+capability (`src/lingtai/tools/web_search/`): W001 covers canonical provider
+default selection and hot settings, W002 covers routing constraints, typed
+failures, and DuckDuckGo fallback. Both guard clauses in
+`src/lingtai/tools/web_search/CONTRACT.md` (frontmatter name `web`).
+
+## Behavior W001 — Web canonical provider routing: default selection and hot config
+
+- **id**: W001
+- **title**: web search→browse canonical provider selection and hot-read settings
+- **guards**: `web` § Provider ownership and routing (built-in default engine resolved live per call; anthropic/gemini are settings-only opt-in; retired-provider composition errors) ([CONTRACT.md](CONTRACT.md#provider-ownership-and-routing))
+- **supersedes**: tests/test_web_canonical_provider_routing.py (CONVERT_BEHAVIOR)
+- **runner**: any LingTai agent with the `web` tool
+- **prerequisites**: repo checkout with src/lingtai/tools/web_search; provider factories are stubbed/recording — no network; env vars are managed per-case (isolated and restored after each case); tool name is `web` per web_search CONTRACT.md; contract section `#provider-ownership-and-routing`.
+- **estimate**: 30 minutes
+
+### Steps
+
+1. Clear all provider env vars, then set `OPENAI_API_KEY` and call the `web` tool's search provider selection.
+2. Clear `OPENAI_API_KEY` too, so no keys exist; select again.
+3. Set only `ANTHROPIC_API_KEY` (or `GEMINI_API_KEY`); select again.
+4. Write `settings/web.search.json` with `{"schema_version": 1, "engine": ...}` and select again without restarting.
+
+### Expected evidence
+
+- [ ] With `OPENAI_API_KEY` set and nothing else: `engine == "openai"`, `source == "built_in_default"`, and the factory tuple is `("openai", api_key=<env value>, model=None)`.
+- [ ] With **no** keys: `engine == "duckduckgo"` (built-in default fallback).
+- [ ] With only anthropic/gemini keys: the corresponding engine is **available but unselected**; `PROVIDERS["providers"]` is exactly `{"duckduckgo", "gemini", "anthropic", "openai"}`.
+- [ ] Settings file present: selection re-reads it hot — `engine` matches the file, and `source == "settings/web.search.json"` (relative to the working dir).
+- [ ] `minimax` and `zhipu` are retired: composing either raises `RetiredProviderError` before any factory runs.
+
+### Pass / Fail
+
+PASS when the selected engine, source, provider set, hot-read settings, and retired-provider errors all match above; FAIL on any wrong engine/source, an unselected provider becoming selected, a non-hot settings read, or a retired provider reaching the factory.
+
+## Behavior W002 — Web routing constraints, typed errors, and fallback
+
+- **id**: W002
+- **title**: settings-only/backend-gated providers, typed failures, DDG fallback, link_ref extraction, browse independence
+- **guards**: `web` § Provider ownership and routing (backend eligibility, `SEARCH_FAILED` hierarchy, OpenAI-only DDG fallback) and § Contract rules (link_ref, browse independence) ([CONTRACT.md](CONTRACT.md#provider-ownership-and-routing))
+- **supersedes**: tests/test_web_canonical_provider_routing.py (CONVERT_BEHAVIOR)
+- **runner**: any LingTai agent with the `web` tool
+- **prerequisites**: same as W001 (stubbed/recording provider factories, managed env, no network); contract sections `#provider-ownership-and-routing` and `#contract-rules`.
+- **estimate**: 30 minutes
+
+### Steps
+
+1. Select anthropic/gemini via `settings/web.search.json` while the active backend is a non-canonical one (`claude-code`, `openai`, `openrouter`, `custom`, or `codex`).
+2. Force each typed failure below and inspect the error envelope.
+3. Make OpenAI-only search fail, then fall back; inspect the fallback result.
+4. Call `web` browse with a URL and with an empty URL.
+
+### Expected evidence
+
+- [ ] **Backend-gated**: settings-selected anthropic/gemini on the non-canonical backends listed above is refused with `error_code == "PROVIDER_BACKEND_INELIGIBLE"` (distinct from `SettingsOnlyProviderError`).
+- [ ] **Typed errors**: provider failures surface as `error_code == "SEARCH_FAILED"` with a `provider_failure_class` field carrying the provider's exception class; a non-provider `TypeError` is **not** classified as `SEARCH_FAILED` and triggers **no** fallback.
+- [ ] **OpenAI-only DDG fallback**: when the sole configured provider (openai) fails, the result is `actual_engine == "duckduckgo"` with `openai_failure_class` set; the result contains no API keys or secrets.
+- [ ] **link_ref**: an item's `link_ref` is truthy iff its `url` is non-empty; items with an empty URL are discarded, not returned with empty link_ref.
+- [ ] **manual**: `web` manual reports `current_setting.source == "not_applicable"` and an `error_code` that is not `PROVIDER_BACKEND_INELIGIBLE`.
+- [ ] **Browse independence**: `web` browse does its own fetch and succeeds regardless of provider selection or provider state.
+
+### Pass / Fail
+
+PASS when error codes, fallback engine, secrets-free results, link_ref, and browse independence all hold; FAIL on any wrong error code, secret leakage, or browse that inherits provider state.

--- a/src/lingtai/tools/web_search/CONTRACT.md
+++ b/src/lingtai/tools/web_search/CONTRACT.md
@@ -87,6 +87,8 @@ browser transport from search.
 
 ## Provider ownership and routing
 
+Guarded by: [W001](BEHAVIORS.md#behavior-w001), [W002](BEHAVIORS.md#behavior-w002)
+
 Built-in Search admits exactly four engines: canonical first-party OpenAI
 Responses Web Search, canonical first-party Anthropic server-side Web Search,
 canonical first-party Gemini Google Search grounding, and DuckDuckGo. MiniMax
@@ -210,6 +212,8 @@ failure the Web use-case policy must observe to drive the DuckDuckGo fallback
 above.
 
 ## Contract rules
+
+Guarded by: [W002](BEHAVIORS.md#behavior-w002)
 
 - The public name is `web`; no browser or web_search registry, schema, prompt,
   check-caps, catalog, or installed manual entry exists.

--- a/tests/test_labt_validation.py
+++ b/tests/test_labt_validation.py
@@ -1,0 +1,403 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ROOT_BEHAVIORS = ROOT / "BEHAVIORS.md"
+
+
+# A LABT id is either the default B### scheme or a per-family prefix followed
+# by three digits (e.g. D003, L005, T009, C001, K004, S002, W001, F001, FE001).
+LABT_ID_RE = re.compile(r"^[A-Z]{1,2}\d{3}$")
+
+REQUIRED_FRONTMATTER_KEYS = {
+    "name",
+    "behavior_version",
+    "labt_version",
+    "contract",
+    "anatomy",
+    "related_files",
+    "maintenance",
+}
+REQUIRED_LABT_FIELDS = {"id", "title", "guards", "runner", "prerequisites", "estimate"}
+OPTIONAL_LABT_FIELDS = {"supersedes"}
+REQUIRED_LABT_SECTIONS = {"Steps", "Expected evidence", "Pass / Fail"}
+
+
+def _read_document(path: Path) -> tuple[dict, str]:
+    """Parse a Markdown document's YAML frontmatter and return its body."""
+    text = path.read_text(encoding="utf-8")
+    assert text.startswith("---\n"), path
+    _, frontmatter, body = text.split("---\n", 2)
+    meta = yaml.safe_load(frontmatter)
+    assert isinstance(meta, dict), path
+    return meta, body
+
+
+def _assert_repo_file(path: str) -> None:
+    """Require a normalized, repository-relative path to a regular file."""
+    assert path == path.strip(), path
+    assert "\\" not in path, path
+    parts = path.split("/")
+    assert parts and all(part not in {"", "."} for part in parts), path
+    relative = Path(*parts)
+    assert not relative.is_absolute(), path
+    target = (ROOT / relative).resolve(strict=True)
+    assert target.is_relative_to(ROOT.resolve()), path
+    assert target.is_file(), path
+
+
+def _assert_dir_relative_file(base_dir: Path, path: str) -> None:
+    """Require a path relative to a child BEHAVIORS.md directory.
+
+    Frontmatter `contract:`/`anatomy:` are relative to the BEHAVIORS.md file's
+    own directory (e.g. `CONTRACT.md`, `ANATOMY.md`, `../CONTRACT.md`).
+    """
+    assert path == path.strip(), path
+    assert "\\" not in path, path
+    parts = path.split("/")
+    assert parts and all(part not in {"", "."} for part in parts), path
+    relative = Path(*parts)
+    assert not relative.is_absolute(), path
+    target = (base_dir / relative).resolve(strict=True)
+    assert target.is_relative_to(ROOT.resolve()), path
+    assert target.is_file(), path
+
+
+def _tracked_files() -> set[str]:
+    """Every tracked path in the repository, as repo-relative POSIX strings."""
+    import subprocess
+
+    proc = subprocess.run(
+        ["git", "-c", "core.quotepath=false", "ls-files"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return {line for line in proc.stdout.splitlines() if line}
+
+
+def _normalize(text: str) -> str:
+    """Normalize a heading or clause name for loose equality checks."""
+    return re.sub(r"[^a-z0-9]+", "-", text.strip().lower()).strip("-")
+
+
+def _clause_tokens(text: str, truncate: bool = False) -> list[str]:
+    """Meaningful lowercase alphanumeric tokens from a clause reference.
+
+    When `truncate` is true (clause side only), annotation prose in
+    parentheses or after an em/en dash is dropped so it cannot create false
+    failures. The contract body side is tokenized WITHOUT truncation.
+    """
+    if truncate:
+        for marker in ("(", "—", "–"):
+            if marker in text:
+                text = text.split(marker, 1)[0]
+    tokens = re.findall(r"[a-z0-9]{3,}", text.lower())
+    # Drop pure connective/number words that add no clause identity.
+    stop = {
+        "and", "the", "for", "with", "from", "that", "this", "must", "not",
+        "shall", "rule", "rules", "section", "clause", "behavior", "contract",
+        "ltp",
+    }
+    return [token for token in tokens if token not in stop]
+
+
+def _contract_name_map() -> dict[str, str]:
+    """Map repo-relative CONTRACT.md paths to their frontmatter `name:`."""
+    result: dict[str, str] = {}
+    for path in _tracked_files():
+        if not path.endswith("/CONTRACT.md") and path != "CONTRACT.md":
+            continue
+        try:
+            meta, _ = _read_document(ROOT / path)
+        except Exception:
+            continue
+        name = meta.get("name")
+        if isinstance(name, str):
+            result[path] = name
+    return result
+
+
+def _child_behavior_paths(root_meta: dict) -> list[str]:
+    """Child BEHAVIORS.md paths linked from the root, excluding the root itself."""
+    related = root_meta.get("related_files")
+    assert isinstance(related, list) and related
+    return [
+        path
+        for path in related
+        if path.endswith("BEHAVIORS.md") and path != "BEHAVIORS.md"
+    ]
+
+
+def _parse_labts(body: str, path: Path) -> list[tuple[str, dict, str]]:
+    """Split a BEHAVIORS.md body into LABT sections.
+
+    Returns `(id, fields_dict, section_text)` for each `## Behavior <id>` section.
+    The fields dict maps `**field**` bullets to their values; section_text is the
+    whole section body used for `### Steps` / `### Expected evidence` checks.
+    """
+    # Split on top-level `## Behavior <id> — <title>` headings.
+    parts = re.split(r"(?m)^## Behavior (\S+)\s+[—-]?\s*(.*)$", body)
+    labts: list[tuple[str, dict, str]] = []
+    # parts[0] is the preamble; then id/title/body triplets follow.
+    idx = 1
+    while idx + 2 < len(parts):
+        labt_id, title, section = parts[idx], parts[idx + 1], parts[idx + 2]
+        fields: dict[str, str] = {}
+        for match in re.finditer(
+            r"^\s*[-*]?\s*\*\*([a-z_]+)\*\*:\s*(.*)$",
+            section,
+            flags=re.MULTILINE,
+        ):
+            fields[match.group(1)] = match.group(2).strip()
+        labts.append((labt_id, fields, section))
+        idx += 3
+    return labts
+
+
+def test_root_behaviors_frontmatter() -> None:
+    """The root BEHAVIORS.md owns the LABT spec and is itself well-formed.
+
+    The root is the meta-behavior file (it has no sibling CONTRACT.md of its
+    own), so it is exempt from the `contract`/`anatomy` keys required of
+    children; it must still declare labt_version and link every child.
+    """
+    meta, _ = _read_document(ROOT_BEHAVIORS)
+    required = REQUIRED_FRONTMATTER_KEYS - {"contract", "anatomy"}
+    assert required <= set(meta), meta.keys()
+    assert meta["labt_version"] >= 1
+    related = meta["related_files"]
+    assert isinstance(related, list) and related
+    for path in related:
+        _assert_repo_file(path)
+
+
+def test_child_behaviors_are_linked_and_parse() -> None:
+    """Every child BEHAVIORS.md parses with full frontmatter and matches root."""
+    root_meta, _ = _read_document(ROOT_BEHAVIORS)
+    root_labt_version = root_meta["labt_version"]
+    children = _child_behavior_paths(root_meta)
+    assert children, "root BEHAVIORS.md must link at least one child"
+
+    for path in children:
+        child_dir = (ROOT / path).parent
+        meta, body = _read_document(ROOT / path)
+        missing = REQUIRED_FRONTMATTER_KEYS - set(meta)
+        assert not missing, f"{path}: missing frontmatter keys {sorted(missing)}"
+        assert (
+            meta["labt_version"] == root_labt_version
+        ), f"{path}: labt_version {meta['labt_version']} != root {root_labt_version}"
+        # contract may be a single relative path or a list; anatomy single.
+        contract_keys = (
+            meta["contract"] if isinstance(meta["contract"], list) else [meta["contract"]]
+        )
+        for contract in contract_keys:
+            _assert_dir_relative_file(child_dir, contract)
+        _assert_dir_relative_file(child_dir, meta["anatomy"])
+        related = meta["related_files"]
+        assert isinstance(related, list) and related, f"{path}: empty related_files"
+        assert len(related) == len(set(related)), f"{path}: duplicate related_files"
+        for related_path in related:
+            _assert_repo_file(related_path)
+        assert body.strip(), f"{path}: empty body"
+
+
+def test_child_labts_have_required_fields_and_sections() -> None:
+    """Every LABT is self-contained: required fields plus Steps/Evidence/Pass-Fail."""
+    root_meta, _ = _read_document(ROOT_BEHAVIORS)
+    children = _child_behavior_paths(root_meta)
+    seen_ids: dict[str, str] = {}
+
+    for path in children:
+        _, body = _read_document(ROOT / path)
+        labts = _parse_labts(body, ROOT / path)
+        assert labts, f"{path}: no `## Behavior <id>` sections found"
+        for labt_id, fields, section in labts:
+            assert LABT_ID_RE.match(labt_id), (
+                f"{path}: id {labt_id!r} does not match LABT_ID_RE"
+            )
+            # GitHub anchors any `## Behavior <id>` heading as #behavior-<id-lower>.
+            anchor = f"behavior-{labt_id.lower()}"
+            assert f"## Behavior {labt_id}" in body, (
+                f"{path}: section for {labt_id} must be addressable as #{anchor}"
+            )
+            prev = seen_ids.get(labt_id.lower())
+            assert prev is None, f"{path}: duplicate id {labt_id} (also in {prev})"
+            seen_ids[labt_id.lower()] = path
+
+            missing = REQUIRED_LABT_FIELDS - set(fields)
+            assert not missing, f"{path} {labt_id}: missing fields {sorted(missing)}"
+            assert fields["id"] == labt_id, f"{path}: field id != heading id"
+            assert fields["title"], f"{path} {labt_id}: empty title"
+            assert fields["guards"], f"{path} {labt_id}: empty guards"
+            assert fields["runner"], f"{path} {labt_id}: empty runner"
+            # runner must describe an agent shape, not a pytest invocation.
+            assert "pytest" not in fields["runner"].lower(), (
+                f"{path} {labt_id}: runner must be an agent shape, not a pytest command"
+            )
+
+            for section_name in REQUIRED_LABT_SECTIONS:
+                assert f"### {section_name}" in section, (
+                    f"{path} {labt_id}: missing `### {section_name}` section"
+                )
+
+            supersedes = fields.get("supersedes")
+            if supersedes:
+                # Each superseded entry is a repo-relative pytest file, optionally
+                # with a `::test_selector` suffix (strip it before resolving).
+                for entry in re.findall(r"`([^`]+)`", supersedes):
+                    file_part = entry.split("::", 1)[0]
+                    _assert_repo_file(file_part)
+
+
+def test_labt_guards_reference_real_contracts() -> None:
+    """Each LABT guards a clause of a real contract.
+
+    The guards value has the form `<contract-name> § <clause heading>`. The
+    contract name must match the frontmatter `name:` of some tracked
+    CONTRACT.md, and the clause heading must appear (normalized) in that
+    contract's body so the backlink resolves to a real clause.
+    """
+    root_meta, _ = _read_document(ROOT_BEHAVIORS)
+    children = _child_behavior_paths(root_meta)
+    name_to_path = {name: path for path, name in _contract_name_map().items()}
+
+    failures: list[str] = []
+    for path in children:
+        meta, body = _read_document(ROOT / path)
+        # Contracts declared by this file (single or list).
+        declared = (
+            meta["contract"] if isinstance(meta["contract"], list) else [meta["contract"]]
+        )
+        declared_names = {
+            name
+            for contract in declared
+            for contract_path, name in _contract_name_map().items()
+            if contract_path == contract
+        }
+        # Fall back to the full repo map for cross-module guards (tool_family).
+        for labt_id, fields, _ in _parse_labts(body, ROOT / path):
+            guards = fields.get("guards", "")
+            if "§" not in guards:
+                failures.append(f"{path} {labt_id}: guards missing '§': {guards!r}")
+                continue
+            contract_name, clause = (part.strip() for part in guards.split("§", 1))
+            # The name is a backtick-quoted contract name or path; if the guards
+            # value carries extra prose after the backtick token, take that token.
+            quoted = re.match(r"^`([^`]+)`", contract_name)
+            if quoted:
+                contract_name = quoted.group(1)
+            else:
+                contract_name = contract_name.strip("`")
+            # Target may be a frontmatter name, a repo-relative CONTRACT.md path,
+            # or (when the guards value embeds a markdown link) the linked file.
+            target = name_to_path.get(contract_name)
+            if target is None and contract_name.endswith("CONTRACT.md"):
+                target = contract_name
+            if target is None:
+                # Fall back to a markdown link embedded in the guards value
+                # (`[label](../../path/file.md#anchor)`), which names the real
+                # file even when no contract frontmatter name matches (e.g. a
+                # SKILL.md guard when a module has no root contract yet). The
+                # link is relative to the child BEHAVIORS.md directory.
+                linked = re.search(r"\[[^\]]+\]\(([^)]+)\)", guards)
+                if linked:
+                    candidate = linked.group(1).split("#", 1)[0]
+                    if candidate.endswith(("CONTRACT.md", "SKILL.md")):
+                        resolved = (ROOT / path).parent / candidate
+                        target = str(resolved.relative_to(ROOT)).replace("\\", "/")
+            if target is None:
+                failures.append(
+                    f"{path} {labt_id}: guards contract {contract_name!r} not found in repo"
+                )
+                continue
+            try:
+                if target.endswith("SKILL.md"):
+                    # Manuals do not carry YAML frontmatter; read the whole text.
+                    contract_body = (ROOT / target).read_text(encoding="utf-8")
+                else:
+                    _, contract_body = _read_document(ROOT / target)
+            except Exception:
+                contract_body = ""
+            body_tokens = set(_clause_tokens(contract_body))
+            clause_tokens = _clause_tokens(clause, truncate=True)
+            if clause_tokens:
+                missing_tokens = [
+                    token for token in clause_tokens if token not in body_tokens
+                ]
+                if missing_tokens:
+                    failures.append(
+                        f"{path} {labt_id}: guards clause {clause!r} not found in {target} "
+                        f"(missing tokens {missing_tokens})"
+                    )
+
+    assert not failures, "\n".join(failures)
+
+
+def test_contract_clauses_link_guarding_labts() -> None:
+    """Contract → behaviors edge: important clauses carry LABT links.
+
+    This is the half of the tridirectional loop this convention is about: every
+    CONTRACT.md that has a sibling BEHAVIORS.md must carry at least one
+    `[B###](BEHAVIORS.md#behavior-b###)`-style link on its observable behavior
+    clauses. We require the link form for every tracked CONTRACT.md that sits in
+    a directory with a BEHAVIORS.md child.
+    """
+    import subprocess
+
+    proc = subprocess.run(
+        ["git", "-c", "core.quotepath=false", "ls-files"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    tracked = {line for line in proc.stdout.splitlines() if line}
+
+    link_re = re.compile(
+        r"\[([A-Z]{1,2}\d{3})\]\(([^)]*BEHAVIORS\.md#behavior-([a-z0-9]{1,2}\d{3}))\)"
+    )
+    failures: list[str] = []
+    for path in tracked:
+        if not path.endswith("/CONTRACT.md"):
+            continue
+        contract_dir = path[: path.rindex("/")]
+        behaviors = f"{contract_dir}/BEHAVIORS.md"
+        if behaviors not in tracked:
+            continue  # no sibling behaviors file: nothing to link
+        try:
+            _, contract_body = _read_document(ROOT / path)
+        except Exception as exc:
+            failures.append(f"{path}: unparseable ({exc})")
+            continue
+        links = link_re.findall(contract_body)
+        assert links, f"{path}: sibling {behaviors} exists but no LABT links found"
+        # Each linked id must exist (case-insensitive) in the BEHAVIORS.md file
+        # the link actually resolves to: the sibling for same-directory links,
+        # or the declared cross-module file when a contract clause is guarded by
+        # LABTs that live in another module (e.g. the kernel K-LABTs guarding
+        # context/notification clauses).
+        for label, url, anchor_id in links:
+            target_path, _, _ = url.partition("#")
+            target = (ROOT / Path(path).parent / target_path).resolve()
+            try:
+                _, behaviors_body = _read_document(target)
+            except Exception as exc:
+                failures.append(f"{path}: link target {url!r} unparseable ({exc})")
+                continue
+            behavior_ids = {
+                labt_id.lower() for labt_id, _, _ in _parse_labts(behaviors_body, target)
+            }
+            if anchor_id not in behavior_ids:
+                failures.append(
+                    f"{path}: link [{label}]({url}) anchors to missing id {anchor_id} "
+                    f"in {target}"
+                )
+
+    assert not failures, "\n".join(failures)


### PR DESCRIPTION
## Summary
LABT v1 → v2 per fable review (comment 5235186729). All fable blocking issues addressed; validation test lands with the PR.

**Root spec (LABT v2)**
- Family-prefix IDs allowed (D/L/T/C/K/S/F###/W###/FE### etc.), anchor #behavior-<id-lower>; default B###
- contract: may be a list; guards must name the target contract frontmatter name exactly (or path)
- runner = agent shape (NOT pytest command); self-containment normative

**Module BEHAVIORS.md (7 families, ~44 LABTs)**
- tools/daemon 7 (D001-D007), tools/context 8 (L001-L008), tools/tool_family 9 (T001-T009), tools/telegram 2 (C001-C002), tools/web_search (W###), tools/file (F###), tools/feishu (FE###), kernel 7 (K001-K007), tools/bash (S###)

**Fable fixes applied**
- telegram frontmatter bug fixed (7 keys now parse); guards/runner normalized; C003 Pass/Fail added; C003-C006 re-homed to web_search/file/feishu
- shell → tools/bash re-home; old tools/shell/ removed; S004/S005/S002 contract names fixed; venv path removed; S001 POSIX-only
- kernel: K001/K002/K005/K006/K007 rewritten as observable-outcome LABTs (real runtime staging); guards → context-contract; contract list
- tool_family T006/T007 guards names fixed
- Contract → behaviors clause links added (13 Guarded by: lines across 8 CONTRACT.md)

**Validation test (new)**
- tests/test_labt_validation.py: frontmatter/labt_version/related_files, LABT fields + sections, guards→real contract clauses, contract→behaviors link completeness. 5/5 pass

**Verification**: test_labt_validation 5/5 + test_karma 19/19 pass; arch-doc 3 pre-existing Windows failures (baseline unchanged).
