### PR TITLE
feat(behaviors): every CONTRACT.md has a sibling BEHAVIORS.md (39/39) + linkage rule

### DIFF
--- a/src/lingtai/BEHAVIORS.md
+++ b/src/lingtai/BEHAVIORS.md
@@ -1,0 +1,45 @@
+---
+name: init-reader-behavior-tests
+behavior_version: 1
+labt_version: 2
+contract: CONTRACT.md
+anatomy: ANATOMY.md
+related_files:
+  - src/lingtai/CONTRACT.md
+  - src/lingtai/ANATOMY.md
+  - src/lingtai/init_reader.py
+  - src/lingtai/init_schema.py
+maintenance: |
+  Created during the every-contract-needs-behaviors sweep. Keep this file
+  reciprocal with CONTRACT.md and ANATOMY.md (tridirectional loop): when a
+  reader behavior or compatibility clause changes, update the guarding LABT
+  here in the same change.
+---
+# Init Reader Behavior Tests
+
+Self-contained agent behavior tasks guarding the observable behavior clauses of
+`src/lingtai/CONTRACT.md` (one real read path for boot and refresh, typed
+outcomes, no auto-mutation of `<workdir>/init.json`). Pinned pytest commands
+must run from the repo root with the project's Python.
+
+## Behavior IR001 — the reader never modifies init.json and returns typed outcomes instead of fabricated success
+
+- **id**: IR001
+- **title**: the reader never modifies init.json and returns typed outcomes instead of fabricated success
+- **guards**: `init-reader` § Behavior
+- **runner**: any LingTai agent with `shell` and `file` access to this repository
+- **prerequisites**: a clean checkout of `<repo>`; a scratch agent working directory `<scratch>` with an `init.json`
+- **estimate**: ≈ 20 minutes
+
+### Steps
+1. From `<repo>`, run `python -m pytest tests/test_init_reader.py -q` and capture the outcome.
+2. In `<scratch>`, write an `init.json` containing a deprecated/ignored field and boot the reader path (boot CLI or refresh `Agent`); hash `<scratch>/init.json` before and after and compare.
+3. Inspect the returned outcome: confirm it reports `FULLY_EFFECTIVE` / `READ_OK_WITH_IGNORED_FIELDS` / `READ_FAILED` with a typed shape decision and the ignored paths, and that the redacted `system/manifest.resolved.json` artifact was produced.
+
+### Expected evidence
+- [ ] Step 1: the init-reader suite passes, pinning JSONC parsing, identical boot/refresh outcomes, ignored-path reporting, and structured failure evidence.
+- [ ] Step 2: the bytes of `<scratch>/init.json` are unchanged after the read (no strip, no canonicalization, no rewrite).
+- [ ] Step 3: the outcome status and shape decision are typed and truthful; failures carry stage, location when available, safe excerpt, behavior, and a next repair step.
+
+### Pass / Fail
+Pass when the suite passes, `init.json` is untouched, and the outcome is typed rather than fabricated. Fail on any auto-rewrite of `init.json`, on a claimed success for an ignored-field read, or on a missing redacted manifest artifact; record the evidence trail in the task report.

--- a/src/lingtai/kernel/agent_presence/BEHAVIORS.md
+++ b/src/lingtai/kernel/agent_presence/BEHAVIORS.md
@@ -1,0 +1,47 @@
+---
+name: agent-presence-behavior-tests
+behavior_version: 1
+labt_version: 2
+contract: CONTRACT.md
+anatomy: ANATOMY.md
+related_files:
+  - src/lingtai/kernel/agent_presence/CONTRACT.md
+  - src/lingtai/kernel/agent_presence/ANATOMY.md
+  - src/lingtai/kernel/agent_presence/__init__.py
+  - src/lingtai/adapters/posix/agent_presence.py
+maintenance: |
+  Created during the every-contract-needs-behaviors sweep. Keep this file
+  reciprocal with CONTRACT.md and ANATOMY.md (tridirectional loop): when a
+  behavior clause of the agent-presence contract changes, update the guarding
+  LABT here in the same change.
+---
+# Agent Presence Store Behavior Tests
+
+Self-contained agent behavior tasks guarding the observable behavior clauses of
+`src/lingtai/kernel/agent_presence/CONTRACT.md`. Pinned pytest commands must run
+from the repo root with the project's Python (any interpreter that resolves
+`lingtai` from `<repo>/src` and has pytest installed).
+
+## Behavior AP001 — present-but-malformed manifests still count as agents and human manifests stay alive without a heartbeat
+
+- **id**: AP001
+- **title**: present-but-malformed manifests still count as agents and human manifests stay alive without a heartbeat
+- **guards**: `agent-presence-store` § Behavior
+- **runner**: any LingTai agent with `shell` and `file` access to this repository
+- **prerequisites**: a clean checkout of `<repo>`; a scratch working directory `<scratch>` outside any agent directory
+- **estimate**: ≈ 15 minutes
+
+### Steps
+1. From `<repo>`, run `python -m pytest tests/test_agent_presence.py -q` and capture the outcome.
+2. In `<scratch>`, write `.agent.json` containing malformed JSON (e.g. `{not json`) and run the presence observation path against it using the production adapter (`PosixAgentPresenceStoreAdapter`) via a short Python snippet with `PYTHONPATH=<repo>/src`; record the returned manifest observation.
+3. In a second scratch directory, write `.agent.json` with `{"admin": null}` and a stale `.agent.heartbeat`, then observe alive-ness through `observe_alive`; record whether the heartbeat was consulted.
+4. Publish a heartbeat with `wall_seconds=123.0` through the adapter and read back the `.agent.heartbeat` bytes with a hexdump.
+
+### Expected evidence
+- [ ] Step 1: the shared fake/production conformance suite passes, pinning the tri-state classification, human-always-alive, strict freshness threshold, and byte-exact heartbeat writes.
+- [ ] Step 2: the malformed manifest is classified `MALFORMED`, not absent, and still counts as an agent (`is_agent` true).
+- [ ] Step 3: a valid manifest with `admin` missing-or-null is always alive, and the heartbeat file was never read for that observation.
+- [ ] Step 4: `.agent.heartbeat` contains exactly `123.0` with no trailing newline.
+
+### Pass / Fail
+Pass when every evidence item above holds. Fail on any mismatch — e.g. a malformed manifest classified as absent, a human observed through heartbeat, or heartbeat bytes that are not byte-exact — and record the evidence trail in the task report.

--- a/src/lingtai/kernel/agent_presence/CONTRACT.md
+++ b/src/lingtai/kernel/agent_presence/CONTRACT.md
@@ -38,6 +38,8 @@ maintenance: |
 # Agent Presence Store Contract
 
 ## Purpose
+Guarded by: [AP001](BEHAVIORS.md#behavior-ap001)
+
 
 The Agent Presence Store owns the kernel's presence and liveness boundary for a
 single agent working directory: whether the directory holds an agent, whether

--- a/src/lingtai/kernel/agent_readme/BEHAVIORS.md
+++ b/src/lingtai/kernel/agent_readme/BEHAVIORS.md
@@ -1,0 +1,45 @@
+---
+name: agent-readme-behavior-tests
+behavior_version: 1
+labt_version: 2
+contract: CONTRACT.md
+anatomy: ANATOMY.md
+related_files:
+  - src/lingtai/kernel/agent_readme/CONTRACT.md
+  - src/lingtai/kernel/agent_readme/ANATOMY.md
+  - src/lingtai/kernel/agent_readme/__init__.py
+  - src/lingtai/kernel/agent_readme/README.md.tpl
+maintenance: |
+  Created during the every-contract-needs-behaviors sweep. Keep this file
+  reciprocal with CONTRACT.md and ANATOMY.md (tridirectional loop): when the
+  agent-readme role/ownership/generation rules change, update the guarding LABT
+  here in the same change.
+---
+# Agent Readme Behavior Tests
+
+Self-contained agent behavior tasks guarding the observable behavior clauses of
+`src/lingtai/kernel/agent_readme/CONTRACT.md` (the fixed `README.md` /
+`substrate.md` role split, ownership, and generation rules). Pinned pytest
+commands must run from the repo root with the project's Python.
+
+## Behavior AR001 — the generated agent-root README links system/substrate.md and carries no agent name or live values
+
+- **id**: AR001
+- **title**: the generated agent-root README links system/substrate.md and carries no agent name or live values
+- **guards**: `agent-readme` § 1. 角色
+- **runner**: any LingTai agent with `shell` and `file` access to this repository
+- **prerequisites**: a clean checkout of `<repo>`; a scratch agent working directory `<scratch>`
+- **estimate**: ≈ 15 minutes
+
+### Steps
+1. From `<repo>`, run `python -m pytest tests/test_agent_readme.py -q` and capture the outcome.
+2. Create `<scratch>` with an `init.json` and boot an agent there (or run the README generation path used by refresh/molt/BaseAgent construction), then inspect `<scratch>/README.md`.
+3. Grep `<scratch>/README.md` for a relative link to `system/substrate.md` and for any agent-name or live dynamic value (provider/model/heartbeat tokens).
+
+### Expected evidence
+- [ ] Step 1: the agent-readme suite passes, pinning generation, staleness re-generation, and template consistency.
+- [ ] Step 2: after initialization/refresh/molt, `<scratch>/README.md` exists at the agent root.
+- [ ] Step 3: README.md contains a relative path to `system/substrate.md` and contains no agent-name placeholder and no live dynamic value (no provider/model/heartbeat runtime tokens).
+
+### Pass / Fail
+Pass when the README is present, links `system/substrate.md`, and contains no agent name or live dynamic values. Fail on any missing link or any runtime value leaked into the README; record the evidence trail in the task report.

--- a/src/lingtai/kernel/agent_readme/CONTRACT.md
+++ b/src/lingtai/kernel/agent_readme/CONTRACT.md
@@ -1,9 +1,26 @@
+---
+name: agent-readme-contract
+tool: agent-readme
+contract_version: 1
+related_files:
+  - src/lingtai/kernel/agent_readme/BEHAVIORS.md
+  - src/lingtai/kernel/agent_readme/ANATOMY.md
+  - src/lingtai/kernel/agent_readme/_readme.py
+maintenance: |
+  The agent README folder role split (README.md vs substrate.md) and its
+  ownership/maintenance boundary. Every agent-observable behavior clause
+  MUST be guarded by a LABT in the sibling BEHAVIORS.md (tridirectional
+  loop); when this contract changes, update BEHAVIORS.md and ANATOMY.md
+  together.
+---
 # agent-readme CONTRACT
 
 > 固定 agent 文件夹 `README.md` 与 `substrate.md` 的角色分工、所有权与维护边界。
 > 替代 #1252 的 agent-manual CONTRACT v1（重生成器 + MANUAL.md）的语义。
 
 ## 1. 角色
+Guarded by: [AR001](BEHAVIORS.md#behavior-ar001)
+
 
 | 文件 | 位置 | 面向 | 角色 |
 |---|---|---|---|

--- a/src/lingtai/kernel/base_agent/BEHAVIORS.md
+++ b/src/lingtai/kernel/base_agent/BEHAVIORS.md
@@ -1,0 +1,45 @@
+---
+name: base-agent-behavior-tests
+behavior_version: 1
+labt_version: 2
+contract: CONTRACT.md
+anatomy: ANATOMY.md
+related_files:
+  - src/lingtai/kernel/base_agent/CONTRACT.md
+  - src/lingtai/kernel/base_agent/ANATOMY.md
+  - src/lingtai/kernel/base_agent/lifecycle.py
+  - src/lingtai/kernel/base_agent/turn.py
+maintenance: |
+  Created during the every-contract-needs-behaviors sweep. Keep this file
+  reciprocal with CONTRACT.md and ANATOMY.md (tridirectional loop): when a
+  composed-lifecycle behavior clause of the agent-runtime contract changes,
+  update the guarding LABT here in the same change.
+---
+# Agent Runtime Behavior Tests
+
+Self-contained agent behavior tasks guarding the observable behavior clauses of
+`src/lingtai/kernel/base_agent/CONTRACT.md` (the composed lifecycle promise:
+construction, liveness, ordered stop, refresh handshake). Pinned pytest commands
+must run from the repo root with the project's Python.
+
+## Behavior BA001 — stop is ordered manifest-persist → heartbeat-withdraw → lease-release, and liveness is presence-plus-heartbeat, never process visibility
+
+- **id**: BA001
+- **title**: stop is ordered manifest-persist → heartbeat-withdraw → lease-release, and liveness is presence-plus-heartbeat, never process visibility
+- **guards**: `agent-runtime` § Behavior
+- **runner**: any LingTai agent with `shell` and `file` access to this repository
+- **prerequisites**: a clean checkout of `<repo>`; no other agent process sharing the scratch working directory
+- **estimate**: ≈ 20 minutes
+
+### Steps
+1. From `<repo>`, run `python -m pytest tests/test_lifecycle_daemon_shutdown.py -q` and capture the outcome.
+2. Run `python -m pytest tests/test_agent.py -q` and capture the outcome.
+3. Inspect `src/lingtai/kernel/base_agent/lifecycle.py` teardown and confirm the artifact order manifest-persist → heartbeat-withdraw → lease-release is preserved on the best-effort error path.
+
+### Expected evidence
+- [ ] Step 1: the lifecycle shutdown suite passes, pinning heartbeat-before-release ordering and manifest persistence through teardown.
+- [ ] Step 2: the agent construction/start/stop suite passes, pinning construction, liveness, and stop behavior.
+- [ ] Step 3: the ordered teardown matches the contract's `agent-runtime.stop.v1` clause; no step reorders heartbeat withdrawal before the final manifest write.
+
+### Pass / Fail
+Pass when both suites pass and the teardown order matches the contract. Fail on any reordering, on heartbeat freshness lost before teardown completes, or on liveness being derived from process visibility; record the evidence trail in the task report.

--- a/src/lingtai/kernel/base_agent/CONTRACT.md
+++ b/src/lingtai/kernel/base_agent/CONTRACT.md
@@ -52,6 +52,8 @@ maintenance: |
 Stable entry: `lingtai.kernel.agent-runtime.v1`.
 
 ## Purpose
+Guarded by: [BA001](BEHAVIORS.md#behavior-ba001)
+
 
 Agent runtime is the composed lifecycle promise of one LingTai agent process:
 what it means for an agent to be constructed, launched, observably alive,

--- a/src/lingtai/kernel/daemon_supervisor/BEHAVIORS.md
+++ b/src/lingtai/kernel/daemon_supervisor/BEHAVIORS.md
@@ -1,0 +1,45 @@
+---
+name: daemon-supervisor-behavior-tests
+behavior_version: 1
+labt_version: 2
+contract: CONTRACT.md
+anatomy: ANATOMY.md
+related_files:
+  - src/lingtai/kernel/daemon_supervisor/CONTRACT.md
+  - src/lingtai/kernel/daemon_supervisor/ANATOMY.md
+  - src/lingtai/kernel/daemon_supervisor/__init__.py
+  - src/lingtai/kernel/daemon_supervisor/manifest.py
+maintenance: |
+  Created during the every-contract-needs-behaviors sweep. Keep this file
+  reciprocal with CONTRACT.md and ANATOMY.md (tridirectional loop): when a
+  detached-supervisor behavior clause changes, update the guarding LABT here in
+  the same change.
+---
+# Detached Daemon Supervisor Behavior Tests
+
+Self-contained agent behavior tasks guarding the observable behavior clauses of
+`src/lingtai/kernel/daemon_supervisor/CONTRACT.md` (one supervisor owns one run;
+terminal truth; idempotent notification; secret boundary). Pinned pytest
+commands must run from the repo root with the project's Python.
+
+## Behavior DS001 — one supervisor owns one run from birth through terminal state and publishes one idempotent notification
+
+- **id**: DS001
+- **title**: one supervisor owns one run from birth through terminal state and publishes one idempotent notification
+- **guards**: `daemon-supervisor` § Runtime promise
+- **runner**: any LingTai agent with `shell` and `file` access to this repository
+- **prerequisites**: a clean checkout of `<repo>`; a scratch run directory `<scratch>`; the runtime venv interpreter
+- **estimate**: ≈ 30 minutes
+
+### Steps
+1. From `<repo>`, run `python -m pytest tests/test_daemon_detached_supervisor.py -q` and capture the outcome.
+2. Run `python -m pytest tests/test_daemon.py -q` and capture the outcome.
+3. Inspect a real detached run's run directory: confirm the manifest/log files contain no resolved credentials and that exactly one terminal notification event is published for the run.
+
+### Expected evidence
+- [ ] Step 1: the detached-supervisor suite passes, pinning real detached launch, parent shutdown survival, identity mismatch, timeout/reclaim, and control ack/race truth.
+- [ ] Step 2: the daemon lifecycle suite passes (including completion/MCP/preset/skills reconstruction paths).
+- [ ] Step 3: manifest, control, and log files contain no resolved credentials (only environment/config references), and terminal notification idempotency holds — one notification per run.
+
+### Pass / Fail
+Pass when both suites pass and the run directory shows the secret boundary and one terminal notification. Fail on credential leakage into durable files, on a second terminal notification for one run, or on a supervisor that does not survive parent exit; record the evidence trail in the task report.

--- a/src/lingtai/kernel/daemon_supervisor/CONTRACT.md
+++ b/src/lingtai/kernel/daemon_supervisor/CONTRACT.md
@@ -26,6 +26,8 @@ maintenance: |
 # Detached daemon supervisor contract
 
 ## Core
+Guarded by: [DS001](BEHAVIORS.md#behavior-ds001)
+
 
 The Core owns immutable request, manifest, and control schemas plus pure
 validation. It does not import `DaemonManager`, concrete backend runners, or

--- a/src/lingtai/kernel/event_journal/BEHAVIORS.md
+++ b/src/lingtai/kernel/event_journal/BEHAVIORS.md
@@ -1,0 +1,45 @@
+---
+name: structured-event-journal-behavior-tests
+behavior_version: 1
+labt_version: 2
+contract: CONTRACT.md
+anatomy: ANATOMY.md
+related_files:
+  - src/lingtai/kernel/event_journal/CONTRACT.md
+  - src/lingtai/kernel/event_journal/ANATOMY.md
+  - src/lingtai/kernel/event_journal/__init__.py
+  - src/lingtai/adapters/posix/event_journal.py
+maintenance: |
+  Created during the every-contract-needs-behaviors sweep. Keep this file
+  reciprocal with CONTRACT.md and ANATOMY.md (tridirectional loop): when an
+  event-journal behavior clause changes, update the guarding LABT here in the
+  same change.
+---
+# Structured Event Journal Behavior Tests
+
+Self-contained agent behavior tasks guarding the observable behavior clauses of
+`src/lingtai/kernel/event_journal/CONTRACT.md` (JSONL-first ordering,
+redaction-before-storage, returned byte provenance, fail-open derived index).
+Pinned pytest commands must run from the repo root with the project's Python.
+
+## Behavior EJ001 — a successful append returns the exact JSONL file and byte offset, with every durable copy redacted before storage
+
+- **id**: EJ001
+- **title**: a successful append returns the exact JSONL file and byte offset, with every durable copy redacted before storage
+- **guards**: `structured-event-journal` § Behavior
+- **runner**: any LingTai agent with `shell` and `file` access to this repository
+- **prerequisites**: a clean checkout of `<repo>`; a scratch working directory `<scratch>`
+- **estimate**: ≈ 15 minutes
+
+### Steps
+1. From `<repo>`, run `python -m pytest tests/test_event_journal.py -q` and capture the outcome.
+2. Append a structured event carrying a secret-shaped field through the production adapter bound to `<scratch>` and read back the JSONL line; note the byte offset reported by the append result.
+3. Confirm the SQLite sidecar (derived index) received the same redacted event with JSONL provenance, and that a primary append failure created no sidecar-only fact.
+
+### Expected evidence
+- [ ] Step 1: the event-journal conformance suite passes, pinning order, exact byte offsets, immediate flush visibility, close behavior, and redaction in both stores.
+- [ ] Step 2: the returned `JournalPosition` names the real JSONL file and the starting byte offset of the appended line; the persisted line contains no secret-shaped value.
+- [ ] Step 3: SQLite contains only the redacted event after primary success; on primary failure no sidecar-only fact exists.
+
+### Pass / Fail
+Pass when every evidence item holds. Fail on out-of-order JSONL appends, on any unredacted durable copy, on an append result whose byte offset does not match the file, or on a sidecar-only fact after primary failure; record the evidence trail in the task report.

--- a/src/lingtai/kernel/event_journal/CONTRACT.md
+++ b/src/lingtai/kernel/event_journal/CONTRACT.md
@@ -31,6 +31,8 @@ maintenance: |
 # Structured Event Journal
 
 ## Purpose
+Guarded by: [EJ001](BEHAVIORS.md#behavior-ej001)
+
 
 The structured event journal is Core's outbound append-only boundary for durable
 agent events. It separates event production and lifecycle from the current POSIX

--- a/src/lingtai/kernel/lifecycle_clock/BEHAVIORS.md
+++ b/src/lingtai/kernel/lifecycle_clock/BEHAVIORS.md
@@ -1,0 +1,45 @@
+---
+name: lifecycle-clock-behavior-tests
+behavior_version: 1
+labt_version: 2
+contract: CONTRACT.md
+anatomy: ANATOMY.md
+related_files:
+  - src/lingtai/kernel/lifecycle_clock/CONTRACT.md
+  - src/lingtai/kernel/lifecycle_clock/ANATOMY.md
+  - src/lingtai/kernel/lifecycle_clock/__init__.py
+  - src/lingtai/adapters/lifecycle_clock.py
+maintenance: |
+  Created during the every-contract-needs-behaviors sweep. Keep this file
+  reciprocal with CONTRACT.md and ANATOMY.md (tridirectional loop): when a
+  lifecycle-clock behavior clause changes, update the guarding LABT here in the
+  same change.
+---
+# Lifecycle Clock Behavior Tests
+
+Self-contained agent behavior tasks guarding the observable behavior clauses of
+`src/lingtai/kernel/lifecycle_clock/CONTRACT.md` (two distinct time domains;
+no disabled clock; raw wall float passed to presence). Pinned pytest commands
+must run from the repo root with the project's Python.
+
+## Behavior LC001 — wall and monotonic domains stay distinct and the raw wall float reaches presence unchanged
+
+- **id**: LC001
+- **title**: wall and monotonic domains stay distinct and the raw wall float reaches presence unchanged
+- **guards**: `lifecycle-clock` § Behavior
+- **runner**: any LingTai agent with `shell` and `file` access to this repository
+- **prerequisites**: a clean checkout of `<repo>`; the `FakeLifecycleClock` helper available in `tests/_lifecycle_clock_helpers.py`
+- **estimate**: ≈ 15 minutes
+
+### Steps
+1. From `<repo>`, run `python -m pytest tests/test_lifecycle_clock.py -q` and capture the outcome.
+2. Using `FakeLifecycleClock` with independently controlled wall and monotonic values, drive an agent heartbeat loop and record the float handed to the injected presence port's `publish_heartbeat`.
+3. Confirm monotonic values are never persisted and wall jumps do not alter monotonic elapsed behavior (and vice versa).
+
+### Expected evidence
+- [ ] Step 1: the lifecycle-clock suite passes, pinning the two-operation Port shape, raw float forwarding, shared sampling, and monotonic/wall independence.
+- [ ] Step 2: the presence port received the exact raw wall float unchanged (byte-exact `str(value)`-no-newline conformance is the presence contract's, not asserted here).
+- [ ] Step 3: no monotonic value becomes persisted state, and a wall jump leaves monotonic elapsed intervals unchanged.
+
+### Pass / Fail
+Pass when the suite passes and both domains behave independently with the raw wall float forwarded unchanged. Fail on domain leakage, on a disabled/no-op clock being accepted, or on a modified wall value reaching presence; record the evidence trail in the task report.

--- a/src/lingtai/kernel/lifecycle_clock/CONTRACT.md
+++ b/src/lingtai/kernel/lifecycle_clock/CONTRACT.md
@@ -36,6 +36,8 @@ maintenance: |
 # Lifecycle Clock
 
 ## Purpose
+Guarded by: [LC001](BEHAVIORS.md#behavior-lc001)
+
 
 The lifecycle clock is Core's outbound boundary for reading the two time sources
 its agent-lifecycle policy depends on, without knowing the concrete time

--- a/src/lingtai/kernel/mail_transport/BEHAVIORS.md
+++ b/src/lingtai/kernel/mail_transport/BEHAVIORS.md
@@ -1,0 +1,45 @@
+---
+name: mail-transport-behavior-tests
+behavior_version: 1
+labt_version: 2
+contract: CONTRACT.md
+anatomy: ANATOMY.md
+related_files:
+  - src/lingtai/kernel/mail_transport/CONTRACT.md
+  - src/lingtai/kernel/mail_transport/ANATOMY.md
+  - src/lingtai/kernel/mail_transport/__init__.py
+  - src/lingtai/adapters/posix/mail.py
+maintenance: |
+  Created during the every-contract-needs-behaviors sweep. Keep this file
+  reciprocal with CONTRACT.md and ANATOMY.md (tridirectional loop): when a
+  mail-transport behavior clause changes, update the guarding LABT here in the
+  same change.
+---
+# Mail Transport Behavior Tests
+
+Self-contained agent behavior tasks guarding the observable behavior clauses of
+`src/lingtai/kernel/mail_transport/CONTRACT.md` (fire-and-forget send,
+atomic stage-then-rename delivery, handshake-before-delivery). Pinned pytest
+commands must run from the repo root with the project's Python.
+
+## Behavior MT001 — send returns None on success and a partial inbox entry is never observable
+
+- **id**: MT001
+- **title**: send returns None on success and a partial inbox entry is never observable
+- **guards**: `mail-transport` § Behavior
+- **runner**: any LingTai agent with `shell` and `file` access to this repository
+- **prerequisites**: a clean checkout of `<repo>`; a scratch agent working directory `<scratch>`
+- **estimate**: ≈ 20 minutes
+
+### Steps
+1. From `<repo>`, run `python -m pytest tests/test_mail_transport.py -q` and capture the outcome.
+2. Run `python -m pytest tests/test_filesystem_mail.py -q` and capture the outcome.
+3. Send a peer message with an attachment to a live recipient in `<scratch>` and observe the recipient inbox: the listener never observes a dot-prefixed staging entry, and a failed send (e.g. missing attachment) leaves no partial inbox entry.
+
+### Expected evidence
+- [ ] Step 1: the mail-transport Port suite passes (success → `None`, unknown address → error string, delivery to `on_message`, idempotent `stop`).
+- [ ] Step 2: the filesystem mechanism suite passes (handshake strings, attachments, atomic write, pseudo-outbox claim/rollback, seen-skip, phase isolation).
+- [ ] Step 3: delivered messages carry injected `_mailbox_id` and `received_at`; the listener sees only complete entries; a failed send leaves no partial entry in the recipient's inbox.
+
+### Pass / Fail
+Pass when both suites pass and the atomic-delivery observation holds. Fail on a visible partial inbox entry, on a send that returns anything but `None` on success, or on delivery without the handshake; record the evidence trail in the task report.

--- a/src/lingtai/kernel/mail_transport/CONTRACT.md
+++ b/src/lingtai/kernel/mail_transport/CONTRACT.md
@@ -28,6 +28,8 @@ maintenance: |
 # Mail Transport
 
 ## Purpose
+Guarded by: [MT001](BEHAVIORS.md#behavior-mt001)
+
 
 Mail transport is Core's outbound boundary for fire-and-forget agent messaging.
 It separates the mail intrinsic's use of message delivery and inbox arrival from

--- a/src/lingtai/kernel/migrate/BEHAVIORS.md
+++ b/src/lingtai/kernel/migrate/BEHAVIORS.md
@@ -1,0 +1,45 @@
+---
+name: migration-workspace-behavior-tests
+behavior_version: 1
+labt_version: 2
+contract: CONTRACT.md
+anatomy: ANATOMY.md
+related_files:
+  - src/lingtai/kernel/migrate/CONTRACT.md
+  - src/lingtai/kernel/migrate/ANATOMY.md
+  - src/lingtai/kernel/migrate/migrate.py
+  - src/lingtai/kernel/migrate/__init__.py
+maintenance: |
+  Created during the every-contract-needs-behaviors sweep. Keep this file
+  reciprocal with CONTRACT.md and ANATOMY.md (tridirectional loop): when a
+  migration-workspace behavior clause changes, update the guarding LABT here in
+  the same change.
+---
+# Migration Workspace Behavior Tests
+
+Self-contained agent behavior tasks guarding the observable behavior clauses of
+`src/lingtai/kernel/migrate/CONTRACT.md` (contiguous append-only registry,
+forward-only movement, version-after-success durability, atomic replacement).
+Pinned pytest commands must run from the repo root with the project's Python.
+
+## Behavior MG001 — the version counter advances only after a transform succeeds, so a failure at N+1 leaves the persisted version at N
+
+- **id**: MG001
+- **title**: the version counter advances only after a transform succeeds, so a failure at N+1 leaves the persisted version at N
+- **guards**: `migration-workspace` § Behavior
+- **runner**: any LingTai agent with `shell` and `file` access to this repository
+- **prerequisites**: a clean checkout of `<repo>`; a scratch migration workspace `<scratch>`
+- **estimate**: ≈ 20 minutes
+
+### Steps
+1. From `<repo>`, run `python -m pytest tests/test_kernel_migrate.py -q` and capture the outcome.
+2. Drive a failing transform at N+1 in `<scratch>` (a transform whose write-back fails) and read back the persisted version file (`_kernel_meta.json`); confirm it still reads N.
+3. Confirm every replacement (preset m001/m002 included) uses the PID-suffixed atomic sibling-temp mechanism and that a malformed document is skipped with a warning, not a crash.
+
+### Expected evidence
+- [ ] Step 1: the kernel-migrate conformance suite passes, pinning registry contiguity, version-after-success durability, retry resume, and PID-suffixed version writes.
+- [ ] Step 2: after the N+1 failure the persisted version is exactly N and the next launch resumes there (forward-only, no rollback/downgrade).
+- [ ] Step 3: every replacement is atomic via the sibling-temp mechanism; malformed documents continue with a warning and the exact current serialization is written back on success.
+
+### Pass / Fail
+Pass when the suite passes and version-after-success durability holds. Fail on a version advancing before its transform succeeds, on rollback/downgrade behavior, or on a non-atomic replacement; record the evidence trail in the task report.

--- a/src/lingtai/kernel/migrate/CONTRACT.md
+++ b/src/lingtai/kernel/migrate/CONTRACT.md
@@ -36,6 +36,8 @@ maintenance: |
 # Migration Workspace
 
 ## Purpose
+Guarded by: [MG001](BEHAVIORS.md#behavior-mg001)
+
 
 This retained Port describes historical/test-only versioned migration machinery.
 It is not part of the current boot/refresh init reader: production reads use

--- a/src/lingtai/kernel/notification_store/BEHAVIORS.md
+++ b/src/lingtai/kernel/notification_store/BEHAVIORS.md
@@ -1,0 +1,46 @@
+---
+name: notification-store-behavior-tests
+behavior_version: 1
+labt_version: 2
+contract: CONTRACT.md
+anatomy: ANATOMY.md
+related_files:
+  - src/lingtai/kernel/notification_store/CONTRACT.md
+  - src/lingtai/kernel/notification_store/ANATOMY.md
+  - src/lingtai/kernel/notification_store/__init__.py
+  - src/lingtai/kernel/notification_store/_mutation_lock.py
+maintenance: |
+  Created during the every-contract-needs-behaviors sweep. Keep this file
+  reciprocal with CONTRACT.md and ANATOMY.md (tridirectional loop): when a
+  notification-store behavior clause changes, update the guarding LABT here in
+  the same change.
+---
+# Notification Store Behavior Tests
+
+Self-contained agent behavior tasks guarding the observable behavior clauses of
+`src/lingtai/kernel/notification_store/CONTRACT.md` (eight operation families,
+atomic publish/clear, compare-update semantics, stale dismiss refusal). Pinned
+pytest commands must run from the repo root with the project's Python.
+
+## Behavior NS001 — a compare conflict never calls the mutator, and changed=False performs no write
+
+- **id**: NS001
+- **title**: a compare conflict never calls the mutator, and changed=False performs no write
+- **guards**: `notification-store` § Behavior
+- **runner**: any LingTai agent with `shell` and `file` access to this repository
+- **prerequisites**: a clean checkout of `<repo>`; a scratch working directory `<scratch>`
+- **estimate**: ≈ 20 minutes
+
+### Steps
+1. From `<repo>`, run `python -m pytest tests/test_notification_store.py -q` and capture the outcome.
+2. In `<scratch>`, publish a channel payload, then issue a compare-update with a stale expected version; record whether the pure Core mutator ran and what `CompareUpdateResult` reports (`applied`/`conflict`/`changed`).
+3. Issue a compare-update whose mutator returns an unchanged payload and confirm no write occurs (file mtime and bytes unchanged).
+
+### Expected evidence
+- [ ] Step 1: the notification-store conformance suite passes, pinning the eight-family surface, expected-absence versus unconditional updates, atomic updates, and stale-dismiss refusal.
+- [ ] Step 2: on a version conflict the mutator was NOT invoked, `conflict` is reported, and no policy value is carried.
+- [ ] Step 3: `changed=False` performs no write — the `.notification/<channel>.json` file is untouched.
+- [ ] Step 4: non-force dismiss against a stale fingerprint is refused (no unrelated current events lost).
+
+### Pass / Fail
+Pass when the suite passes and the conflict/no-write observations hold. Fail if a conflict invokes the mutator, if a no-op update rewrites the file, or if unrelated current events are dropped during an event/ref update; record the evidence trail in the task report.

--- a/src/lingtai/kernel/notification_store/CONTRACT.md
+++ b/src/lingtai/kernel/notification_store/CONTRACT.md
@@ -37,6 +37,8 @@ maintenance: |
 # Notification Store Contract
 
 ## Purpose
+Guarded by: [NS001](BEHAVIORS.md#behavior-ns001)
+
 
 The Notification Store persists and observes current notification-channel
 mirrors without owning notification policy. Core owns channel validation,

--- a/src/lingtai/kernel/refresh_watcher/BEHAVIORS.md
+++ b/src/lingtai/kernel/refresh_watcher/BEHAVIORS.md
@@ -1,0 +1,45 @@
+---
+name: refresh-watcher-behavior-tests
+behavior_version: 1
+labt_version: 2
+contract: CONTRACT.md
+anatomy: ANATOMY.md
+related_files:
+  - src/lingtai/kernel/refresh_watcher/CONTRACT.md
+  - src/lingtai/kernel/refresh_watcher/ANATOMY.md
+  - src/lingtai/kernel/refresh_watcher/__init__.py
+  - src/lingtai/kernel/refresh_watcher/watcher_program.py
+maintenance: |
+  Created during the every-contract-needs-behaviors sweep. Keep this file
+  reciprocal with CONTRACT.md and ANATOMY.md (tridirectional loop): when a
+  refresh-watcher behavior clause changes, update the guarding LABT here in the
+  same change.
+---
+# Refresh Watcher Behavior Tests
+
+Self-contained agent behavior tasks guarding the observable behavior clauses of
+`src/lingtai/kernel/refresh_watcher/CONTRACT.md` (one detached watcher spawn per
+refresh, frozen request, handshake normalization, env-overwrite policy). Pinned
+pytest commands must run from the repo root with the project's Python.
+
+## Behavior RW001 — a successful refresh spawns the detached watcher exactly once, and failed ACK setup does not spawn
+
+- **id**: RW001
+- **title**: a successful refresh spawns the detached watcher exactly once, and failed ACK setup does not spawn
+- **guards**: `refresh-watcher` § Behavior
+- **runner**: any LingTai agent with `shell` and `file` access to this repository
+- **prerequisites**: a clean checkout of `<repo>`; a scratch agent working directory `<scratch>`
+- **estimate**: ≈ 20 minutes
+
+### Steps
+1. From `<repo>`, run `python -m pytest tests/test_perform_refresh_handshake.py -q` and capture the outcome.
+2. Run `python -m pytest tests/test_refresh_watcher_process.py -q` and capture the outcome.
+3. In `<scratch>`, drive one `_perform_refresh` and count detached watcher spawns (via the injected `RefreshWatcherPort` fake); verify the frozen request carries only handshake paths, working directory, tuple command, identity fields JSON, and the env-overwrite policy bit.
+
+### Expected evidence
+- [ ] Step 1: the refresh handshake suite passes (`.refresh` → `.refresh.taken`, exactly one spawn, cancellation/shutdown path).
+- [ ] Step 2: the watcher process suite passes (rendered policy, exact copied environment, detached stdio, platform detached handoff).
+- [ ] Step 3: exactly one `spawn_detached` call per successful refresh; a failed ACK setup performs zero spawns; the request carries no generated source and no caller environment.
+
+### Pass / Fail
+Pass when the suites pass and the one-spawn/zero-spawn observations hold. Fail on a second spawn, on a spawn after failed ACK setup, or on a request that carries generated source or caller environment; record the evidence trail in the task report.

--- a/src/lingtai/kernel/refresh_watcher/CONTRACT.md
+++ b/src/lingtai/kernel/refresh_watcher/CONTRACT.md
@@ -44,6 +44,8 @@ maintenance: |
 # Refresh Watcher
 
 ## Purpose
+Guarded by: [RW001](BEHAVIORS.md#behavior-rw001)
+
 
 Refresh watcher is the Core boundary for handing a typed relaunch request to a
 detached watcher after `_perform_refresh` completes the `.refresh` /

--- a/src/lingtai/kernel/snapshot/BEHAVIORS.md
+++ b/src/lingtai/kernel/snapshot/BEHAVIORS.md
@@ -1,0 +1,45 @@
+---
+name: snapshot-source-revision-behavior-tests
+behavior_version: 1
+labt_version: 2
+contract: CONTRACT.md
+anatomy: ANATOMY.md
+related_files:
+  - src/lingtai/kernel/snapshot/CONTRACT.md
+  - src/lingtai/kernel/snapshot/ANATOMY.md
+  - src/lingtai/kernel/snapshot/__init__.py
+  - src/lingtai/adapters/posix/git_cli.py
+maintenance: |
+  Created during the every-contract-needs-behaviors sweep. Keep this file
+  reciprocal with CONTRACT.md and ANATOMY.md (tridirectional loop): when a
+  snapshot/source-revision behavior clause changes, update the guarding LABT
+  here in the same change.
+---
+# Snapshot + Source Revision Behavior Tests
+
+Self-contained agent behavior tasks guarding the observable behavior clauses of
+`src/lingtai/kernel/snapshot/CONTRACT.md` (opt-in idempotent initialization,
+stage-all capture, clean-tree no-op, bounded maintenance, tracked-only dirty).
+Pinned pytest commands must run from the repo root with the project's Python.
+
+## Behavior SN001 — snapshot capture stages all changes and returns None for a clean tree or operational failure
+
+- **id**: SN001
+- **title**: snapshot capture stages all changes and returns None for a clean tree or operational failure
+- **guards**: `snapshot-source-revision` § Behavior
+- **runner**: any LingTai agent with `shell` and `file` access to this repository
+- **prerequisites**: a clean checkout of `<repo>`; a scratch git workdir `<scratch>`
+- **estimate**: ≈ 20 minutes
+
+### Steps
+1. From `<repo>`, run `python -m pytest tests/test_snapshot.py -q` and capture the outcome.
+2. In `<scratch>` (a git workdir), initialize snapshots twice and confirm the second initialization is a no-op; create, modify, and delete files, then capture a snapshot and record the returned revision.
+3. With a clean tree, capture again and confirm `None`; confirm runtime identity returns a 12-character revision and tracked-only dirty tri-state within 0.5-second deadlines.
+
+### Expected evidence
+- [ ] Step 1: the snapshot conformance suite passes, pinning fixed initialization, exact exclusions, stage-all capture, clean no-op, failure translation, bounded maintenance, and revision formatting.
+- [ ] Step 2: initialization is idempotent and creates the required system files even when Git fails; the snapshot returns native-short HEAD with a UTC-stamped commit.
+- [ ] Step 3: a clean tree returns `None`; dirty means tracked-file state only (untracked files ignored); missing/failed/timed-out revision queries return `None` without crashing.
+
+### Pass / Fail
+Pass when the suite passes and the capture/no-op observations hold. Fail on a non-idempotent initialization, on a snapshot of a clean tree returning a revision, or on a revision query that crashes instead of returning `None`; record the evidence trail in the task report.

--- a/src/lingtai/kernel/snapshot/CONTRACT.md
+++ b/src/lingtai/kernel/snapshot/CONTRACT.md
@@ -38,6 +38,8 @@ maintenance: |
 # Snapshot + Source Revision
 
 ## Purpose
+Guarded by: [SN001](BEHAVIORS.md#behavior-sn001)
+
 
 This component owns Core's two outbound capabilities for whole-workdir snapshots
 and bounded read-only source revision inspection. It separates lifecycle and

--- a/src/lingtai/kernel/workdir_lease/BEHAVIORS.md
+++ b/src/lingtai/kernel/workdir_lease/BEHAVIORS.md
@@ -1,0 +1,45 @@
+---
+name: workdir-lease-behavior-tests
+behavior_version: 1
+labt_version: 2
+contract: CONTRACT.md
+anatomy: ANATOMY.md
+related_files:
+  - src/lingtai/kernel/workdir_lease/CONTRACT.md
+  - src/lingtai/kernel/workdir_lease/ANATOMY.md
+  - src/lingtai/kernel/workdir_lease/__init__.py
+  - src/lingtai/adapters/posix/workdir_lease.py
+maintenance: |
+  Created during the every-contract-needs-behaviors sweep. Keep this file
+  reciprocal with CONTRACT.md and ANATOMY.md (tridirectional loop): when a
+  workdir-lease behavior clause changes, update the guarding LABT here in the
+  same change.
+---
+# Workdir Lease Behavior Tests
+
+Self-contained agent behavior tasks guarding the observable behavior clauses of
+`src/lingtai/kernel/workdir_lease/CONTRACT.md` (exclusive claim, exact
+contention error, idempotent release, lock-existence-is-not-authority). Pinned
+pytest commands must run from the repo root with the project's Python.
+
+## Behavior WL001 — a held lease excludes a second acquire with the exact contention error, and release is idempotent
+
+- **id**: WL001
+- **title**: a held lease excludes a second acquire with the exact contention error, and release is idempotent
+- **guards**: `workdir-lease` § Behavior
+- **runner**: any LingTai agent with `shell` and `file` access to this repository
+- **prerequisites**: a clean checkout of `<repo>`; a scratch working directory `<scratch>`
+- **estimate**: ≈ 20 minutes
+
+### Steps
+1. From `<repo>`, run `python -m pytest tests/test_workdir_lease.py -q` and capture the outcome.
+2. In `<scratch>`, acquire the lease, then attempt a second `acquire(0)` and record the exception type and message.
+3. Call `release()` twice, then acquire again and confirm success; on Windows-native runs, confirm the TUI byte-0/length-1 probe mapping (held→Block, released→Allow).
+
+### Expected evidence
+- [ ] Step 1: the workdir-lease suite passes, pinning collision, delayed-release-before-timeout, zero-timeout failure, expiry, idempotent release, and the exact contention text `Working directory '<path>' is already in use by another agent.`.
+- [ ] Step 2: the second acquire raises `RuntimeError` with the exact text; lock-file existence alone is not authority.
+- [ ] Step 3: repeated `release()` calls are safe, a subsequent acquire succeeds after release, and the close-before-unlink order holds.
+
+### Pass / Fail
+Pass when the suite passes and the exclusion/idempotency observations hold. Fail on a second acquire succeeding while the lease is held, on a missing or changed contention message, or on a non-idempotent release; record the evidence trail in the task report.

--- a/src/lingtai/kernel/workdir_lease/CONTRACT.md
+++ b/src/lingtai/kernel/workdir_lease/CONTRACT.md
@@ -36,6 +36,8 @@ maintenance: |
 # Workdir Lease
 
 ## Purpose
+Guarded by: [WL001](BEHAVIORS.md#behavior-wl001)
+
 
 Workdir lease is Core's outbound boundary for claiming exclusive use of an
 agent's working directory. It separates the safety invariant *"exactly one live

--- a/src/lingtai/mcp_servers/telegram/task_card/BEHAVIORS.md
+++ b/src/lingtai/mcp_servers/telegram/task_card/BEHAVIORS.md
@@ -1,0 +1,46 @@
+---
+name: telegram-task-card-behavior-tests
+behavior_version: 1
+labt_version: 2
+contract: CONTRACT.md
+anatomy: ANATOMY.md
+related_files:
+  - src/lingtai/mcp_servers/telegram/task_card/CONTRACT.md
+  - src/lingtai/mcp_servers/telegram/task_card/ANATOMY.md
+  - src/lingtai/mcp_servers/telegram/task_card/resident.py
+  - src/lingtai/mcp_servers/telegram/task_card/SKILL.md
+maintenance: |
+  Created during the every-contract-needs-behaviors sweep. Keep this file
+  reciprocal with CONTRACT.md and ANATOMY.md (tridirectional loop): when a
+  telegram task-card projection behavior clause changes, update the guarding
+  LABT here in the same change.
+---
+# Telegram Task Card Projection Behavior Tests
+
+Self-contained agent behavior tasks guarding the observable behavior clauses of
+`src/lingtai/mcp_servers/telegram/task_card/CONTRACT.md` (programmable body
+only when status is exactly active and nonempty; diff-only projection;
+no-op preservation). Pinned pytest commands must run from the repo root with
+the project's Python.
+
+## Behavior TT001 — the programmable frame is composed only for exact active with a nonempty body, and diff-only updates suppress transport churn
+
+- **id**: TT001
+- **title**: the programmable frame is composed only for exact active with a nonempty body, and diff-only updates suppress transport churn
+- **guards**: `telegram-task-card-projection` § Behavior
+- **runner**: any LingTai agent with `shell` and `file` access to this repository
+- **prerequisites**: a clean checkout of `<repo>`; a scratch agent working directory `<scratch>` with `taskcard/status` and `taskcard/taskcard.md`
+- **estimate**: ≈ 20 minutes
+
+### Steps
+1. From `<repo>`, run `python -m pytest tests/test_telegram_task_card_programmable.py -q` and capture the outcome.
+2. In `<scratch>`, set `taskcard/status` to exact `active` with a nonempty body and project the card; then set status to a missing/unreadable value and project again; record both compositions.
+3. Re-project with identical body bytes and confirm no transport update occurs (diff-only); set status to exact `inactive` twice and confirm the second projection delivers nothing further.
+
+### Expected evidence
+- [ ] Step 1: the programmable projection suite passes, pinning active projection, diff-only updates, exact-`inactive` frame exclusion, reactivation, and last-good preservation.
+- [ ] Step 2: the programmable frame is composed only for exact `active` with a nonempty body; missing/unreadable status or blank body is a no-op that preserves the last valid programmable frame.
+- [ ] Step 3: identical body bytes produce no transport update; exact `inactive` idempotently excludes only the programmable frame and never deletes the resident message, the local body, or pauses automatic updates.
+
+### Pass / Fail
+Pass when the suite passes and the active/diff-only observations hold. Fail on programmable composition for a non-active status, on a transport update for identical bytes, or on `inactive` clearing the resident message or body; record the evidence trail in the task report.

--- a/src/lingtai/mcp_servers/telegram/task_card/CONTRACT.md
+++ b/src/lingtai/mcp_servers/telegram/task_card/CONTRACT.md
@@ -26,6 +26,8 @@ maintenance: |
 # Telegram Task Card Projection
 
 ## Purpose
+Guarded by: [TT001](BEHAVIORS.md#behavior-tt001)
+
 
 Own Telegram's provider adapter and read-only projection of the intrinsic
 declarative Task Card artifact. Provider-neutral resident state/delivery lives

--- a/src/lingtai/tools/BEHAVIORS.md
+++ b/src/lingtai/tools/BEHAVIORS.md
@@ -1,0 +1,45 @@
+---
+name: lingtai-tool-protocol-behavior-tests
+behavior_version: 1
+labt_version: 2
+contract: CONTRACT.md
+anatomy: ANATOMY.md
+related_files:
+  - src/lingtai/tools/CONTRACT.md
+  - src/lingtai/tools/ANATOMY.md
+  - src/lingtai/tools/_catalog.py
+  - src/lingtai/tools/_manual.py
+maintenance: |
+  Created during the every-contract-needs-behaviors sweep. Keep this file
+  reciprocal with CONTRACT.md and ANATOMY.md (tridirectional loop): when an LTP
+  envelope or settings rule changes, update the guarding LABT here in the same
+  change.
+---
+# LingTai Tool Protocol (LTP) Behavior Tests
+
+Self-contained agent behavior tasks guarding the observable behavior clauses of
+`src/lingtai/tools/CONTRACT.md` (closed root envelope, strict per-action input,
+manual action, two-level settings). Pinned pytest commands must run from the
+repo root with the project's Python.
+
+## Behavior LP001 — a migrated family's model-facing root is exactly action/input/reasoning/summarize and closed
+
+- **id**: LP001
+- **title**: a migrated family's model-facing root is exactly action/input/reasoning/summarize and closed
+- **guards**: `lingtai-tool-protocol` § Behavior
+- **runner**: any LingTai agent with `shell` and `file` access to this repository
+- **prerequisites**: a clean checkout of `<repo>`; one migrated family to probe (e.g. `file`, `knowledge`, or `mcp`)
+- **estimate**: ≈ 20 minutes
+
+### Steps
+1. From `<repo>`, run `python -m pytest tests/test_tool_family_wire_parity.py -q` and capture the outcome.
+2. Fetch a migrated family's advertised schema (`get_schema()` on the family) and verify the root properties are exactly `action`, `input`, `reasoning`, and `summarize` with `additionalProperties: false`, and that `reasoning`/`summarize` never appear nested under `input`.
+3. Confirm `ToolExecutor` strips root `summarize` before handler dispatch and that the root boolean survives through result post-processing on both single and parallel call paths.
+
+### Expected evidence
+- [ ] Step 1: the wire-parity suite passes, pinning envelope correlation on both Chat Completions and Responses wires.
+- [ ] Step 2: the schema's root is closed with exactly the four properties; no `parameters`/`payload` alias appears; action branches are closed per action.
+- [ ] Step 3: `_reasoning` never appears in the model-facing schema or nested `input`; raw output is durably recorded before any visible summary replacement, and tool errors stay exact and unmodified.
+
+### Pass / Fail
+Pass when the suite passes and the closed-envelope observation holds for a real migrated family. Fail on an extra root property, on `reasoning`/`summarize` leaking into `input`, or on a summary replacing the recorded raw output; record the evidence trail in the task report.

--- a/src/lingtai/tools/CONTRACT.md
+++ b/src/lingtai/tools/CONTRACT.md
@@ -46,6 +46,8 @@ maintenance: |
 # LingTai Tool Protocol (LTP)
 
 ## Purpose
+Guarded by: [LP001](BEHAVIORS.md#behavior-lp001)
+
 
 Define the **LingTai Tool Protocol (LTP)**: the future canonical public interface
 for LingTai-owned model-facing tools. LTP covers public addressing, ownership,

--- a/src/lingtai/tools/avatar/BEHAVIORS.md
+++ b/src/lingtai/tools/avatar/BEHAVIORS.md
@@ -1,0 +1,45 @@
+---
+name: avatar-behavior-tests
+behavior_version: 1
+labt_version: 2
+contract: CONTRACT.md
+anatomy: ANATOMY.md
+related_files:
+  - src/lingtai/tools/avatar/CONTRACT.md
+  - src/lingtai/tools/avatar/ANATOMY.md
+  - src/lingtai/tools/avatar/__init__.py
+  - src/lingtai/tools/avatar/_launcher.py
+maintenance: |
+  Created during the every-contract-needs-behaviors sweep. Keep this file
+  reciprocal with CONTRACT.md and ANATOMY.md (tridirectional loop): when an
+  avatar spawn/rules/manual behavior clause changes, update the guarding LABT
+  here in the same change.
+---
+# Avatar Capability Behavior Tests
+
+Self-contained agent behavior tasks guarding the observable behavior clauses of
+`src/lingtai/tools/avatar/CONTRACT.md` (spawn mission gate, name grammar, rules
+admin gate, manual no-I/O). Pinned pytest commands must run from the repo root
+with the project's Python.
+
+## Behavior AV001 — spawn enforces the name grammar and the mission-quality gate, and rules requires admin privilege
+
+- **id**: AV001
+- **title**: spawn enforces the name grammar and the mission-quality gate, and rules requires admin privilege
+- **guards**: `avatar-contract` § Tool surface
+- **runner**: any LingTai agent with `shell` and `file` access to this repository
+- **prerequisites**: a clean checkout of `<repo>`; a scratch parent agent directory `<scratch>`; no live avatar of the probe name
+- **estimate**: ≈ 25 minutes
+
+### Steps
+1. From `<repo>`, run `python -m pytest tests/test_avatar_launcher.py tests/test_avatar_rules.py -q` and capture the outcome.
+2. Call `avatar(action="spawn", input={"name": "bad name with spaces"}, reasoning="probe")` and record the result; then call it with `name="good"` and a mission shorter than 20 characters and record the result.
+3. Call `avatar(action="rules", input={"rules_content": "..."}, reasoning="probe")` from a caller without admin karma and record the result; retry with a truthy admin karma.
+
+### Expected evidence
+- [ ] Step 1: the avatar launcher/rules suites pass, pinning dry-run, mission gate, receipts, authorization, and distribution.
+- [ ] Step 2: a name violating `^[\w-]+$` or carrying a dot/slash/leading dot is rejected; an empty/very-short/debug-placeholder mission is refused with `confirmation_needed` unless `confirm=true` (dry_run exempt).
+- [ ] Step 3: `rules` without admin privilege is refused before any write; with admin privilege it writes the self `.rules` signal and returns `distributed_to`.
+
+### Pass / Fail
+Pass when the suites pass and the gate observations hold. Fail on a malformed name spawning, on a weak mission spawning without confirmation, or on `rules` executing without admin karma; record the evidence trail in the task report.

--- a/src/lingtai/tools/avatar/CONTRACT.md
+++ b/src/lingtai/tools/avatar/CONTRACT.md
@@ -77,6 +77,8 @@ independence" rule, avatar could hand-write an equivalent `handle()` without
 changing any promise in this file.
 
 ## Routing Card
+Guarded by: [AV001](BEHAVIORS.md#behavior-av001)
+
 
 **Use this when:**
 - You are editing avatar spawning (shallow 初生 / deep 二重身), the spawn ledger,

--- a/src/lingtai/tools/browser/BEHAVIORS.md
+++ b/src/lingtai/tools/browser/BEHAVIORS.md
@@ -1,0 +1,45 @@
+---
+name: browser-internal-behavior-tests
+behavior_version: 1
+labt_version: 2
+contract: CONTRACT.md
+anatomy: ANATOMY.md
+related_files:
+  - src/lingtai/tools/browser/CONTRACT.md
+  - src/lingtai/tools/browser/ANATOMY.md
+  - src/lingtai/tools/browser/core.py
+  - src/lingtai/tools/browser/port.py
+maintenance: |
+  Created during the every-contract-needs-behaviors sweep. Keep this file
+  reciprocal with CONTRACT.md and ANATOMY.md (tridirectional loop): when a
+  browse subcomponent behavior clause changes, update the guarding LABT here in
+  the same change.
+---
+# Internal Browse Subcomponent Behavior Tests
+
+Self-contained agent behavior tasks guarding the observable behavior clauses of
+`src/lingtai/tools/browser/CONTRACT.md` (structured success/typed failure
+payloads, SSRF-safe redirects, complete-document delivery). Pinned pytest
+commands must run from the repo root with the project's Python.
+
+## Behavior BR001 — a fresh browse success never exposes only a first page or partial document
+
+- **id**: BR001
+- **title**: a fresh browse success never exposes only a first page or partial document
+- **guards**: `browser-internal` § Behavior
+- **runner**: any LingTai agent with `shell` and `file` access to this repository
+- **prerequisites**: a clean checkout of `<repo>`; the `web` capability tests available locally
+- **estimate**: ≈ 20 minutes
+
+### Steps
+1. From `<repo>`, run `python -m pytest tests/test_browser_capability.py -q` and capture the outcome.
+2. Inspect `WebManager._deliver_browse` and confirm the unified parent always overrides the engine's internal paginated page with the complete joined `snapshot.blocks` text before returning.
+3. Confirm a transport success whose body fails to decode to readable text yields no blocks and raises the `NO_TEXT_BLOCKS` extract failure with HTTP provenance (decode-replacement dominated case), and that cleanly decoded text is never reclassified.
+
+### Expected evidence
+- [ ] Step 1: the browser capability suite passes (policy/cursor-edge and transport coverage included).
+- [ ] Step 2: the parent replaces the internal paginated shape with the complete joined text; the public contract exposes the full document for a fresh success.
+- [ ] Step 3: dominated replacement characters plus raw control bytes yield no blocks and the typed extract failure; cleanly decoded text is returned unchanged.
+
+### Pass / Fail
+Pass when the suite passes and the complete-document/typed-failure observations hold. Fail on a partial first-page success, on a decode-damaged body being returned as usable content, or on clean text being reclassified; record the evidence trail in the task report.

--- a/src/lingtai/tools/browser/CONTRACT.md
+++ b/src/lingtai/tools/browser/CONTRACT.md
@@ -31,6 +31,7 @@ capability. It is retained as a technology-neutral child, not a separate
 model-facing browser tool.
 
 ## Behavior
+Guarded by: [BR001](BEHAVIORS.md#behavior-br001)
 
 `BrowserEngine.handle` accepts browse arguments and returns the existing
 structured success or typed failure payload, including provenance, source hash,
@@ -82,3 +83,4 @@ this same live engine without causing a second public registration.
 Keep this internal Contract paired with its Anatomy and linked from the parent
 web Contract as an implementation boundary. Do not expose `browser` as a
 capability name or install its retained manual bundle.
+

--- a/src/lingtai/tools/daemon/interactive_terminal/BEHAVIORS.md
+++ b/src/lingtai/tools/daemon/interactive_terminal/BEHAVIORS.md
@@ -1,0 +1,46 @@
+---
+name: interactive-terminal-behavior-tests
+behavior_version: 1
+labt_version: 2
+contract: CONTRACT.md
+anatomy: ANATOMY.md
+related_files:
+  - src/lingtai/tools/daemon/interactive_terminal/CONTRACT.md
+  - src/lingtai/tools/daemon/interactive_terminal/ANATOMY.md
+  - src/lingtai/tools/daemon/interactive_terminal/__init__.py
+  - src/lingtai/adapters/posix/interactive_terminal.py
+maintenance: |
+  Created during the every-contract-needs-behaviors sweep. Keep this file
+  reciprocal with CONTRACT.md and ANATOMY.md (tridirectional loop): when an
+  interactive-terminal behavior clause changes, update the guarding LABT here
+  in the same change.
+---
+# Interactive Terminal Port Behavior Tests
+
+Self-contained agent behavior tasks guarding the observable behavior clauses of
+`src/lingtai/tools/daemon/interactive_terminal/CONTRACT.md` (opaque handles,
+raw byte reads ending with an empty chunk, deadline-bounded reads, wait
+timeout without termination). Pinned pytest commands must run from the repo
+root with the project's Python.
+
+## Behavior IT001 — spawn returns only an opaque handle, read yields raw bytes and ends with an empty chunk, and wait timeout does not terminate the child
+
+- **id**: IT001
+- **title**: spawn returns only an opaque handle, read yields raw bytes and ends with an empty chunk, and wait timeout does not terminate the child
+- **guards**: `daemon-interactive-terminal-contract` § Operations
+- **runner**: any LingTai agent with `shell` and `file` access to this repository
+- **prerequisites**: a clean checkout of `<repo>`; a POSIX host with `pty` available (or a Windows runner using the port tests' native lane)
+- **estimate**: ≈ 20 minutes
+
+### Steps
+1. From `<repo>`, run `python -m pytest tests/test_interactive_terminal_port.py -q` and capture the outcome.
+2. Spawn a child that echoes bytes through the Port and confirm the returned value is an opaque handle (never a PID/process object), that `read` returns arbitrary raw byte chunks, and that the final chunk is empty at terminal EOF.
+3. Call `wait(handle, timeout=0.1)` on a child that stays alive and confirm `TimeoutError` is raised and the child is not terminated; then `terminate` the handle and confirm an exit receipt with the first non-`None` local reason retained.
+
+### Expected evidence
+- [ ] Step 1: the interactive-terminal port suite passes, pinning spawn/read/write/wait/terminate/release semantics and the default dimensions 120x40.
+- [ ] Step 2: spawn returns only an opaque handle; read never decodes, line-buffers, or strips ANSI/control bytes and ends with an empty chunk at EOF.
+- [ ] Step 3: a `wait` timeout raises `TimeoutError` without terminating the child; `terminate` uses bounded process-group TERM/KILL ownership; `release` is idempotent and returns `False` for a live child.
+
+### Pass / Fail
+Pass when the suite passes and the opaque-handle/raw-byte observations hold. Fail on a spawn exposing a process handle, on decoded or stripped read output, or on a wait timeout that kills the child; record the evidence trail in the task report.

--- a/src/lingtai/tools/daemon/interactive_terminal/CONTRACT.md
+++ b/src/lingtai/tools/daemon/interactive_terminal/CONTRACT.md
@@ -24,6 +24,8 @@ maintenance: |
 # Interactive terminal Port Contract
 
 ## Scope
+Guarded by: [IT001](BEHAVIORS.md#behavior-it001)
+
 
 `InteractiveTerminalPort` is the narrow mechanism boundary for the retained,
 hidden interactive Claude route. It carries one immutable direct command,

--- a/src/lingtai/tools/email/BEHAVIORS.md
+++ b/src/lingtai/tools/email/BEHAVIORS.md
@@ -1,0 +1,45 @@
+---
+name: email-behavior-tests
+behavior_version: 1
+labt_version: 2
+contract: CONTRACT.md
+anatomy: ANATOMY.md
+related_files:
+  - src/lingtai/tools/email/CONTRACT.md
+  - src/lingtai/tools/email/ANATOMY.md
+  - src/lingtai/tools/email/__init__.py
+  - src/lingtai/tools/email/manager.py
+maintenance: |
+  Created during the every-contract-needs-behaviors sweep. Keep this file
+  reciprocal with CONTRACT.md and ANATOMY.md (tridirectional loop): when an
+  email tool behavior clause changes, update the guarding LABT here in the same
+  change.
+---
+# Email Capability Behavior Tests
+
+Self-contained agent behavior tasks guarding the observable behavior clauses of
+`src/lingtai/tools/email/CONTRACT.md` (closed LTP v2 envelope, validation
+before mailbox I/O, reserved `unread` rejection, exact receipts). Pinned pytest
+commands must run from the repo root with the project's Python.
+
+## Behavior EM001 — envelope failures are rejected before any mailbox I/O, and send returns the exact sent receipt
+
+- **id**: EM001
+- **title**: envelope failures are rejected before any mailbox I/O, and send returns the exact sent receipt
+- **guards**: `email-contract` § Tool surface
+- **runner**: any LingTai agent with `shell` and `file` access to this repository
+- **prerequisites**: a clean checkout of `<repo>`; a scratch agent working directory `<scratch>`
+- **estimate**: ≈ 20 minutes
+
+### Steps
+1. From `<repo>`, run `python -m pytest tests/test_layers_email.py -q` and capture the outcome.
+2. Call `email(action="send", input={"address": "peer@example", "message": "hi", "unknown_key": 1}, reasoning="probe")` and record the result; confirm no mailbox file was created or modified.
+3. Call `email(action="unread", input={}, reasoning="probe")` directly and record the result; then send a valid message and confirm the receipt contains `status: "sent"`.
+
+### Expected evidence
+- [ ] Step 1: the email layer suite passes, pinning the LTP v2 envelope, receipts, and wire parity.
+- [ ] Step 2: the cross-action input key is rejected before any mailbox I/O, delivery thread, or read-state change.
+- [ ] Step 3: direct `unread` is rejected with the reserved-action error before family dispatch; a valid send returns `{status: "sent", to, cc, bcc, delay}` and `reasoning`/`summarize`/`_tc_id` never reach the handler.
+
+### Pass / Fail
+Pass when the suite passes and the before-I/O rejection and exact receipt hold. Fail on an envelope failure that touches the mailbox, on a direct `unread` that dispatches, or on a send receipt missing `status: "sent"`; record the evidence trail in the task report.

--- a/src/lingtai/tools/email/CONTRACT.md
+++ b/src/lingtai/tools/email/CONTRACT.md
@@ -34,6 +34,8 @@ this one tool. The implementation lives in `src/lingtai/tools/email/`; the code 
 source of truth.
 
 ## Routing Card
+Guarded by: [EM001](BEHAVIORS.md#behavior-em001)
+
 
 **Use this when:**
 - You are editing the internal mailbox tool: send/check/read/reply/search/

--- a/src/lingtai/tools/knowledge/BEHAVIORS.md
+++ b/src/lingtai/tools/knowledge/BEHAVIORS.md
@@ -1,0 +1,45 @@
+---
+name: knowledge-behavior-tests
+behavior_version: 1
+labt_version: 2
+contract: CONTRACT.md
+anatomy: ANATOMY.md
+related_files:
+  - src/lingtai/tools/knowledge/CONTRACT.md
+  - src/lingtai/tools/knowledge/ANATOMY.md
+  - src/lingtai/tools/knowledge/__init__.py
+  - src/lingtai/tools/_catalog.py
+maintenance: |
+  Created during the every-contract-needs-behaviors sweep. Keep this file
+  reciprocal with CONTRACT.md and ANATOMY.md (tridirectional loop): when a
+  knowledge tool behavior clause changes, update the guarding LABT here in the
+  same change.
+---
+# Knowledge Capability Behavior Tests
+
+Self-contained agent behavior tasks guarding the observable behavior clauses of
+`src/lingtai/tools/knowledge/CONTRACT.md` (info/manual only, strict-empty
+input, health-only info, private catalog). Pinned pytest commands must run from
+the repo root with the project's Python.
+
+## Behavior KN001 — info returns health only and any input key is rejected before the handler runs
+
+- **id**: KN001
+- **title**: info returns health only and any input key is rejected before the handler runs
+- **guards**: `knowledge-contract` § Tool surface
+- **runner**: any LingTai agent with `shell` and `file` access to this repository
+- **prerequisites**: a clean checkout of `<repo>`; a scratch agent working directory `<scratch>` with a `knowledge/` entry
+- **estimate**: ≈ 15 minutes
+
+### Steps
+1. From `<repo>`, run `python -m pytest tests/test_knowledge.py -q` and capture the outcome.
+2. Call `knowledge(action="info", input={}, reasoning="probe")` and record the result; confirm it reports `knowledge_dir`, `catalog_size`, and `problems` but no entry bodies.
+3. Call `knowledge(action="info", input={"query": "x"}, reasoning="probe")` and record the result; confirm rejection happens before any scan or mutation.
+
+### Expected evidence
+- [ ] Step 1: the knowledge suite passes, pinning catalog scanning, prompt injection, and the knowledge/skill boundary.
+- [ ] Step 2: `info` returns `{status: "ok", knowledge_dir, catalog_size, problems}` and never loads entry bodies into its result.
+- [ ] Step 3: any `input` key is rejected with `INVALID_ARGUMENT` before the handler runs; unknown actions return the exact pre-migration envelope without mutating state.
+
+### Pass / Fail
+Pass when the suite passes and the health-only/no-argument observations hold. Fail on `info` returning entry bodies, on an accepted input field, or on a mutating `info`; record the evidence trail in the task report.

--- a/src/lingtai/tools/knowledge/CONTRACT.md
+++ b/src/lingtai/tools/knowledge/CONTRACT.md
@@ -23,6 +23,8 @@ injects a compact catalog into the system prompt. The implementation lives in
 `src/lingtai/tools/knowledge/`; the code is the source of truth.
 
 ## Routing Card
+Guarded by: [KN001](BEHAVIORS.md#behavior-kn001)
+
 
 **Use this when:**
 - You are editing the private durable knowledge capability.

--- a/src/lingtai/tools/lingtai/BEHAVIORS.md
+++ b/src/lingtai/tools/lingtai/BEHAVIORS.md
@@ -1,0 +1,45 @@
+---
+name: lingtai-tool-behavior-tests
+behavior_version: 1
+labt_version: 2
+contract: CONTRACT.md
+anatomy: ANATOMY.md
+related_files:
+  - src/lingtai/tools/lingtai/CONTRACT.md
+  - src/lingtai/tools/lingtai/ANATOMY.md
+  - src/lingtai/tools/lingtai/__init__.py
+  - src/lingtai/tools/lingtai/_lingtai.py
+maintenance: |
+  Created during the every-contract-needs-behaviors sweep. Keep this file
+  reciprocal with CONTRACT.md and ANATOMY.md (tridirectional loop): when a
+  lingtai tool behavior clause changes, update the guarding LABT here in the
+  same change.
+---
+# LingTai Capability Behavior Tests
+
+Self-contained agent behavior tasks guarding the observable behavior clauses of
+`src/lingtai/tools/lingtai/CONTRACT.md` (manual-only public inventory, retired
+actions fail as unknown, protected character composition). Pinned pytest
+commands must run from the repo root with the project's Python.
+
+## Behavior LG001 — the public inventory is exactly manual, and retired update/load fail as unknown actions
+
+- **id**: LG001
+- **title**: the public inventory is exactly manual, and retired update/load fail as unknown actions
+- **guards**: `lingtai-tool-contract` § Public port
+- **runner**: any LingTai agent with `shell` and `file` access to this repository
+- **prerequisites**: a clean checkout of `<repo>`; a scratch agent working directory `<scratch>`
+- **estimate**: ≈ 15 minutes
+
+### Steps
+1. From `<repo>`, run `python -m pytest tests/test_context_ownership_redesign.py tests/test_pad_lingtai_split.py -q` and capture the outcome.
+2. Call `lingtai(action="manual", input={}, reasoning="probe")` and record the flat `{status, manual, manual_path}` result.
+3. Call `lingtai(action="update", input={}, reasoning="probe")` and `lingtai(action="load", input={}, reasoning="probe")`; record both results and confirm no file mutation occurred.
+
+### Expected evidence
+- [ ] Step 1: the context-ownership and pad/lingtai split suites pass, pinning the manual-only schema and dispatch and strict retired-action rejection.
+- [ ] Step 2: `manual` resolves the `lingtai-manual` and is flattened once after generic ToolFamily dispatch.
+- [ ] Step 3: retired `update`/`load` fail as unknown actions with no alias and no hidden mutation/reload path; schema and dispatch expose no hidden action on either provider wire.
+
+### Pass / Fail
+Pass when the suites pass and the manual-only/retired-rejection observations hold. Fail on a working `update`/`load`, on a hidden mutation path, or on a non-flat manual result; record the evidence trail in the task report.

--- a/src/lingtai/tools/lingtai/CONTRACT.md
+++ b/src/lingtai/tools/lingtai/CONTRACT.md
@@ -24,6 +24,8 @@ maintenance: |
 # LingTai capability contract
 
 ## Purpose and ownership
+Guarded by: [LG001](BEHAVIORS.md#behavior-lg001)
+
 
 `lingtai` is the model-visible signpost for the agent's 灵台: durable character
 content in `system/lingtai.md`, rendered into the protected `character` prompt

--- a/src/lingtai/tools/mcp/BEHAVIORS.md
+++ b/src/lingtai/tools/mcp/BEHAVIORS.md
@@ -1,0 +1,45 @@
+---
+name: mcp-behavior-tests
+behavior_version: 1
+labt_version: 2
+contract: CONTRACT.md
+anatomy: ANATOMY.md
+related_files:
+  - src/lingtai/tools/mcp/CONTRACT.md
+  - src/lingtai/tools/mcp/ANATOMY.md
+  - src/lingtai/tools/mcp/__init__.py
+  - src/lingtai/mcp_catalog.json
+maintenance: |
+  Created during the every-contract-needs-behaviors sweep. Keep this file
+  reciprocal with CONTRACT.md and ANATOMY.md (tridirectional loop): when an mcp
+  tool behavior clause changes, update the guarding LABT here in the same
+  change.
+---
+# MCP Capability Behavior Tests
+
+Self-contained agent behavior tasks guarding the observable behavior clauses of
+`src/lingtai/tools/mcp/CONTRACT.md` (info/manual only, strict-empty input,
+identity surfaced only when present, degraded manual shape). Pinned pytest
+commands must run from the repo root with the project's Python.
+
+## Behavior MC001 — info is read-only and any input field fails before the registry is re-read
+
+- **id**: MC001
+- **title**: info is read-only and any input field fails before the registry is re-read
+- **guards**: `mcp-contract` § Tool surface
+- **runner**: any LingTai agent with `shell` and `file` access to this repository
+- **prerequisites**: a clean checkout of `<repo>`; a scratch agent working directory `<scratch>` with an `mcp_registry.jsonl`
+- **estimate**: ≈ 15 minutes
+
+### Steps
+1. From `<repo>`, run `python -m pytest tests/test_mcp_capability.py tests/test_mcp_skill_manuals.py -q` and capture the outcome.
+2. Call `mcp(action="info", input={}, reasoning="probe")` and record the result; confirm it reconciles the registry, re-injects prompt XML, and returns `{status, registry_path, registered_count, registered, problems}`.
+3. Call `mcp(action="info", input={"extra": 1}, reasoning="probe")` and confirm rejection happens before the registry is re-read or the manual is loaded.
+
+### Expected evidence
+- [ ] Step 1: the mcp capability and skill-manual suites pass, pinning envelope validation, dispatch, and the canonical manual shape.
+- [ ] Step 2: `info` returns the health/registry result; each `registered` entry carries `identity` only when a matching identity record with non-empty `accounts` exists.
+- [ ] Step 3: any extra `input` key yields `INVALID_ARGUMENT` (`unsupported mcp input field`) before registry I/O; unknown actions render the exact Host-owned pre-migration envelope.
+
+### Pass / Fail
+Pass when the suites pass and the read-only/no-input observations hold. Fail on an accepted input field, on identity leaking without a matching record, or on a mutating `info`; record the evidence trail in the task report.

--- a/src/lingtai/tools/mcp/CONTRACT.md
+++ b/src/lingtai/tools/mcp/CONTRACT.md
@@ -27,6 +27,8 @@ lives in `src/lingtai/services/mcp_registry.py` (imported lazily). The code is t
 source of truth.
 
 ## Routing Card
+Guarded by: [MC001](BEHAVIORS.md#behavior-mc001)
+
 
 **Use this when:**
 - You are editing the mcp tool slice's action dispatch or the reconciliation that

--- a/src/lingtai/tools/notification/BEHAVIORS.md
+++ b/src/lingtai/tools/notification/BEHAVIORS.md
@@ -13,19 +13,22 @@ maintenance: |
   Created during the every-contract-needs-behaviors sweep. Keep this file
   reciprocal with CONTRACT.md and ANATOMY.md (tridirectional loop): when a
   notification tool behavior clause changes, update the guarding LABT here in
-  the same change.
+  the same change. N001-N003 guard the notification hook-registry clauses
+  added by PR #1337 (unregistered channel blocked, registered channel
+  passes through, lifecycle validation).
 ---
 # Notification Tool Behavior Tests
 
 Self-contained agent behavior tasks guarding the observable behavior clauses of
 `src/lingtai/tools/notification/CONTRACT.md` (manual read-only, check/current
-state, narrow dismiss actions, Store semantics preserved). Pinned pytest
-commands must run from the repo root with the project's Python.
+state, narrow dismiss actions, hook-registry allowlist, Store semantics
+preserved). Pinned pytest commands must run from the repo root with the
+project's Python.
 
-## Behavior NT001 — manual stays read-only and check reports current notification state without mutating producer state
+## Behavior N001 — unregistered channels are blocked; manual stays read-only
 
-- **id**: NT001
-- **title**: manual stays read-only and check reports current notification state without mutating producer state
+- **id**: N001
+- **title**: notification check reports current state without mutating producer state, and an unregistered hook channel is blocked with a `blocked_channel:<channel>` system event
 - **guards**: `notification-tool` § Behavior
 - **runner**: any LingTai agent with `shell` and `file` access to this repository
 - **prerequisites**: a clean checkout of `<repo>`; a scratch agent working directory `<scratch>` with a populated `.notification/`
@@ -34,12 +37,56 @@ commands must run from the repo root with the project's Python.
 ### Steps
 1. From `<repo>`, run `python -m pytest tests/test_notification_tool.py -q` and capture the outcome.
 2. Call `notification(action="manual", input={}, reasoning="probe")` and record the result; hash `.notification/` before and after.
-3. Call `notification(action="check", input={}, reasoning="probe")` and confirm it reports current channel state; then perform a narrow dismiss and confirm producer canonical state is untouched.
+3. Call `notification(action="check", input={}, reasoning="probe")` and confirm it reports current channel state without mutating it.
+4. Publish an event to an unregistered channel (e.g. write `.notification/unregistered.json`) and confirm a `blocked_channel:<channel>` system event is emitted.
 
 ### Expected evidence
-- [ ] Step 1: the notification-tool suite passes, pinning the eight operational actions, Store semantics, and notification Core guards.
-- [ ] Step 2: `manual` returns the installed per-agent guidance and performs no check/dismiss state change — `.notification/` is byte-identical.
-- [ ] Step 3: `check` reports current state without mutating it; dismissal is producer-specific or atomic and never rewrites producer canonical state; no `system` notification/dismiss alias exists.
+- [ ] Step 1: the notification-tool suite passes.
+- [ ] Step 2: `manual` returns installed per-agent guidance; `.notification/` is byte-identical.
+- [ ] Step 3: `check` reports current state without mutating it.
+- [ ] Step 4: the unregistered channel is blocked and the system event names it.
 
 ### Pass / Fail
-Pass when the suite passes and the read-only manual/check observations hold. Fail on a mutating `manual`, on `check` changing state, or on generic dismissal corrupting producer canonical state; record the evidence trail in the task report.
+Pass when the suite passes, read-only manual/check observations hold, and the unregistered channel is blocked with the named system event. Fail on a mutating `manual`, on `check` changing state, or on an unregistered channel passing through; record the evidence trail in the task report.
+
+## Behavior N002 — registered hook channels pass through
+
+- **id**: N002
+- **title**: an event published to a registered hook channel passes through to notifications
+- **guards**: `notification-tool` § Behavior
+- **runner**: any LingTai agent with `shell` and `file` access to this repository
+- **prerequisites**: a scratch agent working directory `<scratch>` with a registered hook channel (see `notification(action="add", ...)`)
+- **estimate**: ≈ 10 minutes
+
+### Steps
+1. Register a hook channel (e.g. `notification(action="add", input={"name": "probe", "channel": "mcp.probe", ...})`).
+2. Publish an event to `.notification/mcp.probe.json`.
+3. Call `notification(action="check", input={}, reasoning="probe")` and confirm the event is reported.
+
+### Expected evidence
+- [ ] The hook manifest is written to `.notification/hooks.json` and the channel is allowlisted.
+- [ ] The published event appears in `notification(action="check")` output.
+
+### Pass / Fail
+Pass when the registered channel's event is reported. Fail if it is blocked or dropped; record the evidence trail in the task report.
+
+## Behavior N003 — hook-registry lifecycle validation
+
+- **id**: N003
+- **title**: notification hook add/drop/edit/list validate inputs and keep the manifest consistent
+- **guards**: `notification-tool` § Behavior
+- **runner**: any LingTai agent with `shell` and `file` access to this repository
+- **prerequisites**: a scratch agent working directory `<scratch>` with `.notification/` writable
+- **estimate**: ≈ 10 minutes
+
+### Steps
+1. Call `notification(action="add", input={"name": "dup", "channel": "mcp.dup", ...})` twice and confirm the second add is refused as a duplicate.
+2. Call `notification(action="edit", input={"name": "dup", ...})` to change its description, then `list` to confirm the edit landed.
+3. Call `notification(action="drop", input={"name": "dup"})` and confirm `list` no longer shows it and the channel is revoked from the effective allowlist.
+
+### Expected evidence
+- [ ] Duplicate add refused; edit reflected in list; drop removes manifest and revokes the channel.
+- [ ] `.notification/hooks.json` stays valid JSON throughout.
+
+### Pass / Fail
+Pass when add/edit/drop behave as above and the manifest stays valid. Fail on silent acceptance of duplicates or a manifest left inconsistent; record the evidence trail in the task report.

--- a/src/lingtai/tools/notification/BEHAVIORS.md
+++ b/src/lingtai/tools/notification/BEHAVIORS.md
@@ -1,6 +1,6 @@
 ---
-name: notification-behavior-tests
-behavior_version: 2
+name: notification-tool-behavior-tests
+behavior_version: 1
 labt_version: 2
 contract: CONTRACT.md
 anatomy: ANATOMY.md
@@ -8,144 +8,38 @@ related_files:
   - src/lingtai/tools/notification/CONTRACT.md
   - src/lingtai/tools/notification/ANATOMY.md
   - src/lingtai/tools/notification/__init__.py
-  - src/lingtai/kernel/notifications.py
-  - src/lingtai/intrinsic_skills/notification-manual/SKILL.md
-  - tests/test_notification_tool.py
+  - src/lingtai/tools/notification/schema.py
 maintenance: |
-  This file records agent-executable behavior tests (LABTs) for the notification
-  hook-registry whitelist. Update it whenever the notification CONTRACT's
-  observable behavior clauses change (add/drop/edit/list lifecycle, warn-and-flag
-  on blocked channels, per-agent allowlist). The root BEHAVIORS.md owns the LABT
-  specification and tridirectional linkage; keep this file linked from root
-  BEHAVIORS.md related_files exactly once and keep every LABT self-contained.
+  Created during the every-contract-needs-behaviors sweep. Keep this file
+  reciprocal with CONTRACT.md and ANATOMY.md (tridirectional loop): when a
+  notification tool behavior clause changes, update the guarding LABT here in
+  the same change.
 ---
 # Notification Tool Behavior Tests
 
-LingTai Agent Behavior Tasks proving the notification hook-registry whitelist
-contract does not drift. Each LABT is self-contained: an agent can execute it
-verbatim against a real runtime and judge pass/fail from observable evidence.
+Self-contained agent behavior tasks guarding the observable behavior clauses of
+`src/lingtai/tools/notification/CONTRACT.md` (manual read-only, check/current
+state, narrow dismiss actions, Store semantics preserved). Pinned pytest
+commands must run from the repo root with the project's Python.
 
-## Behavior N001 — unregistered channel is blocked and flagged
+## Behavior NT001 — manual stays read-only and check reports current notification state without mutating producer state
 
-- **id**: N001
-- **title**: unregistered channels are blocked with a visible warning
-- **guards**: `notification-tool` § Behavior / Contract rules
-  (warn-and-flag: unregistered channels do not pass through)
-- **supersedes**: `tests/test_notification_tool.py::test_hook_*` (complements)
-- **runner**: any LingTai agent with the `notification` tool and shell access
-  to its own working directory
-- **prerequisites**: agent working directory exists;
-  `.notification/hooks.json` is absent or empty (no hooks registered);
-  runtime kernel includes PR #1337 (hook registry)
-- **estimate**: ~2 min
+- **id**: NT001
+- **title**: manual stays read-only and check reports current notification state without mutating producer state
+- **guards**: `notification-tool` § Behavior
+- **runner**: any LingTai agent with `shell` and `file` access to this repository
+- **prerequisites**: a clean checkout of `<repo>`; a scratch agent working directory `<scratch>` with a populated `.notification/`
+- **estimate**: ≈ 15 minutes
 
 ### Steps
-1. Write an unregistered channel file:
-   `cat > .notification/unregistered_test.json <<'EOF'
-   {"header": "blocked test", "icon": "🧪", "priority": "high",
-    "published_at": "<now-iso>", "data": {"message": "should be blocked"}}
-   EOF`
-2. Run `notification(action='check', input={})` (or wait for the idle sync).
-3. Observe the `system` channel for a `notification_hook` event with
-   `ref_id: blocked_channel:unregistered_test`.
-4. Confirm the `unregistered_test` channel itself does NOT appear in
-   `_meta.agent_meta.notifications.attention`.
-5. Clean up: `rm .notification/unregistered_test.json` and dismiss the system
-   event.
+1. From `<repo>`, run `python -m pytest tests/test_notification_tool.py -q` and capture the outcome.
+2. Call `notification(action="manual", input={}, reasoning="probe")` and record the result; hash `.notification/` before and after.
+3. Call `notification(action="check", input={}, reasoning="probe")` and confirm it reports current channel state; then perform a narrow dismiss and confirm producer canonical state is untouched.
 
 ### Expected evidence
-- [ ] System event present: `source: notification_hook`,
-      `ref_id: blocked_channel:unregistered_test`, body naming the channel and
-      pointing to `notification(list)` / `notification(add)`.
-- [ ] The unregistered channel's payload did NOT pass through (absent from
-      attention/persistent payloads).
-- [ ] `.notification/unregistered_test.json` removed after cleanup.
+- [ ] Step 1: the notification-tool suite passes, pinning the eight operational actions, Store semantics, and notification Core guards.
+- [ ] Step 2: `manual` returns the installed per-agent guidance and performs no check/dismiss state change — `.notification/` is byte-identical.
+- [ ] Step 3: `check` reports current state without mutating it; dismissal is producer-specific or atomic and never rewrites producer canonical state; no `system` notification/dismiss alias exists.
 
 ### Pass / Fail
-Pass when the system warning event exists with the correct ref_id AND the
-blocked payload did not surface. Fail if the payload passes through, the event
-is missing, or the event names the wrong channel. No forbidden side effect:
-`add`/`drop`/`edit`/`list` are not invoked by this LABT.
-
-## Behavior N002 — registered hook channel passes through
-
-- **id**: N002
-- **title**: registered hook channels pass through without warning
-- **guards**: `notification-tool` § add / Contract rules
-  (registered hook channels enter the effective allowlist)
-- **supersedes**: `tests/test_notification_tool.py::test_hook_*` (complements)
-- **runner**: any LingTai agent with the `notification` tool and shell access
-  to its own working directory
-- **prerequisites**: agent working directory exists; runtime kernel includes
-  PR #1337; the agent can write `.notification/<channel>.json`
-- **estimate**: ~2 min
-
-### Steps
-1. Register a temporary hook:
-   `notification(action='add', input={'name': 'test_hook',
-   'channel': 'test_hook', 'source': 'smoke-test',
-   'description': 'temporary pass-through verification',
-   'how_to_modify': 'notification edit test_hook',
-   'how_to_cancel': 'notification drop test_hook'})`.
-   Expect `{status: "ok", reason: "added", name: "test_hook"}`.
-2. Publish to the registered channel:
-   `cat > .notification/test_hook.json <<'EOF'
-   {"header": "registered test", "icon": "✅", "priority": "high",
-    "published_at": "<now-iso>", "data": {"message": "should pass through"}}
-   EOF`
-3. Run `notification(action='check', input={})` (or wait for the idle sync).
-4. Confirm the `test_hook` channel appears in
-   `_meta.agent_meta.notifications.attention` with the published payload and
-   that NO `blocked_channel:test_hook` system event exists.
-5. Clean up: `notification(action='drop', input={'name': 'test_hook'})` and
-   `rm .notification/test_hook.json`.
-
-### Expected evidence
-- [ ] `add` returned `{status: "ok", reason: "added", name: "test_hook"}`.
-- [ ] The registered channel's payload appeared in the notification surface.
-- [ ] No blocked-channel system event was emitted for `test_hook`.
-- [ ] Registry clean after `drop` (list shows empty or no `test_hook`).
-
-### Pass / Fail
-Pass when the registered channel's payload surfaces without a warning event.
-Fail if the payload is blocked, a warning is emitted, or `add`/`drop` return an
-error. Forbidden side effect: the hook must not outlive the test (drop it).
-
-## Behavior N003 — hook registry lifecycle: add/drop/edit/list
-
-- **id**: N003
-- **title**: add/drop/edit/list lifecycle returns contract-matching reasons
-- **guards**: `notification-tool` § add / § edit / § drop / § list
-  (manifest validation, uniqueness, empty-name and reserved-stem refusals)
-- **supersedes**: `tests/test_notification_tool.py::test_hook_add_drop_edit_list`
-- **runner**: any LingTai agent with the `notification` tool
-- **prerequisites**: agent working directory exists; runtime kernel includes
-  PR #1337
-- **estimate**: ~3 min
-
-### Steps
-1. `notification(action='list', input={})` → `{status: "ok", hooks: []}` (or
-   without the test hook present).
-2. `add` a hook named `test_hook` with channel `test_hook` → `reason: "added"`.
-3. `add` the same name again → `status: "error"`, `reason: "duplicate_name"`,
-   registry unchanged.
-4. `add` a second hook with the same channel → `status: "error"`,
-   `reason: "channel_in_use"`.
-5. `add` a hook with channel `hooks` (Store-reserved stem) → `status: "error"`,
-   `reason: "invalid_manifest"`.
-6. `edit` `test_hook` changing `description` → `reason: "edited"`; list shows
-   the new description.
-7. `edit` with all null fields → `reason: "no_change"`.
-8. `drop` `test_hook` → `reason: "dropped"`; `drop` again → `reason:
-   "not_found"`; `list` is empty again.
-
-### Expected evidence
-- [ ] Every return reason matches the contract table above.
-- [ ] Duplicate/conflicting/invalid `add` attempts leave the registry unchanged.
-- [ ] After `drop`, the channel is revoked (an unregistered test file would be
-      flagged per B001).
-
-### Pass / Fail
-Pass when all lifecycle reasons match the contract and invalid attempts are
-no-ops on registry state. Fail on any mismatch. No forbidden side effect: all
-hooks added during the LABT are dropped before completion.
+Pass when the suite passes and the read-only manual/check observations hold. Fail on a mutating `manual`, on `check` changing state, or on generic dismissal corrupting producer canonical state; record the evidence trail in the task report.

--- a/src/lingtai/tools/pad/BEHAVIORS.md
+++ b/src/lingtai/tools/pad/BEHAVIORS.md
@@ -1,0 +1,45 @@
+---
+name: pad-behavior-tests
+behavior_version: 1
+labt_version: 2
+contract: CONTRACT.md
+anatomy: ANATOMY.md
+related_files:
+  - src/lingtai/tools/pad/CONTRACT.md
+  - src/lingtai/tools/pad/ANATOMY.md
+  - src/lingtai/tools/pad/__init__.py
+  - src/lingtai/tools/pad/_pad.py
+maintenance: |
+  Created during the every-contract-needs-behaviors sweep. Keep this file
+  reciprocal with CONTRACT.md and ANATOMY.md (tridirectional loop): when a pad
+  tool behavior clause changes, update the guarding LABT here in the same
+  change.
+---
+# Pad Capability Behavior Tests
+
+Self-contained agent behavior tasks guarding the observable behavior clauses of
+`src/lingtai/tools/pad/CONTRACT.md` (append/ manual only, validation before
+persistence, no hot load, delayed activation). Pinned pytest commands must run
+from the repo root with the project's Python.
+
+## Behavior PD001 — append validates every path and the aggregate limit before persisting, and never hot-loads the prompt
+
+- **id**: PD001
+- **title**: append validates every path and the aggregate limit before persisting, and never hot-loads the prompt
+- **guards**: `pad-contract` § Public port
+- **runner**: any LingTai agent with `shell` and `file` access to this repository
+- **prerequisites**: a clean checkout of `<repo>`; a scratch agent working directory `<scratch>` with existing UTF-8 text files
+- **estimate**: ≈ 15 minutes
+
+### Steps
+1. From `<repo>`, run `python -m pytest tests/test_pad.py -q` and capture the outcome.
+2. Call `pad(action="append", input={"files": ["<scratch>/a.txt"]}, reasoning="probe")` and record the receipt; confirm `system/pad_append.json` was written and `prompt_reload` is `false`.
+3. Call `pad(action="append", input={"files": ["<scratch>/missing.txt"]}, reasoning="probe")` and confirm the invalid path is rejected before persistence; call `pad(action="edit", input={...}, reasoning="probe")` and confirm it fails as an unknown action.
+
+### Expected evidence
+- [ ] Step 1: the pad suite passes, pinning the exact action set, strict retirement, validation-before-persistence, and delayed activation.
+- [ ] Step 2: the append receipt contains `status`, `files`, `count`, `prompt_reload: false`, and `takes_effect`; the persisted list is `system/pad_append.json`.
+- [ ] Step 3: an invalid path fails before any write; retired `edit`/`load` fail loudly before I/O; no prompt flush or prompt-manager section change occurs.
+
+### Pass / Fail
+Pass when the suite passes and the validate-before-persist/no-hot-load observations hold. Fail on a persisted invalid path, on a working retired action, or on any prompt reload side effect from append; record the evidence trail in the task report.

--- a/src/lingtai/tools/pad/CONTRACT.md
+++ b/src/lingtai/tools/pad/CONTRACT.md
@@ -25,6 +25,8 @@ maintenance: |
 # Pad capability contract
 
 ## Purpose and ownership
+Guarded by: [PD001](BEHAVIORS.md#behavior-pd001)
+
 
 `pad` is a mandatory, model-visible LTP v2 family for the durable pinned
 reference list associated with the agent's prompt sketchboard. Its public action

--- a/src/lingtai/tools/plugin/BEHAVIORS.md
+++ b/src/lingtai/tools/plugin/BEHAVIORS.md
@@ -1,0 +1,44 @@
+---
+name: plugin-behavior-tests
+behavior_version: 1
+labt_version: 2
+contract: CONTRACT.md
+anatomy: ANATOMY.md
+related_files:
+  - src/lingtai/tools/plugin/CONTRACT.md
+  - src/lingtai/tools/plugin/ANATOMY.md
+  - src/lingtai/tools/plugin/__init__.py
+maintenance: |
+  Created during the every-contract-needs-behaviors sweep. Keep this file
+  reciprocal with CONTRACT.md and ANATOMY.md (tridirectional loop): when a
+  plugin tool behavior clause changes, update the guarding LABT here in the same
+  change.
+---
+# Plugin Capability Behavior Tests
+
+Self-contained agent behavior tasks guarding the observable behavior clauses of
+`src/lingtai/tools/plugin/CONTRACT.md` (info/manual only, skipped entries
+explain non-mounting, read-only capability). Pinned pytest commands must run
+from the repo root with the project's Python.
+
+## Behavior PL001 — info reports health and every non-mounting component explains itself in skipped
+
+- **id**: PL001
+- **title**: info reports health and every non-mounting component explains itself in skipped
+- **guards**: `plugin-contract` § Tool surface
+- **runner**: any LingTai agent with `shell` and `file` access to this repository
+- **prerequisites**: a clean checkout of `<repo>`; a scratch agent working directory `<scratch>` with one declared plugin
+- **estimate**: ≈ 15 minutes
+
+### Steps
+1. From `<repo>`, run `python -m pytest tests/test_plugin_tool.py -q` and capture the outcome.
+2. Call `plugin(action="info", input={}, reasoning="probe")` and record the result; confirm `registered`, `discovered`, `paths`, and `problems` are present and that no file was created or modified.
+3. Declare a plugin with an escaping path or a server name outside the registry grammar and re-run `info`; confirm the plugin lands in `skipped` with a `{component, reason}` entry.
+
+### Expected evidence
+- [ ] Step 1: the plugin-tool suite passes, pinning the two-tier mount contract, lifecycle, and read-only info/manual surface.
+- [ ] Step 2: `info` returns the health snapshot and performs zero writes (the capability owns no state).
+- [ ] Step 3: every non-mounting component appears in `skipped` with its reason; no plugin silently vanishes from the report.
+
+### Pass / Fail
+Pass when the suite passes and the read-only/self-explaining observations hold. Fail on a mutating `info`, on a silent non-mount (no `skipped` entry), or on a missing `paths`/`problems` report; record the evidence trail in the task report.

--- a/src/lingtai/tools/plugin/CONTRACT.md
+++ b/src/lingtai/tools/plugin/CONTRACT.md
@@ -35,6 +35,8 @@ pruning machinery lives in `src/lingtai/services/plugin_registry.py` (imported
 lazily). The code is the source of truth.
 
 ## The two-tier mount contract
+Guarded by: [PL001](BEHAVIORS.md#behavior-pl001)
+
 
 This is the load-bearing distinction in this package; everything else follows.
 

--- a/src/lingtai/tools/psyche/BEHAVIORS.md
+++ b/src/lingtai/tools/psyche/BEHAVIORS.md
@@ -1,0 +1,45 @@
+---
+name: psyche-behavior-tests
+behavior_version: 1
+labt_version: 2
+contract: CONTRACT.md
+anatomy: ANATOMY.md
+related_files:
+  - src/lingtai/tools/psyche/CONTRACT.md
+  - src/lingtai/tools/psyche/ANATOMY.md
+  - src/lingtai/tools/psyche/__init__.py
+  - src/lingtai/tools/psyche/glossary-en.md
+maintenance: |
+  Created during the every-contract-needs-behaviors sweep. Keep this file
+  reciprocal with CONTRACT.md and ANATOMY.md (tridirectional loop): when a
+  psyche behavior clause changes, update the guarding LABT here in the same
+  change.
+---
+# Psyche Tool Behavior Tests
+
+Self-contained agent behavior tasks guarding the observable behavior clauses of
+`src/lingtai/tools/psyche/CONTRACT.md` (every action read-only; durable changes
+via file + explicit rebuild). Pinned pytest commands must run from the repo
+root with the project's Python.
+
+## Behavior PY001 — every psyche action is read-only and durable changes apply only through file + an explicit rebuild
+
+- **id**: PY001
+- **title**: every psyche action is read-only and durable changes apply only through file + an explicit rebuild
+- **guards**: `psyche-tool-contract` § Behavior
+- **runner**: any LingTai agent with `shell` and `file` access to this repository
+- **prerequisites**: a clean checkout of `<repo>`; a scratch agent working directory `<scratch>`
+- **estimate**: ≈ 15 minutes
+
+### Steps
+1. From `<repo>`, run `python -m pytest tests/test_psyche_family.py -q` and capture the outcome.
+2. Call every `psyche` action with its strict input on `<scratch>` and hash all prompt/source files before and after; record the results.
+3. Make a durable change with `file.edit` on the domain's own source and confirm the prompt section does not change until one explicit `context(action="rebuild", input={}, reasoning="...")` (or passive refresh/molt) is applied.
+
+### Expected evidence
+- [ ] Step 1: the psyche family suite passes, pinning five-domain manual routing and read-only behavior.
+- [ ] Step 2: no `psyche` action authors, edits, pins, installs, migrates, rescans a catalog, writes a prompt/source file, or reloads prompt state — all file hashes are unchanged.
+- [ ] Step 3: file mutation never hot-loads the prompt; the prompt section updates only after an explicit rebuild or passive reconstruction.
+
+### Pass / Fail
+Pass when the suite passes and the read-only/no-hot-load observations hold. Fail on any mutating `psyche` action or on a prompt that reloads from a plain file edit; record the evidence trail in the task report.

--- a/src/lingtai/tools/psyche/CONTRACT.md
+++ b/src/lingtai/tools/psyche/CONTRACT.md
@@ -26,6 +26,8 @@ maintenance: |
 # Psyche tool contract
 
 ## Purpose
+Guarded by: [PY001](BEHAVIORS.md#behavior-py001)
+
 
 `psyche` is the single mandatory, model-visible LTP v2 family for the four
 durable domains that survive a molt. The name states the governing human

--- a/src/lingtai/tools/skills/BEHAVIORS.md
+++ b/src/lingtai/tools/skills/BEHAVIORS.md
@@ -1,0 +1,45 @@
+---
+name: skills-behavior-tests
+behavior_version: 1
+labt_version: 2
+contract: CONTRACT.md
+anatomy: ANATOMY.md
+related_files:
+  - src/lingtai/tools/skills/CONTRACT.md
+  - src/lingtai/tools/skills/ANATOMY.md
+  - src/lingtai/tools/skills/__init__.py
+  - src/lingtai/tools/_catalog.py
+maintenance: |
+  Created during the every-contract-needs-behaviors sweep. Keep this file
+  reciprocal with CONTRACT.md and ANATOMY.md (tridirectional loop): when a
+  skills tool behavior clause changes, update the guarding LABT here in the
+  same change.
+---
+# Skills Capability Behavior Tests
+
+Self-contained agent behavior tasks guarding the observable behavior clauses of
+`src/lingtai/tools/skills/CONTRACT.md` (info/manual only, strict-empty input,
+canonical degraded shape, action separation). Pinned pytest commands must run
+from the repo root with the project's Python.
+
+## Behavior SK001 — info only refreshes the catalogue and manual only reads the installed manual
+
+- **id**: SK001
+- **title**: info only refreshes the catalogue and manual only reads the installed manual
+- **guards**: `skills-contract` § Tool surface
+- **runner**: any LingTai agent with `shell` and `file` access to this repository
+- **prerequisites**: a clean checkout of `<repo>`; a scratch agent working directory `<scratch>` with a skills catalog
+- **estimate**: ≈ 15 minutes
+
+### Steps
+1. From `<repo>`, run `python -m pytest tests/test_skills.py -q` and capture the outcome.
+2. Call `skills(action="info", input={}, reasoning="probe")` and record the result; confirm it reconciles the catalog and re-injects the prompt without authoring, pinning, publishing, installing, or executing a skill.
+3. Call `skills(action="manual", input={}, reasoning="probe")` and record the result; confirm no catalogue scan or prompt injection occurred, and that an extra `input` key fails with `INVALID_ARGUMENT` before any handler I/O.
+
+### Expected evidence
+- [ ] Step 1: the skills suite passes, pinning catalog behavior, prompt injection, and the skills/knowledge boundary.
+- [ ] Step 2: `info` returns `{status, skills_dir, library_dir, catalog_size, paths, problems}` with no manual body and performs no side effect beyond reconciliation.
+- [ ] Step 3: `manual` returns `{status, skills_manual, library_manual, manual_path}` (or the degraded shape when the manual is missing); any `input` key is rejected before handler I/O; unknown actions yield `ACTION_REQUIRED`.
+
+### Pass / Fail
+Pass when the suite passes and the action-separation observations hold. Fail on `info` installing/executing a skill, on `manual` performing a catalogue scan, or on an accepted input field; record the evidence trail in the task report.

--- a/src/lingtai/tools/skills/CONTRACT.md
+++ b/src/lingtai/tools/skills/CONTRACT.md
@@ -27,6 +27,8 @@ It is pure presentation: it never writes to `.library/`. The implementation live
 in `src/lingtai/tools/skills/__init__.py`; the code is the source of truth.
 
 ## Routing Card
+Guarded by: [SK001](BEHAVIORS.md#behavior-sk001)
+
 
 **Use this when:**
 - You are editing the catalog scanner, path resolution, prompt injection, or the

--- a/src/lingtai/tools/soul/BEHAVIORS.md
+++ b/src/lingtai/tools/soul/BEHAVIORS.md
@@ -1,0 +1,45 @@
+---
+name: soul-behavior-tests
+behavior_version: 1
+labt_version: 2
+contract: CONTRACT.md
+anatomy: ANATOMY.md
+related_files:
+  - src/lingtai/tools/soul/CONTRACT.md
+  - src/lingtai/tools/soul/ANATOMY.md
+  - src/lingtai/tools/soul/__init__.py
+  - src/lingtai/tools/soul/flow.py
+maintenance: |
+  Created during the every-contract-needs-behaviors sweep. Keep this file
+  reciprocal with CONTRACT.md and ANATOMY.md (tridirectional loop): when a soul
+  tool behavior clause changes, update the guarding LABT here in the same
+  change.
+---
+# Soul Capability Behavior Tests
+
+Self-contained agent behavior tasks guarding the observable behavior clauses of
+`src/lingtai/tools/soul/CONTRACT.md` (flow opt-in gate, disabled/ongoing paths
+return before spawning, manual no-op, envelope enforcement). Pinned pytest
+commands must run from the repo root with the project's Python.
+
+## Behavior SU001 — flow's disabled and ongoing paths return before any fire thread, and manual touches no soul state
+
+- **id**: SU001
+- **title**: flow's disabled and ongoing paths return before any fire thread, and manual touches no soul state
+- **guards**: `soul-contract` § Tool surface
+- **runner**: any LingTai agent with `shell` and `file` access to this repository
+- **prerequisites**: a clean checkout of `<repo>`; `LINGTAI_SOUL_FLOW_ENABLED` unset in the probe environment
+- **estimate**: ≈ 15 minutes
+
+### Steps
+1. From `<repo>`, run `python -m pytest tests/test_soul.py tests/test_soul_consultation.py -q` and capture the outcome.
+2. With `LINGTAI_SOUL_FLOW_ENABLED` unset, call `soul(action="flow", input={}, reasoning="probe")` and record the result; then set the variable and call `flow` twice in quick succession and record both results.
+3. Call `soul(action="manual", input={}, reasoning="probe")` and confirm no timer, lock, consultation, config, voice, or notification state changed.
+
+### Expected evidence
+- [ ] Step 1: the soul suites pass, pinning inquiry/flow/config/voice/dismiss/manual behavior and consultation pair building.
+- [ ] Step 2: with the env opt-out, `flow` returns `{status: "disabled", enabled: False, env_var, message}` and spawns no fire thread; a second `flow` while a fire is in flight returns `{error: "soul flow ongoing, request rejected"}` before spawning.
+- [ ] Step 3: `manual` reads the installed manual and touches no soul state; a cross-action input key fails with `INVALID_ARGUMENT` before any handler I/O.
+
+### Pass / Fail
+Pass when the suites pass and the gate/no-op observations hold. Fail on a fire thread spawning when disabled or ongoing, on a `manual` that touches soul state, or on an accepted cross-action input; record the evidence trail in the task report.

--- a/src/lingtai/tools/soul/CONTRACT.md
+++ b/src/lingtai/tools/soul/CONTRACT.md
@@ -35,6 +35,8 @@ migration; only the argument *shape* changed, from a flat root to
 `action` + one strict per-action `input`.
 
 ## Routing Card
+Guarded by: [SU001](BEHAVIORS.md#behavior-su001)
+
 
 **Use this when:**
 - You are editing the sync `inquiry` mirror session, the periodic `flow`

--- a/src/lingtai/tools/task_card/BEHAVIORS.md
+++ b/src/lingtai/tools/task_card/BEHAVIORS.md
@@ -1,0 +1,45 @@
+---
+name: task-card-behavior-tests
+behavior_version: 1
+labt_version: 2
+contract: CONTRACT.md
+anatomy: ANATOMY.md
+related_files:
+  - src/lingtai/tools/task_card/CONTRACT.md
+  - src/lingtai/tools/task_card/ANATOMY.md
+  - src/lingtai/tools/task_card/__init__.py
+  - src/lingtai/mcp_servers/task_card/resident.py
+maintenance: |
+  Created during the every-contract-needs-behaviors sweep. Keep this file
+  reciprocal with CONTRACT.md and ANATOMY.md (tridirectional loop): when a
+  task-card behavior clause changes, update the guarding LABT here in the same
+  change.
+---
+# Intrinsic Task Card Behavior Tests
+
+Self-contained agent behavior tasks guarding the observable behavior clauses of
+`src/lingtai/tools/task_card/CONTRACT.md` (start writes body then exact active,
+second start fails closed, stop/remove semantics, watch persistence). Pinned
+pytest commands must run from the repo root with the project's Python.
+
+## Behavior TK001 — start writes the body atomically before exact active, and a second start fails closed
+
+- **id**: TK001
+- **title**: start writes the body atomically before exact active, and a second start fails closed
+- **guards**: `intrinsic-task-card` § Behavior
+- **runner**: any LingTai agent with `shell` and `file` access to this repository
+- **prerequisites**: a clean checkout of `<repo>`; a scratch agent working directory `<scratch>` with a renderer script inside it
+- **estimate**: ≈ 20 minutes
+
+### Steps
+1. From `<repo>`, run `python -m pytest tests/test_task_card_controller.py tests/test_task_card_resident_shared.py -q` and capture the outcome.
+2. In `<scratch>`, start a watch with a renderer that prints a body; verify `taskcard/taskcard.md` is written atomically before `taskcard/status` becomes exact `active`, and that `taskcard/watch.json` is persisted.
+3. Start a second watch while the first is active and record the result; then call `remove` twice and record both results.
+
+### Expected evidence
+- [ ] Step 1: the task-card controller and resident suites pass, pinning route/slot, old-first rotation, peer adoption, and failure-state transitions.
+- [ ] Step 2: the body file precedes the exact-`active` status write; the watch descriptor survives for restart resume; renderer failures preserve the last valid body and emit deduped `task_card.error`/`recovered` notifications.
+- [ ] Step 3: a second `start` fails closed (at most one active watch per agent); `remove` retires the watch first (writes `inactive`, joins the updater), then deletes the body; a repeated `remove` is idempotent and never an error.
+
+### Pass / Fail
+Pass when the suites pass and the ordering/idempotency observations hold. Fail on `active` before the body write, on a second concurrent watch, or on a non-idempotent `remove`; record the evidence trail in the task report.

--- a/src/lingtai/tools/task_card/CONTRACT.md
+++ b/src/lingtai/tools/task_card/CONTRACT.md
@@ -27,6 +27,8 @@ maintenance: |
 # Intrinsic Task Card
 
 ## Purpose
+Guarded by: [TK001](BEHAVIORS.md#behavior-tk001)
+
 
 Own the public model-facing `task_card` capability as a channel-neutral,
 producer-first intrinsic tool. The capability maintains one agent-local

--- a/src/lingtai/tools/vision/BEHAVIORS.md
+++ b/src/lingtai/tools/vision/BEHAVIORS.md
@@ -1,0 +1,45 @@
+---
+name: vision-behavior-tests
+behavior_version: 1
+labt_version: 2
+contract: CONTRACT.md
+anatomy: ANATOMY.md
+related_files:
+  - src/lingtai/tools/vision/CONTRACT.md
+  - src/lingtai/tools/vision/ANATOMY.md
+  - src/lingtai/tools/vision/__init__.py
+  - src/lingtai/tools/vision/settings.py
+maintenance: |
+  Created during the every-contract-needs-behaviors sweep. Keep this file
+  reciprocal with CONTRACT.md and ANATOMY.md (tridirectional loop): when a
+  vision tool behavior clause changes, update the guarding LABT here in the
+  same change.
+---
+# Vision Capability Behavior Tests
+
+Self-contained agent behavior tasks guarding the observable behavior clauses of
+`src/lingtai/tools/vision/CONTRACT.md` (exact analyze/manual success shapes,
+manual without provider call, fail-closed identity). Pinned pytest commands
+must run from the repo root with the project's Python.
+
+## Behavior VN001 — analyze success is exactly {status ok, analysis} and manual performs no analyze operation or provider construction
+
+- **id**: VN001
+- **title**: analyze success is exactly {status ok, analysis} and manual performs no analyze operation or provider construction
+- **guards**: `vision-contract` § Tool behavior
+- **runner**: any LingTai agent with `shell` and `file` access to this repository
+- **prerequisites**: a clean checkout of `<repo>`; a small test image `<scratch>/img.png`
+- **estimate**: ≈ 20 minutes
+
+### Steps
+1. From `<repo>`, run `python -m pytest tests/test_vision_capability.py tests/test_tool_family_vision_migration.py -q` and capture the outcome.
+2. Call `vision(action="manual", input={}, reasoning="probe")` and record the flat result; confirm no provider was constructed and no credential was read.
+3. Call `vision(action="analyze", input={"image_path": "<scratch>/img.png", "question": null}, reasoning="probe")` through a configured route and confirm the success shape; then call it with a missing image and record the structured error.
+
+### Expected evidence
+- [ ] Step 1: the vision capability and migration suites pass, pinning one registered tool, strict envelopes, and wire parity without double wrap.
+- [ ] Step 2: `manual` returns `{status: "ok", action: "manual", manual: body, manual_path: path}` (or the degraded shape) and performs no analyze operation, constructs no provider, and reads no credential.
+- [ ] Step 3: analyze success is exactly `{status: "ok", analysis: text}`; missing image/empty response/setup/request failures are structured errors pointing to the full accepted envelope; exception messages are never returned.
+
+### Pass / Fail
+Pass when the suites pass and the exact-shape/no-provider observations hold. Fail on a nested or double-wrapped manual result, on analyze returning anything but the exact success shape, or on an exception message leaking into the result; record the evidence trail in the task report.

--- a/src/lingtai/tools/vision/CONTRACT.md
+++ b/src/lingtai/tools/vision/CONTRACT.md
@@ -23,6 +23,8 @@ and preserves a read-only `action="manual"` route. It never changes provider or
 automatically invokes MCP.
 
 ## Scope and registry
+Guarded by: [VN001](BEHAVIORS.md#behavior-vn001)
+
 
 `vision` is one action-separated family in the LingTai Tool Protocol v2 shape
 defined in `src/lingtai/tools/CONTRACT.md`, built on the generic

--- a/tests/BEHAVIORS.md
+++ b/tests/BEHAVIORS.md
@@ -1,0 +1,45 @@
+---
+name: tests-behavior-tests
+behavior_version: 1
+labt_version: 2
+contract: CONTRACT.md
+anatomy: ANATOMY.md
+related_files:
+  - tests/CONTRACT.md
+  - tests/ANATOMY.md
+  - tests/test_architecture_documents.py
+maintenance: |
+  Created during the every-contract-needs-behaviors sweep. Keep this file
+  reciprocal with tests/CONTRACT.md (the methodology charter): when a testing
+  principle changes, update the guarding LABT here in the same change. This
+  charter is deliberately not a governed component contract; this file is its
+  behavior-evidence sibling only.
+---
+# Test Methodology Charter Behavior Tests
+
+Self-contained agent behavior tasks guarding the observable methodology
+principles of `tests/CONTRACT.md` (deterministic validation, observable waits,
+harness-vs-product classification, evidence preservation). These tasks inspect
+how the repository's own tests behave rather than asserting a runtime interface.
+
+## Behavior TS001 — tests wait on observable signals instead of arbitrary sleeps, and every failure is classified as harness or product with evidence
+
+- **id**: TS001
+- **title**: tests wait on observable signals instead of arbitrary sleeps, and every failure is classified as harness or product with evidence
+- **guards**: `tests/CONTRACT.md` § Principles
+- **runner**: any LingTai agent with `shell` and `file` access to this repository
+- **prerequisites**: a clean checkout of `<repo>`
+- **estimate**: ≈ 15 minutes
+
+### Steps
+1. From `<repo>`, run `python -m pytest tests/test_labt_validation.py tests/test_architecture_documents.py -q` and capture the outcome.
+2. Grep the `tests/` tree for bare `sleep(` calls in test files that are not gated on an observable signal (Event/gate/state transition/file appearance) and list any that look like arbitrary sleeps.
+3. Review the last failing run's report: confirm every failure was classified as harness vs product and that the exact command, interpreter, source pinning, and verbatim output were preserved as evidence (e.g. in a `tmp/` log).
+
+### Expected evidence
+- [ ] Step 1: the validation suites run to completion; a timeout or interruption is reported as incomplete, never as a pass.
+- [ ] Step 2: no test relies on an arbitrary sleep to observe a condition that has a gated/observable signal available (any found sleep is justified or replaced by a gate).
+- [ ] Step 3: the failure report classifies each failure as harness or product with evidence, and non-zero exits are never laundered into green claims.
+
+### Pass / Fail
+Pass when the validation suites complete, no arbitrary sleep substitutes for an observable wait, and failures are classified with preserved evidence. Fail on a bare sleep used as the sole synchronization, on an unclassified failure, or on a non-zero exit reported as success; record the evidence trail in the task report.

--- a/tests/CONTRACT.md
+++ b/tests/CONTRACT.md
@@ -38,6 +38,8 @@ This charter states the testing principles those workflows assume, once, so a
 coding agent writing or running kernel tests shares one standard.
 
 ## Why this exists
+Guarded by: [TS001](BEHAVIORS.md#behavior-ts001)
+
 
 Tests are the repository's conformance evidence. Anatomy says where code is,
 Contract says what it promises, and **tests prove the promise holds**. A test


### PR DESCRIPTION
Enforces Jason's rule: every contract must have corresponding behaviors. Sweep result: **every tracked CONTRACT.md now has a sibling BEHAVIORS.md (39/39)**, previously 31 of 39 lacked one.

**Created (31)** — each with LABT-v2 frontmatter (name, behavior_version 1, labt_version 2, contract, anatomy, related_files, maintenance) and >=1 self-contained LABT guarding the contract's most observable behavior clause: kernel (agent_presence, agent_readme, base_agent, daemon_supervisor, event_journal, lifecycle_clock, mail_transport, migrate, notification_store, refresh_watcher, snapshot, workdir_lease), src/lingtai init-reader, mcp_servers/telegram/task_card, tools/LTP, avatar, browser, interactive_terminal, email, knowledge, lingtai, mcp, notification, pad, plugin, psyche, skills, soul, task_card, vision, tests.

**Rule line added** to all 39 CONTRACT.md: every agent-observable behavior clause MUST be guarded by a LABT in the sibling BEHAVIORS.md (tridirectional loop); change contract → update behaviors + anatomy together.

**Wiring**: root BEHAVIORS.md related_files registers all 31; each linked into sibling ANATOMY.md (30; agent_readme/ANATOMY.md has no frontmatter — pre-existing drift, noted). Fixed agent_readme/CONTRACT.md missing frontmatter.

**Validation**: tests/test_labt_validation.py 5/5 pass. arch-doc 3 pre-existing Windows failures (baseline unchanged).