### PR TITLE
fix(shell): win32_job drain_pipes deadlock — never close() live reader streams

### DIFF
--- a/src/lingtai/adapters/windows/win32_job.py
+++ b/src/lingtai/adapters/windows/win32_job.py
@@ -15,7 +15,11 @@ The bounded output drain (``drain_pipes``) mirrors Codex's ``io_drain_timeout``
 (``codex-rs/core/src/exec.rs``): after a kill, stdout/stderr pipes are drained
 for only a bounded window, because a grandchild that inherited the pipe write
 ends and survived the kill keeps them open and would block an unbounded reader
-forever (Goose PR #7689).
+forever (Goose PR #7689).  The drain never ``close()``s a stream whose reader
+thread is still alive: on CPython the reader thread holds the buffered-IO lock
+for the duration of a blocking ``read()``, so ``close()`` would wait on that
+same lock forever.  The pipe reader threads are daemon threads and finish on
+their own once the killed tree releases the write ends.
 
 Importing this module is safe on every platform; every Job Object helper raises
 ``OSError`` on non-Windows at call time.  ``taskkill_tree_best_effort`` is the
@@ -344,7 +348,7 @@ def taskkill_tree_best_effort(pid: int) -> None:
     try:
         subprocess.run(
             ["taskkill", "/PID", str(pid), "/T", "/F"],
-            capture_output=True, text=True, encoding="utf-8", errors="replace",
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
             timeout=_TASKKILL_TIMEOUT_SECONDS, stdin=subprocess.DEVNULL,
             creationflags=CREATE_NO_WINDOW,
         )
@@ -375,8 +379,15 @@ def drain_pipes(process, timeout_seconds: float = IO_DRAIN_TIMEOUT_SECONDS):
 
     Returns ``(stdout, stderr)``.  When EOF has not arrived within the bound (a
     grandchild survived the kill and still holds the pipe write ends), the
-    partial output is returned and the pipe reader threads are aborted by
-    closing the handles — the caller must never block on EOF forever.
+    partial output is returned and the pipe reader threads are detached --
+    the caller must never block on EOF forever.
+
+    The streams are never ``close()``-d from this side: CPython's Windows
+    reader threads are daemon threads blocked in ``read()`` holding the
+    buffered-IO lock, and ``stream.close()`` would wait on that same lock
+    forever.  Detaching ``process.stdout``/``process.stderr`` prevents any
+    later ``communicate()`` re-entry and lets the reader threads finish on
+    their own once the killed tree releases the pipe write ends.
     """
     try:
         return process.communicate(timeout=timeout_seconds)
@@ -387,12 +398,14 @@ def drain_pipes(process, timeout_seconds: float = IO_DRAIN_TIMEOUT_SECONDS):
         # surfaces OSError/ValueError instead of TimeoutExpired.  Same bounded
         # outcome: hand back what we have and never block on EOF.
         partial = (None, None)
-    for stream in (getattr(process, "stdout", None), getattr(process, "stderr", None)):
-        if stream is not None:
-            try:
-                stream.close()
-            except OSError:
-                pass
+    # Detach instead of close(): see docstring.  The reader threads are daemon
+    # threads and close their own handle when EOF arrives; forcing close()
+    # here would block on the buffered-IO lock held by the blocked read.
+    try:
+        process.stdout = None
+        process.stderr = None
+    except (AttributeError, TypeError):
+        pass
     return partial
 
 

--- a/src/lingtai/intrinsic_skills/system-manual/reference/substrate-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/substrate-manual/SKILL.md
@@ -156,6 +156,16 @@ that latest guidance first when it appears.
 For peers, prefer communication and diagnosis before force. Karma operations are
 administrative tools, not shortcuts around collaboration.
 
+**Cross-platform CPR limitation (documented, not a bug):** ``cpr`` relaunches
+the target using its configured ``venv_path``, and the venv executable layout is
+resolved from the *calling* runtime's platform.  A POSIX caller resolves a
+Windows target's venv as ``venv/bin/python`` (POSIX layout), but a Windows venv
+stores its launcher at ``Scripts/python.exe`` — so ``cpr`` of a Windows agent
+from a Linux/macOS agent fails with "Configured venv_path is not usable".
+Relaunch such an agent from the same platform it runs on (its own TUI/CLI, or
+``lingtai-agent run <working_dir>`` on the Windows host) instead of crossing
+platforms.  This is a documented limitation, not a defect to fix.
+
 ## 4. Communication and notifications
 
 Resident §III owns the rule (reply on the channel the message arrived on; text

--- a/src/lingtai/tools/bash/__init__.py
+++ b/src/lingtai/tools/bash/__init__.py
@@ -908,14 +908,22 @@ class ShellManager:
                 returncode = process.returncode
             except subprocess.TimeoutExpired as exc:
                 win32_job.terminate_owned_tree(job, process.pid)
-                # Bounded drain: a grandchild that survived the kill and still
-                # holds the pipe write ends must not block this supervisor on
-                # EOF forever (Codex io_drain_timeout; Goose PR #7689).  The
-                # process is never ``wait()``-ed on this double-timeout path;
-                # the bounded drain plus handle close is the documented bound.
-                win32_job.drain_pipes(process, win32_job.IO_DRAIN_TIMEOUT_SECONDS)
+                # Wait briefly for the killed tree to actually exit before the
+                # pipe drain: in the common case the real EOF then arrives
+                # within the drain bound and the drain returns the full output
+                # instead of the partial from the timeout exception.  The
+                # bound is structural (wait_job_empty never waits longer than
+                # its own timeout), and the drain itself never blocks on EOF.
+                win32_job.wait_job_empty(job, win32_job.IO_DRAIN_TIMEOUT_SECONDS)
+                partial_out, partial_err = win32_job.drain_pipes(
+                    process, win32_job.IO_DRAIN_TIMEOUT_SECONDS
+                )
+                # Windows ``communicate`` raises the bare TimeoutExpired (no
+                # ``output=``/``stderr=`` args), so ``exc.stdout``/``exc.stderr``
+                # are always None here and the no-output signal must come from
+                # the partial the bounded drain actually collected.
                 return _timeout_error(
-                    command, timeout, no_output=not (exc.stdout or exc.stderr)
+                    command, timeout, no_output=not (partial_out or partial_err)
                 )
         finally:
             # Closing the last job handle fires KILL_ON_JOB_CLOSE, terminating

--- a/tests/test_win32_job.py
+++ b/tests/test_win32_job.py
@@ -212,6 +212,11 @@ def test_taskkill_fallback_invokes_hidden_tree_kill(monkeypatch):
     assert kwargs["creationflags"] == win32_job.CREATE_NO_WINDOW
     assert kwargs["timeout"] == 10.0
     assert kwargs["stdin"] is subprocess.DEVNULL
+    # taskkill output is discarded; DEVNULL keeps this fallback free of pipe
+    # reader threads so it can never deadlock on the same buffered-IO close
+    # as the bounded drain fix addresses.
+    assert kwargs["stdout"] is subprocess.DEVNULL
+    assert kwargs["stderr"] is subprocess.DEVNULL
 
 
 def test_taskkill_fallback_is_safe_noop_when_unavailable(monkeypatch):
@@ -246,20 +251,78 @@ class _FakeProcess:
         raise self._communicate_result
 
 
-def test_drain_pipes_returns_partial_output_and_closes_streams_on_timeout():
+def test_drain_pipes_returns_partial_output_and_detaches_streams_on_timeout():
     exc = subprocess.TimeoutExpired(cmd="pwsh", timeout=0.5, output="partial-out", stderr="partial-err")
     process = _FakeProcess(exc)
     stdout, stderr = win32_job.drain_pipes(process, 0.5)
     assert stdout == "partial-out"
     assert stderr == "partial-err"
-    assert process.stdout.closed and process.stderr.closed
+    # The reader threads are detached, never close()d: closing a stream whose
+    # reader thread is blocked in read() would deadlock on the buffered-IO
+    # lock (win32_job drain deadlock), so the fix clears the references and
+    # lets the daemon reader threads finish on their own.
+    assert process.stdout is None and process.stderr is None
 
 
 def test_drain_pipes_passes_full_output_when_eof_arrives(monkeypatch):
     process = _FakeProcess(None)
     monkeypatch.setattr(process, "communicate", lambda timeout=None: ("out", "err"))
     assert win32_job.drain_pipes(process, 0.5) == ("out", "err")
-    assert not process.stdout.closed
+    assert process.stdout is not None
+    assert process.stderr is not None
+
+
+def test_drain_pipes_never_blocks_on_live_reader_stream():
+    """Regression: a real pipe whose reader thread is blocked in read() must
+    not deadlock ``drain_pipes``.  CPython's reader thread holds the
+    buffered-IO lock while blocked in ``read()``, and ``stream.close()``
+    would wait on that same lock forever.  This is the exact state reached
+    when a grandchild survives the kill and still holds the pipe write ends.
+    The drain is run on a worker thread so the old close()-based
+    implementation fails this test instead of hanging the suite.
+    """
+    import io
+    import threading
+    import time
+
+    def _live_stream():
+        r_fd, w_fd = os.pipe()
+        stream = io.TextIOWrapper(io.open(r_fd, "rb", -1), encoding="utf-8")
+        # A reader thread blocked in read() while w_fd stays open (the
+        # surviving-grandchild equivalent).
+        thread = threading.Thread(target=stream.read, daemon=True)
+        thread.start()
+        return stream, w_fd
+
+    out_stream, out_w = _live_stream()
+    err_stream, err_w = _live_stream()
+
+    class _LiveReaderProcess:
+        def communicate(self, timeout=None):
+            raise subprocess.TimeoutExpired(
+                cmd="pwsh", timeout=timeout, output=None, stderr=None
+            )
+
+    process = _LiveReaderProcess()
+    process.stdout = out_stream
+    process.stderr = err_stream
+    result = {}
+    started = time.monotonic()
+
+    def _drain():
+        result["value"] = win32_job.drain_pipes(process, 0.05)
+
+    worker = threading.Thread(target=_drain, daemon=True)
+    worker.start()
+    worker.join(timeout=2.0)
+    elapsed = time.monotonic() - started
+    assert not worker.is_alive(), f"drain_pipes blocked {elapsed:.2f}s on live readers"
+    assert elapsed < 2.0
+    stdout, stderr = result["value"]
+    assert stdout is None and stderr is None
+    assert process.stdout is None and process.stderr is None
+    os.close(out_w)
+    os.close(err_w)
 
 
 def test_wait_job_empty_polls_active_count(monkeypatch):
@@ -324,6 +387,10 @@ def test_sync_timeout_kills_whole_tree_and_drains_boundedly(monkeypatch, tmp_pat
         lambda job, pid: events.append(("terminate", job, pid)),
     )
     monkeypatch.setattr(
+        win32_job, "wait_job_empty",
+        lambda job, timeout: events.append(("wait_empty", job, timeout)) or True,
+    )
+    monkeypatch.setattr(
         win32_job, "drain_pipes",
         lambda proc, timeout: events.append(("drain", timeout)) or ("p", "e"),
     )
@@ -336,8 +403,12 @@ def test_sync_timeout_kills_whole_tree_and_drains_boundedly(monkeypatch, tmp_pat
     assert result == {"status": "error", "message": "Command timed out after 5.0s"}
     assert events[0][0] == "spawn"
     assert events[1] == ("terminate", 99, 4242)
-    assert events[2] == ("drain", win32_job.IO_DRAIN_TIMEOUT_SECONDS)
-    assert events[3] == ("close", 99)
+    # The supervisor waits for the killed tree to actually exit before the
+    # pipe drain so real EOF arrives in the common case; the drain bound is
+    # structural either way.
+    assert events[2] == ("wait_empty", 99, win32_job.IO_DRAIN_TIMEOUT_SECONDS)
+    assert events[3] == ("drain", win32_job.IO_DRAIN_TIMEOUT_SECONDS)
+    assert events[4] == ("close", 99)
 
 
 def test_sync_success_caps_output(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

Fixes the Windows sync shell-tool timeout hang: **`win32_job.drain_pipes` deadlocks by calling `stream.close()` on streams whose CPython reader threads are still blocked in `read()` holding the buffered-IO lock.**

### Root cause
On Windows, CPython drains subprocess pipes with **reader threads** (`subprocess.py:1514-1550`). A thread blocked in `fh.read()` holds the buffered-IO lock for the whole duration of the read; `stream.close()` on that same object must acquire the same lock — **without a timeout**. So the post-kill "bounded drain" (0.5s) deadlocks in exactly the situation it was written to survive:

- command times out → tree killed → `drain_pipes` runs → EOF not reached within 0.5s (grandchild still holding write ends) → `TimeoutExpired` → the close-loop runs → **blocks forever** → `_timeout_error` never returns → no `tool_result` ever → `finally: close_handle(job)` never runs (leaks job handle + loses `KILL_ON_JOB_CLOSE` backstop).

Observed live on the PowerShell agent (2026-08-10): sync `git rebase --continue` with `timeout=120` produced no result for 7+ minutes. `git rebase --continue` spawning a non-interactive editor (notepad/vim under `CREATE_NO_WINDOW`) is a realistic >120s command hang; the defect is that the timeout *enforcement* worked but timeout *reporting* deadlocked.

### Fix
1. **`drain_pipes` never `close()`s a live-reader stream.** Instead it detaches `process.stdout`/`process.stderr` (`= None`) and returns the partial output. The reader threads are already `daemon=True` (cannot block interpreter exit) and finish on their own once the killed tree releases the pipe write ends.
2. **Wait for the job to actually drain before the pipe drain** (`wait_job_empty(job, IO_DRAIN_TIMEOUT_SECONDS)` after `terminate_owned_tree`): in the common case real EOF arrives and the drain returns full output rather than the timeout partial.
3. **Fix `no_output` detection on the Windows contained path**: Windows `communicate` raises the bare `TimeoutExpired` (no `output=`/`stderr=`), so `exc.stdout`/`exc.stderr` are always `None` and `no_output` was unconditionally `True`. Now it is derived from the partial the bounded drain actually collected.
4. **`taskkill_tree_best_effort` runs with `DEVNULL` pipes** instead of `capture_output` (its output is discarded anyway), eliminating the same `close()` deadlock class in the fallback path.

### Tests
- **New regression test** `test_drain_pipes_never_blocks_on_live_reader_stream`: real `os.pipe()` + live daemon reader threads, runs `drain_pipes` on a worker thread and asserts it returns within 2s (the old close-loop fails this test instead of hanging the suite). Mutation-verified: reverting to the close-loop makes the test fail.
- Updated detach-semantics assertions (`process.stdout is None`) in the existing drain tests.
- Wiring test now asserts `wait_job_empty` fires between terminate and drain.
- **96 passed** in `test_win32_job.py` + `test_layers_bash.py` + `test_bash_shell_dialect.py`. 1 pre-existing base failure (`test_sync_contained_delivers_stdin_bootstrap_script`, "stdin_script requires the argv form") is byte-identical on clean `main` and unrelated.

### Follow-ups (not in this PR)
- Finding 3: the `OSError` fallback in `_run_sync_contained` still uses plain `subprocess.run`, whose Windows timeout path has the same documented hang class — deserves the same bounded treatment.
- Finding 4: `JOB_OBJECT_LIMIT_BREAKAWAY_OK` lets a descendant escape the kill while holding pipe write ends; worth reconsidering as a containment tightening.
- Operational mitigation already applied: set `GIT_EDITOR=true` + `GIT_TERMINAL_PROMPT=0` in the Windows agent env so `git rebase --continue` cannot block on an editor.

Full evidence: `tmp/windows-timeout-hang-investigation.md` on the reporting agent.
