### PR TITLE
chore(release): bump version to 1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lingtai"
-version = "0.19.5"
+version = "1.0.0"
 description = "Generic research agent with intrinsic tools and MCP-compatible extension interface"
 readme = "README.md"
 # Architecture-specific macOS Python limits are expressed by the uv resolution


### PR DESCRIPTION
## Summary

Kernel 1.0.0 milestone release: bumps pyproject version 0.19.5 → 1.0.0. 168 commits / 23+ merged PRs since v0.19.5 (08-02).

## Scope

- daemon supervisor + terminal notifications, worker-hang rehydrate
- Telegram/IMAP/Feishu/WeChat reliability
- shell hard timeout ceiling (#1343/#1344)
- nudge folder-size channel
- Agent Plugins capability (#1232)
- file glob, system ToolFamily, preset/daemon allowlist fixes

Telegram: @lingtaidev3bot | Nickname: 澄一
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai