### PR TITLE
fix(openai): stop scrub from injecting type into description property maps

### DIFF
--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -1198,7 +1198,22 @@ def _scrub_responses_schema(node: Any, is_root: bool = False) -> Any:
         # Coerce typeless property schemas: a node describing a value (has a
         # description) but lacking any kind key. Skip bare containers like an
         # empty {} or {"required": [...]} that aren't value descriptors.
-        if "description" in out and not any(k in out for k in _SCHEMA_KIND_KEYS):
+        #
+        # Guard on the description being a plain string, not merely present:
+        # a properties map may legitimately contain a property literally named
+        # ``description`` (e.g. notification add/edit hook fields), where the
+        # value is a nested schema dict rather than a prose string. Without
+        # this guard the scrub would inject ``type: "string"`` into the
+        # properties map as a new property key, producing an invalid schema
+        # node (``properties.type`` must itself be an object or boolean) that
+        # the Codex backend rejects with
+        # ``Invalid schema for function '<name>': 'string' is not of type
+        # 'object', 'boolean'``.
+        if (
+            "description" in out
+            and isinstance(out["description"], str)
+            and not any(k in out for k in _SCHEMA_KIND_KEYS)
+        ):
             out["type"] = "string"
         # A typed object with no `properties` is rejected; give it an empty map.
         if out.get("type") == "object" and "properties" not in out:

--- a/tests/test_notification_schema_wire_scrub.py
+++ b/tests/test_notification_schema_wire_scrub.py
@@ -1,0 +1,116 @@
+"""``notification`` schema must survive the Codex Responses wire scrub intact.
+
+Regression for the v1.0.0 blocker: ``_scrub_responses_schema``'s typeless
+coercion fired on the ``add`` / ``edit`` hook-registry branches, whose
+properties map legitimately contains a property literally named
+``description`` (value = nested schema dict). The scrub saw a ``description``
+key plus no kind key and injected ``type: "string"`` **into the properties
+map as a new property key**, producing ``properties.type = "string"`` — a
+node that violates the JSON-Schema meta-schema (every ``properties`` value
+must be an object or boolean). The Codex backend rejects the whole function
+with ``Invalid schema for function 'notification': 'string' is not of type
+'object', 'boolean'.``, which put every codex-provider agent into an AED
+stuck loop.
+
+The fix restricts coercion to nodes whose ``description`` value is a plain
+string (a true typeless value descriptor); a properties map whose
+``description`` key holds a nested schema dict is left alone.
+"""
+from __future__ import annotations
+
+import copy
+
+from lingtai.kernel.llm.base import FunctionSchema
+from lingtai.llm.openai.adapter import (
+    _build_responses_tools,
+    _build_tools,
+    _scrub_responses_schema,
+)
+from lingtai.tools.notification import get_schema
+
+
+def _notification_schema() -> dict:
+    return get_schema("en")
+
+
+def _any_branch_input(schema: dict, title: str) -> dict:
+    inputs = schema["properties"]["input"]
+    branches = inputs.get("oneOf") or inputs.get("anyOf")
+    return next(b for b in branches if b["title"] == f"{title} input")
+
+
+def test_scrub_does_not_inject_type_into_description_property_map():
+    """A properties map containing a ``description`` key stays a pure map."""
+    # Canonical branch for ``add`` has a property literally named description.
+    branch = _any_branch_input(_notification_schema(), "add")
+    assert "description" in branch["properties"]
+    scrubbed = _scrub_responses_schema(copy.deepcopy(branch))
+    assert "type" not in scrubbed["properties"], (
+        "scrub must not inject type: 'string' into the properties map "
+        f"(got properties.type={scrubbed['properties'].get('type')!r})"
+    )
+    # The nested description schema itself is untouched (a dict, not coerced).
+    assert isinstance(scrubbed["properties"]["description"], dict)
+
+
+def test_scrub_still_coerces_typeless_string_description():
+    """Genuine typeless value descriptors keep the existing coercion."""
+    node = {"description": "some prose about a field"}
+    scrubbed = _scrub_responses_schema(copy.deepcopy(node))
+    assert scrubbed == {"description": "some prose about a field", "type": "string"}
+
+
+def test_notification_responses_wire_is_meta_schema_valid():
+    """The whole notification parameters root survives the Responses scrub."""
+    schema = FunctionSchema(
+        name="notification",
+        description="x",
+        parameters=_notification_schema(),
+    )
+    tools = _build_responses_tools([schema])
+    params = tools[0]["parameters"]
+    # Every value in every properties map must be a dict or bool (meta-schema
+    # requirement the Codex backend enforces). Walk the whole tree.
+    stack = [params]
+    while stack:
+        node = stack.pop()
+        if isinstance(node, dict):
+            for key, value in node.items():
+                if key == "properties":
+                    assert isinstance(value, dict)
+                    for prop_name, prop_schema in value.items():
+                        assert isinstance(prop_schema, (dict, bool)), (
+                            f"properties.{prop_name} must be object/boolean, "
+                            f"got {type(prop_schema).__name__}: {prop_schema!r}"
+                        )
+                        stack.append(prop_schema)
+                else:
+                    stack.append(value)
+        elif isinstance(node, list):
+            stack.extend(node)
+
+
+def test_notification_chat_wire_parameters_is_object():
+    """The Chat Completions wire keeps parameters as an object."""
+    schema = FunctionSchema(
+        name="notification",
+        description="x",
+        parameters=_notification_schema(),
+    )
+    tools = _build_tools([schema])
+    assert isinstance(tools[0]["function"]["parameters"], dict)
+
+
+def test_scrub_preserves_add_edit_branches_without_type_key():
+    """Branches 4 (add) and 6 (edit) keep no stray ``type`` property."""
+    schema = FunctionSchema(
+        name="notification",
+        description="x",
+        parameters=_notification_schema(),
+    )
+    params = _build_responses_tools([schema])[0]["parameters"]
+    branches = params["properties"]["input"]["anyOf"]
+    for idx in (4, 6):
+        assert "type" not in branches[idx]["properties"], (
+            f"branch {idx} ({branches[idx]['title']}) must not gain a type property"
+        )


### PR DESCRIPTION
## Problem

Every codex-provider agent on this machine entered an AED stuck loop with:

```
Error code: 400 - {'error': {'message': "Invalid schema for function 'notification': 'string' is not of type 'object', 'boolean'.", 'type': 'invalid_request_error', 'param': 'tools[5].parameters', 'code': 'invalid_function_parameters'}}
```

`_scrub_responses_schema`'s typeless-property coercion fired on a **properties map** that legitimately contains a property literally named `description` (the notification `add` / `edit` hook-registry fields, whose value is a nested schema dict). The scrub saw a `description` key plus no kind key, and injected `type: "string"` **into the properties map as a new property key** — producing `properties.type = "string"`, a node that violates the JSON-Schema meta-schema (every `properties` value must be an object or boolean). The Codex backend rejects the whole function tool, so the agent can never call `notification`, and AED retries into a stuck loop.

## Fix

Restrict the typeless coercion to nodes whose `description` value is a plain **string** (a true typeless value descriptor). A properties map whose `description` key holds a nested schema dict is left alone. This preserves the original intent (coerce `secondary.args.*`-style typeless fields) while no longer corrupting property maps.

## Validation

- New regression test `tests/test_notification_schema_wire_scrub.py` proves the notification schema survives both OpenAI wires meta-schema-valid, that branches `add`/`edit` keep no stray `type` property, and that genuine typeless string-description nodes are still coerced.
- Focused suite: `test_notification_schema_wire_scrub.py` + `test_tool_family_email_wire_parity.py` + `test_psyche_family.py` + `test_tool_family_wire_parity.py` → **89 passed**.
- Broader tool-family + wire suite: **516 passed, 2 failed** — the 2 failures are pre-existing on clean base `624ca441` (daemon migration tests asserting an exact property set that omits the `plugin` field added by #1330); verified by stash base-control (`2 failed, 66 passed` on clean base, identical failures).
- Manual reproduction before fix: 32 meta-schema errors, `properties.type = "string"` at `input.anyOf[4]` and `[6]`; after fix: **0 errors**.

## Changes

- `src/lingtai/llm/openai/adapter.py` — guard the typeless coercion on `isinstance(description, str)` (1 file, +16/−1)
- `tests/test_notification_schema_wire_scrub.py` — new regression test

Telegram: @lingtaidev1bot | Nickname: 知微
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
