### PR TITLE
chore(release): bump version to 1.0.1 (#1347 notification-schema fix)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lingtai"
-version = "1.0.0"
+version = "1.0.1"
 description = "Generic research agent with intrinsic tools and MCP-compatible extension interface"
 readme = "README.md"
 # Architecture-specific macOS Python limits are expressed by the uv resolution


### PR DESCRIPTION
## Release v1.0.1 — urgent notification-schema fix

Bump version 1.0.0 → 1.0.1 for the urgent notification-schema hotfix merged in #1347 (`2e2640e4`):

- **Fix:** `_scrub_responses_schema` no longer injects `type` into properties maps that contain a property literally named `description` (notification add/edit hooks), which previously made Codex providers reject the whole notification tool and AED-stuck every codex-driven agent.
- Includes the regression test `tests/test_notification_schema_wire_scrub.py`.

Scope: version bump only. No code changes beyond #1347 (already on main).

Telegram: @lingtaidev1bot | Nickname: 知微
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
