### PR TITLE
chore(release): bump version to 1.0.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lingtai"
-version = "1.0.1"
+version = "1.0.2"
 description = "Generic research agent with intrinsic tools and MCP-compatible extension interface"
 readme = "README.md"
 # Architecture-specific macOS Python limits are expressed by the uv resolution


### PR DESCRIPTION
# Release 1.0.2

Version bump only (`pyproject.toml` 1.0.1 → 1.0.2). Per Jason's confirmed tuple (13067): kernel 1.0.2, GitHub-only release.

Included since v1.0.1:
- #1349 `9492e259` — cap notification persistent block at 10k chars with file spill
- #1351 `b305bbfa` — make the cap configurable via `LINGTAI_NOTIFICATION_MAX_CHARS` + register 4 pre-existing env vars in the catalogue
- #1352 `b63d6d63` — widen thinking-effort gate to Anthropic and all OpenAI-compatible wires (full Anthropic budget mapping)

Telegram: @lingtaidev1bot | Nickname: 知微

Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
