### PR TITLE
fix(mail): disambiguate duplicate attachment basenames

### DIFF
--- a/src/lingtai/adapters/posix/mail.py
+++ b/src/lingtai/adapters/posix/mail.py
@@ -204,11 +204,16 @@ class PosixFilesystemMailAdapter(MailTransportPort):
                 staging_att_dir.mkdir(parents=True, exist_ok=True)
                 # Recipient-local paths recorded in the payload must point at
                 # the final location (``msg_dir``), not the staging path.
+                # Duplicate basenames are disambiguated with a ``-N`` suffix
+                # (``a.txt`` -> ``a-1.txt``) so no attachment silently
+                # overwrites an earlier one (#1354): every accepted source is
+                # delivered as its own physical file with its own payload path.
+                local_names = _unique_attachment_names(srcs)
                 local_copies = [
-                    str(msg_dir / "attachments" / src.name) for src in srcs
+                    str(msg_dir / "attachments" / name) for name in local_names
                 ]
-                for src in srcs:
-                    shutil.copy2(src, staging_att_dir / src.name)
+                for src, name in zip(srcs, local_names):
+                    shutil.copy2(src, staging_att_dir / name)
                 message = {**message, "attachments": local_copies}
 
             (staging_dir / "message.json").write_text(
@@ -729,6 +734,34 @@ class PosixFilesystemMailAdapter(MailTransportPort):
             self._poll_thread.join(timeout=3.0)
         self._poll_thread = None
         self._reset_own_inbox_iter()
+
+
+def _unique_attachment_names(srcs: list[Path]) -> list[str]:
+    """Map each source attachment to a unique recipient-local file name.
+
+    Basenames are preserved when unique. On a collision, a ``-1``, ``-2``,
+    ... counter is inserted before the suffix (``a.txt`` -> ``a-1.txt``) so
+    every accepted attachment keeps its own physical file and payload path
+    instead of silently overwriting an earlier one (#1354).
+    """
+    used: set[str] = set()
+    names: list[str] = []
+    for src in srcs:
+        candidate = src.name
+        if candidate not in used:
+            used.add(candidate)
+            names.append(candidate)
+            continue
+        stem, suffix = src.stem, src.suffix
+        i = 1
+        while True:
+            candidate = f"{stem}-{i}{suffix}"
+            if candidate not in used:
+                break
+            i += 1
+        used.add(candidate)
+        names.append(candidate)
+    return names
 
 
 def _runtime_probe_payload(payload: dict) -> dict | None:

--- a/tests/test_filesystem_mail.py
+++ b/tests/test_filesystem_mail.py
@@ -79,6 +79,53 @@ class TestSend:
         assert len(data["attachments"]) == 1
         assert "report.txt" in data["attachments"][0]
 
+    def test_send_preserves_duplicate_basename_attachments(self, tmp_path):
+        """#1354: two same-basename attachments from different source dirs
+        must both be delivered: two physical files, two distinct payload paths."""
+        from lingtai.adapters.posix.mail import PosixFilesystemMailAdapter
+
+        sender_dir = _make_agent_dir(tmp_path, "sender01")
+        recip_dir = _make_agent_dir(tmp_path, "recip01")
+        (recip_dir / "mailbox" / "inbox").mkdir(parents=True)
+
+        # Two different files that share the same basename, in different dirs.
+        src_a = tmp_path / "src_a" / "same.txt"
+        src_b = tmp_path / "src_b" / "same.txt"
+        src_a.parent.mkdir()
+        src_b.parent.mkdir()
+        src_a.write_text("content-A")
+        src_b.write_text("content-B")
+
+        svc = PosixFilesystemMailAdapter(sender_dir, mailbox_rel="mailbox")
+        result = svc.send(str(recip_dir), {
+            "message": "see attached",
+            "attachments": [str(src_a), str(src_b)],
+        })
+        assert result is None  # success, nothing silently dropped
+
+        inbox = recip_dir / "mailbox" / "inbox"
+        msg_dir = list(inbox.iterdir())[0]
+        att_dir = msg_dir / "attachments"
+        data = json.loads((msg_dir / "message.json").read_text())
+
+        # Both physical files survive with their original contents: the first
+        # keeps its basename, the second is disambiguated to ``same-1.txt``.
+        assert sorted(p.name for p in att_dir.iterdir()) == [
+            "same-1.txt",
+            "same.txt",
+        ]
+        assert (att_dir / "same.txt").read_text() == "content-A"
+        assert (att_dir / "same-1.txt").read_text() == "content-B"
+
+        # The payload carries two distinct recipient-local paths, each naming
+        # a delivered file (not two copies of the same path).
+        assert len(data["attachments"]) == 2
+        assert len(set(data["attachments"])) == 2
+        assert data["attachments"] == [
+            str(att_dir / "same.txt"),
+            str(att_dir / "same-1.txt"),
+        ]
+
     def test_send_fails_no_agent_json(self, tmp_path):
         from lingtai.adapters.posix.mail import PosixFilesystemMailAdapter
 


### PR DESCRIPTION
Closes #1354

## Summary

`PosixFilesystemMailAdapter.send()` could return success after silently replacing an earlier attachment when two source files shared the same basename — both payload entries pointed at the same recipient-local path, so the message claimed two attachments while retaining only the later file.

This PR makes attachment destinations collision-safe while preserving the existing atomic staging + single `os.replace` publication:

- New `_unique_attachment_names()` helper maps each accepted source to a deterministic recipient-local name; on collision a `-1`, `-2`, ... counter is inserted before the suffix (`a.txt` + `a.txt` → `a.txt` + `a-1.txt`).
- Staging copies and payload paths now use the same unique names (`zip(srcs, local_names)`), so every accepted attachment keeps its own physical file and payload path.
- Regression test `test_send_preserves_duplicate_basename_attachments` verifies two same-basename attachments from different dirs are both delivered (two physical files, two distinct payload paths, original contents preserved).

## Validation

- `tests/test_filesystem_mail.py`: 42 passed (incl. new test)
- `git diff --check` clean

Telegram: @lingtaidev3bot | Nickname: 澄一
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
