### PR TITLE
docs(anatomy): repair related_files graph (kernel #1355)

### DIFF
--- a/ANATOMY.md
+++ b/ANATOMY.md
@@ -1,6 +1,7 @@
 ---
 related_files:
   - AGENTS.md
+  - BEHAVIORS.md
   - CLAUDE.md
   - CODE_OF_CONDUCT.md
   - CONTRACT.md

--- a/src/lingtai/ANATOMY.md
+++ b/src/lingtai/ANATOMY.md
@@ -1,6 +1,7 @@
 ---
 related_files:
   - ANATOMY.md
+  - src/lingtai/BEHAVIORS.md
   - src/lingtai/__init__.py
   - src/lingtai/__main__.py
   - src/lingtai/agent.py

--- a/src/lingtai/kernel/ANATOMY.md
+++ b/src/lingtai/kernel/ANATOMY.md
@@ -1,6 +1,7 @@
 ---
 related_files:
-  - BEHAVIORS.md
+  - src/lingtai/kernel/BEHAVIORS.md
+  - src/lingtai/kernel/agent_readme/ANATOMY.md
   - src/lingtai/services/LICC_NOTIFICATION_CONTRACT.md
   - ANATOMY.md
   - MANIFEST.in

--- a/src/lingtai/kernel/agent_presence/ANATOMY.md
+++ b/src/lingtai/kernel/agent_presence/ANATOMY.md
@@ -1,5 +1,6 @@
 ---
 related_files:
+  - src/lingtai/kernel/agent_presence/BEHAVIORS.md
   - src/lingtai/kernel/agent_presence/CONTRACT.md
   - src/lingtai/kernel/ANATOMY.md
   - src/lingtai/kernel/agent_presence/__init__.py

--- a/src/lingtai/kernel/agent_readme/ANATOMY.md
+++ b/src/lingtai/kernel/agent_readme/ANATOMY.md
@@ -1,3 +1,17 @@
+---
+related_files:
+  - src/lingtai/kernel/ANATOMY.md
+  - src/lingtai/kernel/agent_readme/BEHAVIORS.md
+  - src/lingtai/kernel/agent_readme/CONTRACT.md
+  - src/lingtai/kernel/agent_readme/README.md.tpl
+  - src/lingtai/kernel/agent_readme/__init__.py
+maintenance: |
+  Keep related_files repo-relative, duplicate-free, and linked to real files.
+  This anatomy maps the agent_readme folder: the packaged README template,
+  the idempotent writer and pure renderer, and the behavior-test loop. When
+  CONTRACT or BEHAVIORS change, update this anatomy together and revalidate
+  the architecture-document graph before merge.
+---
 # agent_readme ANATOMY
 
 ## Components

--- a/src/lingtai/kernel/agent_readme/CONTRACT.md
+++ b/src/lingtai/kernel/agent_readme/CONTRACT.md
@@ -5,7 +5,7 @@ contract_version: 1
 related_files:
   - src/lingtai/kernel/agent_readme/BEHAVIORS.md
   - src/lingtai/kernel/agent_readme/ANATOMY.md
-  - src/lingtai/kernel/agent_readme/_readme.py
+  - src/lingtai/kernel/agent_readme/__init__.py
 maintenance: |
   The agent README folder role split (README.md vs substrate.md) and its
   ownership/maintenance boundary. Every agent-observable behavior clause

--- a/src/lingtai/kernel/base_agent/ANATOMY.md
+++ b/src/lingtai/kernel/base_agent/ANATOMY.md
@@ -1,5 +1,6 @@
 ---
 related_files:
+  - src/lingtai/kernel/base_agent/BEHAVIORS.md
   - src/lingtai/kernel/base_agent/CONTRACT.md
   - src/lingtai/tools/daemon/ANATOMY.md
   - docs/references/windows-support.md

--- a/src/lingtai/kernel/daemon_supervisor/ANATOMY.md
+++ b/src/lingtai/kernel/daemon_supervisor/ANATOMY.md
@@ -1,5 +1,6 @@
 ---
 related_files:
+  - src/lingtai/kernel/daemon_supervisor/BEHAVIORS.md
   - src/lingtai/kernel/daemon_supervisor/CONTRACT.md
   - src/lingtai/kernel/ANATOMY.md
   - src/lingtai/kernel/daemon_supervisor/__init__.py

--- a/src/lingtai/kernel/event_journal/ANATOMY.md
+++ b/src/lingtai/kernel/event_journal/ANATOMY.md
@@ -1,5 +1,6 @@
 ---
 related_files:
+  - src/lingtai/kernel/event_journal/BEHAVIORS.md
   - src/lingtai/kernel/event_journal/CONTRACT.md
   - src/lingtai/kernel/ANATOMY.md
   - src/lingtai/kernel/event_journal/__init__.py

--- a/src/lingtai/kernel/lifecycle_clock/ANATOMY.md
+++ b/src/lingtai/kernel/lifecycle_clock/ANATOMY.md
@@ -1,5 +1,6 @@
 ---
 related_files:
+  - src/lingtai/kernel/lifecycle_clock/BEHAVIORS.md
   - src/lingtai/kernel/lifecycle_clock/CONTRACT.md
   - src/lingtai/kernel/lifecycle_clock/__init__.py
   - src/lingtai/kernel/ANATOMY.md

--- a/src/lingtai/kernel/mail_transport/ANATOMY.md
+++ b/src/lingtai/kernel/mail_transport/ANATOMY.md
@@ -1,5 +1,6 @@
 ---
 related_files:
+  - src/lingtai/kernel/mail_transport/BEHAVIORS.md
   - src/lingtai/kernel/mail_transport/CONTRACT.md
   - src/lingtai/kernel/mail_transport/__init__.py
   - src/lingtai/kernel/ANATOMY.md

--- a/src/lingtai/kernel/migrate/ANATOMY.md
+++ b/src/lingtai/kernel/migrate/ANATOMY.md
@@ -1,6 +1,7 @@
 ---
 related_files:
   - src/lingtai/kernel/ANATOMY.md
+  - src/lingtai/kernel/migrate/BEHAVIORS.md
   - src/lingtai/kernel/migrate/CONTRACT.md
   - src/lingtai/kernel/migrate/__init__.py
   - src/lingtai/kernel/migrate/agent_m001_init_procedures_override.py

--- a/src/lingtai/kernel/notification_store/ANATOMY.md
+++ b/src/lingtai/kernel/notification_store/ANATOMY.md
@@ -1,5 +1,6 @@
 ---
 related_files:
+  - src/lingtai/kernel/notification_store/BEHAVIORS.md
   - src/lingtai/kernel/notification_store/CONTRACT.md
   - src/lingtai/kernel/ANATOMY.md
   - src/lingtai/kernel/notification_store/__init__.py

--- a/src/lingtai/kernel/refresh_watcher/ANATOMY.md
+++ b/src/lingtai/kernel/refresh_watcher/ANATOMY.md
@@ -1,5 +1,6 @@
 ---
 related_files:
+  - src/lingtai/kernel/refresh_watcher/BEHAVIORS.md
   - src/lingtai/kernel/refresh_watcher/CONTRACT.md
   - src/lingtai/kernel/refresh_watcher/__init__.py
   - src/lingtai/kernel/refresh_watcher/watcher_program.py

--- a/src/lingtai/kernel/snapshot/ANATOMY.md
+++ b/src/lingtai/kernel/snapshot/ANATOMY.md
@@ -2,6 +2,7 @@
 related_files:
   - ANATOMY.md
   - src/lingtai/ANATOMY.md
+  - src/lingtai/kernel/snapshot/BEHAVIORS.md
   - src/lingtai/kernel/snapshot/CONTRACT.md
   - src/lingtai/kernel/snapshot/__init__.py
   - src/lingtai/kernel/ANATOMY.md

--- a/src/lingtai/kernel/workdir_lease/ANATOMY.md
+++ b/src/lingtai/kernel/workdir_lease/ANATOMY.md
@@ -1,5 +1,6 @@
 ---
 related_files:
+  - src/lingtai/kernel/workdir_lease/BEHAVIORS.md
   - src/lingtai/kernel/workdir_lease/CONTRACT.md
   - src/lingtai/kernel/workdir_lease/__init__.py
   - src/lingtai/kernel/ANATOMY.md

--- a/src/lingtai/llm/openai/ANATOMY.md
+++ b/src/lingtai/llm/openai/ANATOMY.md
@@ -13,7 +13,6 @@ related_files:
   - src/lingtai/llm/openai/defaults.py
   - src/lingtai/auth/codex_pool.py
   - tests/test_codex_quota.py
-  - tests/test_codex_pool_quota_exclusion.py
   - src/lingtai/llm/mimo/adapter.py
   - src/lingtai/llm/mimo/ANATOMY.md
   - src/lingtai/llm/service.py

--- a/src/lingtai/mcp_servers/ANATOMY.md
+++ b/src/lingtai/mcp_servers/ANATOMY.md
@@ -1,5 +1,6 @@
 ---
 related_files:
+  - src/lingtai/mcp_servers/telegram/_runtime.py
   - src/lingtai/services/LICC_NOTIFICATION_CONTRACT.md
   - pyproject.toml
   - src/lingtai/ANATOMY.md

--- a/src/lingtai/mcp_servers/telegram/task_card/ANATOMY.md
+++ b/src/lingtai/mcp_servers/telegram/task_card/ANATOMY.md
@@ -1,5 +1,6 @@
 ---
 related_files:
+  - src/lingtai/mcp_servers/telegram/task_card/BEHAVIORS.md
   - src/lingtai/mcp_servers/telegram/task_card/CONTRACT.md
   - src/lingtai/mcp_servers/telegram/task_card/resident.py
   - src/lingtai/mcp_servers/task_card/resident.py

--- a/src/lingtai/tools/ANATOMY.md
+++ b/src/lingtai/tools/ANATOMY.md
@@ -1,12 +1,15 @@
 ---
 related_files:
   - ANATOMY.md
+  - src/lingtai/tools/BEHAVIORS.md
   - src/lingtai/tools/CONTRACT.md
+  - src/lingtai/tools/feishu/BEHAVIORS.md
   - src/lingtai/tools/psyche/ANATOMY.md
   - src/lingtai/tools/plugin/ANATOMY.md
   - src/lingtai/tools/plugin/CONTRACT.md
   - src/lingtai/ANATOMY.md
   - src/lingtai/tools/notification/ANATOMY.md
+  - src/lingtai/tools/telegram/BEHAVIORS.md
   - src/lingtai/tools/web_search/ANATOMY.md
   - src/lingtai/tools/web_search/CONTRACT.md
   - src/lingtai/tools/task_card/ANATOMY.md

--- a/src/lingtai/tools/avatar/ANATOMY.md
+++ b/src/lingtai/tools/avatar/ANATOMY.md
@@ -1,6 +1,7 @@
 ---
 related_files:
   - src/lingtai/ANATOMY.md
+  - src/lingtai/tools/avatar/BEHAVIORS.md
   - src/lingtai/tools/avatar/__init__.py
   - src/lingtai/tools/avatar/_launcher.py
   - src/lingtai/tools/avatar/CONTRACT.md

--- a/src/lingtai/tools/bash/ANATOMY.md
+++ b/src/lingtai/tools/bash/ANATOMY.md
@@ -3,6 +3,7 @@ related_files:
   - ENVIRONMENT_VARIABLES.md
   - src/lingtai/ANATOMY.md
   - src/lingtai/adapters/posix/ANATOMY.md
+  - src/lingtai/tools/bash/BEHAVIORS.md
   - src/lingtai/tools/bash/__init__.py
   - src/lingtai/tools/bash/_tool_family.py
   - src/lingtai/tools/tool_family/ANATOMY.md

--- a/src/lingtai/tools/browser/ANATOMY.md
+++ b/src/lingtai/tools/browser/ANATOMY.md
@@ -1,6 +1,7 @@
 ---
 related_files:
   - src/lingtai/tools/ANATOMY.md
+  - src/lingtai/tools/browser/BEHAVIORS.md
   - src/lingtai/tools/browser/CONTRACT.md
   - src/lingtai/tools/browser/core.py
   - src/lingtai/tools/browser/port.py

--- a/src/lingtai/tools/context/ANATOMY.md
+++ b/src/lingtai/tools/context/ANATOMY.md
@@ -1,10 +1,10 @@
 ---
 related_files:
-  - BEHAVIORS.md
   - src/lingtai/intrinsic_skills/context-manual/SKILL.md
   - src/lingtai/intrinsic_skills/context-manual/assets/session-journal-entry-template.md
   - src/lingtai/tools/ANATOMY.md
   - src/lingtai/tools/CONTRACT.md
+  - src/lingtai/tools/context/BEHAVIORS.md
   - src/lingtai/tools/context/CONTRACT.md
   - src/lingtai/tools/tool_family/ANATOMY.md
   - src/lingtai/tools/pad/ANATOMY.md

--- a/src/lingtai/tools/context/CONTRACT.md
+++ b/src/lingtai/tools/context/CONTRACT.md
@@ -3,7 +3,7 @@ name: context-contract
 tool: context
 contract_version: 5
 related_files:
-  - BEHAVIORS.md
+  - src/lingtai/tools/context/BEHAVIORS.md
   - src/lingtai/tools/context/__init__.py
   - src/lingtai/tools/context/_molt.py
   - src/lingtai/tools/context/_session_journal.py

--- a/src/lingtai/tools/daemon/ANATOMY.md
+++ b/src/lingtai/tools/daemon/ANATOMY.md
@@ -1,7 +1,7 @@
 ---
 related_files:
-  - BEHAVIORS.md
   - src/lingtai/ANATOMY.md
+  - src/lingtai/tools/daemon/BEHAVIORS.md
   - src/lingtai/tools/daemon/CONTRACT.md
   - src/lingtai/tools/daemon/__init__.py
   - src/lingtai/tools/daemon/_tool_family.py

--- a/src/lingtai/tools/daemon/CONTRACT.md
+++ b/src/lingtai/tools/daemon/CONTRACT.md
@@ -10,8 +10,8 @@ status: active
 contract_version: 9
 last_changed_at: "2026-08-10"
 related_files:
-  - BEHAVIORS.md
   - src/lingtai/tools/daemon/ANATOMY.md
+  - src/lingtai/tools/daemon/BEHAVIORS.md
   - src/lingtai/tools/daemon/__init__.py
   - src/lingtai/tools/daemon/_tool_family.py
   - src/lingtai/tools/daemon/system_prompt.py
@@ -39,7 +39,6 @@ related_files:
   - src/lingtai/mcp_servers/daemon_common/server.py
   - src/lingtai/llm/openai/ANATOMY.md
   - src/lingtai/llm/mimo/ANATOMY.md
-  - tests/test_daemon_contract_doc.py
   - tests/test_task_card_proactivity.py
   - tests/test_tool_family_daemon_migration.py
   - tests/test_daemon.py

--- a/src/lingtai/tools/daemon/interactive_terminal/ANATOMY.md
+++ b/src/lingtai/tools/daemon/interactive_terminal/ANATOMY.md
@@ -1,5 +1,6 @@
 ---
 related_files:
+  - src/lingtai/tools/daemon/interactive_terminal/BEHAVIORS.md
   - src/lingtai/tools/daemon/interactive_terminal/__init__.py
   - src/lingtai/tools/daemon/interactive_terminal/CONTRACT.md
   - src/lingtai/adapters/posix/interactive_terminal.py

--- a/src/lingtai/tools/email/ANATOMY.md
+++ b/src/lingtai/tools/email/ANATOMY.md
@@ -2,6 +2,7 @@
 related_files:
   - src/lingtai/__init__.py
   - src/lingtai/tools/ANATOMY.md
+  - src/lingtai/tools/email/BEHAVIORS.md
   - src/lingtai/tools/email/CONTRACT.md
   - src/lingtai/tools/email/__init__.py
   - src/lingtai/tools/email/manager.py

--- a/src/lingtai/tools/file/ANATOMY.md
+++ b/src/lingtai/tools/file/ANATOMY.md
@@ -2,6 +2,7 @@
 related_files:
   - src/lingtai/tools/ANATOMY.md
   - src/lingtai/tools/CONTRACT.md
+  - src/lingtai/tools/file/BEHAVIORS.md
   - src/lingtai/tools/file/CONTRACT.md
   - src/lingtai/tools/file/__init__.py
   - src/lingtai/tools/file/_read.py

--- a/src/lingtai/tools/knowledge/ANATOMY.md
+++ b/src/lingtai/tools/knowledge/ANATOMY.md
@@ -2,6 +2,7 @@
 related_files:
   - src/lingtai/ANATOMY.md
   - src/lingtai/tools/_catalog.py
+  - src/lingtai/tools/knowledge/BEHAVIORS.md
   - src/lingtai/tools/knowledge/CONTRACT.md
   - src/lingtai/tools/knowledge/__init__.py
   - src/lingtai/tools/knowledge/manual/SKILL.md

--- a/src/lingtai/tools/lingtai/ANATOMY.md
+++ b/src/lingtai/tools/lingtai/ANATOMY.md
@@ -1,5 +1,6 @@
 ---
 related_files:
+  - src/lingtai/tools/lingtai/BEHAVIORS.md
   - src/lingtai/tools/lingtai/CONTRACT.md
   - src/lingtai/tools/ANATOMY.md
   - src/lingtai/tools/tool_family/ANATOMY.md

--- a/src/lingtai/tools/mcp/ANATOMY.md
+++ b/src/lingtai/tools/mcp/ANATOMY.md
@@ -2,6 +2,7 @@
 related_files:
   - src/lingtai/services/LICC_NOTIFICATION_CONTRACT.md
   - src/lingtai/ANATOMY.md
+  - src/lingtai/tools/mcp/BEHAVIORS.md
   - src/lingtai/tools/mcp/__init__.py
   - src/lingtai/services/mcp_inbox.py
   - src/lingtai/services/mcp_licc.py

--- a/src/lingtai/tools/pad/ANATOMY.md
+++ b/src/lingtai/tools/pad/ANATOMY.md
@@ -1,5 +1,6 @@
 ---
 related_files:
+  - src/lingtai/tools/pad/BEHAVIORS.md
   - src/lingtai/tools/pad/CONTRACT.md
   - src/lingtai/tools/ANATOMY.md
   - src/lingtai/tools/tool_family/ANATOMY.md

--- a/src/lingtai/tools/plugin/ANATOMY.md
+++ b/src/lingtai/tools/plugin/ANATOMY.md
@@ -1,6 +1,7 @@
 ---
 related_files:
   - src/lingtai/tools/ANATOMY.md
+  - src/lingtai/tools/plugin/BEHAVIORS.md
   - src/lingtai/tools/plugin/__init__.py
   - src/lingtai/tools/plugin/CONTRACT.md
   - src/lingtai/tools/plugin/manual/SKILL.md

--- a/src/lingtai/tools/psyche/ANATOMY.md
+++ b/src/lingtai/tools/psyche/ANATOMY.md
@@ -1,5 +1,6 @@
 ---
 related_files:
+  - src/lingtai/tools/psyche/BEHAVIORS.md
   - src/lingtai/tools/psyche/CONTRACT.md
   - src/lingtai/tools/ANATOMY.md
   - src/lingtai/tools/tool_family/ANATOMY.md

--- a/src/lingtai/tools/skills/ANATOMY.md
+++ b/src/lingtai/tools/skills/ANATOMY.md
@@ -3,6 +3,7 @@ related_files:
   - src/lingtai/ANATOMY.md
   - src/lingtai/agent.py
   - src/lingtai/tools/daemon/__init__.py
+  - src/lingtai/tools/skills/BEHAVIORS.md
   - src/lingtai/tools/skills/__init__.py
   - src/lingtai/tools/skills/manual/SKILL.md
   - src/lingtai/init_schema.py

--- a/src/lingtai/tools/soul/ANATOMY.md
+++ b/src/lingtai/tools/soul/ANATOMY.md
@@ -1,6 +1,7 @@
 ---
 related_files:
   - src/lingtai/tools/ANATOMY.md
+  - src/lingtai/tools/soul/BEHAVIORS.md
   - src/lingtai/tools/soul/__init__.py
   - src/lingtai/tools/soul/config.py
   - src/lingtai/tools/soul/consultation.py

--- a/src/lingtai/tools/task_card/ANATOMY.md
+++ b/src/lingtai/tools/task_card/ANATOMY.md
@@ -1,5 +1,6 @@
 ---
 related_files:
+  - src/lingtai/tools/task_card/BEHAVIORS.md
   - src/lingtai/tools/task_card/CONTRACT.md
   - src/lingtai/tools/task_card/__init__.py
   - src/lingtai/tools/task_card/manual/SKILL.md

--- a/src/lingtai/tools/tool_family/ANATOMY.md
+++ b/src/lingtai/tools/tool_family/ANATOMY.md
@@ -1,6 +1,6 @@
 ---
 related_files:
-  - BEHAVIORS.md
+  - src/lingtai/tools/tool_family/BEHAVIORS.md
   - src/lingtai/tools/tool_family/CONTRACT.md
   - src/lingtai/tools/ANATOMY.md
   - src/lingtai/tools/CONTRACT.md

--- a/src/lingtai/tools/tool_family/CONTRACT.md
+++ b/src/lingtai/tools/tool_family/CONTRACT.md
@@ -3,8 +3,8 @@ name: tool-family
 contract_version: 2
 root_contract: CONTRACT.md
 related_files:
-  - BEHAVIORS.md
   - src/lingtai/tools/tool_family/ANATOMY.md
+  - src/lingtai/tools/tool_family/BEHAVIORS.md
   - src/lingtai/tools/tool_family/__init__.py
   - src/lingtai/tools/tool_family/manual.py
   - src/lingtai/tools/CONTRACT.md

--- a/src/lingtai/tools/vision/ANATOMY.md
+++ b/src/lingtai/tools/vision/ANATOMY.md
@@ -1,6 +1,7 @@
 ---
 related_files:
   - src/lingtai/tools/ANATOMY.md
+  - src/lingtai/tools/vision/BEHAVIORS.md
   - src/lingtai/tools/vision/__init__.py
   - src/lingtai/tools/vision/CONTRACT.md
   - src/lingtai/tools/vision/glossary-en.md

--- a/src/lingtai/tools/web_search/ANATOMY.md
+++ b/src/lingtai/tools/web_search/ANATOMY.md
@@ -3,6 +3,7 @@ related_files:
   - src/lingtai/tools/ANATOMY.md
   - src/lingtai/tools/CONTRACT.md
   - src/lingtai/ANATOMY.md
+  - src/lingtai/tools/web_search/BEHAVIORS.md
   - src/lingtai/tools/web_search/CONTRACT.md
   - src/lingtai/tools/web_search/__init__.py
   - src/lingtai/tools/web_search/settings.py

--- a/tests/ANATOMY.md
+++ b/tests/ANATOMY.md
@@ -6,6 +6,7 @@ related_files:
   - AGENTS.md
   - dev-guide-skill/SKILL.md
   - pyproject.toml
+  - tests/BEHAVIORS.md
   - tests/CONTRACT.md
   - tests/__init__.py
   - tests/_agent_dir_helpers.py
@@ -49,9 +50,11 @@ related_files:
   - tests/test_agent_meta_guidance.py
   - tests/test_agent_presence.py
   - tests/test_agent_preset_manifest.py
+  - tests/test_agent_readme.py
   - tests/test_agent_session.py
   - tests/test_agent_session_wiring.py
   - tests/test_anatomy_drift_checker.py
+  - tests/test_anthropic_thinking_budget.py
   - tests/test_api_gate.py
   - tests/test_apriori_summary_executor.py
   - tests/test_apriori_summary_schema.py
@@ -85,7 +88,6 @@ related_files:
   - tests/test_codex_endpoint_pool.py
   - tests/test_codex_native_multiaccount.py
   - tests/test_codex_pool.py
-  - tests/test_codex_pool_quota_exclusion.py
   - tests/test_codex_prompt_cache_key.py
   - tests/test_codex_quota.py
   - tests/test_codex_raw_reasoning_replay.py
@@ -94,6 +96,7 @@ related_files:
   - tests/test_codex_ws_session.py
   - tests/test_codex_ws_tool_result_freeze.py
   - tests/test_compaction.py
+  - tests/test_config_resolve_jsonc.py
   - tests/test_context.py
   - tests/test_context_ownership_redesign.py
   - tests/test_context_pressure_reminder.py
@@ -110,18 +113,17 @@ related_files:
   - tests/test_daemon_claude_usage.py
   - tests/test_daemon_cli_143_attribution.py
   - tests/test_daemon_cli_watchdog_scope.py
-  - tests/test_daemon_codex_submanual.py
   - tests/test_daemon_codex_usage.py
-  - tests/test_daemon_contract_doc.py
+  - tests/test_daemon_common_finish_mcp.py
   - tests/test_daemon_cursor_backend.py
   - tests/test_daemon_cursor_submanual.py
   - tests/test_daemon_detached_supervisor.py
+  - tests/test_daemon_email_mcp.py
   - tests/test_daemon_empty_parity.py
   - tests/test_daemon_kimicode_submanual.py
   - tests/test_daemon_lingtai_submanual.py
   - tests/test_daemon_manifest.py
   - tests/test_daemon_mimocode_jsonl.py
-  - tests/test_daemon_mimocode_submanual.py
   - tests/test_daemon_missing_finish_guidance.py
   - tests/test_daemon_oh_my_pi_submanual.py
   - tests/test_daemon_opencode_backend.py
@@ -163,7 +165,9 @@ related_files:
   - tests/test_file_io_sidecar.py
   - tests/test_file_tool_family.py
   - tests/test_filesystem_mail.py
+  - tests/test_folder_size_nudge.py
   - tests/test_fsutil.py
+  - tests/test_gated_session_proxy.py
   - tests/test_git_init.py
   - tests/test_goal_notification.py
   - tests/test_handshake.py
@@ -188,12 +192,13 @@ related_files:
   - tests/test_intrinsics_comm.py
   - tests/test_karma.py
   - tests/test_kernel_isolation.py
+  - tests/test_kernel_logging.py
   - tests/test_kernel_migrate.py
-  - tests/test_kernel_package_move.py
   - tests/test_kernel_update_contract.py
   - tests/test_kernel_version_nudge.py
   - tests/test_kimi_code_adapter.py
   - tests/test_knowledge.py
+  - tests/test_labt_validation.py
   - tests/test_large_result_no_notification.py
   - tests/test_large_result_rescan.py
   - tests/test_layers_avatar.py
@@ -210,8 +215,10 @@ related_files:
   - tests/test_llm_adapters_manual.py
   - tests/test_llm_identity_headers.py
   - tests/test_llm_service.py
+  - tests/test_llm_service_adapter_cache.py
   - tests/test_llm_utils.py
   - tests/test_local_command_core.py
+  - tests/test_logging_setup.py
   - tests/test_loop_guard.py
   - tests/test_macos_shell_adapter.py
   - tests/test_mail_transport.py
@@ -237,6 +244,8 @@ related_files:
   - tests/test_molt_notification_persistence.py
   - tests/test_molt_task_persistence.py
   - tests/test_network.py
+  - tests/test_notification_persistent_cap.py
+  - tests/test_notification_schema_wire_scrub.py
   - tests/test_notification_store.py
   - tests/test_notification_sync.py
   - tests/test_notification_tool.py
@@ -257,11 +266,11 @@ related_files:
   - tests/test_portable_adapter_encoding.py
   - tests/test_post_molt_notification.py
   - tests/test_powershell_decode_windows_output.py
+  - tests/test_powershell_extractor_policy.py
   - tests/test_preset_auto_fallback.py
   - tests/test_preset_connectivity.py
   - tests/test_preset_context_guard.py
   - tests/test_preset_materialization.py
-  - tests/test_preset_runtime_model_docs.py
   - tests/test_preset_swap_e2e.py
   - tests/test_presets.py
   - tests/test_process_identity.py
@@ -318,7 +327,7 @@ related_files:
   - tests/test_system_summarize.py
   - tests/test_task_card_controller.py
   - tests/test_task_card_event_projection_shared.py
-  - tests/test_task_card_handoff_guidance.py
+  - tests/test_task_card_locale.py
   - tests/test_task_card_proactivity.py
   - tests/test_task_card_resident_shared.py
   - tests/test_taskcard_resident_meta.py
@@ -332,6 +341,7 @@ related_files:
   - tests/test_telegram_lossless_envelope.py
   - tests/test_telegram_notification_read_state.py
   - tests/test_telegram_rate_limit.py
+  - tests/test_telegram_reaction_states.py
   - tests/test_telegram_rich_formatting.py
   - tests/test_telegram_send_media_contract.py
   - tests/test_telegram_slash_commands.py
@@ -343,6 +353,7 @@ related_files:
   - tests/test_telegram_task_card_programmable.py
   - tests/test_telegram_task_card_result_hook.py
   - tests/test_telegram_task_card_rows.py
+  - tests/test_telegram_task_card_runtime_drift.py
   - tests/test_telegram_task_card_singleton.py
   - tests/test_telegram_task_card_state.py
   - tests/test_telegram_task_card_timestamp.py
@@ -351,13 +362,13 @@ related_files:
   - tests/test_telegram_terra_repairs.py
   - tests/test_telegram_toolfamily_ltpv2.py
   - tests/test_telegram_typing_ttl.py
+  - tests/test_telegram_unread_count.py
   - tests/test_three_agent_email.py
   - tests/test_time_awareness_email.py
   - tests/test_time_awareness_mail.py
   - tests/test_time_awareness_status.py
   - tests/test_time_veil.py
   - tests/test_timely_transient_serialization.py
-  - tests/test_token_counter.py
   - tests/test_token_ledger.py
   - tests/test_tool_dispatch.py
   - tests/test_tool_executor.py
@@ -374,7 +385,6 @@ related_files:
   - tests/test_tool_family_soul_migration.py
   - tests/test_tool_family_system_migration.py
   - tests/test_tool_family_vision_migration.py
-  - tests/test_tool_family_web_migration_parity.py
   - tests/test_tool_family_wire_parity.py
   - tests/test_tool_glossary.py
   - tests/test_tool_meta_comment_overflow.py
@@ -390,14 +400,12 @@ related_files:
   - tests/test_turn_boundary_housekeeping.py
   - tests/test_two_axis_meta_contract.py
   - tests/test_unified_web_capability.py
-  - tests/test_utf8_read_text.py
   - tests/test_utf8_write_text.py
   - tests/test_validate_skill.py
   - tests/test_venv_resolve.py
   - tests/test_vision_capability.py
   - tests/test_vision_services.py
   - tests/test_web_canonical_provider_routing.py
-  - tests/test_web_ltp_v2_summarize_executor.py
   - tests/test_web_output_spill.py
   - tests/test_web_search_capability.py
   - tests/test_wechat_config_resolution.py
@@ -405,7 +413,9 @@ related_files:
   - tests/test_wechat_media_validation.py
   - tests/test_wechat_media_warning_integration.py
   - tests/test_wechat_notification_metadata.py
+  - tests/test_wechat_reply_read_state.py
   - tests/test_wechat_toolfamily_ltpv2.py
+  - tests/test_whatsapp_inbound_replay.py
   - tests/test_whatsapp_notification_metadata.py
   - tests/test_whatsapp_personal_bridge.py
   - tests/test_whatsapp_toolfamily_ltpv2.py


### PR DESCRIPTION
Closes #1355

## Summary

Repairs the architecture/Contract `related_files` graph: 14 references resolved to missing targets and 61 files were orphaned (tracked but unreferenced by any owning document). All changes are frontmatter metadata only — no code, no deletions.

## Changes (44 files)

- **14 missing edges → 0**: removed 11 stale test references (tests deliberately deleted as redundant in commit `073d3473`, so references removed, not restored); fixed `agent_readme/_readme.py` → `__init__.py` (actual module file); bare `BEHAVIORS.md` refs → explicit local paths.
- **61 orphans → 0**: added owned entries for orphaned test/behavior files in `tests/ANATOMY.md`; added governed frontmatter to `src/lingtai/kernel/agent_readme/ANATOMY.md` with owning-parent + reciprocal links; root `ANATOMY.md` gained `BEHAVIORS.md`; per-directory reciprocal links added where owning-parent relationships existed.
- 21 orphaned test/behavior entries registered; 11 deleted-test references removed.

## Validation

- All 44 changed files parse as valid YAML frontmatter
- `git diff --check` clean; metadata-only diff (79 insertions / 21 deletions)

Telegram: @lingtaidev3bot | Nickname: 澄一
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
