### PR TITLE
feat(openai): implement request_history_rebuild on OpenAIChatSession

### DIFF
--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -1821,6 +1821,16 @@ class OpenAIChatSession(ChatSession):
         """The canonical ChatInterface for this session."""
         return self._interface
 
+    def request_history_rebuild(self, reason: str = "summarize_rebuild_only") -> bool:
+        """Start a fresh full replay on the next model request.
+
+        Chat Completions is client-managed: every request re-serializes the
+        canonical ChatInterface, so after ``context(action='rebuild')`` applies
+        pending summaries the next send naturally carries the compacted
+        history. Return True so callers surface ``rebuild_requested=true``.
+        """
+        return True
+
     def _build_messages(self) -> list[dict]:
         """Return the message list to send to the API.
 

--- a/tests/test_openai_prompt_cache_key.py
+++ b/tests/test_openai_prompt_cache_key.py
@@ -318,3 +318,58 @@ def test_chat_session_omits_cache_key_when_unset():
 
     sent = _chat_kwargs(session._client)
     assert "prompt_cache_key" not in sent
+
+
+def test_chat_session_request_history_rebuild_reports_true_without_key():
+    """request_history_rebuild on OpenAIChatSession returns True even when no
+    prompt cache key is configured: the session is client-managed and the next
+    request re-serializes the compacted interface regardless."""
+    from lingtai.kernel.llm.interface import ChatInterface
+
+    iface = ChatInterface()
+    iface.add_system("system prompt")
+    session = OpenAIChatSession(
+        client=_chat_client(),
+        model="gpt-5.5",
+        interface=iface,
+        tools=None,
+        tool_choice=None,
+        extra_kwargs={},
+    )
+
+    assert session.request_history_rebuild() is True
+
+    session.send("hello")
+    sent = _chat_kwargs(session._client)
+    assert "prompt_cache_key" not in sent
+
+
+def test_chat_session_request_history_rebuild_keeps_stable_cache_key():
+    """request_history_rebuild on OpenAIChatSession returns True and leaves the
+    configured prompt_cache_key stable: the session is client-managed, the next
+    request re-serializes the compacted interface, and the same cache-affinity
+    key keeps routing to the same provider cache slot across rebuilds."""
+    from lingtai.kernel.llm.interface import ChatInterface
+
+    iface = ChatInterface()
+    iface.add_system("system prompt")
+    session = OpenAIChatSession(
+        client=_chat_client(),
+        model="gpt-5.5",
+        interface=iface,
+        tools=None,
+        tool_choice=None,
+        extra_kwargs={},
+        prompt_cache_key="lingtai-test:gpt-5.5:v1",
+    )
+
+    # Before rebuild: stable key.
+    session.send("hello")
+    assert _chat_kwargs(session._client)["prompt_cache_key"] == "lingtai-test:gpt-5.5:v1"
+
+    # Rebuild reports True and does not churn the cache key.
+    assert session.request_history_rebuild() is True
+
+    # After rebuild: same key (no epoch suffix), next request carries compacted history.
+    session.send("again")
+    assert _chat_kwargs(session._client)["prompt_cache_key"] == "lingtai-test:gpt-5.5:v1"


### PR DESCRIPTION
## Summary

OpenAIChatSession (Chat Completions path) inherited the base ChatSession.request_history_rebuild default of False, so OpenAI-compatible backends without continuation (opencode zen / deepseek-v4-flash / most third-party endpoints) always reported `rebuild_requested=false` after `context(action='rebuild')`. The rebuild DID apply pending summaries to the canonical ChatInterface locally, but the tool result misleadingly claimed no provider rebuild was possible.

This PR implements `request_history_rebuild` on OpenAIChatSession:
- Returns `True`: the session is client-managed and re-serializes the canonical ChatInterface on every request, so the next send naturally carries the compacted history (provider context is rebuilt by construction).
- Leaves the configured `prompt_cache_key` stable across rebuilds: the same cache-affinity key keeps routing to the same provider cache slot, and the compacted history is what changes between requests.

## Validation

- `tests/test_openai_prompt_cache_key.py`: 15 passed (13 existing + 2 new focused tests for the hook).
- `tests/test_openai_overflow_recovery.py` + `test_openai_compact_threshold.py`: 54 passed.
- `tests/test_deepseek_adapter.py`: 22 passed.
- `git diff --check` clean.

## Background

Investigated at Jason's request (Telegram 3059/3063): `rebuild_requested=false` was a coverage gap (never implemented on the OpenAI-compatible Chat Completions path), not a removed PR. Git history: `request_history_rebuild` was introduced in #900 only on CodexResponsesSession.

---
Telegram: @lingtaidev4bot | Nickname: 守真-lingtaidev4bot
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
