### PR TITLE
test: trim over-defensive documentation contracts

### DIFF
--- a/tests/test_daemon_claude_p_submanual.py
+++ b/tests/test_daemon_claude_p_submanual.py
@@ -68,7 +68,6 @@ def test_claude_p_child_frontmatter_and_location():
     meta = _frontmatter(CHILD)
     assert meta["name"] == "daemon-backend-claude-p"
     assert meta["description"].strip()
-    assert meta["last_changed_at"]
 
 
 def test_claude_p_child_routes_to_live_help_and_generic_backend_options():
@@ -111,11 +110,3 @@ def test_claude_p_child_states_alias_and_harness_boundary():
         "CLAUDE_CODE_OAUTH_TOKEN",
     ):
         assert env_var in body, env_var
-
-
-def test_claude_p_child_stays_tiny_not_a_flag_catalog():
-    line_count = len(CHILD.read_text(encoding="utf-8").splitlines())
-    assert line_count <= 230, (
-        "the claude-p backend submanual is a tiny entrypoint to live CLI help; "
-        f"{line_count} lines suggests it is growing into a flag catalog"
-    )

--- a/tests/test_daemon_cursor_submanual.py
+++ b/tests/test_daemon_cursor_submanual.py
@@ -64,7 +64,6 @@ def test_cursor_child_frontmatter_and_location():
     meta = _frontmatter(CHILD)
     assert meta["name"] == "daemon-backend-cursor"
     assert meta["description"].strip()
-    assert meta["last_changed_at"]
 
 
 def test_cursor_child_routes_to_live_help_and_generic_backend_options():
@@ -86,11 +85,3 @@ def test_cursor_child_routes_to_live_help_and_generic_backend_options():
     assert "not validate, enumerate, or simulate" in body
     # MCP wiring status must be stated, not implied.
     assert "not wired" in body
-
-
-def test_cursor_child_stays_tiny_not_a_flag_catalog():
-    line_count = len(CHILD.read_text(encoding="utf-8").splitlines())
-    assert line_count <= 90, (
-        "the Cursor backend submanual is a tiny entrypoint to live CLI help; "
-        f"{line_count} lines suggests it is growing into a flag catalog"
-    )

--- a/tests/test_daemon_kimicode_submanual.py
+++ b/tests/test_daemon_kimicode_submanual.py
@@ -74,7 +74,6 @@ def test_kimicode_child_frontmatter_and_location():
     meta = _frontmatter(CHILD)
     assert meta["name"] == "daemon-backend-kimicode"
     assert meta["description"].strip()
-    assert meta["last_changed_at"]
 
 
 def test_kimicode_child_routes_to_live_help_and_generic_backend_options():
@@ -106,12 +105,3 @@ def test_kimicode_child_names_canonical_alias_and_limitations():
     assert "unsupported" in body
     assert "kimi-code-home/mcp.json" in body
     assert "backend_harness_files.kimicode_mcp_config" in body
-
-
-def test_kimicode_child_stays_tiny_not_a_flag_catalog():
-    line_count = len(CHILD.read_text(encoding="utf-8").splitlines())
-    # 120 not 230: the page is ~100 lines, so a 230 cap would stop guarding.
-    assert line_count <= 120, (
-        "the Kimi Code backend submanual is a tiny entrypoint to live CLI "
-        f"help; {line_count} lines suggests it is growing into a flag catalog"
-    )

--- a/tests/test_daemon_lingtai_submanual.py
+++ b/tests/test_daemon_lingtai_submanual.py
@@ -75,7 +75,6 @@ def test_lingtai_child_frontmatter_and_location():
     meta = _frontmatter(CHILD)
     assert meta["name"] == "daemon-backend-lingtai"
     assert meta["description"].strip()
-    assert meta["last_changed_at"]
 
 
 def test_lingtai_child_routes_to_live_authorities():
@@ -113,11 +112,3 @@ def test_lingtai_child_has_exactly_one_example_with_explicit_surface():
     for field in ('"preset"', '"tools"', '"skills"', '"mcp"'):
         assert field in example, field
     assert '"backend_options"' not in example
-
-
-def test_lingtai_child_stays_tiny_not_a_rules_catalog():
-    line_count = len(CHILD.read_text(encoding="utf-8").splitlines())
-    assert line_count <= 90, (
-        "the LingTai backend submanual is a tiny entrypoint to live authorities; "
-        f"{line_count} lines suggests it is growing into a duplicated rules catalog"
-    )

--- a/tests/test_daemon_oh_my_pi_submanual.py
+++ b/tests/test_daemon_oh_my_pi_submanual.py
@@ -72,7 +72,6 @@ def test_oh_my_pi_child_frontmatter_and_location():
     meta = _frontmatter(CHILD)
     assert meta["name"] == "daemon-backend-oh-my-pi"
     assert meta["description"].strip()
-    assert meta["last_changed_at"]
 
 
 def test_oh_my_pi_child_routes_to_live_help_and_generic_backend_options():
@@ -115,11 +114,3 @@ def test_oh_my_pi_child_mcp_status_matches_source():
     assert not _cli_backend_loads_common_mcp("oh-my-pi")
     body = _body(CHILD)
     assert "not wired yet" in body
-
-
-def test_oh_my_pi_child_stays_tiny_not_a_flag_catalog():
-    line_count = len(_body(CHILD).splitlines())
-    assert line_count <= 90, (
-        "the Oh-My-Pi backend submanual is a tiny entrypoint to live CLI help; "
-        f"{line_count} lines suggests it is growing into a flag catalog"
-    )

--- a/tests/test_daemon_opencode_submanual.py
+++ b/tests/test_daemon_opencode_submanual.py
@@ -64,7 +64,6 @@ def test_opencode_child_frontmatter_and_location():
     meta = _frontmatter(CHILD)
     assert meta["name"] == "daemon-backend-opencode"
     assert meta["description"].strip()
-    assert meta["last_changed_at"]
 
 
 def test_opencode_child_routes_to_live_help_and_generic_backend_options():
@@ -92,11 +91,3 @@ def test_opencode_child_states_reserved_format_flag_and_mcp_env():
     # variable, not argv. The child must state both harness boundaries.
     assert "`--format`" in body
     assert "OPENCODE_CONFIG_CONTENT" in body
-
-
-def test_opencode_child_stays_tiny_not_a_flag_catalog():
-    line_count = len(CHILD.read_text(encoding="utf-8").splitlines())
-    assert line_count <= 230, (
-        "the OpenCode backend submanual is a tiny entrypoint to live CLI help; "
-        f"{line_count} lines suggests it is growing into a flag catalog"
-    )

--- a/tests/test_daemon_qwen_code_submanual.py
+++ b/tests/test_daemon_qwen_code_submanual.py
@@ -67,7 +67,6 @@ def test_qwen_code_child_frontmatter_and_location():
     meta = _frontmatter(CHILD)
     assert meta["name"] == "daemon-backend-qwen-code"
     assert meta["description"].strip()
-    assert meta["last_changed_at"]
 
 
 def test_qwen_code_child_routes_to_live_help_and_generic_backend_options():
@@ -99,11 +98,3 @@ def test_qwen_code_child_states_harness_boundaries():
     assert "QWEN_CODE_SYSTEM_SETTINGS_PATH" in body
     assert "qwen-daemon-settings.json" in body
     assert "daemon(action='ask', input={'id': ..., 'message': ...})" in body
-
-
-def test_qwen_code_child_stays_tiny_not_a_flag_catalog():
-    line_count = len(CHILD.read_text(encoding="utf-8").splitlines())
-    assert line_count <= 90, (
-        "the Qwen Code backend submanual is a tiny entrypoint to live CLI "
-        f"help; {line_count} lines suggests it is growing into a flag catalog"
-    )

--- a/tests/test_docs_governance.py
+++ b/tests/test_docs_governance.py
@@ -565,27 +565,15 @@ def test_unrecognized_top_level_key_rejected():
         checker.validate_docs_contract_shape(bad)
 
 
-def test_pr_template_visible_body_byte_identical_and_metadata_hidden():
+def test_pr_template_metadata_hidden_and_visible_body_starts_with_summary():
     contract = checker.load_docs_contract()
     path = ROOT / ".github/PULL_REQUEST_TEMPLATE.md"
     text = path.read_text(encoding="utf-8")
     visible = text.split("-->\n", 1)[1]
-    expected_visible = (
-        "## Summary\n"
-        "\n"
-        "- TODO\n"
-        "\n"
-        "## Validation\n"
-        "\n"
-        "- [ ] `git diff --check`\n"
-        "- [ ] Relevant tests or documentation checks:\n"
-        "\n"
-        "## Notes\n"
-        "\n"
-        "- Link related issues or context here.\n"
-        "- Confirm that logs, screenshots, and examples do not contain secrets.\n"
-    )
-    assert visible == expected_visible
+    assert not visible.startswith("---")
+    assert "related_files:" not in visible
+    assert "maintenance:" not in visible
+    assert visible.startswith("## Summary")
     failures = checker.check_one_document_path(path, contract, repo_root=ROOT)
     assert not failures, failures
 
@@ -598,27 +586,14 @@ def test_all_four_notification_managers_preserve_exact_runtime_body():
     from lingtai.mcp_servers.whatsapp import manager as m4
 
     expected = {
-        m1.__name__: (
-            987,
-            "8065f55c16561adedf8b71d788efa29d80ff1b9a1196ffab38f239bf06302364",
-        ),
-        m2.__name__: (
-            2166,
-            "17c7e5086686354379cc6bf22d8cedf7d97863a04702af9928d187180877fff5",
-        ),
-        m3.__name__: (
-            987,
-            "8065f55c16561adedf8b71d788efa29d80ff1b9a1196ffab38f239bf06302364",
-        ),
-        m4.__name__: (
-            1245,
-            "e671f269c783a6a68b9d2294f0de1eb8e397ce22e13cd73b6cd9426453b8cb9e",
-        ),
+        m1.__name__: "8065f55c16561adedf8b71d788efa29d80ff1b9a1196ffab38f239bf06302364",
+        m2.__name__: "17c7e5086686354379cc6bf22d8cedf7d97863a04702af9928d187180877fff5",
+        m3.__name__: "8065f55c16561adedf8b71d788efa29d80ff1b9a1196ffab38f239bf06302364",
+        m4.__name__: "e671f269c783a6a68b9d2294f0de1eb8e397ce22e13cd73b6cd9426453b8cb9e",
     }
     for mod in (m1, m2, m3, m4):
         template = mod._NOTIFICATION_HEADER_TEMPLATE
-        expected_length, expected_sha256 = expected[mod.__name__]
-        assert len(template) == expected_length
+        expected_sha256 = expected[mod.__name__]
         assert hashlib.sha256(template.encode("utf-8")).hexdigest() == expected_sha256
         assert template.startswith("**How to read this {channel} conversation preview")
         assert not template.startswith("\n")


### PR DESCRIPTION
## Summary

- remove seven arbitrary daemon-submanual line caps
- remove seven per-file timestamp truthiness checks already subsumed by the strict repo-wide ISO/timezone validator
- remove four template lengths already implied by retained SHA-256 pins
- replace the copied PR-template visible body with hidden-metadata and `## Summary` semantic checks

## Test-first evidence

Temporary mutations proved the retained owners fail for submanual metadata/source relationships, invalid timestamps, notification-body hash drift, and PR-template metadata leakage or missing Summary. All mutations were reverted before the committed changes.

## Validation

- affected semantic-owner suite: 42 passed
- independent literal Opus 5 / high review: unconditional PASS on exact HEAD `8e8d8009`
- reviewer targeted suites: 143 passed with 2 base failures described below; 244 adjacent checks passed
- all 92 per-family envelope tests remain unchanged
- `git diff --check`: clean

## Pre-existing base failures

Two `tests/test_docs_governance.py` checks are already red on base and remain red for unrelated committed content:

- the Feishu notification body is length 1214 with SHA `515a2472…` on both base and head, while the retained expected pin is WeChat's `8065f55c…`; removing the redundant length check now exposes that authoritative hash mismatch
- three Feishu reference documents already lack required metadata on base

This PR deliberately does not update hashes, Feishu production/docs content, meta wording, or any envelope case.
