### PR TITLE
test: parametrize IMAP and schema data cases

### DIFF
--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -169,13 +169,20 @@ def test_eigen_schema_has_molt(tmp_path):
     assert {"action", "input", "reasoning"} == set(s["required"])
 
 
-def test_context_rejects_invalid_action(tmp_path):
-    """A former valid-object/invalid-action pair is now an unknown action.
+@pytest.mark.parametrize(
+    "invalid_action",
+    [
+        pytest.param("context_load", id="former-context-action"),
+        pytest.param("bogus_edit", id="invalid-object-action"),
+        pytest.param("pad_bogus", id="invalid-pad-action"),
+    ],
+)
+def test_context_rejects_invalid_action(tmp_path, invalid_action):
+    """Former valid-object/invalid-action pairs are now unknown actions.
 
-    Pre-migration `(object='context', action='load')` was a real object with
-    an out-of-set action. Under the flat LTP v2 enum there is no such pair:
-    `context_load` was never a registered operation, so dispatch rejects it
-    as an unknown action before any handler runs.
+    Under the flat LTP v2 enum there are no object/action pairs, and none of
+    these pre-migration-shaped action names is registered. Dispatch rejects
+    each as an unknown action before any handler runs.
     """
     agent = BaseAgent(
         intrinsics=_TEST_INTRINSICS,
@@ -183,7 +190,7 @@ def test_context_rejects_invalid_action(tmp_path):
         workdir_lease=make_test_lease(),
         agent_presence=make_test_presence_store(), snapshot_port=make_test_snapshot_port(), lifecycle_clock=make_test_lifecycle_clock(), source_revision_port=make_test_source_revision_port(), notification_store=notification_store_for(tmp_path / "test"),
     )
-    result = agent._intrinsics["context"]({"action": "context_load", "input": {}})
+    result = agent._intrinsics["context"]({"action": invalid_action, "input": {}})
     assert "error" in result
     assert "Unknown context action" in result["error"]
     # The error names the real surface, including the molt operation.

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -246,30 +246,6 @@ def test_eigen_forget_wipes_context(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_eigen_unknown_object(tmp_path):
-    agent = BaseAgent(
-        intrinsics=_TEST_INTRINSICS,
-        service=make_mock_service(), agent_name="test", working_dir=tmp_path / "test",
-        workdir_lease=make_test_lease(),
-        agent_presence=make_test_presence_store(), snapshot_port=make_test_snapshot_port(), lifecycle_clock=make_test_lifecycle_clock(), source_revision_port=make_test_source_revision_port(), notification_store=notification_store_for(tmp_path / "test"),
-    )
-    result = agent._intrinsics["context"]({"action": "bogus_edit", "input": {}})
-    assert "error" in result
-    agent.stop(timeout=1.0)
-
-
-def test_eigen_unknown_action(tmp_path):
-    agent = BaseAgent(
-        intrinsics=_TEST_INTRINSICS,
-        service=make_mock_service(), agent_name="test", working_dir=tmp_path / "test",
-        workdir_lease=make_test_lease(),
-        agent_presence=make_test_presence_store(), snapshot_port=make_test_snapshot_port(), lifecycle_clock=make_test_lifecycle_clock(), source_revision_port=make_test_source_revision_port(), notification_store=notification_store_for(tmp_path / "test"),
-    )
-    result = agent._intrinsics["context"]({"action": "pad_bogus", "input": {}})
-    assert "error" in result
-    agent.stop(timeout=1.0)
-
-
 def test_eigen_is_gone_and_psyche_is_the_durable_domain_root(tmp_path):
     """`eigen` is gone; `context` and `psyche` are the intrinsics now.
 

--- a/tests/test_imap_empty_args.py
+++ b/tests/test_imap_empty_args.py
@@ -82,13 +82,6 @@ def test_empty_account_uses_default_account(account_arg):
     assert result["account"] == "me@example.com"
 
 
-def test_whitespace_account_uses_default_account():
-    account = FakeAccount()
-    result = _manager(account).handle({"action": "check", "account": "   "})
-    assert result["status"] == "ok"
-    assert result["account"] == "me@example.com"
-
-
 # --- empty/whitespace folder treated like omitted (INBOX) ------------------
 
 @pytest.mark.parametrize(
@@ -105,13 +98,6 @@ def test_empty_folder_for_check_uses_inbox(folder_arg):
     assert account.checked_folders == ["INBOX"]
 
 
-def test_whitespace_folder_for_check_uses_inbox():
-    account = FakeAccount()
-    result = _manager(account).handle({"action": "check", "folder": "  \t "})
-    assert result["status"] == "ok"
-    assert account.checked_folders == ["INBOX"]
-
-
 @pytest.mark.parametrize(
     "folder_arg",
     [
@@ -123,15 +109,6 @@ def test_empty_folder_for_search_uses_inbox(folder_arg):
     account = FakeAccount()
     result = _manager(account).handle({
         "action": "search", "query": "unseen", "folder": folder_arg,
-    })
-    assert result["status"] == "ok"
-    assert account.searched == [("INBOX", "unseen")]
-
-
-def test_whitespace_folder_for_search_uses_inbox():
-    account = FakeAccount()
-    result = _manager(account).handle({
-        "action": "search", "query": "unseen", "folder": "   ",
     })
     assert result["status"] == "ok"
     assert account.searched == [("INBOX", "unseen")]
@@ -157,17 +134,6 @@ def test_move_empty_destination_still_errors(folder_arg):
     assert account.moved == []
 
 
-def test_move_whitespace_destination_still_errors():
-    account = FakeAccount()
-    result = _manager(account).handle({
-        "action": "move",
-        "email_id": "me@example.com:INBOX:42",
-        "folder": "   ",
-    })
-    assert "error" in result
-    assert account.moved == []
-
-
 # --- flag error ergonomics --------------------------------------------------
 
 @pytest.mark.parametrize(
@@ -187,18 +153,6 @@ def test_flag_missing_flags_returns_helpful_error(flag_args):
     assert result.get("status") == "error"
     assert "flags is required" in result.get("error", "")
     assert "flags={'seen': true}" in result.get("error", "")
-    assert account.flag_calls == []
-
-
-def test_flag_empty_flags_returns_helpful_error():
-    account = FakeAccount()
-    result = _manager(account).handle({
-        "action": "flag",
-        "email_id": "me@example.com:INBOX:42",
-        "flags": {},
-    })
-    assert result.get("status") == "error"
-    assert "flags is required" in result.get("error", "")
     assert account.flag_calls == []
 
 

--- a/tests/test_imap_empty_args.py
+++ b/tests/test_imap_empty_args.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from lingtai.mcp_servers.imap.manager import IMAPMailManager
 
 
@@ -66,9 +68,16 @@ def _manager(account: FakeAccount) -> IMAPMailManager:
 
 # --- empty/whitespace account treated like omitted -------------------------
 
-def test_empty_account_uses_default_account():
+@pytest.mark.parametrize(
+    "account_arg",
+    [
+        pytest.param("", id="empty"),
+        pytest.param("   ", id="whitespace"),
+    ],
+)
+def test_empty_account_uses_default_account(account_arg):
     account = FakeAccount()
-    result = _manager(account).handle({"action": "check", "account": ""})
+    result = _manager(account).handle({"action": "check", "account": account_arg})
     assert result["status"] == "ok"
     assert result["account"] == "me@example.com"
 
@@ -82,9 +91,16 @@ def test_whitespace_account_uses_default_account():
 
 # --- empty/whitespace folder treated like omitted (INBOX) ------------------
 
-def test_empty_folder_for_check_uses_inbox():
+@pytest.mark.parametrize(
+    "folder_arg",
+    [
+        pytest.param("", id="empty"),
+        pytest.param("  \t ", id="whitespace"),
+    ],
+)
+def test_empty_folder_for_check_uses_inbox(folder_arg):
     account = FakeAccount()
-    result = _manager(account).handle({"action": "check", "folder": ""})
+    result = _manager(account).handle({"action": "check", "folder": folder_arg})
     assert result["status"] == "ok"
     assert account.checked_folders == ["INBOX"]
 
@@ -96,10 +112,17 @@ def test_whitespace_folder_for_check_uses_inbox():
     assert account.checked_folders == ["INBOX"]
 
 
-def test_empty_folder_for_search_uses_inbox():
+@pytest.mark.parametrize(
+    "folder_arg",
+    [
+        pytest.param("", id="empty"),
+        pytest.param("   ", id="whitespace"),
+    ],
+)
+def test_empty_folder_for_search_uses_inbox(folder_arg):
     account = FakeAccount()
     result = _manager(account).handle({
-        "action": "search", "query": "unseen", "folder": "",
+        "action": "search", "query": "unseen", "folder": folder_arg,
     })
     assert result["status"] == "ok"
     assert account.searched == [("INBOX", "unseen")]
@@ -116,12 +139,19 @@ def test_whitespace_folder_for_search_uses_inbox():
 
 # --- move destination must NOT be normalized away --------------------------
 
-def test_move_empty_destination_still_errors():
+@pytest.mark.parametrize(
+    "folder_arg",
+    [
+        pytest.param("", id="empty"),
+        pytest.param("   ", id="whitespace"),
+    ],
+)
+def test_move_empty_destination_still_errors(folder_arg):
     account = FakeAccount()
     result = _manager(account).handle({
         "action": "move",
         "email_id": "me@example.com:INBOX:42",
-        "folder": "",
+        "folder": folder_arg,
     })
     assert "error" in result
     assert account.moved == []
@@ -140,11 +170,19 @@ def test_move_whitespace_destination_still_errors():
 
 # --- flag error ergonomics --------------------------------------------------
 
-def test_flag_missing_flags_returns_helpful_error():
+@pytest.mark.parametrize(
+    "flag_args",
+    [
+        pytest.param({}, id="missing"),
+        pytest.param({"flags": {}}, id="empty"),
+    ],
+)
+def test_flag_missing_flags_returns_helpful_error(flag_args):
     account = FakeAccount()
     result = _manager(account).handle({
         "action": "flag",
         "email_id": "me@example.com:INBOX:42",
+        **flag_args,
     })
     assert result.get("status") == "error"
     assert "flags is required" in result.get("error", "")

--- a/tests/test_init_schema.py
+++ b/tests/test_init_schema.py
@@ -313,13 +313,6 @@ def test_wrong_type_streaming():
         validate_init(data)
 
 
-def test_legacy_manifest_stamina_bool_is_ignored():
-    """stamina is a retired legacy manifest field and is no longer type-checked."""
-    data = _valid_init()
-    data["manifest"]["stamina"] = True
-    validate_init(data)
-
-
 # --- optional fields ---
 
 
@@ -616,43 +609,6 @@ def test_time_awareness_field_valid_bool(field):
 def test_time_awareness_field_wrong_type_raises(field):
     data = _valid_init()
     data["manifest"][field] = "yes"
-    with pytest.raises(ValueError):
-        validate_init(data)
-
-
-def test_timezone_awareness_field_valid_bool():
-    from lingtai.init_schema import validate_init
-
-    data = {
-        "manifest": {
-            "llm": {"provider": "minimax", "model": "x"},
-            "timezone_awareness": False,
-        },
-        "covenant": "hi",
-        "lingtai": "hello",
-        "pad": "",
-        "soul": "",
-        "principle": "",
-    }
-    warnings = validate_init(data)
-    assert all("timezone_awareness" not in w for w in warnings)
-
-
-def test_timezone_awareness_field_wrong_type_raises():
-    import pytest
-    from lingtai.init_schema import validate_init
-
-    data = {
-        "manifest": {
-            "llm": {"provider": "minimax", "model": "x"},
-            "timezone_awareness": "yes",
-        },
-        "covenant": "hi",
-        "lingtai": "hello",
-        "pad": "",
-        "soul": "",
-        "principle": "",
-    }
     with pytest.raises(ValueError):
         validate_init(data)
 

--- a/tests/test_init_schema.py
+++ b/tests/test_init_schema.py
@@ -80,10 +80,18 @@ def test_wrong_type_top_level():
         validate_init(data)
 
 
-def test_legacy_manifest_stamina_wrong_type_is_ignored():
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param("one hour", id="wrong-type"),
+        pytest.param(True, id="bool"),
+    ],
+)
+def test_legacy_manifest_stamina_wrong_type_is_ignored(value):
     data = _valid_init()
-    data["manifest"]["stamina"] = "one hour"
-    validate_init(data)  # legacy ignored field
+    data["manifest"]["stamina"] = value
+    warnings = validate_init(data)  # legacy ignored field
+    assert all("stamina" not in warning for warning in warnings)
 
 
 def test_summarize_notification_threshold_rejects_negative():
@@ -596,39 +604,18 @@ def test_mcp_section_wrong_type_rejected():
         validate_init(data)
 
 
-def test_time_awareness_field_valid_bool():
-    from lingtai.init_schema import validate_init
-
-    data = {
-        "manifest": {
-            "llm": {"provider": "minimax", "model": "x"},
-            "time_awareness": False,
-        },
-        "covenant": "hi",
-        "lingtai": "hello",
-        "pad": "",
-        "soul": "",
-        "principle": "",
-    }
+@pytest.mark.parametrize("field", ["time_awareness", "timezone_awareness"])
+def test_time_awareness_field_valid_bool(field):
+    data = _valid_init()
+    data["manifest"][field] = False
     warnings = validate_init(data)
-    assert all("time_awareness" not in w for w in warnings)
+    assert all(field not in warning for warning in warnings)
 
 
-def test_time_awareness_field_wrong_type_raises():
-    import pytest
-    from lingtai.init_schema import validate_init
-
-    data = {
-        "manifest": {
-            "llm": {"provider": "minimax", "model": "x"},
-            "time_awareness": "yes",
-        },
-        "covenant": "hi",
-        "lingtai": "hello",
-        "pad": "",
-        "soul": "",
-        "principle": "",
-    }
+@pytest.mark.parametrize("field", ["time_awareness", "timezone_awareness"])
+def test_time_awareness_field_wrong_type_raises(field):
+    data = _valid_init()
+    data["manifest"][field] = "yes"
     with pytest.raises(ValueError):
         validate_init(data)
 


### PR DESCRIPTION
## Summary

- consolidate five same-responsibility test-overlap units while preserving all 19 collected cases as explicit parameters;
- remove 10 physical duplicate test functions only after the nine authoritative owners land in the preceding commit;
- keep production and documentation byte-identical.

## Scope

This PR contains exactly:

- `K03-C1` — IMAP empty/whitespace defaults and move validation;
- `K03-C2` — missing/empty flag-map error behavior;
- `K03-C4` — time-awareness and timezone-awareness schema cases;
- `K03-C5` — legacy stamina string/bool behavior;
- `K03-C6` — context invalid-action variants.

`K03-C3` is deliberately deferred while PR #1350 owns the adjacent `manifest.llm.thinking` validation-test contract. Its region is byte-identical to base in both commits here.

## Evidence

- exact canonical base: `80980d7470fb0ff35331d1c55d1acef7c877276b`;
- exact reviewed head: `6ebf98828eb8f77d5ce9c40e23b1621e12d26118`;
- touched-file baseline/final: **180 passed → 180 passed**;
- owner-commit chronology: **180 → 190 → 180** collected executions;
- exact authoritative-owner collection: **19 cases**;
- base-to-head diff: 3 test files, +82/-164, with no `src/` or documentation diff;
- five temporary production-break probes were restored and each made the retained owner fail before duplicate removal;
- fresh merge-tree preflight against live PR #1350 has the same three pre-existing production conflict paths as canonical main and adds no test-file conflict;
- literal Claude Opus 5/high/plan exact-head review: **PASS, 0 P0 / 0 P1**.

A wider 732-test neighboring gate is identical at base and head (**730 passed, 2 unrelated pre-existing failures**). `scripts/check_docs_governance.py --check` also has identical pre-existing Feishu reference-document debt at base and head. Neither is caused by this test-only change.

Related: #1350 for the deliberately deferred K03-C3 dependency.
