### PR TITLE
test: trim core runtime test overlap

### DIFF
--- a/src/lingtai/kernel/BEHAVIORS.md
+++ b/src/lingtai/kernel/BEHAVIORS.md
@@ -437,7 +437,7 @@ summary is accepted or a non-error result is returned.
   large-result compaction through the notification tool, and the kernel no
   longer publishes a `large_tool_result` source
   ([CONTRACT.md](../tools/notification/CONTRACT.md#behavior))
-- **supersedes**: `tests/test_large_result_no_notification.py::test_rescan_never_publishes_for_huge_result`,
+- **supersedes**: `tests/test_large_result_rescan.py::test_rescan_returns_zero_for_huge_history`,
   `tests/test_large_result_no_notification.py::test_large_result_still_reported_by_current_tool_result_chars`,
   `tests/test_large_result_no_notification.py::test_current_tool_result_chars_reports_threshold_and_over_count`
 - **runner**: any LingTai agent with `shell` and `file` tools at a checkout of

--- a/tests/contracts/llm_conversation_input/test_regime_inventory.py
+++ b/tests/contracts/llm_conversation_input/test_regime_inventory.py
@@ -85,13 +85,26 @@ def test_registry_matrix_builds_expected_classes(edge: regimes.RegistryEdge) -> 
 
 
 def test_registry_matrix_covers_exactly_the_registered_providers() -> None:
-    """The union of exact provider names the registry matrix builds equals the
-    current registry key set. Adding a provider (a new registry key) or dropping
-    one from the matrix fails here — this is factory coverage, not a name union
-    that stays green when a provider is mapped to the wrong regime."""
-    registered = regimes.registered_provider_names()
-    built = regimes.registry_edge_provider_names()
+    """A fresh ``register_all_adapters()`` registry exactly matches the matrix.
 
+    Clear/re-register proves startup freshness rather than inheriting import-time
+    state; snapshot/restore keeps this stateful assertion isolated from siblings.
+    This is factory coverage, not a name union that stays green when a provider
+    is mapped to the wrong regime.
+    """
+    from lingtai.llm._register import register_all_adapters
+
+    registry = LLMService._adapter_registry  # type: ignore[attr-defined]
+    snapshot = dict(registry)
+    try:
+        registry.clear()
+        register_all_adapters()
+        registered = set(registry)
+    finally:
+        registry.clear()
+        registry.update(snapshot)
+
+    built = regimes.registry_edge_provider_names()
     missing = registered - built
     extra = built - registered
     assert not missing, (

--- a/tests/test_adapter_registry.py
+++ b/tests/test_adapter_registry.py
@@ -53,16 +53,3 @@ class TestAdapterRegistry:
         LLMService("prov", "model", api_key="key")
         factory_b.assert_called_once()
         factory_a.assert_not_called()
-
-
-def test_default_adapters_registered():
-    """All default adapters should be registered after importing lingtai.llm."""
-    from lingtai.llm._register import register_all_adapters
-    # Clear and re-register
-    saved = dict(LLMService._adapter_registry)
-    LLMService._adapter_registry.clear()
-    register_all_adapters()
-    expected = {"gemini", "anthropic", "openai", "minimax", "deepseek", "grok", "qwen", "glm", "kimi", "custom", "claude-code", "claude_code", "kimi-code", "kimi_code"}
-    assert expected.issubset(set(LLMService._adapter_registry.keys()))
-    LLMService._adapter_registry.clear()
-    LLMService._adapter_registry.update(saved)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -93,11 +93,6 @@ def test_add_remove_tool(tmp_path):
     assert "custom" not in agent._tool_handlers
 
 
-def test_mcp_tools_registered(tmp_path):
-    agent = BaseAgent(intrinsics=_TEST_INTRINSICS, service=make_mock_service(), agent_name="test", working_dir=tmp_path / "test", workdir_lease=make_test_lease(), agent_presence=make_test_presence_store(), snapshot_port=make_test_snapshot_port(), lifecycle_clock=make_test_lifecycle_clock(), source_revision_port=make_test_source_revision_port(), notification_store=notification_store_for(tmp_path / "test"))
-    agent.add_tool("domain_tool", schema={}, description="test", handler=lambda a: {"r": 1})
-    assert "domain_tool" in agent._tool_handlers
-
 
 def test_add_tool_replaces_existing(tmp_path):
     agent = BaseAgent(intrinsics=_TEST_INTRINSICS, service=make_mock_service(), agent_name="test", working_dir=tmp_path / "test", workdir_lease=make_test_lease(), agent_presence=make_test_presence_store(), snapshot_port=make_test_snapshot_port(), lifecycle_clock=make_test_lifecycle_clock(), source_revision_port=make_test_source_revision_port(), notification_store=notification_store_for(tmp_path / "test"))

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -80,7 +80,14 @@ def test_intrinsics_enabled_by_default(tmp_path):
 
 def test_add_remove_tool(tmp_path):
     agent = BaseAgent(intrinsics=_TEST_INTRINSICS, service=make_mock_service(), agent_name="test", working_dir=tmp_path / "test", workdir_lease=make_test_lease(), agent_presence=make_test_presence_store(), snapshot_port=make_test_snapshot_port(), lifecycle_clock=make_test_lifecycle_clock(), source_revision_port=make_test_source_revision_port(), notification_store=notification_store_for(tmp_path / "test"))
-    agent.add_tool("custom", schema={"type": "object"}, handler=lambda args: {"ok": True})
+    # Preserve the MCP registration argument shape here: an empty schema plus
+    # an explicit description must still register a callable tool.
+    agent.add_tool(
+        "custom",
+        schema={},
+        description="test tool",
+        handler=lambda args: {"ok": True},
+    )
     assert "custom" in agent._tool_handlers
     agent.remove_tool("custom")
     assert "custom" not in agent._tool_handlers

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -392,9 +392,10 @@ def test_started_at_format_consistent_across_tiers(tmp_path):
     t3 = _rebuild_via_full_scan(events_path, molt_count=2)
 
     expected = _expected_iso(BOUNDARY_TS)
-    assert t1.started_at == expected
-    assert t2.started_at == expected
-    assert t3.started_at == expected
+    for rebuilt in (t1, t2, t3):
+        assert rebuilt.started_at == expected
+        assert rebuilt.started_at.endswith("Z")
+        assert rebuilt.started_at != str(BOUNDARY_TS)
 
 
 def test_started_at_none_when_no_boundary(tmp_path):

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -347,32 +347,6 @@ def _expected_iso(ts: float) -> str:
     )
 
 
-def test_reverse_scan_started_at_is_iso8601(tmp_path):
-    events = [
-        _molt_ev(BOUNDARY_TS, 1),
-        _token_ev(BOUNDARY_TS + 1.0, 1000, 200, 700),
-    ]
-    events_path = _write_events(tmp_path, events)
-
-    rev = _rebuild_via_reverse_scan(events_path, molt_count=1)
-
-    assert rev.started_at == _expected_iso(BOUNDARY_TS)
-    assert rev.started_at.endswith("Z")
-    assert rev.started_at != str(BOUNDARY_TS)
-
-
-def test_full_scan_started_at_is_iso8601(tmp_path):
-    events = [
-        _molt_ev(BOUNDARY_TS, 1),
-        _token_ev(BOUNDARY_TS + 1.0, 1000, 200, 700),
-    ]
-    events_path = _write_events(tmp_path, events)
-
-    full = _rebuild_via_full_scan(events_path, molt_count=1)
-
-    assert full.started_at == _expected_iso(BOUNDARY_TS)
-    assert full.started_at.endswith("Z")
-    assert full.started_at != str(BOUNDARY_TS)
 
 
 def test_started_at_format_consistent_across_tiers(tmp_path):

--- a/tests/test_claude_code_adapter.py
+++ b/tests/test_claude_code_adapter.py
@@ -145,15 +145,11 @@ def test_extract_returns_none_on_garbage():
 # Registration
 # ---------------------------------------------------------------------------
 
-
-def test_claude_code_is_registered():
-    import lingtai.llm  # noqa: F401 — triggers register_all_adapters
-    from lingtai.llm.service import LLMService
-
-    # Both the dash and underscore spellings are registered (there is no
-    # dash/underscore normalization, and preset_connectivity aliases both).
-    assert "claude-code" in LLMService._adapter_registry
-    assert "claude_code" in LLMService._adapter_registry
+# Exact provider names, including both ``claude-code`` spellings, and their
+# concrete classes are owned by
+# ``tests/contracts/llm_conversation_input/test_regime_inventory.py``'s registry
+# matrix. Keep registration assertions there rather than regrowing a weaker
+# provider-local name-only copy.
 
 
 def test_service_builds_keyless():

--- a/tests/test_claude_code_effort.py
+++ b/tests/test_claude_code_effort.py
@@ -80,9 +80,6 @@ def test_omitted_thinking_sends_no_effort_flag(thinking):
     assert "--effort" not in _run_claude(thinking=thinking)
 
 
-def test_create_chat_without_thinking_sends_no_effort_flag():
-    assert "--effort" not in _run_claude()
-
 
 @pytest.mark.parametrize("bad", ["ultra", "", 42, "HIGH", "minimal", "none"])
 def test_out_of_vocabulary_thinking_raises(bad):

--- a/tests/test_claude_code_effort.py
+++ b/tests/test_claude_code_effort.py
@@ -38,7 +38,10 @@ def _envelope(result_str):
     )
 
 
-def _run_claude(thinking="default", extra_argv=None):
+_OMITTED = object()
+
+
+def _run_claude(thinking=_OMITTED, extra_argv=None):
     captured = {}
     adapter = ClaudeCodeAdapter(extra_argv=extra_argv)
 
@@ -49,7 +52,12 @@ def _run_claude(thinking="default", extra_argv=None):
     with patch(
         "lingtai.llm.claude_code.adapter.subprocess.run", side_effect=fake_run
     ):
-        session = adapter.create_chat("opus", "sys", thinking=thinking)
+        if thinking is _OMITTED:
+            # Exercise create_chat with the kwarg genuinely absent, not merely
+            # forwarded as the default sentinel.
+            session = adapter.create_chat("opus", "sys")
+        else:
+            session = adapter.create_chat("opus", "sys", thinking=thinking)
         session.send("hello")
     return captured["cmd"]
 
@@ -61,10 +69,14 @@ def test_explicit_thinking_becomes_effort_flag(thinking):
     assert cmd[cmd.index("--effort") + 1] == thinking
 
 
-@pytest.mark.parametrize("thinking", [None, "default"])
+@pytest.mark.parametrize(
+    "thinking",
+    [None, "default", _OMITTED],
+    ids=["none", "default", "kwarg-absent"],
+)
 def test_omitted_thinking_sends_no_effort_flag(thinking):
-    """The omission sentinel emits no ``--effort`` flag; the CLI's own default
-    applies and the command stays byte-identical to pre-effort behavior."""
+    """Explicit sentinels and a genuinely absent ``thinking`` kwarg emit no
+    ``--effort`` flag, leaving the CLI's own default in force."""
     assert "--effort" not in _run_claude(thinking=thinking)
 
 

--- a/tests/test_intrinsics_comm.py
+++ b/tests/test_intrinsics_comm.py
@@ -7,40 +7,8 @@ from tests._notification_store_helpers import notification_store_for
 from tests._agent_presence_helpers import make_test_presence_store
 
 
-def test_system_prompt_manager():
-    mgr = SystemPromptManager()
-    mgr.write_section("role", "You are an orchestrator", protected=True)
-    mgr.write_section("pad", "User likes concise")
-    sections = mgr.list_sections()
-    assert "role" in [s["name"] for s in sections]
-    assert "pad" in [s["name"] for s in sections]
-    assert mgr.read_section("role") == "You are an orchestrator"
-    assert mgr.read_section("pad") == "User likes concise"
 
 
-def test_system_prompt_manager_render():
-    mgr = SystemPromptManager()
-    mgr.write_section("role", "You are a test agent")
-    mgr.write_section("pad", "Remember: user likes concise")
-    rendered = mgr.render()
-    assert "## role" in rendered
-    assert "## pad" in rendered
-    assert "You are a test agent" in rendered
-    assert "Remember: user likes concise" in rendered
-
-
-def test_system_prompt_manager_delete():
-    mgr = SystemPromptManager()
-    mgr.write_section("temp", "temporary content")
-    assert mgr.read_section("temp") == "temporary content"
-    assert mgr.delete_section("temp") is True
-    assert mgr.read_section("temp") is None
-    assert mgr.delete_section("temp") is False
-
-
-def test_system_prompt_manager_read_nonexistent():
-    mgr = SystemPromptManager()
-    assert mgr.read_section("nonexistent") is None
 
 
 def test_mail_send_passes_attachments(tmp_path):

--- a/tests/test_karma.py
+++ b/tests/test_karma.py
@@ -270,9 +270,12 @@ class TestSelfSleepPendingNotificationsGuard:
         return path
 
     def test_sleep_refused_when_notification_pending(self, tmp_path):
+        """Pin the exact kernel#112 race: the turn observed an empty queue,
+        mail arrived during the LLM call, then the agent requested sleep."""
         from lingtai.tools.system import handle
         agent = _make_agent(tmp_path)
-        # Simulate the pre-turn baseline: no notifications observed yet.
+        # Simulate the pre-turn baseline: no notifications observed yet; the
+        # payload below is the mail that arrives mid-turn.
         agent._notification_fp = ()
 
         self._write_notification(agent, "email.json", {
@@ -287,8 +290,10 @@ class TestSelfSleepPendingNotificationsGuard:
         assert result.get("status") == "ok"
         # Refusal message, not the sleep confirmation
         assert "refused" in result.get("message", "").lower()
-        # State must NOT have transitioned
-        assert agent.state != AgentState.ASLEEP
+        # State must NOT have transitioned.
+        assert agent.state != AgentState.ASLEEP, (
+            "kernel#112 regression: agent must not sleep with mail waiting"
+        )
         assert not agent._asleep.is_set()
 
     def test_sleep_refused_when_notification_arrived_mid_turn(self, tmp_path):

--- a/tests/test_karma.py
+++ b/tests/test_karma.py
@@ -296,28 +296,6 @@ class TestSelfSleepPendingNotificationsGuard:
         )
         assert not agent._asleep.is_set()
 
-    def test_sleep_refused_when_notification_arrived_mid_turn(self, tmp_path):
-        """The exact race from kernel#112: agent observed an EMPTY queue
-        at the start of the turn, mail arrived during the LLM call, and
-        the agent then calls system(sleep). _notification_fp is still ()
-        from the pre-turn baseline; the on-disk fp is non-empty."""
-        from lingtai.tools.system import handle
-        agent = _make_agent(tmp_path)
-        agent._notification_fp = ()  # baseline: queue was empty
-
-        # Mail arrives MID-TURN
-        self._write_notification(agent, "email.json", {
-            "header": "human mail", "icon": "📧",
-            "priority": "normal", "data": {"count": 1},
-        })
-
-        result = handle(agent, {"action": "sleep", "input": {"reason": "no unread mail"}})
-
-        assert agent.state != AgentState.ASLEEP, (
-            "kernel#112 regression: agent must not sleep with mail waiting"
-        )
-        assert "refused" in result.get("message", "").lower()
-
     def test_sleep_force_true_overrides_pending_guard(self, tmp_path):
         from lingtai.tools.system import handle
         agent = _make_agent(tmp_path)

--- a/tests/test_kernel_isolation.py
+++ b/tests/test_kernel_isolation.py
@@ -211,23 +211,3 @@ def test_import_lingtai_tools_does_not_pull_high_level_lingtai():
         f"stdout: {result.stdout}\n"
         f"stderr: {result.stderr}"
     )
-
-
-def test_import_kernel_does_not_load_lingtai_tools():
-    """``import lingtai.kernel`` must not pull in ``lingtai.tools`` (kernel isolation)."""
-    result = subprocess.run(
-        [
-            sys.executable, "-c",
-            "import sys; import lingtai.kernel; "
-            "leaked = [k for k in sys.modules if k == 'lingtai.tools' or k.startswith('lingtai.tools.')]; "
-            "print('LEAKED:', leaked) if leaked else print('CLEAN')"
-        ],
-        capture_output=True,
-        text=True,
-        cwd=str(_repo_root()),
-        env=_env_with_src_path(),
-    )
-    assert result.returncode == 0, f"Subprocess error:\nstdout: {result.stdout}\nstderr: {result.stderr}"
-    assert "CLEAN" in result.stdout, (
-        f"lingtai.kernel eagerly loaded lingtai.tools:\nstdout: {result.stdout}\nstderr: {result.stderr}"
-    )

--- a/tests/test_kernel_isolation.py
+++ b/tests/test_kernel_isolation.py
@@ -169,7 +169,8 @@ def test_kernel_import_only_loads_parent_and_kernel():
     )
     assert result.returncode == 0, f"Subprocess error:\nstdout: {result.stdout}\nstderr: {result.stderr}"
     assert "CLEAN" in result.stdout, (
-        f"The 'lingtai' or 'tools' package leaked into sys.modules after importing lingtai.kernel.\n"
+        f"The 'lingtai' or 'tools' package leaked into sys.modules after importing lingtai.kernel; "
+        f"lingtai.kernel must not eagerly load lingtai.tools.\n"
         f"stdout: {result.stdout}\n"
         f"stderr: {result.stderr}"
     )

--- a/tests/test_kernel_migrate.py
+++ b/tests/test_kernel_migrate.py
@@ -125,23 +125,6 @@ def test_run_migrations_idempotent_within_same_process(tmp_path):
     assert first_mtime == second_mtime
 
 
-def test_run_migrations_advances_version_on_success(tmp_path):
-    """After a successful migration, the on-disk version equals CURRENT_VERSION."""
-    plib = tmp_path / "presets"
-    plib.mkdir()
-    _write_preset(plib, "p", {
-        "name": "p",
-        "manifest": {
-            "llm": {"provider": "x", "model": "y"},
-            "capabilities": {},
-            "context_limit": 8192,
-        },
-    })
-
-    run_migrations(plib)
-
-    assert _read(plib / meta_filename())["version"] == CURRENT_VERSION
-
 
 def test_run_migrations_skips_version_already_done_on_legacy_preset(tmp_path):
     """Forward-only invariant: with version=N already on disk, migrations

--- a/tests/test_large_result_no_notification.py
+++ b/tests/test_large_result_no_notification.py
@@ -52,18 +52,6 @@ def _add_tool_pair(iface: ChatInterface, call_id: str, tool_name: str, content):
     iface.add_tool_results([ToolResultBlock(id=call_id, name=tool_name, content=content)])
 
 
-def test_rescan_never_publishes_for_huge_result():
-    """A single result well over any old gate must NOT publish a notification."""
-    iface = ChatInterface()
-    # 80k chars — far above the old 50000-char total-length gate.
-    _add_tool_pair(iface, "tc-huge", "bash", {"output": "X" * 80000, "status": "ok"})
-    agent = _make_stub_agent(iface)
-
-    count = _rescan_large_tool_results(agent)
-
-    assert count == 0
-    assert agent._published == []
-
 
 def test_rescan_never_publishes_for_many_large_results():
     """Many large results together must still publish nothing."""

--- a/tests/test_meta_block.py
+++ b/tests/test_meta_block.py
@@ -273,17 +273,6 @@ def test_current_tool_result_chars_tail_omits_readme_and_resident_readme_describ
     assert "proactive summarization" in readme
     assert "ids/previews" not in readme
 
-def test_current_tool_result_chars_readme_is_resident_not_tail_state():
-    agent = SimpleNamespace(_conversation=[])
-
-    current = current_tool_result_chars(agent)
-
-    assert "_readme" not in current
-    readme = json.dumps(build_meta_readme())
-    assert "proactive summarization" in readme
-    assert "top_results" in readme
-    assert "ids/previews" not in readme
-
 def test_build_meta_readme_mentions_tool_result_char_count_and_summarize():
     readme = build_meta_readme()
 
@@ -504,17 +493,6 @@ def test_slim_adapter_comment_for_tail_trims_ledger_without_static_key_guessing(
     assert "reason" not in slim["maintenance_hint"]
     # A hook points at the resident meta_guidance section.
     assert "meta_guidance_ref" not in slim
-
-def test_attach_active_runtime_tail_guidance_is_ref_not_full_sections():
-    agent = _runtime_agent(total_calls=1)
-    block = _stamped_result({"current_time": "T"}, 12)
-
-    attach_active_runtime(agent, [block], prior_holder=None)
-
-    guidance = block.metadata["agent_meta"]["guidance"]["persistent"]
-    # Tail guidance is a lightweight ref/hook, not the full ordered sections.
-    assert "sections" not in guidance
-    assert "meta_guidance" in guidance.get("ref", "") + json.dumps(guidance)
 
 
 def test_attach_active_runtime_tail_adapter_comment_has_no_ledger_rows():
@@ -755,17 +733,6 @@ def _fake_agent_with_session(
         ),
     )
 
-
-def test_build_meta_omits_numeric_context_fields_when_decomp_ran():
-    agent = _fake_agent_with_session(
-        system_prompt_tokens=5000,
-        tools_tokens=500,
-        history_tokens=200,
-        context_limit=100000,
-    )
-    meta = build_meta(agent)
-    assert "context" not in meta
-    assert meta_block._current_context_usage(agent) == pytest.approx(0.057)
 
 
 def test_build_meta_carries_latest_token_usage_for_tool_meta_only():
@@ -1586,25 +1553,6 @@ def test_build_meta_omits_context_before_decomp_runs():
     assert "context" not in meta
     assert meta_block._current_context_usage(agent) == -1.0
 
-
-def test_build_meta_history_falls_back_to_interface_estimate_after_restore():
-    """After start() rehydrates the wire ChatInterface from chat_history.jsonl,
-    _latest_input_tokens is still 0 until the first LLM call completes. The
-    meta-line must fall back to interface.estimate_context_tokens() so the
-    first post-refresh text_input shows the restored history, not '对话 0'."""
-    agent = _fake_agent_with_session(
-        system_prompt_tokens=5000,
-        tools_tokens=500,
-        history_tokens=50000,  # restored from JSONL
-    )
-    # Simulate pre-first-LLM-call state: interface has history but server
-    # has not reported an input count yet.
-    agent._session._latest_input_tokens = 0
-    meta = build_meta(agent)
-    # The local usage helper still falls back to interface.estimate_context_tokens(),
-    # but the numeric breakdown is no longer duplicated in agent_meta.
-    assert "context" not in meta
-    assert meta_block._current_context_usage(agent) == pytest.approx(0.555)
 
 
 def test_build_meta_time_blind_still_omits_numeric_context_fields():
@@ -3880,18 +3828,6 @@ def test_attach_active_runtime_empty_meta_keeps_prior_snapshot():
 # onto every latest tool result when unchanged.
 # ---------------------------------------------------------------------------
 
-
-def test_attach_active_runtime_first_snapshot_is_attached():
-    # The very first material snapshot always attaches — there is no prior
-    # signature to compare against.
-    agent = _runtime_agent(total_calls=1)
-    block = _stamped_result({"current_time": "T1"}, 5)
-
-    holder = attach_active_runtime(agent, [block], prior_holder=None)
-
-    assert holder is block
-    assert "agent_meta" in block.metadata
-    assert "guidance" in block.metadata["agent_meta"]
 
 
 def test_attach_active_runtime_unchanged_snapshot_not_restamped_on_latest():

--- a/tests/test_meta_block.py
+++ b/tests/test_meta_block.py
@@ -270,6 +270,8 @@ def test_current_tool_result_chars_tail_omits_readme_and_resident_readme_describ
     assert "top_results" in readme
     assert "no preview" in readme
     assert "top 5" not in readme
+    assert "proactive summarization" in readme
+    assert "ids/previews" not in readme
 
 def test_current_tool_result_chars_readme_is_resident_not_tail_state():
     agent = SimpleNamespace(_conversation=[])
@@ -1636,10 +1638,14 @@ def test_render_meta_time_blind_with_context_present_emits_empty_time_slot():
 
 
 def test_build_meta_history_tokens_does_not_double_count_system_and_tools():
-    """Regression: history_tokens must NOT include the system prompt or tool
-    schema tokens (they belong to system_tokens). Computed from the server's
+    """Regression: after decomposition has run, numeric context stays absent
+    from ``build_meta`` while the local usage estimate remains correct.
+
+    ``history_tokens`` must NOT include the system prompt or tool schema tokens
+    (they belong to ``system_tokens``). It is computed from the server's
     authoritative input count minus system + tools, mirroring
-    SessionManager.get_token_usage's ctx_history_tokens."""
+    ``SessionManager.get_token_usage``'s ``ctx_history_tokens``.
+    """
     agent = _fake_agent_with_session(
         system_prompt_tokens=5000,
         tools_tokens=500,
@@ -1654,8 +1660,9 @@ def test_build_meta_history_tokens_does_not_double_count_system_and_tools():
 
 
 def test_build_meta_usage_matches_get_context_pressure_after_restore():
-    """Regression: on the very first turn after a restore (before the first
-    LLM call returns), the meta-prefix usage% must match what
+    """Regression: on the first post-refresh ``text_input`` after restoring
+    the wire conversation from ``chat_history.jsonl`` (before the first LLM call
+    returns), the meta-prefix usage% must match what
     SessionManager.get_context_pressure() would report for the same state.
     Otherwise the molt warning and the injected '[... | context: X%]'
     prefix show different numbers on the same turn, confusing the agent.

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -19,6 +19,34 @@ def test_build_system_prompt_with_sections():
     assert "Remember: user likes concise" in prompt
 
 
+def test_system_prompt_manager_section_metadata_round_trip():
+    mgr = SystemPromptManager()
+    mgr.write_section("role", "You are an orchestrator", protected=True)
+    mgr.write_section("pad", "User likes concise")
+
+    assert mgr.list_sections() == [
+        {"name": "role", "protected": True, "length": 23},
+        {"name": "pad", "protected": False, "length": 18},
+    ]
+    assert mgr.read_section("role") == "You are an orchestrator"
+    assert mgr.read_section("pad") == "User likes concise"
+
+
+def test_system_prompt_manager_delete_is_idempotent():
+    mgr = SystemPromptManager()
+    mgr.write_section("temp", "temporary content")
+
+    assert mgr.read_section("temp") == "temporary content"
+    assert mgr.delete_section("temp") is True
+    assert mgr.read_section("temp") is None
+    assert mgr.delete_section("temp") is False
+
+
+def test_system_prompt_manager_reads_never_written_section_as_none():
+    mgr = SystemPromptManager()
+    assert mgr.read_section("nonexistent") is None
+
+
 def test_rules_renders_after_covenant_and_tools():
     """Section order is grouped by mutation frequency for cache stability:
     Batch 1 (immovable, prefix-cacheable) — principle, covenant, tools, substrate, ...


### PR DESCRIPTION
## Summary

This branch accounts for all 19 K-C units by relocating or strengthening core runtime test owners before removing overlapping cases.

- Branch: `tzzheng/trim-core-runtime-test-overlap`
- Head: `e45bc5e7`
- Exact scope: **14 files changed, 100 insertions, 244 deletions**

## What changed

- Consolidated dynamic tool registration, omitted Claude effort, provider registry, three-tier session timestamps, prompt-manager, notification sleep guard, import isolation, meta, migration, and large-result ownership.
- Landed owner work in `c772027c` before the removal commit `e45bc5e7`.
- Repointed the K005 `BEHAVIORS.md` selector to the retained stronger large-result rescan owner in the same removal commit.

## Validation

- **RED chronology:** after owner strengthening and before removal, 19 reversible production/document mutations each made the named retained owner fail with exit 1 at the cited assertion. Mutated paths were restored immediately; the final tree has no production-Python mutation residue.
- Parent exact-head gates passed: touched core/provider/session/prompt modules (**338 passed**), complete meta and large-result modules (**216 passed**), and migration plus LABT validation (**43 passed**). Focused governance for the changed `BEHAVIORS.md` passed.
- No deselections were used in these gates. The repository-wide docs checker remains red on three unchanged Feishu files; the broader docs test reported **111 passed, 2 failed** for that existing frontmatter/template drift. Those paths and tests are byte-unchanged by K-C.
- Current open-PR overlap preflight found one shared file with PR #1361 (`tests/test_prompt.py`). A real merged tree (`bd2c5e53`) is conflict-free and keeps K-C's three new prompt-manager owners while preserving #1361's two duplicate removals.

## Review

Literal Opus 5 review (`claude-opus-5`, high, plan): **PASS**, with **P0=0, P1=0, P2=5**. The reviewer reproduced all three parent counts, exact scope/chronology, and direct execution of the three retained K005 selectors.

The five non-blocking P2s are disclosed: K-C did not preserve per-probe RED logs; the 19-definition absence claim is file-qualified because a same-named base copy exists elsewhere; LABT validates the cited file but strips the `::selector`; a “583” figure in the review brief was unsourced and is not a report claim; and one body-passthrough assertion moved from `render()` to `render_batches()` while render headings remain directly pinned.

## Boundaries

- **No production Python changes.** The only `src/` change is the one-line `BEHAVIORS.md` citation repoint; every other change is in tests.
- Provider/registry/session semantics, OWNER/KEEP units, and unrelated Feishu debt remain outside scope.
- These focused gates do not claim the full repository suite or generic docs gate is green.

Related: full-corpus test audit
