### PR TITLE
test: trim notification and executor test overlap

### DIFF
--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -382,35 +382,6 @@ def test_mail_of_human_sender_and_recipient(tmp_path, human_addr):
     }
 
 
-def test_mail_of_external_non_node_correspondent(tmp_path):
-    agent_addr = _write_manifest(tmp_path / "agent", "agent")
-    external_addr = "dead@example.test"
-    _write_mail(tmp_path / "agent", "inbox", [
-        {
-            "from": external_addr,
-            "to": [agent_addr],
-            "subject": "old inbound",
-            "received_at": "2026-03-20T10:00:00Z",
-        },
-    ])
-    _write_mail(tmp_path / "agent", "sent", [
-        {
-            "from": agent_addr,
-            "to": [external_addr],
-            "subject": "old outbound",
-            "sent_at": "2026-03-20T11:00:00Z",
-        },
-    ])
-
-    net = build_network(tmp_path)
-
-    assert external_addr not in net.nodes
-    assert {(e.sender, e.recipient) for e in net.mail_of(external_addr)} == {
-        (external_addr, agent_addr),
-        (agent_addr, external_addr),
-    }
-
-
 def test_mail_of_unknown_agent(tmp_path):
     net = build_network(tmp_path)
     assert net.mail_of("unknown") == []

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -353,9 +353,9 @@ def test_mail_of(tmp_path):
     assert alice_mail[0].sender == alice_addr
 
 
-def test_mail_of_human_sender_and_recipient(tmp_path):
+@pytest.mark.parametrize("human_addr", ["../human", "dead@example.test"])
+def test_mail_of_human_sender_and_recipient(tmp_path, human_addr):
     agent_addr = _write_manifest(tmp_path / "agent", "agent")
-    human_addr = "../human"
     _write_mail(tmp_path / "agent", "inbox", [
         {
             "from": human_addr,

--- a/tests/test_notification_sync.py
+++ b/tests/test_notification_sync.py
@@ -241,23 +241,6 @@ def test_check_action_returns_placeholder(tmp_path: Path) -> None:
     assert "_meta" not in res
 
 
-def test_system_notification_action_is_removed(tmp_path: Path) -> None:
-    """system(action="notification") is no longer a valid action."""
-    from lingtai.tools.system import handle
-
-    @dataclass
-    class _Stub:
-        _working_dir: Path = tmp_path
-        _logs: list[tuple[str, dict]] = field(default_factory=list)
-
-        def _log(self, evt: str, **fields: Any) -> None:
-            self._logs.append((evt, fields))
-
-    res = handle(_Stub(), {"action": "notification"})
-    assert res["status"] == "error"
-    assert "Unknown system action" in res["message"]
-
-
 # ---------------------------------------------------------------------------
 # §13.6 — producer migrations
 # ---------------------------------------------------------------------------
@@ -680,46 +663,11 @@ def test_sync_idle_posts_wake_message(tmp_path: Path) -> None:
     without posting a wake message left the run loop blocked on
     ``inbox.get()`` even though the wire was correct on disk.
     """
-    from lingtai.kernel.base_agent import BaseAgent
-    from lingtai.kernel.state import AgentState
     from lingtai.kernel.message import MSG_TC_WAKE
 
-    chat = _make_chat_stub()
-
-    class _Agent(BaseAgent):
-        def __init__(self, workdir):
-            self._working_dir = workdir
-            self._notification_store = notification_store_for(workdir)
-            self._state = AgentState.IDLE
-            self._notification_fp = ()
-            self._notification_deferred_log_fp = ()
-            self._notification_block_id = None
-            self._chat_stub = chat
-            self._logs = []
-            self.agent_name = "stub"
-            import queue
-            self.inbox = queue.Queue()
-
-        @property
-        def _chat(self):
-            return self._chat_stub
-
-        def _save_chat_history(self, *, ledger_source="main"):
-            pass
-
-        def _log(self, evt, **fields):
-            self._logs.append((evt, fields))
-
-        def _wake_nap(self, *_a, **_kw):
-            pass
-
-        def _set_state(self, *_a, **_kw):
-            pass
-
-        def _reset_uptime(self):
-            pass
-
-    agent = _Agent(tmp_path)
+    agent = _make_stub_agent_for_block_log(
+        tmp_path, notification_deferred_log_fp=(),
+    )
     publish_test_payload(tmp_path, "email", {"count": 1})
     agent._sync_notifications()
 
@@ -808,45 +756,9 @@ def test_sync_idle_injects_post_molt_after_molt_batch_deferred_stamp(tmp_path: P
     Here we reproduce the uncommitted-fp state left by the per-molt-batch
     deferral and assert IDLE sync injects the wake.
     """
-    from lingtai.kernel.base_agent import BaseAgent
-    from lingtai.kernel.state import AgentState
     from lingtai.kernel.message import MSG_TC_WAKE
 
-    chat = _make_chat_stub()
-
-    class _Agent(BaseAgent):
-        def __init__(self, workdir):
-            self._working_dir = workdir
-            self._notification_store = notification_store_for(workdir)
-            self._state = AgentState.IDLE
-            self._notification_fp = ()
-            self._notification_block_id = None
-            self._chat_stub = chat
-            self._logs = []
-            self.agent_name = "stub"
-            import queue
-            self.inbox = queue.Queue()
-
-        @property
-        def _chat(self):
-            return self._chat_stub
-
-        def _save_chat_history(self, *, ledger_source="main"):
-            pass
-
-        def _log(self, evt, **fields):
-            self._logs.append((evt, fields))
-
-        def _wake_nap(self, *_a, **_kw):
-            pass
-
-        def _set_state(self, *_a, **_kw):
-            pass
-
-        def _reset_uptime(self):
-            pass
-
-    agent = _Agent(tmp_path)
+    agent = _make_stub_agent_for_block_log(tmp_path)
     # The molt wrote the continuation channel while ACTIVE.
     publish_test_payload(tmp_path, "post-molt", {
         "header": "post-molt #1 — resume work",
@@ -874,52 +786,14 @@ def test_sync_idle_injects_post_molt_after_molt_batch_deferred_stamp(tmp_path: P
 def test_sync_idle_injects_pair_with_synthesized_marker(tmp_path: Path) -> None:
     """IDLE: fingerprint change → synthetic pair appended; result block
     has synthesized=True and JSON body carries `_synthesized: true`."""
-    from lingtai.kernel.base_agent import BaseAgent
-    from lingtai.kernel.state import AgentState
     from lingtai.kernel.llm.interface import ToolCallBlock, ToolResultBlock
     from lingtai.kernel.message import _make_message  # noqa: F401
 
-    chat = _make_chat_stub()
-
-    # Build a partial agent: we override only what _sync_notifications
-    # touches, since constructing a real BaseAgent requires a full
-    # filesystem agent dir + LLM service.
-    class _Agent(BaseAgent):
-        def __init__(self, workdir):
-            self._working_dir = workdir
-            self._notification_store = notification_store_for(workdir)
-            self._state = AgentState.IDLE
-            self._notification_fp = ()
-            self._notification_block_id = None
-            self._chat_stub = chat
-            self._logs = []
-            self.agent_name = "stub"
-            self._asleep_evt = threading.Event()
-            self._cancel_event = threading.Event()
-            # inbox for any wake messages
-            import queue
-            self.inbox = queue.Queue()
-
-        @property
-        def _chat(self):
-            return self._chat_stub
-
-        def _save_chat_history(self, *, ledger_source: str = "main") -> None:
-            pass
-
-        def _log(self, evt, **fields):
-            self._logs.append((evt, fields))
-
-        def _wake_nap(self, *_a, **_kw):
-            pass
-
-        def _set_state(self, *_a, **_kw):
-            pass
-
-        def _reset_uptime(self):
-            pass
-
-    agent = _Agent(tmp_path)
+    asleep_evt = threading.Event()
+    cancel_event = threading.Event()
+    agent = _make_stub_agent_for_block_log(
+        tmp_path, asleep_evt=asleep_evt, cancel_event=cancel_event,
+    )
     publish_test_payload(tmp_path, "email", {"count": 1, "data": {"count": 1}})
 
     agent._sync_notifications()
@@ -1017,44 +891,8 @@ def test_synthesized_notification_call_args_survive_real_dispatch(
 def test_sync_idle_releases_then_reinjects(tmp_path: Path) -> None:
     """Payload A — payload B — payload A again keeps append-only history
     and gives each synthetic result a fresh injection sequence."""
-    from lingtai.kernel.base_agent import BaseAgent
-    from lingtai.kernel.state import AgentState
 
-    chat = _make_chat_stub()
-
-    class _Agent(BaseAgent):
-        def __init__(self, workdir):
-            self._working_dir = workdir
-            self._notification_store = notification_store_for(workdir)
-            self._state = AgentState.IDLE
-            self._notification_fp = ()
-            self._notification_block_id = None
-            self._chat_stub = chat
-            self._logs = []
-            self.agent_name = "stub"
-            import queue
-            self.inbox = queue.Queue()
-
-        @property
-        def _chat(self):
-            return self._chat_stub
-
-        def _save_chat_history(self, *, ledger_source="main"):
-            pass
-
-        def _log(self, evt, **fields):
-            self._logs.append((evt, fields))
-
-        def _wake_nap(self, *_a, **_kw):
-            pass
-
-        def _set_state(self, *_a, **_kw):
-            pass
-
-        def _reset_uptime(self):
-            pass
-
-    agent = _Agent(tmp_path)
+    agent = _make_stub_agent_for_block_log(tmp_path)
     payload_a = {"count": 1}
     payload_b = {"count": 2, "extra": "more bytes"}
 
@@ -1092,44 +930,8 @@ def test_sync_idle_releases_then_reinjects(tmp_path: Path) -> None:
 def test_sync_idle_empty_releases_holder(tmp_path: Path) -> None:
     """When all producer files are cleared, the live holder is released
     from tracking without mutating its recorded wire content."""
-    from lingtai.kernel.base_agent import BaseAgent
-    from lingtai.kernel.state import AgentState
 
-    chat = _make_chat_stub()
-
-    class _Agent(BaseAgent):
-        def __init__(self, workdir):
-            self._working_dir = workdir
-            self._notification_store = notification_store_for(workdir)
-            self._state = AgentState.IDLE
-            self._notification_fp = ()
-            self._notification_block_id = None
-            self._chat_stub = chat
-            self._logs = []
-            self.agent_name = "stub"
-            import queue
-            self.inbox = queue.Queue()
-
-        @property
-        def _chat(self):
-            return self._chat_stub
-
-        def _save_chat_history(self, *, ledger_source="main"):
-            pass
-
-        def _log(self, evt, **fields):
-            self._logs.append((evt, fields))
-
-        def _wake_nap(self, *_a, **_kw):
-            pass
-
-        def _set_state(self, *_a, **_kw):
-            pass
-
-        def _reset_uptime(self):
-            pass
-
-    agent = _Agent(tmp_path)
+    agent = _make_stub_agent_for_block_log(tmp_path)
     publish_test_payload(tmp_path, "email", {"count": 1})
     agent._sync_notifications()
     assert len(agent._chat_stub.interface.entries) == 2
@@ -1151,44 +953,10 @@ def test_sync_idle_empty_releases_holder(tmp_path: Path) -> None:
 
 def test_sync_no_change_is_noop(tmp_path: Path) -> None:
     """Two syncs without any filesystem change → second is a no-op."""
-    from lingtai.kernel.base_agent import BaseAgent
-    from lingtai.kernel.state import AgentState
 
-    chat = _make_chat_stub()
-
-    class _Agent(BaseAgent):
-        def __init__(self, workdir):
-            self._working_dir = workdir
-            self._notification_store = notification_store_for(workdir)
-            self._state = AgentState.IDLE
-            self._notification_fp = ()
-            self._notification_block_id = None
-            self._chat_stub = chat
-            self._logs = []
-            self.agent_name = "stub"
-            import queue
-            self.inbox = queue.Queue()
-
-        @property
-        def _chat(self):
-            return self._chat_stub
-
-        def _save_chat_history(self, *, ledger_source="main"):
-            pass
-
-        def _log(self, evt, **fields):
-            self._logs.append((evt, fields))
-
-        def _wake_nap(self, *_a, **_kw):
-            pass
-
-        def _set_state(self, *_a, **_kw):
-            pass
-
-        def _reset_uptime(self):
-            pass
-
-    agent = _Agent(tmp_path)
+    agent = _make_stub_agent_for_block_log(
+        tmp_path, notification_deferred_log_fp=(),
+    )
     publish_test_payload(tmp_path, "email", {"count": 1})
     agent._sync_notifications()
     first_id = agent._notification_block_id
@@ -2770,45 +2538,10 @@ def test_sync_notifications_serialized_across_runloop_and_heartbeat(tmp_path: Pa
     the second caller blocks on ``_notification_sync_lock``, re-reads the
     fingerprint after the first caller commits, and no-ops.
     """
-    from lingtai.kernel.base_agent import BaseAgent
-    from lingtai.kernel.state import AgentState
 
-    chat = _make_chat_stub()
-
-    class _Agent(BaseAgent):
-        def __init__(self, workdir):
-            self._working_dir = workdir
-            self._notification_store = notification_store_for(workdir)
-            self._state = AgentState.IDLE
-            self._notification_fp = ()
-            self._notification_deferred_log_fp = ()
-            self._notification_block_id = None
-            self._chat_stub = chat
-            self._logs = []
-            self.agent_name = "stub"
-            import queue
-            self.inbox = queue.Queue()
-
-        @property
-        def _chat(self):
-            return self._chat_stub
-
-        def _save_chat_history(self, *, ledger_source="main"):
-            pass
-
-        def _log(self, evt, **fields):
-            self._logs.append((evt, fields))
-
-        def _wake_nap(self, *_a, **_kw):
-            pass
-
-        def _set_state(self, *_a, **_kw):
-            pass
-
-        def _reset_uptime(self):
-            pass
-
-    agent = _Agent(tmp_path)
+    agent = _make_stub_agent_for_block_log(
+        tmp_path, notification_deferred_log_fp=(),
+    )
     publish_test_payload(tmp_path, "email", {"count": 1, "data": {"count": 1}})
 
     release = threading.Event()

--- a/tests/test_notification_sync.py
+++ b/tests/test_notification_sync.py
@@ -2049,8 +2049,14 @@ def test_non_molt_batch_after_molt_can_consume_post_molt(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def _make_stub_agent_for_block_log(tmp_path: Path):
-    """Build a minimal agent stub carrying _logs for notification_block_injected tests."""
+def _make_stub_agent_for_block_log(
+    tmp_path: Path,
+    *,
+    notification_deferred_log_fp=None,
+    asleep_evt=None,
+    cancel_event=None,
+):
+    """Build the shared notification-sync agent, preserving optional state fields."""
     from dataclasses import dataclass, field as dc_field
     from lingtai.kernel.base_agent import BaseAgent
     from lingtai.kernel.state import AgentState
@@ -2063,10 +2069,16 @@ def _make_stub_agent_for_block_log(tmp_path: Path):
             self._notification_store = notification_store_for(workdir)
             self._state = AgentState.IDLE
             self._notification_fp = ()
+            if notification_deferred_log_fp is not None:
+                self._notification_deferred_log_fp = notification_deferred_log_fp
             self._notification_block_id = None
             self._chat_stub = chat
             self._logs: list = []
             self.agent_name = "stub"
+            if asleep_evt is not None:
+                self._asleep_evt = asleep_evt
+            if cancel_event is not None:
+                self._cancel_event = cancel_event
             import queue
             self.inbox = queue.Queue()
 

--- a/tests/test_notification_tool.py
+++ b/tests/test_notification_tool.py
@@ -412,13 +412,6 @@ def test_check_returns_placeholder_dict(tmp_path: Path) -> None:
     assert "notifications" not in res
 
 
-def test_unknown_action_errors(tmp_path: Path) -> None:
-    agent = _StubAgent(tmp_path)
-    res = _call(agent, "bogus")
-    assert res["status"] == "error"
-    assert "Unknown notification action" in res["message"]
-
-
 # ---------------------------------------------------------------------------
 # dismiss_channel.
 # ---------------------------------------------------------------------------
@@ -944,27 +937,6 @@ def test_manual_takes_no_input_and_performs_no_io(tmp_path: Path) -> None:
     assert res["status"] == "failed"
     assert res["error_code"] == "INVALID_ARGUMENT"
     assert not (tmp_path / ".notification").exists()
-
-
-def test_manual_result_is_flattened_not_double_wrapped(tmp_path: Path) -> None:
-    """Host presentation flattens the canonical child result; no nested envelope.
-
-    ``ToolFamily.handle`` returns ``build_manual_child``'s canonical
-    ``content``/``structuredContent`` result verbatim. Notification's pinned
-    public shape is the flat one, so the adaptation happens after dispatch —
-    and the canonical keys must not survive into the public result.
-    """
-    agent = _StubAgent(tmp_path)
-    manual_path = _notification_manual_path(tmp_path)
-    manual_path.parent.mkdir(parents=True)
-    manual_path.write_text("# body\n", encoding="utf-8")
-
-    res = _call(agent, "manual")
-
-    assert set(res) == {"status", "notification_manual", "manual_path"}
-    assert res["notification_manual"] == "# body\n"
-    for canonical in ("content", "structuredContent", "manual"):
-        assert canonical not in res
 
 
 def test_family_schema_survives_chat_and_responses_wires() -> None:

--- a/tests/test_notification_tool.py
+++ b/tests/test_notification_tool.py
@@ -350,6 +350,7 @@ def _notification_manual_path(workdir: Path) -> Path:
 def test_manual_returns_installed_notification_manual_without_state_mutation(
     tmp_path: Path,
 ) -> None:
+    """The installed manual result stays flat, never double-wrapped as ``content``."""
     agent = _StubAgent(tmp_path)
     manual_path = _notification_manual_path(tmp_path)
     manual_path.parent.mkdir(parents=True)

--- a/tests/test_nudge_policy.py
+++ b/tests/test_nudge_policy.py
@@ -592,35 +592,6 @@ def test_blocked_lifecycle_renders_blocked_title_and_preserves_raw(tmp_path):
     assert init.read_text(encoding="utf-8") == raw
 
 
-def test_failed_lifecycle_keeps_supplemental_compatibility_mapping(tmp_path):
-    """Mixed evidence on PRESET failure: compatibility mapping survives as
-    supplemental data while the headline classification stays UNKNOWN; raw
-    bytes untouched."""
-    from lingtai.kernel.nudge.init_config import check as check_init_config
-    from lingtai.init_reader import reader_callbacks
-
-    agent = _Agent(tmp_path)
-    init = _seed_finding(tmp_path, agent)
-
-    def broken_load_preset(name, working_dir=None):
-        raise KeyError(name)
-
-    materialize, prepare = reader_callbacks(tmp_path, load_preset=broken_load_preset)
-    manifest = json.loads(init.read_text(encoding="utf-8"))["manifest"]
-    manifest["preset"] = {"active": "missing", "default": "missing", "allowed": ["missing"]}
-    bad = json.dumps({"manifest": manifest, **{
-        "covenant": "operator contract", "pad": "durable state"}})
-    init.write_text(bad, encoding="utf-8")
-    failed = read_init(tmp_path, materialize=materialize, prepare=prepare,
-                       failure_behavior="KEEP_PREVIOUS_EFFECTIVE")
-    assert failed.status.value == "READ_FAILED"
-    assert failed.stage == "PRESET"
-    assert failed.finding_decision.value == "UNKNOWN"
-    check_init_config(agent, failed)
-    _assert_persisted_non_benign(tmp_path, "PRESET", expect_mapping=True)
-    assert init.read_text(encoding="utf-8") == bad
-
-
 def _frontmatter_related_files(text):
     """Parse the leading YAML frontmatter and return the related_files list."""
     import re

--- a/tests/test_plugin_tool.py
+++ b/tests/test_plugin_tool.py
@@ -1359,18 +1359,6 @@ def test_default_plugin_root_is_scanned_without_declaration(tmp_path):
     assert "<name>s</name>" not in _prompt_section_named(agent, "mcp")
 
 
-def test_plugin_sourced_mcp_is_hidden_from_the_vanilla_mcp_field(tmp_path):
-    """Registered plugin MCPs appear only under plugins, not <registered_mcp>."""
-    agent, workdir = _mk_agent(tmp_path, plugins=[])
-    root = workdir / "plugin"
-    _write_plugin(root, "auto", mcp_servers={"s": {"type": "stdio", "command": "node"}})
-    _refresh_plugins(agent, [])
-    from lingtai.tools import plugin as pluginmod
-    pluginmod._reconcile(agent, [])
-    assert "<mcp_names>s</mcp_names>" in _prompt_section_named(agent, "plugin")
-    assert "<name>s</name>" not in _prompt_section_named(agent, "mcp")
-
-
 def test_mcp_field_is_resident_when_no_standalone_servers(tmp_path):
     """The mcp field explains itself even with an empty registry."""
     agent, _workdir = _mk_agent(tmp_path, plugins=[])

--- a/tests/test_telegram_task_card.py
+++ b/tests/test_telegram_task_card.py
@@ -62,26 +62,6 @@ def _manager(tmp_path):
 # Card create / update / finalize
 # ===========================================================================
 
-def test_task_card_create_shows_header_and_current_tool(tmp_path):
-    manager, account = _manager(tmp_path)
-    r = manager._handle_task_card_update({
-        "sub_action": "create",
-        "account": "mybot",
-        "chat_id": 999,
-        "tool": "bash",
-        "tool_action": "run",
-        "reasoning": "Check project structure",
-    })
-    assert r["status"] == "ok"
-    assert "message_id" in r
-    send_calls = [c for c in account.calls if c[0] == "send_message"]
-    assert len(send_calls) == 1
-    text = send_calls[0][2]
-    assert "📋 ACTIVITIES" in text
-    assert "bash.run" in text
-    assert "Check project structure" in text
-
-
 def test_task_card_update_same_message_id(tmp_path):
     """Sequential tools edit the same card — single current step."""
     manager, account = _manager(tmp_path)

--- a/tests/test_telegram_task_card_singleton.py
+++ b/tests/test_telegram_task_card_singleton.py
@@ -118,18 +118,6 @@ def _edits(account):
 # First create (no resident) sends once, stores the id, deletes nothing
 # ---------------------------------------------------------------------------
 
-def test_first_create_stores_id_and_deletes_nothing(tmp_path):
-    manager, service = _manager(tmp_path)
-    acct = service.default_account
-
-    r = _create(manager)
-    assert r["status"] == "ok"
-    assert len(_sends(acct)) == 1
-    assert not _deletes(acct)
-    assert not _edits(acct)
-    assert acct.get_task_card(999) == r["message_id"]
-
-
 # ---------------------------------------------------------------------------
 # Repeated create with a valid resident EDITS it in place: same id, no
 # new send, no delete — the card never flickers (Jason #6894/#6899).

--- a/tests/test_telegram_task_card_timestamp.py
+++ b/tests/test_telegram_task_card_timestamp.py
@@ -114,12 +114,3 @@ def test_api_error_row_never_carries_a_stamp_alongside_a_tool_row():
     api_line = next(ln for ln in text.splitlines() if "API error" in ln)
     assert "UTC" not in api_line
     assert text.splitlines()[-1] == "Last Updated: 17:18:36 U-7"
-
-
-def test_render_tool_row_without_started_at_is_safe():
-    text = TelegramManager._format_task_card_text("", "", "", rows=[
-        {"tool": "bash", "tool_action": "run", "reasoning": "x",
-         "elapsed_s": 1, "done": False},
-    ], now=_NOW)
-    assert "bash.run" in text
-    assert text.splitlines()[-1] == "Last Updated: 17:18:36 U-7"

--- a/tests/test_telegram_task_card_timestamp.py
+++ b/tests/test_telegram_task_card_timestamp.py
@@ -90,6 +90,7 @@ def test_current_time_line_present_even_when_no_row_has_a_stamp():
         {"tool": "read", "tool_action": "", "reasoning": "y",
          "elapsed_s": 2, "done": False},
     ], now=_NOW)
+    assert "bash.run" in text
     # Last Updated never depends on any row carrying a stamp — it always
     # reflects the render instant.
     assert text.splitlines()[-1] == "Last Updated: 17:18:36 U-7"

--- a/tests/test_telegram_task_card_transport.py
+++ b/tests/test_telegram_task_card_transport.py
@@ -83,12 +83,6 @@ def _payload(result):
     return json.loads(block.text)
 
 
-def test_list_tools_exposes_only_the_public_telegram_family(tmp_path):
-    manager, _account = _make_manager(tmp_path)
-    names = [t.name for t in _list_tools_via_transport(manager)]
-    assert names == ["telegram"]
-
-
 def test_public_telegram_action_reaches_manager(tmp_path):
     manager, account = _make_manager(tmp_path)
 

--- a/tests/test_telegram_terra_repairs.py
+++ b/tests/test_telegram_terra_repairs.py
@@ -252,29 +252,6 @@ def test_public_search_accepts_reserved_bucket_chat_id(tmp_path: Path) -> None:
     assert payload["messages"][0]["telegram"]["event_id"] == "main:update:5003"
 
 
-def test_send_rejects_reserved_bucket_and_reply_rejects_event_records(
-    tmp_path: Path,
-) -> None:
-    manager = _manager(tmp_path)
-    result = _call_tool(manager, {
-        "action": "send",
-        "chat_id": tg_updates.SYNTHETIC_EVENTS_CHAT_ID,
-        "text": "hi",
-    })
-    # Strict action-owned send input rejects the reserved read/search-only
-    # bucket before manager I/O. Under v2 that refusal carries the protocol
-    # error bit (v1 emitted a bare text block with no flag), so the model sees
-    # a readable, correctly-marked failure.
-    assert result.is_error is True
-
-    reply = manager.handle({
-        "action": "reply",
-        "message_id": f"main:{tg_updates.SYNTHETIC_EVENTS_CHAT_ID}:5001",
-        "text": "hi",
-    })
-    assert "synthetic events-bucket" in reply["error"]
-
-
 def test_arbitrary_string_chat_id_still_schema_rejected(tmp_path: Path) -> None:
     manager = _manager(tmp_path)
     result = _call_tool(manager, {

--- a/tests/test_time_awareness_email.py
+++ b/tests/test_time_awareness_email.py
@@ -26,24 +26,6 @@ def test_scrub_schedule_payload_time_blind():
     assert out["status"] == "scheduled"
 
 
-def test_scrub_email_summary_time_blind():
-    agent = _agent(False)
-    summary = {
-        "id": "abc",
-        "from": "alice",
-        "to": ["bob"],
-        "subject": "hi",
-        "preview": "hello",
-        "time": "2026-04-15T12:00:00Z",
-        "folder": "inbox",
-        "unread": True,
-    }
-    out = scrub_time_fields(agent, summary)
-    assert out["time"] == ""
-    assert out["subject"] == "hi"
-    assert out["unread"] is True
-
-
 def test_scrub_passthrough_when_time_aware():
     agent = _agent(True)
     payload = {"scheduled_at": "2026-04-15T12:00:00Z", "time": "2026-04-15T12:00:00Z"}

--- a/tests/test_time_veil.py
+++ b/tests/test_time_veil.py
@@ -49,12 +49,20 @@ def test_scrub_time_fields_time_blind_blanks_listed_keys():
     payload = {
         "received_at": "2026-04-15T12:00:00Z",
         "sent_at": "2026-04-15T12:01:00Z",
+        "deliver_at": "2026-04-15T12:02:00Z",
+        "scheduled_at": "2026-04-15T12:03:00Z",
+        "last_sent_at": "2026-04-15T12:04:00Z",
+        "estimated_finish": "2026-04-15T12:05:00Z",
         "subject": "hi",
         "from": "alice",
     }
     out = scrub_time_fields(agent, payload)
     assert out["received_at"] == ""
     assert out["sent_at"] == ""
+    assert out["deliver_at"] == ""
+    assert out["scheduled_at"] == ""
+    assert out["last_sent_at"] == ""
+    assert out["estimated_finish"] == ""
     assert out["subject"] == "hi"  # non-time keys untouched
     assert out["from"] == "alice"
 

--- a/tests/test_tool_executor.py
+++ b/tests/test_tool_executor.py
@@ -646,6 +646,7 @@ def test_lifecycle_trace_events_for_dispatch_exception():
     assert any("Do not blindly retry" in item for item in meta["guidance"])
     assert any("current state" in item for item in meta["guidance"])
     assert any("boom" in error for error in errors)
+    assert any(error.startswith("explode: ") for error in errors)
     events = _trace_events(logs, "err-trace")
     assert "tool_call_dispatch_failed" in events
     assert "tool_call_dispatch_done" not in events

--- a/tests/test_tool_executor.py
+++ b/tests/test_tool_executor.py
@@ -70,15 +70,6 @@ def _trace_events(logs, trace_id):
     return [event for event, fields in logs if fields.get("tool_trace_id") == trace_id]
 
 
-def test_execute_single_tool():
-    executor = make_executor()
-    calls = [ToolCall(name="read", args={"path": "/tmp"}, id="tc1")]
-    results, intercepted, text = executor.execute(calls)
-    assert len(results) == 1
-    assert not intercepted
-
-
-
 def test_tool_call_guard_default_allow_preserves_pass_through_log():
     logs = []
     dispatch_calls = []
@@ -801,18 +792,6 @@ def test_on_result_hook_receives_model_visible_spill_manifest(tmp_path):
     assert seen[0][2]["original_char_count"] > 120
 
 
-def test_error_collected():
-    def dispatch(tc):
-        raise ValueError("something broke")
-    executor = make_executor(dispatch_fn=dispatch)
-    calls = [ToolCall(name="bad", args={}, id="1")]
-    errors = []
-    results, intercepted, text = executor.execute(calls, collected_errors=errors)
-    assert len(results) == 1
-    assert "bad" in errors[0]
-    assert "something broke" in errors[0]
-
-
 def test_tool_returned_error_is_enriched_for_agent_repair():
     def dispatch(tc):
         return {"status": "error", "message": "chat_id must be integer", "tool": "telegram"}
@@ -854,15 +833,6 @@ def test_cancel_event_stops_sequential():
     calls = [ToolCall(name="a", args={}, id="1")]
     results, intercepted, text = executor.execute(calls, cancel_event=cancel)
     assert results == []
-
-
-def test_unknown_tool_with_known_tools():
-    executor = make_executor(known_tools={"read", "write"})
-    calls = [ToolCall(name="bogus", args={}, id="1")]
-    errors = []
-    results, intercepted, text = executor.execute(calls, collected_errors=errors)
-    assert len(results) == 1
-    assert any("bogus" in e for e in errors)
 
 
 def test_guard_property():

--- a/tests/test_tool_family_avatar_migration.py
+++ b/tests/test_tool_family_avatar_migration.py
@@ -174,22 +174,6 @@ class TestAvatarFamilySchema:
         # not a local restatement that could drift from it.
         assert dict(avatar_tool._CHILD_SPECS)["manual"] is MANUAL_INPUT_SCHEMA
 
-    def test_module_level_registry_rejects_a_reserved_manual_collision(self):
-        from lingtai.tools.tool_family import ChildTool
-
-        def _unused(_input):
-            raise AssertionError("never dispatched")
-
-        with pytest.raises(ToolFamilyError):
-            ToolFamily(
-                "avatar",
-                [
-                    ChildTool("manual", MANUAL_INPUT_SCHEMA, _unused),
-                    ChildTool("manual", MANUAL_INPUT_SCHEMA, _unused),
-                ],
-            )
-
-
 class TestAvatarSchemaSurvivesBothWires:
     """The composed schema must correlate action→input on Chat and Responses.
 
@@ -587,12 +571,6 @@ class TestManualThroughTheEnvelope:
         assert not (network / "delegates").exists()
         assert not (network / "logs").exists()
         assert sorted(p.name for p in network.parent.iterdir()) == before
-
-    def test_manual_rejects_any_input_field(self, network, launcher):
-        mgr, _ = _manager(network, launcher)
-        result = mgr.handle({"action": "manual", "input": {"name": "helper"}})
-        assert result["status"] == "failed"
-        assert result["error_code"] == "INVALID_ARGUMENT"
 
     def test_missing_packaged_manual_degrades_truthfully(self, network, launcher, monkeypatch):
         mgr, _ = _manager(network, launcher)

--- a/tests/test_tool_family_daemon_migration.py
+++ b/tests/test_tool_family_daemon_migration.py
@@ -711,20 +711,6 @@ def test_manual_documents_the_read_only_versus_side_effect_split():
     assert "former flat `summary` field." in manual
 
 
-def test_manual_name_is_reserved_once_by_the_family(tmp_path):
-    """Registering a second ``manual`` child must fail at construction."""
-    from lingtai.tools.tool_family import ChildTool, ToolFamily
-
-    with pytest.raises(ToolFamilyError):
-        ToolFamily(
-            "daemon",
-            [
-                ChildTool("manual", MANUAL_INPUT_SCHEMA, lambda _i: {}, title="a"),
-                ChildTool("manual", MANUAL_INPUT_SCHEMA, lambda _i: {}, title="b"),
-            ],
-        )
-
-
 def test_the_engines_flat_manual_branch_is_not_the_model_facing_path(tmp_path):
     """``DaemonManager.handle``'s own ``action='manual'`` branch is retained for
     historical/internal flat callers, but the registered surface serves the

--- a/tests/test_tool_family_email_migration.py
+++ b/tests/test_tool_family_email_migration.py
@@ -490,15 +490,6 @@ def test_manual_degraded_case_preserves_the_loader_error_verbatim(tmp_path):
         assert generic not in result
 
 
-def test_manual_reserved_name_collision_raises_at_construction():
-    """Registering a second ``manual`` child is a defect, not a precedence call."""
-    from lingtai.tools.tool_family import ChildTool, ToolFamily, ToolFamilyError
-
-    child = ChildTool("manual", dict(MANUAL_INPUT_SCHEMA), lambda _i: {})
-    with pytest.raises(ToolFamilyError):
-        ToolFamily("email", [child, child])
-
-
 def test_manual_performs_no_mailbox_io(tmp_path):
     """``manual`` is read-only: no send, no read-state change."""
     agent = _agent(tmp_path)

--- a/tests/test_tool_family_email_wire_parity.py
+++ b/tests/test_tool_family_email_wire_parity.py
@@ -124,17 +124,6 @@ def test_every_action_branch_is_disclosed_on_both_wires(tmp_path):
             assert branch["additionalProperties"] is False
 
 
-def test_reasoning_is_required_on_both_wires(tmp_path):
-    """The family declares it itself; Agent composition never sets ``required``."""
-    email = _email_schema(tmp_path)
-    for params in (
-        _build_tools([email])[0]["function"]["parameters"],
-        _build_responses_tools([email])[0]["parameters"],
-    ):
-        assert params["properties"]["reasoning"]["type"] == "string"
-        assert "reasoning" in params["required"]
-
-
 def test_handler_parity_dispatches_through_the_registered_intrinsic(tmp_path):
     """The registered handler and the module entry point are the same boundary."""
     from lingtai.agent import Agent

--- a/tests/test_tool_family_email_wire_parity.py
+++ b/tests/test_tool_family_email_wire_parity.py
@@ -78,6 +78,7 @@ def test_closed_root_survives_both_wires(tmp_path):
         assert params["additionalProperties"] is False
         assert set(params["required"]) == {"action", "input", "reasoning"}
         assert params["properties"]["action"]["enum"] == _PUBLIC_ACTIONS
+        assert params["properties"]["reasoning"]["type"] == "string"
 
 
 def test_action_input_all_of_correlation_survives_both_wires(tmp_path):

--- a/tests/test_tool_family_generic.py
+++ b/tests/test_tool_family_generic.py
@@ -105,6 +105,7 @@ def test_schema_composes_action_input_reasoning_summarize_root():
     assert spin_branch["additionalProperties"] is False
     assert manual_branch["properties"] == {}
     for branch in branches:
+        assert branch["additionalProperties"] is False
         assert "reasoning" not in branch.get("properties", {})
         assert "_reasoning" not in branch.get("properties", {})
         assert "summarize" not in branch.get("properties", {})

--- a/tests/test_tool_family_generic.py
+++ b/tests/test_tool_family_generic.py
@@ -312,21 +312,6 @@ def test_manual_child_dispatch_returns_full_manual_shape():
     }
 
 
-def test_manual_child_rejects_nonempty_input():
-    fam = _widget_family()
-    # The manual branch's own strict-empty schema is model-facing guidance;
-    # dispatch-time correspondence is a separate, real check per
-    # tools/CONTRACT.md "Dispatch and actions": a family MUST validate
-    # action/input correspondence, not just rely on schema conformance.
-    # ChildTool handlers here do not themselves reject extra keys (that is
-    # each child's own responsibility, per "implementation independence"),
-    # but the family-level schema composition still advertises strict-empty.
-    schema = fam.build_schema()
-    manual_branch = next(b for b in schema["properties"]["input"]["oneOf"] if b["title"] == "manual input")
-    assert manual_branch["additionalProperties"] is False
-    assert manual_branch["properties"] == {}
-
-
 def _minimal_evaluate_if_then(condition: dict, action: str, input_value: dict) -> bool | None:
     """Tiny, dependency-free structural evaluator for exactly the ``if``/
     ``then`` shape :meth:`ToolFamily.build_schema` generates — not a general

--- a/tests/test_tool_family_generic_summarize_executor.py
+++ b/tests/test_tool_family_generic_summarize_executor.py
@@ -70,12 +70,6 @@ def _raw_logged(events, *, needle):
     return False
 
 
-def test_generic_family_result_is_not_double_wrapped_before_reaching_executor():
-    fam = _widget_family()
-    result = fam.handle({"action": "spin", "input": {}, "reasoning": "r"})
-    assert result == {"status": "ok", "action": "spin", "marker": "WIDGETRAW-marker"}
-
-
 def test_generic_family_legacy_summary_flag_raw_logged_before_summary(tmp_path):
     fam = _widget_family()
     events = []

--- a/tests/test_tool_family_manual_contract.py
+++ b/tests/test_tool_family_manual_contract.py
@@ -112,39 +112,6 @@ def test_a_family_without_any_manual_child_is_still_valid():
     assert not fam.has_manual()
 
 
-def test_web_manual_child_shares_the_same_reserved_contract(tmp_path):
-    from lingtai.tools.web_search import setup
-
-    class _Agent:
-        def __init__(self, working_dir):
-            self._working_dir = working_dir
-
-        def add_tool(self, *args, **kwargs):
-            pass
-
-    class _Port:
-        def handle(self, args):
-            return {"status": "ok"}
-
-    manual_dir = tmp_path / ".library" / "intrinsic" / "capabilities" / "web"
-    manual_dir.mkdir(parents=True)
-    (manual_dir / "SKILL.md").write_text("web manual body", encoding="utf-8")
-
-    manager = setup(_Agent(tmp_path), browser_port=_Port())
-    result = manager.handle({"action": "manual", "input": {}, "reasoning": "load web guidance"})
-    assert result["status"] == "ok"
-    assert result["manual"] == "web manual body"
-    assert result["manual_path"] == str(manual_dir / "SKILL.md")
-    assert result["action"] == "manual"
-    assert "current_setting" in result
-    # The generic child's canonical MCP-compatible fields must not leak into
-    # Web's own pre-migration public flat shape — that adaptation is Web's
-    # own Host/presentation job (``WebManager._adapt_manual_result``),
-    # applied strictly after ``self._family.handle(...)`` dispatch.
-    assert "content" not in result
-    assert "structuredContent" not in result
-
-
 def test_web_family_handle_returns_canonical_manual_result_verbatim_before_host_adaptation(tmp_path):
     """Proves the ownership boundary directly: ``manager._family.handle(...)``
     — the real ``ToolFamily`` this family registers its ``manual`` child in —

--- a/tests/test_tool_family_soul_migration.py
+++ b/tests/test_tool_family_soul_migration.py
@@ -196,20 +196,6 @@ def test_optional_knobs_use_the_provider_compatible_nullable_shape():
     assert voice["properties"]["prompt"]["maxLength"] == soul.SOUL_VOICE_PROMPT_MAX
 
 
-def test_registry_fails_loudly_on_a_reserved_manual_collision():
-    from lingtai.tools.tool_family import ChildTool, ToolFamily
-
-    empty = {"type": "object", "properties": {}, "additionalProperties": False}
-    with pytest.raises(ToolFamilyError):
-        ToolFamily(
-            "soul",
-            [
-                ChildTool("manual", empty, lambda _i: {}),
-                ChildTool("manual", empty, lambda _i: {}),
-            ],
-        )
-
-
 # ---------------------------------------------------------------------------
 # Handlers — one per action, exact preserved semantics.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This branch implements all 22 K-G units by strengthening retained notification/executor/Telegram/tool-family owners before trimming assigned duplicates and migrating seven inline notification-sync stubs to their shared factory.

- Branch: `tzzheng/trim-notification-executor-tests`
- Head: `ba468290`
- Exact scope: **21 files changed, 46 insertions, 628 deletions**

## What changed

- Preserved exact notification errors and flat manual results, executor error provenance, strict action schemas, public Telegram family/routing, Task Card semantics, and time-blind mail ownership.
- Extended the shared notification-sync factory before migrating exactly seven assigned inline agents.
- Removed only the four assigned manual-collision copies. The report-retained sites remain in generic, manual-contract, notification, and system-migration tests; exact-head review additionally identified a fifth surviving shell-family site with the same node name as the removed daemon copy. Inventories must therefore stay file-qualified.
- Owner strengthening is commit `d4c06377`; all mapped removals are in the later `ba468290` commit.

## Validation

- **RED chronology:** six temporary production mutations exercised exact notification action text, flat manual shape, system rejection, executor unknown-tool text, public Telegram synthetic-bucket rejection, and the one-public-family schema. Each named owner went RED and every mutation was restored; the final `src/` diff is empty.
- Parent focused owner set: **37 passed**. The broader coherent suite first reported **1,357 passed, 10 failed**; all ten nodes failed against an isolated exact-base archive. The same suite with exactly those ten base failures deselected reported **1,357 passed, 10 deselected**.
- Exact-head review independently ran all 21 changed modules: **685 passed, 3 failed**; the same three nodes failed at exact base, and the matching deselection run reported **685 passed, 3 deselected**. This smaller review gate is a corroborating subset, not a replacement claim for the parent gate.

## Review

Literal Opus 5 review (`claude-opus-5`, high, plan): **PASS**, with **P0=0, P1=0, P2=5**. This is a complete exact-head artifact with P0/P1 both zero, so K-G is marked ready.

The five non-blocking P2s are disclosed: one factory call gains an inert default-valued deferred-log field although the report called all three sites original; three unused imports; one blank-line style residue; the Task Card missing-`started_at` owner preserves crash safety but re-anchors the direct label assertion; and the manual-collision disclosure omitted the fifth surviving shell-family site noted above.

## Boundaries

- **No production, docs, contract, anatomy, or configuration changes.** All 21 changed paths are tests.
- The protected Task Card toggle test and its OWNER unit are byte-unchanged.
- Public payloads, Telegram error surfaces, executor state transitions, and the ten exact-base failures were not altered.

Related: full-corpus test audit
