### PR TITLE
test: consolidate vision, web, and glossary coverage

### DIFF
--- a/tests/test_tool_family_vision_migration.py
+++ b/tests/test_tool_family_vision_migration.py
@@ -136,7 +136,8 @@ def test_all_child_input_schemas_are_exposed_before_invocation():
     assert manual_branch["additionalProperties"] is False
 
 
-def test_reasoning_and_summarize_never_leak_into_child_input():
+@pytest.mark.parametrize("reasoning", ["chat-wire", "responses-wire"])
+def test_reasoning_and_summarize_never_leak_into_child_input(tmp_path, reasoning):
     schema = get_schema()
     for branch in schema["properties"]["input"]["oneOf"]:
         assert not {"reasoning", "_reasoning", "summarize", "action"} & set(
@@ -146,6 +147,22 @@ def test_reasoning_and_summarize_never_leak_into_child_input():
         assert not {"reasoning", "_reasoning", "summarize", "action"} & set(
             cond["then"]["properties"]["input"]["properties"]
         )
+
+    svc = MagicMock(spec=VisionService)
+    svc.analyze_image.return_value = "same answer"
+    img = tmp_path / "x.png"
+    img.write_bytes(b"fake")
+
+    result = _manager(tmp_path, svc).handle(
+        {
+            "action": "analyze",
+            "input": {"image_path": str(img), "question": "Q"},
+            "reasoning": reasoning,
+            "summarize": True,
+        }
+    )
+    assert result == {"status": "ok", "analysis": "same answer"}
+    svc.analyze_image.assert_called_once_with(str(img), prompt="Q")
 
 
 # ---------------------------------------------------------------------------
@@ -239,6 +256,7 @@ def test_analyze_success_shape_is_exact(tmp_path):
         }
     )
     assert result == {"status": "ok", "analysis": "A dog in the park"}
+    svc.analyze_image.assert_called_once_with(str(img), prompt="What animal?")
 
 
 def test_analyze_null_question_uses_the_unchanged_default_prompt(tmp_path):
@@ -281,11 +299,22 @@ def test_analyze_input_failures_keep_their_exact_messages(
     assert expected_fragment in result["message"]
 
 
-def test_analyze_request_failure_is_sanitized_and_points_to_manual(tmp_path):
+@pytest.mark.parametrize(
+    ("provider_error", "forbidden_fragments"),
+    [
+        pytest.param(
+            "token=secret https://user:pw@example.test/v1",
+            ("secret", "example.test"),
+            id="secret-shaped-error",
+        ),
+        pytest.param("API down", ("API down",), id="plain-provider-error"),
+    ],
+)
+def test_analyze_request_failure_is_sanitized_and_points_to_manual(
+    tmp_path, provider_error, forbidden_fragments
+):
     svc = MagicMock(spec=VisionService)
-    svc.analyze_image.side_effect = RuntimeError(
-        "token=secret https://user:pw@example.test/v1"
-    )
+    svc.analyze_image.side_effect = RuntimeError(provider_error)
     img = tmp_path / "x.png"
     img.write_bytes(b"fake")
 
@@ -298,8 +327,8 @@ def test_analyze_request_failure_is_sanitized_and_points_to_manual(tmp_path):
     # pre-migration bare shorthand the dispatcher now rejects.
     assert "vision(action='manual', input={}" in result["message"]
     assert "reasoning=" in result["message"]
-    assert "secret" not in result["message"]
-    assert "example.test" not in result["message"]
+    for fragment in forbidden_fragments:
+        assert fragment not in result["message"]
 
 
 def test_analyze_empty_response_is_an_error(tmp_path):

--- a/tests/test_tool_family_vision_migration.py
+++ b/tests/test_tool_family_vision_migration.py
@@ -641,23 +641,6 @@ def test_root_summarize_reaches_the_single_centralized_summarizer(tmp_path):
     )
 
 
-def test_dispatch_is_identical_regardless_of_originating_wire(tmp_path):
-    """Dispatch depends only on the normalized args dict both wires converge to."""
-    svc = MagicMock(spec=VisionService)
-    svc.analyze_image.return_value = "same answer"
-    img = tmp_path / "x.png"
-    img.write_bytes(b"fake")
-    mgr = _manager(tmp_path, svc)
-
-    chat_call = mgr.handle(
-        {"action": "analyze", "input": {"image_path": str(img), "question": "Q"}, "reasoning": "chat-wire"}
-    )
-    responses_call = mgr.handle(
-        {"action": "analyze", "input": {"image_path": str(img), "question": "Q"}, "reasoning": "responses-wire"}
-    )
-    assert chat_call == responses_call == {"status": "ok", "analysis": "same answer"}
-
-
 # ---------------------------------------------------------------------------
 # preset borrowing: one call may borrow another allowed preset's vision service
 # ---------------------------------------------------------------------------

--- a/tests/test_tool_glossary.py
+++ b/tests/test_tool_glossary.py
@@ -471,6 +471,11 @@ assert "file" in _ALL_PACKAGES
 assert not ({"read", "write", "edit", "glob", "grep"} & set(_ALL_PACKAGES))
 
 
+def test_file_zh_glossary_keeps_read_action_term():
+    """The localized file glossary keeps a bridge to its canonical action name."""
+    assert "read" in load_tool_glossary("lingtai.tools.file", "zh")
+
+
 class TestAllGlossaryOwnerInvariance:
     @pytest.mark.parametrize("pkg", _ALL_PACKAGES)
     def test_english_body_empty(self, pkg):
@@ -495,8 +500,8 @@ class TestAllGlossaryOwnerInvariance:
     def test_frontmatter_stripped(self, pkg):
         for lang in ("zh", "wen"):
             body = load_tool_glossary(f"lingtai.tools.{pkg}", lang)
-            assert "kind:" not in body
-            assert "schema_version:" not in body
+            for marker in ("---", "kind:", "tool_package:", "schema_version:"):
+                assert marker not in body
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tool_glossary.py
+++ b/tests/test_tool_glossary.py
@@ -214,33 +214,6 @@ class TestStrictGrammar:
 
 
 class TestLoadToolGlossary:
-    def test_english_body_is_empty(self):
-        body = load_tool_glossary("lingtai.tools.file", "en")
-        assert body == ""
-
-    def test_chinese_body_is_non_empty(self):
-        body = load_tool_glossary("lingtai.tools.file", "zh")
-        assert body.strip()
-        assert "read" in body
-
-    def test_wen_body_is_non_empty(self):
-        body = load_tool_glossary("lingtai.tools.file", "wen")
-        assert body.strip()
-
-    def test_wen_uses_classical_chinese_not_zh(self):
-        """wen must use classical Chinese vocabulary, not be identical to zh."""
-        zh = load_tool_glossary("lingtai.tools.file", "zh")
-        wen = load_tool_glossary("lingtai.tools.file", "wen")
-        assert zh != wen, "wen body must not be identical to zh body"
-
-    def test_frontmatter_never_in_body(self):
-        for lang in ("zh", "wen"):
-            body = load_tool_glossary("lingtai.tools.file", lang)
-            assert "---" not in body
-            assert "kind:" not in body
-            assert "tool_package:" not in body
-            assert "schema_version:" not in body
-
     def test_unknown_package_returns_empty(self):
         with pytest.warns(UserWarning, match="ModuleNotFoundError") as caught:
             body = load_tool_glossary("lingtai.tools.nonexistent", "zh")

--- a/tests/test_vision_capability.py
+++ b/tests/test_vision_capability.py
@@ -279,6 +279,7 @@ def test_claude_family_returns_cli_guidance_not_service(tmp_path, provider):
     assert mgr._vision_service is None
     assert "claude -p" in mgr._manual_reason
     assert "vision(action='manual'" in mgr._manual_reason
+    assert mgr.manual()["status"] in {"ok", "degraded"}
     result = mgr._dispatch_analyze({"image_path": "x.png", "question": None})
     assert result["status"] == "error"
     assert "claude -p" in result["message"]
@@ -1281,6 +1282,7 @@ def test_vision_setup_unsupported_provider_keeps_manual_route(tmp_path):
 def test_vision_setup_without_provider_keeps_manual_route(tmp_path):
     agent = make_mock_agent(tmp_path)
     mgr = setup(agent)
+    assert isinstance(mgr, VisionManager)
     assert mgr.manual()["status"] in {"ok", "degraded"}
 
 

--- a/tests/test_vision_capability.py
+++ b/tests/test_vision_capability.py
@@ -67,85 +67,6 @@ def make_provider_agent(
     return make_mock_agent(tmp_path, svc=svc)
 
 
-def test_vision_added_by_setup(tmp_path):
-    """setup() should register the vision tool on the agent."""
-    mock_svc = MagicMock(spec=VisionService)
-    agent = make_mock_agent(tmp_path)
-    mgr = setup(agent, vision_service=mock_svc)
-    agent.add_tool.assert_called_once()
-    assert agent.add_tool.call_args[1]["schema"] is not None or agent.add_tool.call_args[0][1] is not None
-    assert isinstance(mgr, VisionManager)
-
-
-def test_vision_with_dedicated_service(tmp_path):
-    """Vision capability should use VisionService if provided."""
-    mock_vision_svc = MagicMock(spec=VisionService)
-    mock_vision_svc.analyze_image.return_value = "A dog in the park"
-
-    agent = make_mock_agent(tmp_path)
-    mgr = VisionManager(agent, vision_service=mock_vision_svc)
-
-    img_path = tmp_path / "test.jpg"
-    img_path.write_bytes(b"\xff\xd8\xff fake jpeg")
-    result = mgr.handle(analyze(str(img_path)))
-    assert result["status"] == "ok"
-    assert "dog" in result["analysis"]
-    mock_vision_svc.analyze_image.assert_called_once()
-
-
-def test_vision_missing_image(tmp_path):
-    """Vision should return error for missing image file."""
-    mock_vision_svc = MagicMock(spec=VisionService)
-    agent = make_mock_agent(tmp_path)
-    mgr = VisionManager(agent, vision_service=mock_vision_svc)
-    result = mgr.handle(analyze("/nonexistent/image.png"))
-    assert result.get("status") == "error"
-
-
-def test_vision_relative_path(tmp_path):
-    """VisionManager should resolve relative paths against working directory."""
-    mock_vision_svc = MagicMock(spec=VisionService)
-    mock_vision_svc.analyze_image.return_value = "An image"
-
-    agent = make_mock_agent(tmp_path)
-    mgr = VisionManager(agent, vision_service=mock_vision_svc)
-    img_path = tmp_path / "photo.png"
-    img_path.write_bytes(b"\x89PNG fake")
-    result = mgr.handle(analyze("photo.png"))
-    assert result["status"] == "ok"
-    mock_vision_svc.analyze_image.assert_called_once_with(str(img_path), prompt="Describe what you see in this image.")
-
-
-def test_vision_service_error_handled(tmp_path):
-    """VisionManager should catch VisionService exceptions and return error dict."""
-    mock_vision_svc = MagicMock(spec=VisionService)
-    mock_vision_svc.analyze_image.side_effect = RuntimeError("API down")
-
-    agent = make_mock_agent(tmp_path)
-    mgr = VisionManager(agent, vision_service=mock_vision_svc)
-    img_path = tmp_path / "test.png"
-    img_path.write_bytes(b"\x89PNG fake")
-    result = mgr.handle(analyze(str(img_path)))
-    assert result["status"] == "error"
-    assert "API down" not in result["message"]
-    assert "RuntimeError" in result["message"]
-
-
-def test_vision_service_error_does_not_echo_secret_or_url(tmp_path):
-    mock_vision_svc = MagicMock(spec=VisionService)
-    mock_vision_svc.analyze_image.side_effect = RuntimeError(
-        "token=secret https://user:pw@example.test/v1"
-    )
-    agent = make_mock_agent(tmp_path)
-    mgr = VisionManager(agent, vision_service=mock_vision_svc)
-    img_path = tmp_path / "test.png"
-    img_path.write_bytes(b"fake")
-    result = mgr.handle(analyze(str(img_path)))
-    assert result["status"] == "error"
-    assert "secret" not in result["message"]
-    assert "example.test" not in result["message"]
-
-
 @pytest.mark.parametrize(
     "provider",
     ["openrouter", "deepseek", "zhipu", "glm", "grok", "qwen", "kimi", "custom"],
@@ -257,18 +178,6 @@ def test_generic_openai_compatible_unknown_wire_remains_manual(tmp_path):
     assert "unproven_wire" not in result["message"]
 
 
-def test_claude_code_remains_manual_only(tmp_path):
-    """Claude Code providers return explicit "use the Claude CLI" guidance."""
-    agent = make_provider_agent(
-        tmp_path, provider="claude-code", model="text-only", base_url="https://relay.example/v1"
-    )
-    mgr = setup(agent, provider="claude-code", api_key="sk-test")
-    assert mgr._vision_service is None
-    assert "claude -p" in mgr._manual_reason
-    assert "vision(action='manual'" in mgr._manual_reason
-    assert mgr.manual()["status"] in {"ok", "degraded"}
-
-
 @pytest.mark.parametrize("provider", ["claude-p", "claude-code", "claude_code"])
 def test_claude_family_returns_cli_guidance_not_service(tmp_path, provider):
     """Every claude-family spelling routes to the claude-cli guidance comment."""
@@ -283,19 +192,6 @@ def test_claude_family_returns_cli_guidance_not_service(tmp_path, provider):
     result = mgr._dispatch_analyze({"image_path": "x.png", "question": None})
     assert result["status"] == "error"
     assert "claude -p" in result["message"]
-
-
-def test_vision_empty_response_is_error(tmp_path):
-    """VisionManager should return error when service returns empty string."""
-    mock_vision_svc = MagicMock(spec=VisionService)
-    mock_vision_svc.analyze_image.return_value = ""
-
-    agent = make_mock_agent(tmp_path)
-    mgr = VisionManager(agent, vision_service=mock_vision_svc)
-    img_path = tmp_path / "test.png"
-    img_path.write_bytes(b"\x89PNG fake")
-    result = mgr.handle(analyze(str(img_path)))
-    assert result["status"] == "error"
 
 
 def test_vision_setup_with_provider_and_key(tmp_path):
@@ -1498,21 +1394,6 @@ def test_vision_service_abc_cannot_instantiate():
     """VisionService ABC should not be instantiable directly."""
     with pytest.raises(TypeError):
         VisionService()
-
-
-def test_vision_empty_image_path(tmp_path):
-    """VisionManager should return error for empty image path."""
-    mock_vision_svc = MagicMock(spec=VisionService)
-    agent = make_mock_agent(tmp_path)
-    mgr = VisionManager(agent, vision_service=mock_vision_svc)
-    result = mgr.handle(analyze(""))
-    assert result["status"] == "error"
-    assert "image_path" in result["message"].lower() or "provide" in result["message"].lower()
-
-
-def test_vision_setup_no_provider_is_manual_only(tmp_path):
-    agent = make_mock_agent(tmp_path)
-    assert isinstance(setup(agent), VisionManager)
 
 
 def make_custom_agent(tmp_path, *, api_compat=None, base_url=None, model=None):

--- a/tests/test_web_canonical_provider_routing.py
+++ b/tests/test_web_canonical_provider_routing.py
@@ -168,8 +168,7 @@ def test_provider_kwarg_rejects_gated_engines_at_composition(tmp_path, engine):
     mock_factory.assert_not_called()
 
 
-@pytest.mark.parametrize("engine", ["anthropic", "gemini"])
-def test_settings_only_provider_error_is_not_a_retired_provider_error(tmp_path, engine):
+def test_settings_only_provider_error_is_not_a_retired_provider_error():
     # The two error classes must stay distinct types -- a caller catching
     # only RetiredProviderError must not accidentally swallow a
     # SettingsOnlyProviderError for an active canonical provider.

--- a/tests/test_web_canonical_provider_routing.py
+++ b/tests/test_web_canonical_provider_routing.py
@@ -160,8 +160,12 @@ def test_default_engine_kwarg_rejects_gated_engines_at_composition(tmp_path, eng
 
 @pytest.mark.parametrize("engine", ["anthropic", "gemini"])
 def test_provider_kwarg_rejects_gated_engines_at_composition(tmp_path, engine):
-    with pytest.raises(SettingsOnlyProviderError):
+    with (
+        patch("lingtai.services.websearch.create_search_service") as mock_factory,
+        pytest.raises(SettingsOnlyProviderError),
+    ):
         setup(_agent(tmp_path, engine), provider=engine, api_key="x", browser_port=_Port())
+    mock_factory.assert_not_called()
 
 
 @pytest.mark.parametrize("engine", ["anthropic", "gemini"])
@@ -333,8 +337,12 @@ def test_error_hierarchy_openai_anthropic_gemini_share_search_provider_error_bas
 
 @pytest.mark.parametrize("retired", ["minimax", "zhipu"])
 def test_provider_kwarg_rejects_retired_providers_explicitly(tmp_path, retired):
-    with pytest.raises(RetiredProviderError):
+    with (
+        patch("lingtai.services.websearch.create_search_service") as mock_factory,
+        pytest.raises(RetiredProviderError),
+    ):
         setup(_agent(tmp_path, "openai"), provider=retired, api_key="x", browser_port=_Port())
+    mock_factory.assert_not_called()
 
 
 @pytest.mark.parametrize("retired", ["minimax", "zhipu"])

--- a/tests/test_web_search_capability.py
+++ b/tests/test_web_search_capability.py
@@ -6,34 +6,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from lingtai.agent import Agent
-from lingtai.tools.web_search import RetiredProviderError, SettingsOnlyProviderError, WebManager, setup
+from lingtai.tools.web_search import WebManager, setup
 from lingtai.services.websearch import SearchResult, SearchService, create_search_service
 from tests._service_helpers import make_gemini_mock_service as make_mock_service
 
 
-
-
-def test_web_added_by_capability(tmp_path):
-    """capabilities with provider should register the web tool."""
-    agent = Agent(service=make_mock_service(), agent_name="test", working_dir=tmp_path,
-                       capabilities={"web": {"provider": "duckduckgo"}})
-    assert "web" in agent._tool_handlers
-
-
-def test_web_with_dedicated_service():
-    """web capability should use SearchService if provided."""
-    mock_result = MagicMock()
-    mock_result.title = "Python"
-    mock_result.url = "https://python.org"
-    mock_result.snippet = "Python programming language"
-    mock_search_svc = MagicMock()
-    mock_search_svc.search.return_value = [mock_result]
-    agent = MagicMock()
-    mgr = WebManager(agent, search_service=mock_search_svc)
-    result = mgr.handle({"action": "search", "input": {"query": "python"}})
-    assert result["status"] == "ok"
-    assert result["results"][0]["title"] == "Python"
-    mock_search_svc.search.assert_called_once()
 
 
 def test_web_missing_query(tmp_path):
@@ -161,57 +138,6 @@ def test_web_setup_api_key_env_overrides_raw_key(monkeypatch):
         mgr.handle({"action": "search", "input": {"query": "test"}})
 
     assert mock_factory.call_args.kwargs["api_key"] == "sk-from-env"
-
-
-def test_web_setup_provider_kwarg_rejects_gemini():
-    """provider= must never select a settings-only canonical engine, even
-    with a key. Anthropic/Gemini are active canonical providers, never
-    "retired" -- this raises SettingsOnlyProviderError, not RetiredProviderError."""
-    agent = MagicMock()
-    agent._config.language = "en"
-    agent.service.provider = "gemini"
-
-    with patch("lingtai.services.websearch.create_search_service") as mock_factory:
-        with pytest.raises(SettingsOnlyProviderError):
-            setup(agent, provider="gemini", api_key="sk-test")
-
-    mock_factory.assert_not_called()
-
-
-def test_web_setup_minimax_provider_kwarg_fails_explicitly():
-    """MiniMax leaves built-in admission; setup() fails explicitly, never DuckDuckGo."""
-    agent = MagicMock()
-    agent._config.language = "en"
-
-    with patch("lingtai.services.websearch.create_search_service") as mock_factory:
-        with pytest.raises(RetiredProviderError):
-            setup(agent, provider="minimax", api_key="sk-test")
-
-    mock_factory.assert_not_called()
-
-
-def test_web_setup_zhipu_provider_kwarg_fails_explicitly():
-    """Zhipu leaves built-in admission; setup() fails explicitly, never DuckDuckGo."""
-    agent = MagicMock()
-    agent._config.language = "en"
-
-    with patch("lingtai.services.websearch.create_search_service") as mock_factory:
-        with pytest.raises(RetiredProviderError):
-            setup(agent, provider="zhipu", api_key="sk-test")
-
-    mock_factory.assert_not_called()
-
-
-def test_web_engines_map_rejects_minimax_compatibility_admission():
-    """The map-shaped engines= path also refuses minimax/zhipu compatibility admission."""
-    agent = MagicMock()
-    agent._config.language = "en"
-
-    with patch("lingtai.services.websearch.create_search_service") as mock_factory:
-        with pytest.raises(RetiredProviderError):
-            setup(agent, engines={"minimax": {"api_key": "sk-test"}})
-
-    mock_factory.assert_not_called()
 
 
 def test_inherited_web_env_key_registers(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

This branch implements all 23 K-H units by placing shared vision/web/glossary assertions in authoritative owners before removing or de-parametrizing subsumed cases.

- Branch: `tzzheng/consolidate-vision-web-tests`
- Head: `16c9b0e4`
- Exact scope: **5 files changed, 57 insertions, 251 deletions**

## What changed

- Put the two distinct `reasoning` rows and behavioral no-leak check in the dedicated vision metadata owner, while keeping the exact C11 service call in the one-run success-shape owner.
- Consolidated exact vision input/error/manual behavior, gated and retired web provider routing, and all-owner glossary invariants; the glossary owner now checks `---` and `tool_package:` alongside existing markers.
- Applied the shared MiniMax/Zhipu owner edit once and de-parametrized the semantically invariant web error-class case.
- Owner commit `5f3dffd3` precedes removal commit `16c9b0e4`.

## Validation

- **RED chronology:** stored high-stakes probes show real retained-owner failures for empty vision success, provider-error leakage, missing/empty image paths, and retired-provider admission. All temporary `src/` mutations were restored; the post-restore high-stakes run was **7 passed**.
- Parent exact-head gates passed: focused placement **3 passed**, direct vision/web/glossary gate **553 passed**, and coherent related-family gate **881 passed**.
- The broader exploratory family set found one unchanged daemon-schema mismatch: the test omits an existing `plugin` field. The test file is byte-identical to the exact base and K-H has no `src/` diff. The 881-test gate excludes only that proven adjacent base mismatch; it uses no hidden failure smoothing.

## Review

Literal Opus 5 review (`claude-opus-5`, high, plan): **PASS**, with **P0=0, P1=0, P2=3**. The reviewer independently reproduced the exact three-row placement, all five changed files (**416 passed**), the **553** direct gate, and the **881** coherent gate.

The three non-blocking P2s are: the report labels a patch-id as an original commit object even though patch equivalence is real; validation uses the sibling K-A virtualenv because K-H has no local one; and the removed C4 test's two calls shared one manager whereas the two replacement parameters use fresh managers, with no asserted stateful behavior lost.

## Boundaries

- **No production, documentation, Anatomy, Contract, or other audit-unit changes.** The diff is exactly five test files.
- The daemon-schema base debt remains untouched and explicitly outside the passing gate.
- No runtime-performance or full-suite claim is made.

Related: full-corpus test audit
