### PR TITLE
feat(taskcard): show active/terminal daemon counts + stats and absolute path

### DIFF
--- a/src/lingtai/mcp_servers/task_card/event_projection.py
+++ b/src/lingtai/mcp_servers/task_card/event_projection.py
@@ -739,26 +739,68 @@ class TaskCardEventProjection:
             line2_parts.append("device · " + " · ".join(parts))
         working_dir = cls.machine_identifier(metadata.get("working_dir"), limit=220)
         if working_dir is not None:
-            line2_parts.append(f"path · {cls._short_working_dir(working_dir)}")
+            line2_parts.append(f"path · {working_dir}")
         line2 = " | ".join(line2_parts) if line2_parts else None
 
-        lines = [ln for ln in (line1, line2) if ln]
+        # Daemon status + statistics: active runs plus terminal runs finished
+        # within the last ten minutes. Counts only (no id lists); the stats
+        # line aggregates token input/output/cached and call counts over the
+        # same window. Nothing renders when no daemon is in scope.
+        daemons = metadata.get("daemons")
+        line3: str | None = None
+        line4: str | None = None
+        if isinstance(daemons, dict):
+            status_parts: list[str] = []
+            active = daemons.get("active")
+            if isinstance(active, int) and active > 0:
+                status_parts.append(f"active {active}")
+            for key in ("failed", "done", "cancelled", "timeout"):
+                count = daemons.get(key)
+                if isinstance(count, int) and count > 0:
+                    status_parts.append(f"{key} {count}")
+            if status_parts:
+                line3 = "daemons · " + " · ".join(status_parts)
+            stats_parts: list[str] = []
+            input_tokens = daemons.get("input_tokens")
+            output_tokens = daemons.get("output_tokens")
+            cached_tokens = daemons.get("cached_tokens")
+            calls = daemons.get("calls")
+            if isinstance(input_tokens, int) and input_tokens > 0:
+                stats_parts.append(f"in {cls.format_count(input_tokens)}")
+            if isinstance(output_tokens, int) and output_tokens > 0:
+                stats_parts.append(f"out {cls.format_count(output_tokens)}")
+            if (
+                isinstance(cached_tokens, int)
+                and isinstance(input_tokens, int)
+                and input_tokens > 0
+                and cached_tokens > 0
+            ):
+                stats_parts.append(f"cache {min(cached_tokens / input_tokens, 1.0):.1%}")
+            if isinstance(calls, int) and calls > 0:
+                stats_parts.append(f"calls {calls}")
+            if stats_parts:
+                line4 = "daemon stats · " + " · ".join(stats_parts)
+
+        lines = [ln for ln in (line1, line2, line3, line4) if ln]
         if not lines:
             return []
         joined = "\n".join(lines)
         if len(joined) <= cls.METADATA_MAX_CHARS:
             return lines
-        # Prefer preserving the session line; truncate from the identity line.
-        budget1 = cls.METADATA_MAX_CHARS
-        if len(lines) > 1:
-            budget1 = min(budget1, len(lines[0]) + 1)
+        # Prefer preserving the session line; truncate from the identity line
+        # and keep as many trailing lines as fit, each cut at its share.
         first = lines[0][: cls.METADATA_MAX_CHARS]
-        if len(lines) == 1:
-            return [first]
         remaining = cls.METADATA_MAX_CHARS - len(first) - 1
         if remaining <= 0:
             return [first]
-        return [first, lines[1][:remaining]]
+        kept = [first]
+        for extra in lines[1:]:
+            if remaining <= 0:
+                break
+            take = min(len(extra), remaining)
+            kept.append(extra[:take])
+            remaining -= take + 1
+        return kept
 
     @classmethod
     def _short_working_dir(cls, working_dir: str) -> str:

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -2381,7 +2381,94 @@ class TelegramManager:
                 shell_kind = ""
         if shell_kind:
             snapshot["shell_name"] = shell_kind
+        daemon_snapshot = self._task_card_daemon_snapshot()
+        if daemon_snapshot:
+            snapshot["daemons"] = daemon_snapshot
         return snapshot or None
+
+    def _task_card_daemon_snapshot(self) -> dict | None:
+        """Read-only daemon status/statistics for the resident Task Card.
+
+        Scans ``<working_dir>/daemons/*`` state files (``daemon.json``, falling
+        back to legacy ``n``) and returns counts plus token statistics over the
+        active runs plus terminal runs finished within the last ten minutes.
+        Terminal runs older than the window are excluded so the card does not
+        accumulate a permanent daemon history. Missing/invalid state files
+        degrade silently; an empty scan returns ``None`` so no line renders.
+        """
+        daemons_dir = self._working_dir / "daemons"
+        if not daemons_dir.is_dir():
+            return None
+        now = datetime.now(timezone.utc)
+        active = 0
+        terminal_counts: dict[str, int] = {
+            "done": 0,
+            "failed": 0,
+            "cancelled": 0,
+            "timeout": 0,
+        }
+        totals = {"input": 0, "output": 0, "cached": 0, "calls": 0}
+        included = False
+        for run_path in daemons_dir.iterdir():
+            if not run_path.is_dir():
+                continue
+            state: dict | None = None
+            for candidate in ("daemon.json", "n"):
+                state_path = run_path / candidate
+                if not state_path.is_file():
+                    continue
+                try:
+                    loaded = json.loads(state_path.read_text(encoding="utf-8"))
+                except (OSError, ValueError, json.JSONDecodeError, UnicodeDecodeError):
+                    continue
+                if isinstance(loaded, dict):
+                    state = loaded
+                    break
+            if not state:
+                continue
+            status = state.get("state")
+            in_window = False
+            if status in ("running", "active"):
+                active += 1
+                in_window = True
+            elif status in terminal_counts:
+                finished_at = state.get("finished_at")
+                if isinstance(finished_at, str):
+                    try:
+                        finished_dt = datetime.fromisoformat(
+                            finished_at[:-1] + "+00:00"
+                            if finished_at.endswith("Z")
+                            else finished_at
+                        )
+                        if finished_dt.tzinfo is None:
+                            finished_dt = finished_dt.replace(tzinfo=timezone.utc)
+                        age = (now - finished_dt).total_seconds()
+                        if 0 <= age <= 600:
+                            terminal_counts[status] += 1
+                            in_window = True
+                    except ValueError:
+                        pass
+            if not in_window:
+                continue
+            included = True
+            tokens = state.get("tokens")
+            if not isinstance(tokens, dict):
+                tokens = state.get("cli_tokens")
+            if isinstance(tokens, dict):
+                for key in ("input", "output", "cached", "calls"):
+                    value = tokens.get(key)
+                    if isinstance(value, (int, float)) and not isinstance(value, bool):
+                        totals[key] += int(value)
+        if not included and active == 0 and not any(terminal_counts.values()):
+            return None
+        return {
+            "active": active,
+            **terminal_counts,
+            "input_tokens": totals["input"],
+            "output_tokens": totals["output"],
+            "cached_tokens": totals["cached"],
+            "calls": totals["calls"],
+        }
 
     def _task_card_current_model(self) -> str | None:
         """Read the agent's current LLM model from ``.agent.json``.

--- a/tests/test_telegram_task_card_rows.py
+++ b/tests/test_telegram_task_card_rows.py
@@ -664,3 +664,97 @@ def test_event_metadata_snapshot_adds_current_model(tmp_path):
     assert snapshot["model"] == "deepseek-v4-flash"
     assert "device_short_name" in snapshot
     assert "working_dir" in snapshot
+
+
+def test_metadata_renders_absolute_path_not_shortened():
+    lines = TelegramManager._format_task_card_metadata({
+        "working_dir": "/Users/huangzesen/work/projects/lingtai-dev/dev-2/.lingtai/mimo-1",
+        "device_short_name": "MacStudio",
+    })
+    assert len(lines) == 1
+    assert "device · MacStudio | path · /Users/huangzesen/work/projects/lingtai-dev/dev-2/.lingtai/mimo-1" in lines[0]
+    assert "dev-2/.lingtai/mimo-1" not in lines[0].replace("dev-2/.lingtai/mimo-1", "")
+
+
+def test_metadata_renders_daemon_status_and_stats():
+    lines = TelegramManager._format_task_card_metadata({
+        "daemons": {
+            "active": 3,
+            "failed": 1,
+            "done": 2,
+            "cancelled": 0,
+            "timeout": 0,
+            "input_tokens": 1_234_567,
+            "output_tokens": 340_000,
+            "cached_tokens": 1_049_382,
+            "calls": 12,
+        },
+    })
+    assert lines == [
+        "daemons · active 3 · failed 1 · done 2",
+        "daemon stats · in 1.2M · out 340.0k · cache 85.0% · calls 12",
+    ]
+
+
+def test_metadata_omits_daemon_lines_when_no_daemons():
+    lines = TelegramManager._format_task_card_metadata({
+        "working_dir": "/Users/huangzesen/work/projects/lingtai-dev/dev-2/.lingtai/mimo-1",
+        "daemons": {"active": 0, "failed": 0, "done": 0, "cancelled": 0, "timeout": 0},
+    })
+    assert len(lines) == 1
+    assert "daemons" not in lines[0]
+    assert "daemon stats" not in lines[0]
+
+
+def test_metadata_daemon_stats_require_positive_counts():
+    lines = TelegramManager._format_task_card_metadata({
+        "daemons": {
+            "active": 1,
+            "failed": 0,
+            "done": 0,
+            "cancelled": 0,
+            "timeout": 0,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cached_tokens": 0,
+            "calls": 0,
+        },
+    })
+    assert lines == ["daemons · active 1"]
+
+
+def test_daemon_snapshot_scans_daemons_dir_and_windows(tmp_path):
+    import json as _json
+    from datetime import datetime, timedelta, timezone
+
+    daemons = tmp_path / "daemons"
+    (daemons / "em-1").mkdir(parents=True)
+    (daemons / "em-2").mkdir()
+    (daemons / "em-3").mkdir()
+    (daemons / "em-4").mkdir()
+    now = datetime.now(timezone.utc)
+    recent = (now - timedelta(minutes=2)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    old = (now - timedelta(minutes=30)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    for name, state in [
+        ("em-1", {"state": "running", "tokens": {"input": 1000, "output": 500, "cached": 800, "calls": 3}}),
+        ("em-2", {"state": "done", "finished_at": recent, "tokens": {"input": 2000, "output": 700, "cached": 1500, "calls": 4}}),
+        ("em-3", {"state": "failed", "finished_at": recent, "cli_tokens": {"input": 3000, "output": 100, "cached": 0, "calls": 1}}),
+        ("em-4", {"state": "done", "finished_at": old, "tokens": {"input": 9999, "output": 9999, "cached": 9999, "calls": 99}}),
+    ]:
+        (daemons / name / "daemon.json").write_text(_json.dumps(state), encoding="utf-8")
+
+    mgr, _ = _integration_manager(tmp_path)
+    snap = mgr._task_card_daemon_snapshot()
+    assert snap["active"] == 1
+    assert snap["done"] == 1
+    assert snap["failed"] == 1
+    # em-4 outside the 10-minute window is excluded entirely.
+    assert snap["input_tokens"] == 1000 + 2000 + 3000
+    assert snap["output_tokens"] == 500 + 700 + 100
+    assert snap["cached_tokens"] == 800 + 1500 + 0
+    assert snap["calls"] == 3 + 4 + 1
+
+
+def test_daemon_snapshot_returns_none_when_no_daemons(tmp_path):
+    mgr, _ = _integration_manager(tmp_path)
+    assert mgr._task_card_daemon_snapshot() is None


### PR DESCRIPTION
## Summary

Task Card footer now renders up to four metadata lines:
- **line1** agent lifecycle + session identity/usage (unchanged)
- **line2** device + shell + **absolute** working_dir path (path no longer shortened to `<project>/.lingtai/<agent>`)
- **line3** daemon status counts (`daemons · active 3 · failed 1 · done 2`) limited to running daemons plus terminal runs finished within the last **10 minutes**
- **line4** aggregated daemon token statistics (`daemon stats · in 1.2M · out 340k · cache 85% · calls 12`) over the same active-plus-10-minute window

Metadata snapshot reads `<workdir>/daemons/*/daemon.json` (falling back to legacy `n`) **read-only**; missing/invalid state files degrade silently, and no line renders when no daemon is in scope. Terminal runs older than the 10-minute window are excluded so the card does not accumulate a permanent daemon history.

Requested by Jason (Telegram 11711/11724/11728): show current active/failed/finished daemons as counts (not id lists), terminal entries visible for 10 minutes then removed, plus daemon stats (token usage, cache rate, calls); also always show the path as absolute.

## Validation

- `tests/test_telegram_task_card_rows.py`: **52 passed** (6 new focused tests: absolute path, daemon status/stats rendering, no-daemon omission, positive-count stats, daemon.json scan with 10-minute window, empty scan).
- `tests/test_task_card_event_projection_shared.py` + `tests/test_telegram_task_card.py`: **88 passed** on the modified files.
- Full taskcard family: 346 passed; the 8 failures are **pre-existing** in `test_telegram_task_card_blockers/toggle/transport` — confirmed identical on clean base `2fb5cfa2` (8 failed, 42 passed in the same files).
- `git diff --check` clean.

Telegram: @lingtaidev2bot | Nickname: 观一-lingtaidev2bot
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
