### PR TITLE
fix(claude-code): disable all built-in tools via --tools "" for pure reasoning core

### DIFF
--- a/src/lingtai/llm/claude_code/adapter.py
+++ b/src/lingtai/llm/claude_code/adapter.py
@@ -39,9 +39,13 @@ from lingtai.llm.interface_converters import _project_tool_result
 logger = get_logger()
 
 
-# Claude Code built-in tools we disable so the CLI behaves as a pure reasoning
-# core: it must only emit our JSON action, never go off and read/edit/run things.
-# Unknown names here are harmless (the CLI just warns on stderr).
+# Legacy explicit disallow list. The default no longer uses it: with
+# ``disallowed_tools=None`` the adapter passes ``--tools ""`` to disable EVERY
+# Claude Code built-in tool (a pure reasoning core that only emits our JSON
+# action), which also strips the remaining built-in tool schemas
+# (Workflow/PowerShell/DesignSync/Monitor etc.) from every API request. This
+# constant remains for callers that want a partial disallow. Unknown names are
+# harmless (the CLI just warns on stderr).
 DEFAULT_DISALLOWED_TOOLS = (
     "Bash",
     "BashOutput",
@@ -583,10 +587,14 @@ class ClaudeCodeAdapter(LLMAdapter):
         self._system_prompt_mode = system_prompt_mode
         self._model = model or "sonnet"
         self._cli_path = cli_path
+        # Default (disallowed_tools=None) disables EVERY Claude Code built-in
+        # tool via ``--tools ""`` — the CLI becomes a pure reasoning core and
+        # the remaining built-in tool schemas (Workflow/PowerShell/DesignSync/
+        # Monitor etc.) no longer inflate every request. A caller that wants a
+        # partial disallow passes an explicit tool list instead.
+        self._disable_all_builtin_tools = disallowed_tools is None
         self._disallowed = (
-            list(disallowed_tools)
-            if disallowed_tools is not None
-            else list(DEFAULT_DISALLOWED_TOOLS)
+            list(disallowed_tools) if disallowed_tools is not None else []
         )
         self._timeout_s = timeout_s
         self._strip_env = tuple(strip_env) if strip_env is not None else DEFAULT_STRIP_ENV
@@ -747,7 +755,14 @@ class ClaudeCodeAdapter(LLMAdapter):
             cmd += ["--model", model]
         if resume_session_id:
             cmd += ["--resume", resume_session_id]
-        if self._disallowed:
+        if self._disable_all_builtin_tools:
+            # Disable every Claude Code built-in tool. ``--tools ""`` removes
+            # all built-in tool schemas from the API request — a ~85% token cut
+            # on the stable prefix vs the old 14-name ``--disallowedTools``
+            # list, which left the large schemas (Workflow/PowerShell/
+            # DesignSync/Monitor) in the request.
+            cmd += ["--tools", ""]
+        elif self._disallowed:
             cmd += ["--disallowedTools", *self._disallowed]
         if system_prompt_file is _UNSET:
             system_prompt_file = self._system_prompt_file

--- a/tests/test_claude_code_adapter.py
+++ b/tests/test_claude_code_adapter.py
@@ -247,7 +247,7 @@ def test_tool_result_roundtrip_updates_interface():
 # ---------------------------------------------------------------------------
 
 
-def test_command_includes_print_json_model_and_disallowed_tools():
+def test_command_includes_print_json_model_and_disables_all_builtin_tools():
     ad = ClaudeCodeAdapter(model="opus")
     sess = ad.create_chat("opus", "sys", None)
     captured = {}
@@ -263,7 +263,12 @@ def test_command_includes_print_json_model_and_disallowed_tools():
     assert cmd[0] == "claude"
     assert "-p" in cmd and "--output-format" in cmd and "json" in cmd
     assert "--model" in cmd and "opus" in cmd
-    assert "--disallowedTools" in cmd and "Bash" in cmd
+    # Default: disable every Claude Code built-in tool via --tools "" so the
+    # CLI is a pure reasoning core and the built-in tool schemas (Workflow /
+    # PowerShell / DesignSync / Monitor etc.) do not inflate the request.
+    assert "--tools" in cmd
+    assert cmd[cmd.index("--tools") + 1] == ""
+    assert "--disallowedTools" not in cmd
     # prompt is piped via stdin, not argv
     assert captured["kw"]["input"]
     # Stable context (protocol/system/tools) lives in the system-prompt file
@@ -283,6 +288,25 @@ def test_command_includes_print_json_model_and_disallowed_tools():
     assert "(no tools available" in sp_content  # create_chat called with None
     assert "sys" in sp_content  # the system prompt text
     assert "You are the REASONING CORE" in sp_content  # the action protocol
+
+
+def test_explicit_disallowed_tools_keeps_disallowed_tools_flag():
+    ad = ClaudeCodeAdapter(model="opus", disallowed_tools=["Bash", "Read"])
+    sess = ad.create_chat("opus", "sys", None)
+    captured = {}
+
+    def fake_run(cmd, **kw):
+        captured["cmd"] = cmd
+        captured["kw"] = kw
+        return _FakeProc(stdout=_envelope('{"action":"final","text":"ok"}'))
+
+    with patch("lingtai.llm.claude_code.adapter.subprocess.run", side_effect=fake_run):
+        sess.send("hi")
+    cmd = captured["cmd"]
+    # An explicit disallow list keeps the legacy --disallowedTools flag.
+    assert "--disallowedTools" in cmd
+    assert "Bash" in cmd and "Read" in cmd
+    assert "--tools" not in cmd
 
 
 def test_append_system_prompt_mode_keeps_legacy_flag():


### PR DESCRIPTION
## Summary

The `claude_code` adapter previously passed a 14-name `--disallowedTools` list (Bash/Read/Write/Edit/Glob/Grep/...), which left the **largest** built-in tool schemas — Workflow, PowerShell, DesignSync, Monitor — in every API request. Those are exactly the tools that dominate the stable prompt prefix.

This PR changes the default to `--tools ""`, which Claude Code's own help documents as *“Use `""` to disable all tools”*. The CLI becomes a pure reasoning core that can only emit LingTai's JSON action protocol; LingTai's own tools remain available exactly as before (rendered into the system-prompt block / mounted via MCP). Callers that need a partial disallow can still pass an explicit `disallowed_tools` list, which keeps the legacy `--disallowedTools` flag.

## Measurement (Claude Code 2.1.220, same trivial task, LingTai block ≈451 chars)

| Config | tokens | vs default |
|---|---|---|
| default (native prompt + 28 built-in tools) | ~24,937 | — |
| old: `--disallowedTools` 14 names | ~15,974 | -36% |
| new: `--tools ""` (all built-ins disabled) + replaced system prompt | **~3,796** | **-85%** |

External evidence: a captured real Claude Code request shows tool definitions are ~81% of the request (94 KB ≈ 23.4k tokens for 28 tools); the system-prompt instruction layer is only ~6%. Restricting the tool set is how other integrations cut this overhead.

## Tests

- `tests/test_claude_code_adapter.py` — 38 passed (updated default assertion + new explicit-list test)
- `tests/test_claude_code_effort.py` — 18 passed
- `tests/contracts/llm_conversation_input/` — 188 passed
- ruff clean on changed files

Telegram: @lingtaidev1bot | Nickname: 知微
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
