### PR TITLE
fix(wechat): harden outbound media uploads

### DIFF
--- a/src/lingtai/mcp_servers/wechat/SKILL.md
+++ b/src/lingtai/mcp_servers/wechat/SKILL.md
@@ -125,14 +125,22 @@ ATTACHMENTS below), not a mutually exclusive choice.
 - `send` and `reply` deliver to real users — external side effects. Confirm
   recipient and content before sending unsolicited messages.
 - Actions return a result dict on success or `{'error': <message>}` on failure
-  (e.g. missing `user_id`, unreadable `media_path`). If a combined text+media
-  send delivers text and the later media step fails, the result instead has
-  `status: 'partial'`, `partial_delivery: true`, `text_status: 'sent'`,
-  `media_status: 'failed'`, a redacted `failure` stage, and
-  `automatic_retry_allowed: false`. Do not repeat the whole call automatically;
-  reconcile the delivered text before retrying media alone. The CDN upload step
-  itself makes at most three immediate attempts for transport/TLS failures,
-  HTTP 429/5xx, or a success response missing its encrypted media reference;
-  other 4xx responses are not retried. A local media deadline requests coroutine
-  cancellation, but an already accepted remote request cannot be revoked. Check
+  (e.g. missing `user_id`, unreadable `media_path`). If a later text chunk fails
+  after an earlier chunk was delivered, the result and sent history keep a
+  redacted partial record with delivered/total/failed chunk counts and only the
+  delivered text prefix; `automatic_retry_allowed` is false, so send only the
+  reconciled unsent suffix rather than repeating the whole message. If combined
+  text+media delivery reaches the media step and it fails, the result likewise
+  has `status: 'partial'`, `partial_delivery: true`, `text_status: 'sent'`, a
+  redacted `failure` stage, and `automatic_retry_allowed: false`. Final media
+  message transport failures and HTTP 429/5xx responses have
+  `remote_acceptance: 'unknown'` (and `media_status: 'unknown'`) because iLink
+  might have accepted the message before the response was lost; never retry
+  those automatically, including media-only sends. The CDN-byte upload step is
+  separate and makes at most three immediate attempts for transport/TLS
+  failures, HTTP 429/5xx, or a success response missing its encrypted media
+  reference; other 4xx responses are not retried. A local media deadline
+  requests cancellation and returns its terminal timeout only after the child
+  coroutine actually exits; cancellation cannot revoke a remote request already
+  accepted and a resistant child can extend the wall clock while it exits. Check
   for the `'error'`/partial fields rather than assuming complete delivery.

--- a/src/lingtai/mcp_servers/wechat/SKILL.md
+++ b/src/lingtai/mcp_servers/wechat/SKILL.md
@@ -125,5 +125,14 @@ ATTACHMENTS below), not a mutually exclusive choice.
 - `send` and `reply` deliver to real users — external side effects. Confirm
   recipient and content before sending unsolicited messages.
 - Actions return a result dict on success or `{'error': <message>}` on failure
-  (e.g. missing `user_id`, unreadable `media_path`). Check for the `'error'` key
-  and surface or act on it rather than assuming delivery.
+  (e.g. missing `user_id`, unreadable `media_path`). If a combined text+media
+  send delivers text and the later media step fails, the result instead has
+  `status: 'partial'`, `partial_delivery: true`, `text_status: 'sent'`,
+  `media_status: 'failed'`, a redacted `failure` stage, and
+  `automatic_retry_allowed: false`. Do not repeat the whole call automatically;
+  reconcile the delivered text before retrying media alone. The CDN upload step
+  itself makes at most three immediate attempts for transport/TLS failures,
+  HTTP 429/5xx, or a success response missing its encrypted media reference;
+  other 4xx responses are not retried. A local media deadline requests coroutine
+  cancellation, but an already accepted remote request cannot be revoked. Check
+  for the `'error'`/partial fields rather than assuming complete delivery.

--- a/src/lingtai/mcp_servers/wechat/manager.py
+++ b/src/lingtai/mcp_servers/wechat/manager.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
-from concurrent.futures import TimeoutError as FutureTimeoutError
+from concurrent.futures import Future, TimeoutError as FutureTimeoutError
 import logging
 import os
 import re
@@ -17,6 +17,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from typing import Callable
+
+import httpx
 
 from .types import (
     MessageItemType, WeixinMessage, MessageItem, TextItem,
@@ -58,16 +60,17 @@ SESSION_EXPIRED_ERRCODE = -14
 # A complete media upload can legitimately spend 15 seconds obtaining upload
 # parameters and 3 * 120 seconds in Tencent-style immediate CDN attempts. Give
 # encryption, parsing and scheduler cleanup a fixed 15-second local allowance.
-# Cancellation reconciliation is separately bounded; it cannot revoke a request
-# that a remote endpoint already accepted, but prevents queued coroutine work
-# from continuing after the synchronous caller returns whenever cancellation wins.
+# On deadline expiry _run_async requests cancellation, then waits for actual task
+# exit before it reports a terminal timeout. A cancellation-resistant coroutine
+# can therefore extend the wall clock, but it can never continue invisibly after
+# the synchronous caller has been told the operation ended.
 _MEDIA_LOCAL_OVERHEAD_SECONDS = 15.0
+_ASYNC_TASK_START_TIMEOUT_SECONDS = 1.0
 MEDIA_OPERATION_TIMEOUT_SECONDS = (
     media_mod.GET_UPLOAD_URL_TIMEOUT_SECONDS
     + media_mod.CDN_UPLOAD_MAX_ATTEMPTS * media_mod.CDN_UPLOAD_TIMEOUT_SECONDS
     + _MEDIA_LOCAL_OVERHEAD_SECONDS
 )
-_ASYNC_CANCEL_RECONCILE_SECONDS = 1.0
 
 # LICC notification preview window and structured-message text cap. The
 # markdown preview and the structured ``recent_messages`` metadata are built
@@ -568,34 +571,80 @@ class WechatManager:
             if not Path(media_path).is_file():
                 return {"error": f"File not found: {media_path}"}
 
-        results = []
+        results: list[str] = []
         delivered_text_chunks: list[str] = []
+        chunks = _chunk_text(text, TEXT_CHUNK_LIMIT) if text else []
 
         # Snapshot context token under lock (poll thread may update it)
         with self._lock:
             ctx_token = self._context_tokens.get(user_id)
 
-        # Send text (chunked if needed)
-        if text:
-            chunks = _chunk_text(text, TEXT_CHUNK_LIMIT)
-            for chunk in chunks:
-                msg = WeixinMessage(
-                    from_user_id="",
-                    to_user_id=user_id,
-                    client_id=f"lingtai-wechat-{uuid.uuid4().hex}",
-                    message_type=2,   # BOT (matches Hermes/OpenClaw)
-                    message_state=2,  # FINISH
-                    context_token=ctx_token,
-                    item_list=[MessageItem(
-                        type=int(MessageItemType.TEXT),
-                        text_item=TextItem(text=chunk),
-                    )],
-                )
+        # Send text (chunked if needed). If a later chunk fails, preserve only
+        # the already delivered prefix and safe chunk counts; never persist the
+        # failed/unsent suffix or raw provider exception.
+        for chunk_number, chunk in enumerate(chunks, start=1):
+            msg = WeixinMessage(
+                from_user_id="",
+                to_user_id=user_id,
+                client_id=f"lingtai-wechat-{uuid.uuid4().hex}",
+                message_type=2,   # BOT (matches Hermes/OpenClaw)
+                message_state=2,  # FINISH
+                context_token=ctx_token,
+                item_list=[MessageItem(
+                    type=int(MessageItemType.TEXT),
+                    text_item=TextItem(text=chunk),
+                )],
+            )
+            try:
                 self._run_async(
                     api.send_message(self._base_url, self._token, msg)
                 )
-                results.append(f"text ({len(chunk)} chars)")
-                delivered_text_chunks.append(chunk)
+            except Exception as exc:
+                failure = self._text_message_failure(
+                    exc,
+                    failed_chunk=chunk_number,
+                    total_chunks=len(chunks),
+                )
+                if not delivered_text_chunks:
+                    return {
+                        "status": "failed",
+                        "error": failure["message"],
+                        "text_status": "failed",
+                        "failure": failure,
+                        "automatic_retry_allowed": failure["retryable"],
+                    }
+
+                msg_id = self._persist_sent(
+                    user_id=user_id,
+                    text="".join(delivered_text_chunks),
+                    status="partial",
+                    sent=results,
+                    failure=failure,
+                    text_status="partial",
+                    media_status="not_attempted" if media_path else None,
+                    delivered_text_chunks=len(delivered_text_chunks),
+                    total_text_chunks=len(chunks),
+                    failed_text_chunk=chunk_number,
+                )
+                return {
+                    "status": "partial",
+                    "partial_delivery": True,
+                    "sent": results,
+                    "message_id": msg_id,
+                    "text_status": "partial",
+                    **({"media_status": "not_attempted"} if media_path else {}),
+                    "delivered_text_chunks": len(delivered_text_chunks),
+                    "total_text_chunks": len(chunks),
+                    "failed_text_chunk": chunk_number,
+                    "failure": failure,
+                    "automatic_retry_allowed": False,
+                    "warning": (
+                        "A text prefix was already delivered. Do not retry the whole "
+                        "message automatically; reconcile and send only the unsent suffix."
+                    ),
+                }
+            results.append(f"text ({len(chunk)} chars)")
+            delivered_text_chunks.append(chunk)
 
         # Send media (already validated above)
         if media_path:
@@ -613,7 +662,8 @@ class WechatManager:
                     timeout_error=media_mod.OutboundMediaError(
                         stage="media_operation_timeout",
                         message="The local WeChat media operation exceeded its deadline.",
-                        retryable=True,
+                        retryable=False,
+                        remote_acceptance="unknown",
                     ),
                 )
                 media_item = media_mod.make_media_item(upload_info, path)
@@ -639,7 +689,7 @@ class WechatManager:
                     return {
                         "status": "failed",
                         "error": exc.message,
-                        "media_status": "failed",
+                        "media_status": "unknown" if exc.remote_acceptance == "unknown" else "failed",
                         "failure": failure,
                         "automatic_retry_allowed": exc.retryable,
                     }
@@ -651,6 +701,10 @@ class WechatManager:
                     sent=results,
                     media_name=path.name,
                     failure=failure,
+                    text_status="sent",
+                    media_status="unknown" if exc.remote_acceptance == "unknown" else "failed",
+                    delivered_text_chunks=len(delivered_text_chunks),
+                    total_text_chunks=len(chunks),
                 )
                 return {
                     "status": "partial",
@@ -658,7 +712,9 @@ class WechatManager:
                     "sent": results,
                     "message_id": msg_id,
                     "text_status": "sent",
-                    "media_status": "failed",
+                    "media_status": "unknown" if exc.remote_acceptance == "unknown" else "failed",
+                    "delivered_text_chunks": len(delivered_text_chunks),
+                    "total_text_chunks": len(chunks),
                     "failure": failure,
                     "automatic_retry_allowed": False,
                     "warning": (
@@ -673,8 +729,45 @@ class WechatManager:
             status="sent",
             sent=results,
             media_name=Path(media_path).name if media_path else None,
+            delivered_text_chunks=len(delivered_text_chunks) if chunks else None,
+            total_text_chunks=len(chunks) if chunks else None,
         )
         return {"status": "ok", "sent": results, "message_id": msg_id}
+
+    @staticmethod
+    def _text_message_failure(
+        exc: Exception,
+        *,
+        failed_chunk: int,
+        total_chunks: int,
+    ) -> dict[str, object]:
+        """Return a redacted stage/count record for one failed text chunk."""
+        remote_acceptance: str
+        if isinstance(exc, httpx.HTTPStatusError):
+            status_code = exc.response.status_code
+            ambiguous = status_code >= 500 or status_code == 429
+            retryable = False
+            remote_acceptance = "unknown" if ambiguous else "rejected"
+            stage = "text_message_http"
+            message = f"WeChat iLink rejected text chunk {failed_chunk} (HTTP {status_code})."
+        elif isinstance(exc, (httpx.HTTPError, TimeoutError)):
+            retryable = False
+            remote_acceptance = "unknown"
+            stage = "text_message_transport"
+            message = f"Could not reach WeChat iLink while sending text chunk {failed_chunk}."
+        else:
+            retryable = False
+            remote_acceptance = "rejected"
+            stage = "text_message_response"
+            message = f"WeChat iLink did not accept text chunk {failed_chunk}."
+        return {
+            "stage": stage,
+            "message": message,
+            "retryable": retryable,
+            "remote_acceptance": remote_acceptance,
+            "failed_text_chunk": failed_chunk,
+            "total_text_chunks": total_chunks,
+        }
 
     def _persist_sent(
         self,
@@ -685,6 +778,11 @@ class WechatManager:
         sent: list[str],
         media_name: str | None = None,
         failure: dict[str, object] | None = None,
+        text_status: str | None = None,
+        media_status: str | None = None,
+        delivered_text_chunks: int | None = None,
+        total_text_chunks: int | None = None,
+        failed_text_chunk: int | None = None,
     ) -> str:
         """Persist delivered outbound state without retaining local file paths."""
         msg_id = str(uuid.uuid4())
@@ -700,14 +798,21 @@ class WechatManager:
         }
         if media_name:
             sent_data["media_name"] = media_name
+        if delivered_text_chunks is not None:
+            sent_data["delivered_text_chunks"] = delivered_text_chunks
+        if total_text_chunks is not None:
+            sent_data["total_text_chunks"] = total_text_chunks
+        if failed_text_chunk is not None:
+            sent_data["failed_text_chunk"] = failed_text_chunk
         if failure is not None:
             sent_data.update({
                 "partial_delivery": True,
-                "text_status": "sent",
-                "media_status": "failed",
+                "text_status": text_status or "sent",
                 "failure": failure,
                 "automatic_retry_allowed": False,
             })
+            if media_status is not None:
+                sent_data["media_status"] = media_status
         self._atomic_write(
             msg_dir / "message.json",
             json.dumps(sent_data, ensure_ascii=False, indent=2),
@@ -1435,31 +1540,79 @@ class WechatManager:
         timeout: float = 30,
         timeout_error: Exception | None = None,
     ):
-        """Run a coroutine on the poll loop with bounded timeout cancellation.
+        """Run a coroutine on the poll loop within a truthful timeout boundary.
 
-        On synchronous deadline expiry, request cancellation and wait briefly for
-        the thread-safe future to reconcile. Cancellation prevents later coroutine
-        work whenever it wins, but cannot revoke a remote request already accepted.
+        On synchronous deadline expiry, request cancellation and wait for actual
+        coroutine exit before returning a terminal timeout. A coroutine that
+        resists cancellation can extend the wall clock, but cannot be detached to
+        continue invisibly after the caller receives an ended-operation result.
         Callers with partial-delivery semantics provide a fixed redacted exception.
         """
         if not self._loop or not self._loop.is_running():
+            coro.close()
             raise RuntimeError("WeChat addon not started — call start() first")
-        reconciled = threading.Event()
+        outcome: Future = Future()
+        task_ready = threading.Event()
+        start_lock = threading.Lock()
+        start_cancelled = False
+        task_holder: dict[str, asyncio.Task] = {}
 
         async def tracked_operation():
             try:
-                return await coro
-            finally:
-                # Unlike the concurrent Future (which becomes cancelled as soon
-                # as cancel() is requested), this marks actual coroutine exit.
-                reconciled.set()
+                result = await coro
+            except BaseException as exc:
+                if not outcome.done():
+                    outcome.set_exception(exc)
+            else:
+                if not outcome.done():
+                    outcome.set_result(result)
 
-        future = asyncio.run_coroutine_threadsafe(tracked_operation(), self._loop)
+        def start_operation() -> None:
+            nonlocal start_cancelled
+            with start_lock:
+                try:
+                    if start_cancelled:
+                        return
+                    tracked_coro = tracked_operation()
+                    try:
+                        task_holder["task"] = self._loop.create_task(tracked_coro)
+                    except BaseException as exc:
+                        tracked_coro.close()
+                        coro.close()
+                        outcome.set_exception(exc)
+                finally:
+                    task_ready.set()
+
         try:
-            return future.result(timeout=timeout)
+            self._loop.call_soon_threadsafe(start_operation)
+        except BaseException:
+            coro.close()
+            raise
+        if not task_ready.wait(timeout=_ASYNC_TASK_START_TIMEOUT_SECONDS):
+            start_timed_out = False
+            with start_lock:
+                if not task_ready.is_set():
+                    start_cancelled = True
+                    coro.close()
+                    start_timed_out = True
+            if start_timed_out:
+                if timeout_error is not None:
+                    raise timeout_error from None
+                raise FutureTimeoutError()
+        try:
+            return outcome.result(timeout=timeout)
         except FutureTimeoutError:
-            future.cancel()
-            reconciled.wait(timeout=_ASYNC_CANCEL_RECONCILE_SECONDS)
+            task = task_holder.get("task")
+            if task is not None:
+                self._loop.call_soon_threadsafe(task.cancel)
+                # This future is completed only by tracked_operation after the task
+                # actually returns or raises. It therefore cannot report cancellation
+                # merely because cancel() was requested, unlike
+                # run_coroutine_threadsafe.
+                try:
+                    outcome.result()
+                except BaseException:
+                    pass
             if timeout_error is not None:
                 raise timeout_error from None
             raise

--- a/src/lingtai/mcp_servers/wechat/manager.py
+++ b/src/lingtai/mcp_servers/wechat/manager.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+from concurrent.futures import TimeoutError as FutureTimeoutError
 import logging
 import os
 import re
@@ -53,6 +54,20 @@ _SKILL_FRONTMATTER, _SKILL_BODY, _SKILL_PATH = _skill.load_skill(__package__)
 
 TEXT_CHUNK_LIMIT = 4000
 SESSION_EXPIRED_ERRCODE = -14
+
+# A complete media upload can legitimately spend 15 seconds obtaining upload
+# parameters and 3 * 120 seconds in Tencent-style immediate CDN attempts. Give
+# encryption, parsing and scheduler cleanup a fixed 15-second local allowance.
+# Cancellation reconciliation is separately bounded; it cannot revoke a request
+# that a remote endpoint already accepted, but prevents queued coroutine work
+# from continuing after the synchronous caller returns whenever cancellation wins.
+_MEDIA_LOCAL_OVERHEAD_SECONDS = 15.0
+MEDIA_OPERATION_TIMEOUT_SECONDS = (
+    media_mod.GET_UPLOAD_URL_TIMEOUT_SECONDS
+    + media_mod.CDN_UPLOAD_MAX_ATTEMPTS * media_mod.CDN_UPLOAD_TIMEOUT_SECONDS
+    + _MEDIA_LOCAL_OVERHEAD_SECONDS
+)
+_ASYNC_CANCEL_RECONCILE_SECONDS = 1.0
 
 # LICC notification preview window and structured-message text cap. The
 # markdown preview and the structured ``recent_messages`` metadata are built
@@ -538,7 +553,9 @@ class WechatManager:
         if not text and not media_path:
             return {"error": "text or media_path is required"}
 
-        # Validate media_path before sending text to avoid partial sends.
+        # Validate media_path before sending text to avoid partial sends caused by
+        # local path errors. Network/upload failures can still happen after text
+        # delivery; those are returned and persisted as an explicit partial result.
         # Enforce the shared outbound-file containment policy first so a
         # prompt-injected path cannot exfiltrate files outside the workdir.
         if media_path:
@@ -552,6 +569,7 @@ class WechatManager:
                 return {"error": f"File not found: {media_path}"}
 
         results = []
+        delivered_text_chunks: list[str] = []
 
         # Snapshot context token under lock (poll thread may update it)
         with self._lock:
@@ -577,44 +595,124 @@ class WechatManager:
                     api.send_message(self._base_url, self._token, msg)
                 )
                 results.append(f"text ({len(chunk)} chars)")
+                delivered_text_chunks.append(chunk)
 
         # Send media (already validated above)
         if media_path:
             path = Path(media_path)
-            upload_info = self._run_async(
-                media_mod.upload_media(path, self._base_url, self._token, user_id)
-            )
-            media_item = media_mod.make_media_item(upload_info, path)
-            msg = WeixinMessage(
-                from_user_id="",
-                to_user_id=user_id,
-                client_id=f"lingtai-wechat-{uuid.uuid4().hex}",
-                message_type=2,   # BOT
-                message_state=2,  # FINISH
-                context_token=ctx_token,
-                item_list=[media_item],
-            )
-            self._run_async(
-                api.send_message(self._base_url, self._token, msg)
-            )
-            results.append(f"media ({path.name})")
+            try:
+                upload_info = self._run_async(
+                    media_mod.upload_media(
+                        path,
+                        self._base_url,
+                        self._token,
+                        user_id,
+                        cdn_base_url=self._cdn_base_url,
+                    ),
+                    timeout=MEDIA_OPERATION_TIMEOUT_SECONDS,
+                    timeout_error=media_mod.OutboundMediaError(
+                        stage="media_operation_timeout",
+                        message="The local WeChat media operation exceeded its deadline.",
+                        retryable=True,
+                    ),
+                )
+                media_item = media_mod.make_media_item(upload_info, path)
+                msg = WeixinMessage(
+                    from_user_id="",
+                    to_user_id=user_id,
+                    client_id=f"lingtai-wechat-{uuid.uuid4().hex}",
+                    message_type=2,   # BOT
+                    message_state=2,  # FINISH
+                    context_token=ctx_token,
+                    item_list=[media_item],
+                )
+                try:
+                    self._run_async(
+                        api.send_message(self._base_url, self._token, msg)
+                    )
+                except Exception as exc:
+                    raise media_mod.media_message_failure(exc) from None
+                results.append(f"media ({path.name})")
+            except media_mod.OutboundMediaError as exc:
+                failure = exc.as_dict()
+                if not delivered_text_chunks:
+                    return {
+                        "status": "failed",
+                        "error": exc.message,
+                        "media_status": "failed",
+                        "failure": failure,
+                        "automatic_retry_allowed": exc.retryable,
+                    }
 
-        # Persist to sent
+                msg_id = self._persist_sent(
+                    user_id=user_id,
+                    text="".join(delivered_text_chunks),
+                    status="partial",
+                    sent=results,
+                    media_name=path.name,
+                    failure=failure,
+                )
+                return {
+                    "status": "partial",
+                    "partial_delivery": True,
+                    "sent": results,
+                    "message_id": msg_id,
+                    "text_status": "sent",
+                    "media_status": "failed",
+                    "failure": failure,
+                    "automatic_retry_allowed": False,
+                    "warning": (
+                        "Text was already delivered. Do not retry the combined "
+                        "send automatically; reconcile first, then retry media alone."
+                    ),
+                }
+
+        msg_id = self._persist_sent(
+            user_id=user_id,
+            text=text,
+            status="sent",
+            sent=results,
+            media_name=Path(media_path).name if media_path else None,
+        )
+        return {"status": "ok", "sent": results, "message_id": msg_id}
+
+    def _persist_sent(
+        self,
+        *,
+        user_id: str,
+        text: str,
+        status: str,
+        sent: list[str],
+        media_name: str | None = None,
+        failure: dict[str, object] | None = None,
+    ) -> str:
+        """Persist delivered outbound state without retaining local file paths."""
         msg_id = str(uuid.uuid4())
         msg_dir = self._sent_dir / msg_id
         msg_dir.mkdir(parents=True, exist_ok=True)
-        sent_data = {
+        sent_data: dict[str, object] = {
             "id": msg_id,
             "to_user_id": user_id,
             "text": text,
-            "media_path": media_path,
             "date": datetime.now(timezone.utc).isoformat(),
+            "status": status,
+            "sent": list(sent),
         }
-        (msg_dir / "message.json").write_text(
-            json.dumps(sent_data, ensure_ascii=False, indent=2), encoding="utf-8",
+        if media_name:
+            sent_data["media_name"] = media_name
+        if failure is not None:
+            sent_data.update({
+                "partial_delivery": True,
+                "text_status": "sent",
+                "media_status": "failed",
+                "failure": failure,
+                "automatic_retry_allowed": False,
+            })
+        self._atomic_write(
+            msg_dir / "message.json",
+            json.dumps(sent_data, ensure_ascii=False, indent=2),
         )
-
-        return {"status": "ok", "sent": results, "message_id": msg_id}
+        return msg_id
 
     def _handle_check(self, args: dict) -> dict:
         """List conversations with unread counts.
@@ -634,7 +732,10 @@ class WechatManager:
             if not user:
                 continue
             msg_id = data.get("id", "")
-            preview = data.get("body") or data.get("text") or ""
+            preview = self._message_display_text({
+                **data,
+                "_direction": direction,
+            })
             if user not in conversations:
                 contact = self._find_contact_by_user_id(user)
                 conversations[user] = {
@@ -829,8 +930,11 @@ class WechatManager:
     def _message_display_text(message: dict) -> str:
         if message.get("_direction") == "outgoing":
             text = message.get("text") or message.get("body") or ""
-            if not text and message.get("media_path"):
-                text = f"[media: {message['media_path']}]"
+            media_label = message.get("media_name") or message.get("media_path")
+            if not text and media_label:
+                # New records persist basename-only media_name. Keep legacy
+                # media_path readable without exposing its historical directory.
+                text = f"[media: {Path(str(media_label)).name}]"
         else:
             text = message.get("body") or message.get("text") or ""
         return str(text).replace("\n", " ")
@@ -1324,16 +1428,41 @@ class WechatManager:
                 return {"alias": alias, **data}
         return None
 
-    def _run_async(self, coro):
-        """Run an async coroutine from the sync tool handler thread.
+    def _run_async(
+        self,
+        coro,
+        *,
+        timeout: float = 30,
+        timeout_error: Exception | None = None,
+    ):
+        """Run a coroutine on the poll loop with bounded timeout cancellation.
 
-        Schedules onto the poll loop's event loop via run_coroutine_threadsafe.
-        Raises RuntimeError if the addon has not been started.
+        On synchronous deadline expiry, request cancellation and wait briefly for
+        the thread-safe future to reconcile. Cancellation prevents later coroutine
+        work whenever it wins, but cannot revoke a remote request already accepted.
+        Callers with partial-delivery semantics provide a fixed redacted exception.
         """
         if not self._loop or not self._loop.is_running():
             raise RuntimeError("WeChat addon not started — call start() first")
-        future = asyncio.run_coroutine_threadsafe(coro, self._loop)
-        return future.result(timeout=30)
+        reconciled = threading.Event()
+
+        async def tracked_operation():
+            try:
+                return await coro
+            finally:
+                # Unlike the concurrent Future (which becomes cancelled as soon
+                # as cancel() is requested), this marks actual coroutine exit.
+                reconciled.set()
+
+        future = asyncio.run_coroutine_threadsafe(tracked_operation(), self._loop)
+        try:
+            return future.result(timeout=timeout)
+        except FutureTimeoutError:
+            future.cancel()
+            reconciled.wait(timeout=_ASYNC_CANCEL_RECONCILE_SECONDS)
+            if timeout_error is not None:
+                raise timeout_error from None
+            raise
 
 
 def _chunk_text(text: str, limit: int) -> list[str]:

--- a/src/lingtai/mcp_servers/wechat/media.py
+++ b/src/lingtai/mcp_servers/wechat/media.py
@@ -60,6 +60,7 @@ class OutboundMediaError(Exception):
     message: str
     endpoint_host: str | None = None
     retryable: bool = False
+    remote_acceptance: str | None = None
 
     def __post_init__(self) -> None:
         Exception.__init__(self, self.message)
@@ -72,6 +73,8 @@ class OutboundMediaError(Exception):
         }
         if self.endpoint_host:
             result["endpoint_host"] = self.endpoint_host
+        if self.remote_acceptance:
+            result["remote_acceptance"] = self.remote_acceptance
         return result
 
 
@@ -150,24 +153,33 @@ def _cdn_transport_failure(exc: httpx.HTTPError, upload_url: str) -> OutboundMed
 
 
 def media_message_failure(exc: Exception) -> OutboundMediaError:
-    """Redact a failure while sending the final iLink media message."""
+    """Redact a failure while sending the final iLink media message.
+
+    Transport failures and retryable HTTP statuses do not prove non-delivery:
+    iLink may have accepted the message before the response was lost. Keep that
+    ambiguity explicit and never recommend an automatic whole-message retry.
+    """
     if isinstance(exc, httpx.HTTPStatusError):
         status_code = exc.response.status_code
+        ambiguous = status_code >= 500 or status_code == 429
         return OutboundMediaError(
             stage="media_message_http",
             message=f"WeChat iLink rejected the media message (HTTP {status_code}).",
-            retryable=status_code >= 500 or status_code == 429,
+            retryable=False,
+            remote_acceptance="unknown" if ambiguous else "rejected",
         )
     if isinstance(exc, (httpx.HTTPError, TimeoutError)):
         return OutboundMediaError(
             stage="media_message_transport",
             message="Could not reach WeChat iLink while sending the media message.",
-            retryable=True,
+            retryable=False,
+            remote_acceptance="unknown",
         )
     return OutboundMediaError(
         stage="media_message_response",
         message="WeChat iLink did not accept the media message.",
         retryable=False,
+        remote_acceptance="rejected",
     )
 
 

--- a/src/lingtai/mcp_servers/wechat/media.py
+++ b/src/lingtai/mcp_servers/wechat/media.py
@@ -7,6 +7,7 @@ import logging
 import secrets
 from dataclasses import dataclass
 from pathlib import Path
+from urllib.parse import quote, urlsplit
 
 import httpx
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
@@ -36,6 +37,138 @@ class UploadedMediaInfo:
     filekey: str
 
 log = logging.getLogger(__name__)
+
+# The iLink get-upload request uses api.DEFAULT_SEND_TIMEOUT (15 seconds).
+# Tencent v1.0.3 permits three immediate CDN attempts; each LingTai request is
+# independently bounded at 120 seconds. These constants also feed the manager's
+# complete-coroutine deadline rather than leaving mismatched magic numbers.
+GET_UPLOAD_URL_TIMEOUT_SECONDS = api.DEFAULT_SEND_TIMEOUT
+CDN_UPLOAD_TIMEOUT_SECONDS = 120.0
+CDN_UPLOAD_MAX_ATTEMPTS = 3
+
+
+@dataclass
+class OutboundMediaError(Exception):
+    """Redacted outbound upload failure with a machine-readable stage.
+
+    ``upload_media`` constructs or receives a secret-bearing CDN URL. This
+    exception intentionally retains only its hostname; path, query, fragment,
+    token, recipient ID, and local file path must never cross the tool boundary.
+    """
+
+    stage: str
+    message: str
+    endpoint_host: str | None = None
+    retryable: bool = False
+
+    def __post_init__(self) -> None:
+        Exception.__init__(self, self.message)
+
+    def as_dict(self) -> dict[str, object]:
+        result: dict[str, object] = {
+            "stage": self.stage,
+            "message": self.message,
+            "retryable": self.retryable,
+        }
+        if self.endpoint_host:
+            result["endpoint_host"] = self.endpoint_host
+        return result
+
+
+def _safe_hostname(url: str) -> str | None:
+    """Return only a normalized hostname from a CDN URL."""
+    try:
+        return urlsplit(url).hostname
+    except (TypeError, ValueError):
+        return None
+
+
+def _valid_cdn_base_url(url: str) -> bool:
+    """Accept a configured HTTP(S) origin/path with no secret query material."""
+    if not isinstance(url, str) or not url or url != url.strip():
+        return False
+    try:
+        parsed = urlsplit(url)
+    except (TypeError, ValueError):
+        return False
+    return bool(
+        parsed.scheme in {"http", "https"}
+        and parsed.hostname
+        and not parsed.username
+        and not parsed.password
+        and not parsed.query
+        and not parsed.fragment
+    )
+
+
+def _valid_dynamic_upload_url(url: str) -> bool:
+    """Require an absolute HTTP(S) fallback while allowing its signed query."""
+    if not isinstance(url, str) or not url or url != url.strip():
+        return False
+    try:
+        parsed = urlsplit(url)
+    except (TypeError, ValueError):
+        return False
+    return bool(
+        parsed.scheme in {"http", "https"}
+        and parsed.hostname
+        and not parsed.username
+        and not parsed.password
+        and not parsed.fragment
+    )
+
+
+def _official_cdn_upload_url(
+    cdn_base_url: str, upload_param: str, filekey: str,
+) -> str:
+    """Build Tencent's v1.0.3 upload route with exact component encoding."""
+    encode_uri_component_safe = "-_.!~*'()"
+    return (
+        f"{cdn_base_url.rstrip('/')}/upload?encrypted_query_param="
+        f"{quote(upload_param, safe=encode_uri_component_safe)}&filekey="
+        f"{quote(filekey, safe=encode_uri_component_safe)}"
+    )
+
+
+def _usable_encrypted_reference(value: object) -> str | None:
+    """Return only a nonblank string media reference from CDN metadata."""
+    return value if isinstance(value, str) and value.strip() else None
+
+
+def _cdn_transport_failure(exc: httpx.HTTPError, upload_url: str) -> OutboundMediaError:
+    """Map an httpx upload failure without retaining its secret request URL."""
+    if isinstance(exc, httpx.TimeoutException):
+        message = "Timed out while connecting to or uploading bytes to the WeChat CDN."
+    else:
+        message = "Could not connect to or upload bytes to the WeChat CDN."
+    return OutboundMediaError(
+        stage="cdn_upload_transport",
+        message=message,
+        endpoint_host=_safe_hostname(upload_url),
+        retryable=True,
+    )
+
+
+def media_message_failure(exc: Exception) -> OutboundMediaError:
+    """Redact a failure while sending the final iLink media message."""
+    if isinstance(exc, httpx.HTTPStatusError):
+        status_code = exc.response.status_code
+        return OutboundMediaError(
+            stage="media_message_http",
+            message=f"WeChat iLink rejected the media message (HTTP {status_code}).",
+            retryable=status_code >= 500 or status_code == 429,
+        )
+    if isinstance(exc, (httpx.HTTPError, TimeoutError)):
+        return OutboundMediaError(
+            stage="media_message_transport",
+            message="Could not reach WeChat iLink while sending the media message.",
+            retryable=True,
+        )
+    return OutboundMediaError(
+        stage="media_message_response",
+        message="WeChat iLink did not accept the media message.",
+        retryable=False,
+    )
 
 
 # ── Magic-byte validation ──────────────────────────────────────────────────
@@ -292,6 +425,8 @@ async def upload_media(
     base_url: str,
     token: str,
     to_user_id: str,
+    *,
+    cdn_base_url: str = api.CDN_BASE_URL,
 ) -> UploadedMediaInfo:
     """Upload a file to WeChat CDN.
 
@@ -328,59 +463,172 @@ async def upload_media(
     ciphertext = _aes128_ecb_encrypt(data, aeskey)
     filekey = secrets.token_hex(16)
 
-    # Get upload URL. filesize is ciphertext size, rawsize is plaintext size.
-    # Hermes/OpenClaw include filekey + no_need_thumb; without filekey iLink
-    # may return HTTP 200 but omit upload_full_url.
-    upload_resp = await api.get_upload_url(
-        base_url, token,
-        media_type=int(media_type),
-        to_user_id=to_user_id,
-        rawsize=len(data),
-        rawfilemd5=md5,
-        filesize=len(ciphertext),
-        aeskey=aeskey_hex,
-        filekey=filekey,
-        no_need_thumb=True,
-    )
-
-    upload_url = upload_resp.upload_full_url
-    if not upload_url:
-        raise RuntimeError("Server did not return an upload URL")
-
-    # Upload encrypted bytes to CDN. OpenClaw uses POST (not PUT) and reads
-    # the final download encrypted_query_param from the x-encrypted-param
-    # response header. Some CDN responses also embed it in a JSON body.
-    async with httpx.AsyncClient() as client:
-        resp = await client.post(
-            upload_url,
-            content=ciphertext,
-            headers={"Content-Type": "application/octet-stream"},
-            timeout=120.0,
+    # Get upload parameters. filesize is ciphertext size, rawsize is plaintext.
+    # Official Tencent v1.0.3 requires upload_param and constructs the CDN URL
+    # from the configured base. LingTai's extra upload_full_url is retained only
+    # as compatibility fallback when that official parameter is absent.
+    try:
+        upload_resp = await api.get_upload_url(
+            base_url, token,
+            media_type=int(media_type),
+            to_user_id=to_user_id,
+            rawsize=len(data),
+            rawfilemd5=md5,
+            filesize=len(ciphertext),
+            aeskey=aeskey_hex,
+            filekey=filekey,
+            no_need_thumb=True,
         )
-        resp.raise_for_status()
-        raw = resp.text
+    except httpx.HTTPStatusError as exc:
+        status_code = exc.response.status_code
+        raise OutboundMediaError(
+            stage="get_upload_url_http",
+            message=f"WeChat iLink rejected the upload-URL request (HTTP {status_code}).",
+            retryable=status_code >= 500 or status_code == 429,
+        ) from None
+    except httpx.HTTPError as exc:
+        raise OutboundMediaError(
+            stage="get_upload_url_transport",
+            message="Could not reach WeChat iLink to obtain a media upload URL.",
+            retryable=True,
+        ) from None
+    except Exception:
+        raise OutboundMediaError(
+            stage="get_upload_url_response",
+            message="WeChat iLink returned an unusable upload-URL response.",
+            retryable=False,
+        ) from None
 
-    header_param = resp.headers.get("x-encrypted-param")
-    json_param: str | None = None
-    if raw and raw.strip().startswith("{"):
-        try:
-            body = resp.json()
-            json_param = (
-                body.get("encrypt_query_param")
-                or body.get("download_param")
+    raw_upload_param = upload_resp.upload_param
+    upload_full_url = (
+        upload_resp.upload_full_url
+        if isinstance(upload_resp.upload_full_url, str)
+        else ""
+    )
+    if raw_upload_param is not None:
+        if not isinstance(raw_upload_param, str) or not raw_upload_param:
+            raise OutboundMediaError(
+                stage="get_upload_url_response",
+                message="WeChat iLink returned unusable media upload parameters.",
+                retryable=False,
             )
-        except Exception:
-            json_param = None
+        if not _valid_cdn_base_url(cdn_base_url):
+            raise OutboundMediaError(
+                stage="get_upload_url_response",
+                message="WeChat iLink returned unusable media upload parameters.",
+                retryable=False,
+            )
+        upload_url = _official_cdn_upload_url(
+            cdn_base_url, raw_upload_param, filekey,
+        )
+    elif upload_full_url and _valid_dynamic_upload_url(upload_full_url):
+        upload_url = upload_full_url
+    else:
+        raise OutboundMediaError(
+            stage="get_upload_url_response",
+            message="WeChat iLink did not return usable media upload parameters.",
+            retryable=False,
+        )
 
-    download_param = header_param or json_param
-    if not download_param:
-        # Be strict here. The prior code fell back to upload_param/filekey,
-        # which made the function appear to succeed while producing media
-        # the WeChat client could not open. Better to raise loudly.
-        raise RuntimeError(
-            "CDN upload response missing x-encrypted-param header and "
-            "encrypt_query_param / download_param JSON field. The upload "
-            "may have failed silently — refusing to return media reference."
+    # Retry only this encrypted CDN POST, never the surrounding text+media send.
+    # Match Tencent v1.0.3's no-backoff behavior and retry HTTP 200 responses
+    # missing encrypted metadata: such a response is not a usable completion.
+    # Provider x-error-message and response bodies are never copied into errors.
+    download_param: str | None = None
+    last_failure: OutboundMediaError | None = None
+    try:
+        client_context = httpx.AsyncClient()
+    except Exception:
+        raise OutboundMediaError(
+            stage="cdn_upload_response",
+            message="The WeChat CDN upload request could not be prepared.",
+            endpoint_host=_safe_hostname(upload_url),
+            retryable=False,
+        ) from None
+    try:
+        async with client_context as client:
+            for attempt in range(1, CDN_UPLOAD_MAX_ATTEMPTS + 1):
+                try:
+                    resp = await client.post(
+                        upload_url,
+                        content=ciphertext,
+                        headers={"Content-Type": "application/octet-stream"},
+                        timeout=CDN_UPLOAD_TIMEOUT_SECONDS,
+                    )
+                except httpx.HTTPError as exc:
+                    last_failure = _cdn_transport_failure(exc, upload_url)
+                except Exception:
+                    # httpx.InvalidURL is not an HTTPError. Keep any unexpected
+                    # client/request construction detail behind the response stage.
+                    raise OutboundMediaError(
+                        stage="cdn_upload_response",
+                        message="The WeChat CDN upload request could not be prepared.",
+                        endpoint_host=_safe_hostname(upload_url),
+                        retryable=False,
+                    ) from None
+                else:
+                    status_code = resp.status_code
+                    if status_code != 200:
+                        retryable = status_code == 429 or status_code >= 500
+                        last_failure = OutboundMediaError(
+                            stage="cdn_upload_http",
+                            message=(
+                                "The WeChat CDN rejected the media upload "
+                                f"(HTTP {status_code})."
+                            ),
+                            endpoint_host=_safe_hostname(upload_url),
+                            retryable=retryable,
+                        )
+                        if not retryable:
+                            raise last_failure from None
+                    else:
+                        header_param = _usable_encrypted_reference(
+                            resp.headers.get("x-encrypted-param")
+                        )
+                        json_param: str | None = None
+                        raw = resp.text
+                        if raw and raw.strip().startswith("{"):
+                            try:
+                                body = resp.json()
+                                json_param = _usable_encrypted_reference(
+                                    body.get("encrypt_query_param")
+                                ) or _usable_encrypted_reference(
+                                    body.get("download_param")
+                                )
+                            except Exception:
+                                json_param = None
+                        download_param = header_param or json_param
+                        if download_param:
+                            break
+                        last_failure = OutboundMediaError(
+                            stage="cdn_upload_response",
+                            message=(
+                                "The WeChat CDN accepted the upload but did not "
+                                "return the required encrypted media reference."
+                            ),
+                            endpoint_host=_safe_hostname(upload_url),
+                            retryable=True,
+                        )
+
+                if attempt == CDN_UPLOAD_MAX_ATTEMPTS:
+                    assert last_failure is not None
+                    raise last_failure from None
+    except OutboundMediaError:
+        raise
+    except Exception:
+        raise OutboundMediaError(
+            stage="cdn_upload_response",
+            message="The WeChat CDN upload request could not be prepared.",
+            endpoint_host=_safe_hostname(upload_url),
+            retryable=False,
+        ) from None
+
+    if not download_param:  # defensive: loop exits only on a usable reference
+        raise OutboundMediaError(
+            stage="cdn_upload_response",
+            message="The WeChat CDN did not return a usable media reference.",
+            endpoint_host=_safe_hostname(upload_url),
+            retryable=False,
         )
 
     cdn_media = CDNMedia(

--- a/tests/ANATOMY.md
+++ b/tests/ANATOMY.md
@@ -454,10 +454,13 @@ maintenance: |
 The kernel's single pytest suite and the repository's conformance evidence: a
 flat top-level package of ~380 `test_*.py` modules, a small set of shared
 `_`-prefixed helper modules and fake binaries they build on, and two focused
-sub-packages. It is a **validation surface, not an architectural component** —
-it exposes no Port, implements no promise, and nothing in `src/` imports it.
-This anatomy therefore exists to make the file inventory navigable and
-complete, not to pair with a governed contract.
+sub-packages. The WeChat outbound-media regressions include deterministic task
+cancellation/reconciliation, ambiguous final-message acceptance, and chunked
+text partial-delivery evidence without provider traffic. It is a **validation
+surface, not an architectural component** — it exposes no Port, implements no
+promise, and nothing in `src/` imports it. This anatomy therefore exists to make
+the file inventory navigable and complete, not to pair with a governed
+contract.
 
 ## Components
 

--- a/tests/ANATOMY.md
+++ b/tests/ANATOMY.md
@@ -410,6 +410,7 @@ related_files:
   - tests/test_web_search_capability.py
   - tests/test_wechat_config_resolution.py
   - tests/test_wechat_inbound_replay.py
+  - tests/test_wechat_media_upload_errors.py
   - tests/test_wechat_media_validation.py
   - tests/test_wechat_media_warning_integration.py
   - tests/test_wechat_notification_metadata.py

--- a/tests/test_outbound_file_containment.py
+++ b/tests/test_outbound_file_containment.py
@@ -296,19 +296,25 @@ def test_wechat_send_accepts_media_path_inside_workdir(tmp_path, monkeypatch):
     media_path.write_bytes(b"PNG")
     seen: dict = {}
 
-    async def _fake_upload(path, base_url, token, user_id):
+    async def _fake_upload(
+        path, base_url, token, user_id, *, cdn_base_url,
+    ):
         seen["upload_path"] = str(path)
+        seen["cdn_base_url"] = cdn_base_url
         return {"media_id": "m1", "media_type": "image"}
 
     async def _fake_send_message(*args, **kwargs):
         seen["sent"] = True
+
+    def _fake_run_async(coro, **kwargs):
+        return asyncio.run(coro)
 
     monkeypatch.setattr(wx_media, "upload_media", _fake_upload)
     monkeypatch.setattr(
         wx_media, "make_media_item", lambda info, path: object()
     )
     monkeypatch.setattr(wx_api, "send_message", _fake_send_message)
-    monkeypatch.setattr(manager, "_run_async", asyncio.run)
+    monkeypatch.setattr(manager, "_run_async", _fake_run_async)
 
     result = manager._handle_send({
         "user_id": "wxid@im.wechat",
@@ -317,4 +323,5 @@ def test_wechat_send_accepts_media_path_inside_workdir(tmp_path, monkeypatch):
 
     assert result["status"] == "ok"
     assert seen["upload_path"] == str(media_path.resolve())
+    assert seen["cdn_base_url"] == manager._cdn_base_url
     assert seen["sent"] is True

--- a/tests/test_wechat_media_upload_errors.py
+++ b/tests/test_wechat_media_upload_errors.py
@@ -1,0 +1,989 @@
+"""Outbound WeChat media route, retry, timeout, and privacy regressions."""
+from __future__ import annotations
+
+import asyncio
+import json
+import ssl
+from pathlib import Path
+
+import httpx
+import pytest
+
+from lingtai.mcp_servers.wechat import media
+from lingtai.mcp_servers.wechat import manager as manager_mod
+from lingtai.mcp_servers.wechat.manager import WechatManager
+from lingtai.mcp_servers.wechat.types import GetUploadUrlResp
+
+
+_PRESIGNED = (
+    "https://upload.example.invalid/c2c/private-object?"
+    "token=SECRET_QUERY&recipient=SECRET_USER"
+)
+_CDN_BASE = "https://static-cdn.example.invalid/c2c"
+_UPLOAD_PARAM = " upload /?&+=!~*'()SECRET_UPLOAD_PARAM "
+_FILEKEY = "file/key ?&+=!~*'()SECRET_FILEKEY"
+_DOWNLOAD_PARAM = "download-encrypted-param"
+
+
+class FakeResponse:
+    def __init__(
+        self,
+        status_code: int,
+        *,
+        headers: dict[str, str] | None = None,
+        text: str = "",
+        body: dict | None = None,
+    ) -> None:
+        self.status_code = status_code
+        self.headers = headers or {}
+        self.text = text
+        self._body = body if body is not None else {}
+
+    def json(self) -> dict:
+        return self._body
+
+
+class SequenceClient:
+    outcomes: list[FakeResponse | BaseException] = []
+    calls: list[tuple[str, dict]] = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    async def post(self, url, **kwargs):
+        type(self).calls.append((url, kwargs))
+        if not type(self).outcomes:
+            raise AssertionError("unexpected CDN attempt")
+        outcome = type(self).outcomes.pop(0)
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+
+def _manager(tmp_path: Path, *, cdn_base_url: str = _CDN_BASE) -> WechatManager:
+    return WechatManager(
+        token="SECRET_BOT_TOKEN",
+        user_id="test-bot",
+        cdn_base_url=cdn_base_url,
+        working_dir=tmp_path,
+        on_inbound=lambda event: None,
+    )
+
+
+def _source(tmp_path: Path, name: str = "outbound.png") -> Path:
+    source = tmp_path / name
+    source.write_bytes(b"deterministic outbound bytes")
+    return source
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _success_response() -> FakeResponse:
+    return FakeResponse(200, headers={"x-encrypted-param": _DOWNLOAD_PARAM})
+
+
+def _install_upload_mocks(
+    monkeypatch,
+    *,
+    upload_resp: GetUploadUrlResp,
+    outcomes: list[FakeResponse | BaseException],
+    filekey: str = "a" * 32,
+) -> type[SequenceClient]:
+    async def get_upload_url(*args, **kwargs):
+        return upload_resp
+
+    class Client(SequenceClient):
+        pass
+
+    Client.outcomes = list(outcomes)
+    Client.calls = []
+    monkeypatch.setattr(media.api, "get_upload_url", get_upload_url)
+    monkeypatch.setattr(media.httpx, "AsyncClient", Client)
+    monkeypatch.setattr(media.secrets, "token_hex", lambda size: filekey)
+    return Client
+
+
+def _upload(source: Path, *, cdn_base_url: str = _CDN_BASE):
+    return _run(
+        media.upload_media(
+            source,
+            "https://ilink.example.invalid",
+            "SECRET_BOT_TOKEN",
+            "SECRET_USER",
+            cdn_base_url=cdn_base_url,
+        )
+    )
+
+
+def _assert_redacted(value: object, *, local_path: Path | None = None) -> None:
+    rendered = json.dumps(value, ensure_ascii=False)
+    for secret in (
+        _PRESIGNED,
+        "SECRET_QUERY",
+        "SECRET_USER",
+        "SECRET_BOT_TOKEN",
+        "SECRET_UPLOAD_PARAM",
+        "SECRET_FILEKEY",
+        "RAW_PROVIDER_BODY",
+        "RAW_X_ERROR_MESSAGE",
+    ):
+        assert secret not in rendered
+    if local_path is not None:
+        assert str(local_path) not in rendered
+
+
+def test_official_static_url_is_primary_and_exactly_percent_encodes_components(
+    tmp_path, monkeypatch,
+):
+    source = _source(tmp_path)
+    client = _install_upload_mocks(
+        monkeypatch,
+        upload_resp=GetUploadUrlResp(
+            upload_param=_UPLOAD_PARAM,
+            upload_full_url=_PRESIGNED,
+        ),
+        outcomes=[_success_response()],
+        filekey=_FILEKEY,
+    )
+
+    info = _upload(source, cdn_base_url=_CDN_BASE + "/")
+
+    assert info.cdn_media.encrypt_query_param == _DOWNLOAD_PARAM
+    assert len(client.calls) == 1
+    assert client.calls[0][0] == (
+        _CDN_BASE
+        + "/upload?encrypted_query_param="
+        + "%20upload%20%2F%3F%26%2B%3D!~*'()SECRET_UPLOAD_PARAM%20"
+        + "&filekey=file%2Fkey%20%3F%26%2B%3D!~*'()SECRET_FILEKEY"
+    )
+    assert _PRESIGNED not in client.calls[0][0]
+    assert client.calls[0][1]["timeout"] == media.CDN_UPLOAD_TIMEOUT_SECONDS
+
+
+def test_dynamic_upload_full_url_fallback_only_when_upload_param_absent(
+    tmp_path, monkeypatch,
+):
+    source = _source(tmp_path)
+    client = _install_upload_mocks(
+        monkeypatch,
+        upload_resp=GetUploadUrlResp(upload_full_url=_PRESIGNED),
+        outcomes=[_success_response()],
+    )
+
+    _upload(source)
+
+    assert [url for url, _ in client.calls] == [_PRESIGNED]
+
+
+def test_present_whitespace_upload_param_still_uses_official_static_route(
+    tmp_path, monkeypatch,
+):
+    source = _source(tmp_path)
+    client = _install_upload_mocks(
+        monkeypatch,
+        upload_resp=GetUploadUrlResp(
+            upload_param="   ",
+            upload_full_url=_PRESIGNED,
+        ),
+        outcomes=[_success_response()],
+    )
+
+    _upload(source)
+
+    assert len(client.calls) == 1
+    assert client.calls[0][0] == (
+        _CDN_BASE + "/upload?encrypted_query_param=%20%20%20&filekey=" + "a" * 32
+    )
+    assert _PRESIGNED not in client.calls[0][0]
+
+
+def test_present_empty_upload_param_does_not_use_dynamic_fallback(
+    tmp_path, monkeypatch,
+):
+    source = _source(tmp_path)
+    client = _install_upload_mocks(
+        monkeypatch,
+        upload_resp=GetUploadUrlResp(
+            upload_param="",
+            upload_full_url=_PRESIGNED,
+        ),
+        outcomes=[_success_response()],
+    )
+
+    with pytest.raises(media.OutboundMediaError) as raised:
+        _upload(source)
+
+    assert raised.value.as_dict() == {
+        "stage": "get_upload_url_response",
+        "message": "WeChat iLink returned unusable media upload parameters.",
+        "retryable": False,
+    }
+    assert client.calls == []
+    _assert_redacted(raised.value.as_dict(), local_path=source)
+
+
+def test_present_upload_param_with_invalid_cdn_base_does_not_use_dynamic_fallback(
+    tmp_path, monkeypatch,
+):
+    source = _source(tmp_path)
+    client = _install_upload_mocks(
+        monkeypatch,
+        upload_resp=GetUploadUrlResp(
+            upload_param=_UPLOAD_PARAM,
+            upload_full_url=_PRESIGNED,
+        ),
+        outcomes=[_success_response()],
+    )
+
+    with pytest.raises(media.OutboundMediaError) as raised:
+        _upload(source, cdn_base_url="not-an-http-url?SECRET_QUERY")
+
+    assert raised.value.as_dict() == {
+        "stage": "get_upload_url_response",
+        "message": "WeChat iLink returned unusable media upload parameters.",
+        "retryable": False,
+    }
+    assert client.calls == []
+    _assert_redacted(raised.value.as_dict(), local_path=source)
+
+
+def test_missing_both_upload_parameters_fails_at_redacted_get_upload_stage(
+    tmp_path, monkeypatch,
+):
+    source = _source(tmp_path)
+    client = _install_upload_mocks(
+        monkeypatch,
+        upload_resp=GetUploadUrlResp(),
+        outcomes=[_success_response()],
+    )
+
+    with pytest.raises(media.OutboundMediaError) as raised:
+        _upload(source)
+
+    assert raised.value.as_dict() == {
+        "stage": "get_upload_url_response",
+        "message": "WeChat iLink did not return usable media upload parameters.",
+        "retryable": False,
+    }
+    assert client.calls == []
+    _assert_redacted(raised.value.as_dict(), local_path=source)
+
+
+def test_get_upload_url_http_failure_is_stage_aware_and_redacted(
+    tmp_path, monkeypatch,
+):
+    source = _source(tmp_path)
+    request = httpx.Request(
+        "POST", "https://ilink.example.invalid/getuploadurl?token=SECRET_QUERY"
+    )
+    response = httpx.Response(429, request=request, text="RAW_PROVIDER_BODY")
+
+    async def fail_get_upload_url(*args, **kwargs):
+        raise httpx.HTTPStatusError(
+            "RAW_PROVIDER_BODY SECRET_BOT_TOKEN",
+            request=request,
+            response=response,
+        )
+
+    monkeypatch.setattr(media.api, "get_upload_url", fail_get_upload_url)
+
+    with pytest.raises(media.OutboundMediaError) as raised:
+        _upload(source)
+
+    assert raised.value.as_dict() == {
+        "stage": "get_upload_url_http",
+        "message": "WeChat iLink rejected the upload-URL request (HTTP 429).",
+        "retryable": True,
+    }
+    _assert_redacted(raised.value.as_dict(), local_path=source)
+
+
+def test_get_upload_url_unusable_response_is_stage_aware_and_redacted(
+    tmp_path, monkeypatch,
+):
+    source = _source(tmp_path)
+
+    async def fail_get_upload_url(*args, **kwargs):
+        raise ValueError("RAW_PROVIDER_BODY SECRET_QUERY")
+
+    monkeypatch.setattr(media.api, "get_upload_url", fail_get_upload_url)
+
+    with pytest.raises(media.OutboundMediaError) as raised:
+        _upload(source)
+
+    assert raised.value.as_dict() == {
+        "stage": "get_upload_url_response",
+        "message": "WeChat iLink returned an unusable upload-URL response.",
+        "retryable": False,
+    }
+    _assert_redacted(raised.value.as_dict(), local_path=source)
+
+
+def test_get_upload_url_transport_failure_is_stage_aware_and_redacted(
+    tmp_path, monkeypatch,
+):
+    source = _source(tmp_path)
+    request = httpx.Request(
+        "POST", "https://ilink.example.invalid/getuploadurl?token=SECRET_QUERY"
+    )
+
+    async def fail_get_upload_url(*args, **kwargs):
+        raise httpx.ConnectError("contains SECRET_BOT_TOKEN", request=request)
+
+    monkeypatch.setattr(media.api, "get_upload_url", fail_get_upload_url)
+
+    with pytest.raises(media.OutboundMediaError) as raised:
+        _upload(source)
+
+    assert raised.value.as_dict() == {
+        "stage": "get_upload_url_transport",
+        "message": "Could not reach WeChat iLink to obtain a media upload URL.",
+        "retryable": True,
+    }
+    _assert_redacted(raised.value.as_dict(), local_path=source)
+
+
+@pytest.mark.parametrize("first_status", [503, 429])
+def test_retryable_http_status_retries_then_succeeds(
+    first_status, tmp_path, monkeypatch,
+):
+    source = _source(tmp_path)
+    client = _install_upload_mocks(
+        monkeypatch,
+        upload_resp=GetUploadUrlResp(upload_param="param"),
+        outcomes=[
+            FakeResponse(
+                first_status,
+                headers={"x-error-message": "RAW_X_ERROR_MESSAGE"},
+                text="RAW_PROVIDER_BODY",
+            ),
+            _success_response(),
+        ],
+    )
+
+    info = _upload(source)
+
+    assert info.cdn_media.encrypt_query_param == _DOWNLOAD_PARAM
+    assert len(client.calls) == 2
+
+
+def test_transport_tls_failure_retries_then_succeeds(tmp_path, monkeypatch):
+    source = _source(tmp_path)
+    request = httpx.Request("POST", _CDN_BASE + "/upload?SECRET_QUERY")
+    tls_error = httpx.ConnectError(
+        "TLS RAW_PROVIDER_BODY",
+        request=request,
+    )
+    tls_error.__cause__ = ssl.SSLError("SECRET_QUERY TLS handshake failure")
+    client = _install_upload_mocks(
+        monkeypatch,
+        upload_resp=GetUploadUrlResp(upload_param="param"),
+        outcomes=[tls_error, _success_response()],
+    )
+
+    info = _upload(source)
+
+    assert info.cdn_media.encrypt_query_param == _DOWNLOAD_PARAM
+    assert len(client.calls) == 2
+
+
+def test_other_4xx_fails_once_without_provider_detail_leak(tmp_path, monkeypatch):
+    source = _source(tmp_path)
+    client = _install_upload_mocks(
+        monkeypatch,
+        upload_resp=GetUploadUrlResp(upload_param="param"),
+        outcomes=[
+            FakeResponse(
+                403,
+                headers={"x-error-message": "RAW_X_ERROR_MESSAGE"},
+                text="RAW_PROVIDER_BODY SECRET_QUERY",
+            ),
+            _success_response(),
+        ],
+    )
+
+    with pytest.raises(media.OutboundMediaError) as raised:
+        _upload(source)
+
+    assert raised.value.as_dict() == {
+        "stage": "cdn_upload_http",
+        "message": "The WeChat CDN rejected the media upload (HTTP 403).",
+        "retryable": False,
+        "endpoint_host": "static-cdn.example.invalid",
+    }
+    assert len(client.calls) == 1
+    _assert_redacted(raised.value.as_dict(), local_path=source)
+
+
+def test_retryable_failure_stops_after_exactly_three_attempts_and_stays_redacted(
+    tmp_path, monkeypatch,
+):
+    source = _source(tmp_path)
+    client = _install_upload_mocks(
+        monkeypatch,
+        upload_resp=GetUploadUrlResp(upload_param="param"),
+        outcomes=[
+            FakeResponse(
+                503,
+                headers={"x-error-message": "RAW_X_ERROR_MESSAGE"},
+                text="RAW_PROVIDER_BODY SECRET_QUERY",
+            )
+            for _ in range(media.CDN_UPLOAD_MAX_ATTEMPTS)
+        ] + [_success_response()],
+    )
+
+    with pytest.raises(media.OutboundMediaError) as raised:
+        _upload(source)
+
+    assert raised.value.as_dict() == {
+        "stage": "cdn_upload_http",
+        "message": "The WeChat CDN rejected the media upload (HTTP 503).",
+        "retryable": True,
+        "endpoint_host": "static-cdn.example.invalid",
+    }
+    assert len(client.calls) == media.CDN_UPLOAD_MAX_ATTEMPTS == 3
+    _assert_redacted(raised.value.as_dict(), local_path=source)
+
+
+def test_http_200_missing_encrypted_metadata_retries_then_succeeds(
+    tmp_path, monkeypatch,
+):
+    source = _source(tmp_path)
+    client = _install_upload_mocks(
+        monkeypatch,
+        upload_resp=GetUploadUrlResp(upload_param="param"),
+        outcomes=[
+            FakeResponse(200, text="RAW_PROVIDER_BODY"),
+            FakeResponse(200, body={"download_param": _DOWNLOAD_PARAM}, text="{}"),
+        ],
+    )
+
+    info = _upload(source)
+
+    assert info.cdn_media.encrypt_query_param == _DOWNLOAD_PARAM
+    assert len(client.calls) == 2
+
+
+def test_http_200_unusable_header_falls_through_to_valid_json_reference(
+    tmp_path, monkeypatch,
+):
+    source = _source(tmp_path)
+    client = _install_upload_mocks(
+        monkeypatch,
+        upload_resp=GetUploadUrlResp(upload_param="param"),
+        outcomes=[FakeResponse(
+            200,
+            headers={"x-encrypted-param": "   "},
+            body={"encrypt_query_param": 123, "download_param": _DOWNLOAD_PARAM},
+            text="{}",
+        )],
+    )
+
+    info = _upload(source)
+
+    assert info.cdn_media.encrypt_query_param == _DOWNLOAD_PARAM
+    assert len(client.calls) == 1
+
+
+def test_http_200_nonstring_metadata_is_missing_and_retried(
+    tmp_path, monkeypatch,
+):
+    source = _source(tmp_path)
+    client = _install_upload_mocks(
+        monkeypatch,
+        upload_resp=GetUploadUrlResp(upload_param="param"),
+        outcomes=[
+            FakeResponse(
+                200,
+                body={"encrypt_query_param": {"secret": "RAW_PROVIDER_BODY"}},
+                text="{}",
+            ),
+            _success_response(),
+        ],
+    )
+
+    info = _upload(source)
+
+    assert info.cdn_media.encrypt_query_param == _DOWNLOAD_PARAM
+    assert len(client.calls) == 2
+
+
+def test_http_200_missing_metadata_exhaustion_is_structured_and_redacted(
+    tmp_path, monkeypatch,
+):
+    source = _source(tmp_path)
+    client = _install_upload_mocks(
+        monkeypatch,
+        upload_resp=GetUploadUrlResp(upload_param="param"),
+        outcomes=[
+            FakeResponse(200, text="RAW_PROVIDER_BODY SECRET_QUERY")
+            for _ in range(media.CDN_UPLOAD_MAX_ATTEMPTS)
+        ],
+    )
+
+    with pytest.raises(media.OutboundMediaError) as raised:
+        _upload(source)
+
+    assert raised.value.as_dict() == {
+        "stage": "cdn_upload_response",
+        "message": (
+            "The WeChat CDN accepted the upload but did not return the required "
+            "encrypted media reference."
+        ),
+        "retryable": True,
+        "endpoint_host": "static-cdn.example.invalid",
+    }
+    assert len(client.calls) == 3
+    _assert_redacted(raised.value.as_dict(), local_path=source)
+
+
+def test_cdn_client_construction_exception_is_redacted_response_failure(
+    tmp_path, monkeypatch,
+):
+    source = _source(tmp_path)
+
+    async def get_upload_url(*args, **kwargs):
+        return GetUploadUrlResp(upload_full_url=_PRESIGNED)
+
+    monkeypatch.setattr(media.api, "get_upload_url", get_upload_url)
+    monkeypatch.setattr(
+        media.httpx,
+        "AsyncClient",
+        lambda: (_ for _ in ()).throw(ValueError("RAW_PROVIDER_BODY SECRET_QUERY")),
+    )
+
+    with pytest.raises(media.OutboundMediaError) as raised:
+        _upload(source)
+
+    assert raised.value.as_dict() == {
+        "stage": "cdn_upload_response",
+        "message": "The WeChat CDN upload request could not be prepared.",
+        "retryable": False,
+        "endpoint_host": "upload.example.invalid",
+    }
+    _assert_redacted(raised.value.as_dict(), local_path=source)
+
+
+def test_unexpected_cdn_client_exception_is_redacted_response_failure(
+    tmp_path, monkeypatch,
+):
+    source = _source(tmp_path)
+    client = _install_upload_mocks(
+        monkeypatch,
+        upload_resp=GetUploadUrlResp(upload_full_url=_PRESIGNED),
+        outcomes=[httpx.InvalidURL("RAW_PROVIDER_BODY SECRET_QUERY")],
+    )
+
+    with pytest.raises(media.OutboundMediaError) as raised:
+        _upload(source)
+
+    assert raised.value.as_dict() == {
+        "stage": "cdn_upload_response",
+        "message": "The WeChat CDN upload request could not be prepared.",
+        "retryable": False,
+        "endpoint_host": "upload.example.invalid",
+    }
+    assert len(client.calls) == 1
+    _assert_redacted(raised.value.as_dict(), local_path=source)
+
+
+def test_cdn_tls_exhaustion_exposes_hostname_only(tmp_path, monkeypatch):
+    source = _source(tmp_path)
+    failures = []
+    for _ in range(media.CDN_UPLOAD_MAX_ATTEMPTS):
+        request = httpx.Request("POST", _PRESIGNED)
+        exc = httpx.ConnectError("RAW_PROVIDER_BODY", request=request)
+        exc.__cause__ = ssl.SSLError("SECRET_QUERY TLS failure")
+        failures.append(exc)
+    client = _install_upload_mocks(
+        monkeypatch,
+        upload_resp=GetUploadUrlResp(upload_full_url=_PRESIGNED),
+        outcomes=failures,
+    )
+
+    with pytest.raises(media.OutboundMediaError) as raised:
+        _upload(source)
+
+    assert raised.value.as_dict() == {
+        "stage": "cdn_upload_transport",
+        "message": "Could not connect to or upload bytes to the WeChat CDN.",
+        "retryable": True,
+        "endpoint_host": "upload.example.invalid",
+    }
+    assert len(client.calls) == 3
+    _assert_redacted(raised.value.as_dict(), local_path=source)
+
+
+def test_upload_success_preserves_encryption_sizes_and_media_item_behavior(
+    tmp_path, monkeypatch,
+):
+    source = _source(tmp_path)
+    monkeypatch.setattr(media.secrets, "token_bytes", lambda size: b"k" * size)
+    _install_upload_mocks(
+        monkeypatch,
+        upload_resp=GetUploadUrlResp(upload_param="param"),
+        outcomes=[_success_response()],
+    )
+
+    info = _upload(source)
+    item = media.make_media_item(info, source)
+
+    assert info.raw_size == len(source.read_bytes())
+    assert info.ciphertext_size == media._encrypted_size(info.raw_size)
+    assert info.cdn_media.encrypt_query_param == _DOWNLOAD_PARAM
+    assert info.cdn_media.encrypt_type == 1
+    assert info.cdn_media.aes_key == "NmI2YjZiNmI2YjZiNmI2YjZiNmI2YjZiNmI2YjZiNmI="
+    assert item.image_item is not None
+    assert item.image_item.media is info.cdn_media
+    assert item.image_item.mid_size == info.ciphertext_size
+
+
+def test_manager_passes_configured_cdn_base(tmp_path, monkeypatch):
+    source = _source(tmp_path, "report.html")
+    configured = "https://configured-cdn.example.invalid/custom"
+    manager = _manager(tmp_path, cdn_base_url=configured)
+    captured: dict[str, object] = {}
+
+    async def fake_upload(path, base_url, token, user_id, *, cdn_base_url):
+        captured.update({
+            "path": path,
+            "base_url": base_url,
+            "token": token,
+            "user_id": user_id,
+            "cdn_base_url": cdn_base_url,
+        })
+        return object()
+
+    async def fake_send(*args, **kwargs):
+        return None
+
+    def fake_run(coro, **kwargs):
+        return _run(coro)
+
+    monkeypatch.setattr(media, "upload_media", fake_upload)
+    monkeypatch.setattr(media, "make_media_item", lambda info, path: object())
+    monkeypatch.setattr(manager_mod.api, "send_message", fake_send)
+    monkeypatch.setattr(manager, "_run_async", fake_run)
+
+    result = manager._handle_send({
+        "user_id": "SECRET_USER",
+        "media_path": str(source),
+    })
+
+    assert result["status"] == "ok"
+    assert captured["cdn_base_url"] == configured
+    assert captured["path"] == source
+
+
+def test_media_operation_timeout_budget_exceeds_all_inner_request_budgets():
+    complete_inner_budget = (
+        media.GET_UPLOAD_URL_TIMEOUT_SECONDS
+        + media.CDN_UPLOAD_MAX_ATTEMPTS * media.CDN_UPLOAD_TIMEOUT_SECONDS
+    )
+    assert manager_mod.MEDIA_OPERATION_TIMEOUT_SECONDS > complete_inner_budget
+    assert manager_mod.MEDIA_OPERATION_TIMEOUT_SECONDS == 390.0
+
+
+def test_run_async_outer_timeout_cancels_reconciles_and_raises_structured_failure(
+    tmp_path,
+):
+    manager = _manager(tmp_path)
+    loop = asyncio.new_event_loop()
+    thread = manager_mod.threading.Thread(
+        target=loop.run_forever,
+        daemon=True,
+    )
+    thread.start()
+    manager._loop = loop
+    started = manager_mod.threading.Event()
+    reconciled = manager_mod.threading.Event()
+
+    async def operation():
+        started.set()
+        try:
+            await asyncio.sleep(60)
+        finally:
+            reconciled.set()
+
+    expected = media.OutboundMediaError(
+        stage="media_operation_timeout",
+        message="The local WeChat media operation exceeded its deadline.",
+        retryable=True,
+    )
+    try:
+        with pytest.raises(media.OutboundMediaError) as raised:
+            manager._run_async(operation(), timeout=0.05, timeout_error=expected)
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+        thread.join(timeout=1)
+        loop.close()
+
+    assert started.is_set()
+    assert reconciled.is_set()
+    assert raised.value is expected
+    assert raised.value.as_dict() == {
+        "stage": "media_operation_timeout",
+        "message": "The local WeChat media operation exceeded its deadline.",
+        "retryable": True,
+    }
+
+
+def _timeout_fake_run(calls: list[tuple[str, float, str | None]]):
+    def fake_run(coro, *, timeout=30, timeout_error=None):
+        name = coro.cr_code.co_name
+        stage = getattr(timeout_error, "stage", None)
+        calls.append((name, timeout, stage))
+        coro.close()
+        if name == "upload_media":
+            assert isinstance(timeout_error, media.OutboundMediaError)
+            raise timeout_error
+        return None
+
+    return fake_run
+
+
+def test_outer_timeout_after_text_delivery_persists_one_nonretryable_partial(
+    tmp_path, monkeypatch,
+):
+    source = _source(tmp_path, "report.html")
+    manager = _manager(tmp_path)
+    calls: list[tuple[str, float, str | None]] = []
+    monkeypatch.setattr(manager, "_run_async", _timeout_fake_run(calls))
+
+    result = manager._handle_send({
+        "user_id": "SECRET_USER",
+        "text": "already delivered",
+        "media_path": str(source),
+    })
+
+    assert result["status"] == "partial"
+    assert result["partial_delivery"] is True
+    assert result["text_status"] == "sent"
+    assert result["media_status"] == "failed"
+    assert result["automatic_retry_allowed"] is False
+    assert result["failure"] == {
+        "stage": "media_operation_timeout",
+        "message": "The local WeChat media operation exceeded its deadline.",
+        "retryable": True,
+    }
+    assert calls == [
+        ("send_message", 30, None),
+        (
+            "upload_media",
+            manager_mod.MEDIA_OPERATION_TIMEOUT_SECONDS,
+            "media_operation_timeout",
+        ),
+    ]
+    persisted = manager._load_sent_messages()
+    assert len(persisted) == 1
+    assert persisted[0]["status"] == "partial"
+    assert persisted[0]["text"] == "already delivered"
+    assert persisted[0]["media_name"] == "report.html"
+    assert persisted[0]["automatic_retry_allowed"] is False
+    assert "media_path" not in persisted[0]
+    _assert_redacted(result, local_path=source)
+    _assert_redacted(persisted[0]["failure"], local_path=source)
+
+
+def test_media_only_outer_timeout_is_not_persisted(tmp_path, monkeypatch):
+    source = _source(tmp_path, "report.html")
+    manager = _manager(tmp_path)
+    calls: list[tuple[str, float, str | None]] = []
+    monkeypatch.setattr(manager, "_run_async", _timeout_fake_run(calls))
+
+    result = manager._handle_send({
+        "user_id": "SECRET_USER",
+        "media_path": str(source),
+    })
+
+    assert result == {
+        "status": "failed",
+        "error": "The local WeChat media operation exceeded its deadline.",
+        "media_status": "failed",
+        "failure": {
+            "stage": "media_operation_timeout",
+            "message": "The local WeChat media operation exceeded its deadline.",
+            "retryable": True,
+        },
+        "automatic_retry_allowed": True,
+    }
+    assert manager._load_sent_messages() == []
+    assert calls == [
+        (
+            "upload_media",
+            manager_mod.MEDIA_OPERATION_TIMEOUT_SECONDS,
+            "media_operation_timeout",
+        ),
+    ]
+    _assert_redacted(result, local_path=source)
+
+
+def test_text_plus_media_upload_failure_returns_and_persists_partial_result(
+    tmp_path, monkeypatch,
+):
+    source = _source(tmp_path, "report.html")
+    manager = _manager(tmp_path)
+
+    def fake_run(coro, *, timeout=30, timeout_error=None):
+        name = coro.cr_code.co_name
+        coro.close()
+        if name == "upload_media":
+            raise media.OutboundMediaError(
+                stage="cdn_upload_transport",
+                message="Could not connect to or upload bytes to the WeChat CDN.",
+                endpoint_host="upload.example.invalid",
+                retryable=True,
+            )
+        return None
+
+    monkeypatch.setattr(manager, "_run_async", fake_run)
+    result = manager._handle_send({
+        "user_id": "SECRET_USER",
+        "text": "already delivered",
+        "media_path": str(source),
+    })
+
+    assert result["status"] == "partial"
+    assert result["automatic_retry_allowed"] is False
+    assert result["failure"]["stage"] == "cdn_upload_transport"
+    persisted = manager._load_sent_messages()
+    assert len(persisted) == 1
+    assert persisted[0]["status"] == "partial"
+    assert persisted[0]["media_name"] == "report.html"
+    assert "media_path" not in persisted[0]
+    _assert_redacted(result, local_path=source)
+
+
+def test_final_media_message_failure_is_partial_and_redacted(tmp_path, monkeypatch):
+    source = _source(tmp_path, "report.html")
+    manager = _manager(tmp_path)
+    send_calls = 0
+
+    def fake_run(coro, *, timeout=30, timeout_error=None):
+        nonlocal send_calls
+        name = coro.cr_code.co_name
+        coro.close()
+        if name == "upload_media":
+            return object()
+        if name == "send_message":
+            send_calls += 1
+            if send_calls == 2:
+                request = httpx.Request(
+                    "POST",
+                    "https://ilink.example.invalid/sendmessage?token=SECRET_QUERY",
+                )
+                raise httpx.ConnectError(
+                    "RAW_PROVIDER_BODY SECRET_USER", request=request
+                )
+        return None
+
+    monkeypatch.setattr(manager, "_run_async", fake_run)
+    monkeypatch.setattr(media, "make_media_item", lambda info, path: object())
+    result = manager._handle_send({
+        "user_id": "SECRET_USER",
+        "text": "already delivered",
+        "media_path": str(source),
+    })
+
+    assert result["status"] == "partial"
+    assert result["failure"] == {
+        "stage": "media_message_transport",
+        "message": "Could not reach WeChat iLink while sending the media message.",
+        "retryable": True,
+    }
+    assert result["automatic_retry_allowed"] is False
+    _assert_redacted(result, local_path=source)
+
+
+@pytest.mark.parametrize(
+    ("exc", "expected"),
+    [
+        (
+            httpx.HTTPStatusError(
+                "RAW_PROVIDER_BODY SECRET_QUERY",
+                request=httpx.Request("POST", "https://ilink.example.invalid/send"),
+                response=httpx.Response(
+                    503,
+                    request=httpx.Request("POST", "https://ilink.example.invalid/send"),
+                ),
+            ),
+            {
+                "stage": "media_message_http",
+                "message": "WeChat iLink rejected the media message (HTTP 503).",
+                "retryable": True,
+            },
+        ),
+        (
+            ValueError("RAW_PROVIDER_BODY SECRET_QUERY"),
+            {
+                "stage": "media_message_response",
+                "message": "WeChat iLink did not accept the media message.",
+                "retryable": False,
+            },
+        ),
+    ],
+)
+def test_final_media_message_http_and_response_stages_are_redacted(exc, expected):
+    failure = media.media_message_failure(exc).as_dict()
+    assert failure == expected
+    _assert_redacted(failure)
+
+
+@pytest.mark.parametrize(
+    ("record", "expected"),
+    [
+        ({"media_name": "report.html"}, "[media: report.html]"),
+        (
+            {"media_path": "/private/historical/secret/report.html"},
+            "[media: report.html]",
+        ),
+    ],
+)
+def test_handle_check_media_only_preview_uses_basename_only(
+    record, expected, tmp_path,
+):
+    manager = _manager(tmp_path)
+    msg_id = "legacy-or-new"
+    msg_dir = tmp_path / "wechat" / "sent" / msg_id
+    msg_dir.mkdir(parents=True)
+    (msg_dir / "message.json").write_text(
+        json.dumps({
+            "id": msg_id,
+            "to_user_id": "peer-user",
+            "text": "",
+            "date": "2026-08-12T00:00:00+00:00",
+            **record,
+        }),
+        encoding="utf-8",
+    )
+
+    result = manager._handle_check({})
+
+    assert result["conversations"][0]["latest"] == expected
+    rendered = json.dumps(result)
+    assert "/private/historical/secret" not in rendered
+
+
+def test_successful_new_media_record_persists_basename_not_path(tmp_path):
+    manager = _manager(tmp_path)
+    msg_id = manager._persist_sent(
+        user_id="peer-user",
+        text="",
+        status="sent",
+        sent=["media (report.html)"],
+        media_name="report.html",
+    )
+
+    persisted = manager._load_sent_messages()[0]
+    assert persisted["id"] == msg_id
+    assert persisted["media_name"] == "report.html"
+    assert "media_path" not in persisted
+    assert manager._message_display_text({
+        **persisted,
+        "_direction": "outgoing",
+    }) == "[media: report.html]"

--- a/tests/test_wechat_media_upload_errors.py
+++ b/tests/test_wechat_media_upload_errors.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import asyncio
 import json
 import ssl
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import httpx
@@ -706,18 +708,19 @@ def test_run_async_outer_timeout_cancels_reconciles_and_raises_structured_failur
     async def operation():
         started.set()
         try:
-            await asyncio.sleep(60)
+            await asyncio.Event().wait()
         finally:
             reconciled.set()
 
     expected = media.OutboundMediaError(
         stage="media_operation_timeout",
         message="The local WeChat media operation exceeded its deadline.",
-        retryable=True,
+        retryable=False,
+        remote_acceptance="unknown",
     )
     try:
         with pytest.raises(media.OutboundMediaError) as raised:
-            manager._run_async(operation(), timeout=0.05, timeout_error=expected)
+            manager._run_async(operation(), timeout=0, timeout_error=expected)
     finally:
         loop.call_soon_threadsafe(loop.stop)
         thread.join(timeout=1)
@@ -729,8 +732,158 @@ def test_run_async_outer_timeout_cancels_reconciles_and_raises_structured_failur
     assert raised.value.as_dict() == {
         "stage": "media_operation_timeout",
         "message": "The local WeChat media operation exceeded its deadline.",
-        "retryable": True,
+        "retryable": False,
+        "remote_acceptance": "unknown",
     }
+
+
+def test_run_async_timeout_waits_for_cancellation_resistant_child_exit(
+    tmp_path, monkeypatch,
+):
+    manager = _manager(tmp_path)
+    loop = asyncio.new_event_loop()
+    loop_thread = threading.Thread(target=loop.run_forever, daemon=True)
+    loop_thread.start()
+    manager._loop = loop
+    started = threading.Event()
+    cancellation_seen = threading.Event()
+    release_child = threading.Event()
+    child_exited = threading.Event()
+    reconciler_waiting = threading.Event()
+    late_side_effects: list[str] = []
+    expected = media.OutboundMediaError(
+        stage="media_operation_timeout",
+        message="The local WeChat media operation exceeded its deadline.",
+        retryable=False,
+        remote_acceptance="unknown",
+    )
+    real_future = manager_mod.Future
+
+    class ObservedFuture(real_future):
+        def result(self, timeout=None):
+            if timeout is None:
+                reconciler_waiting.set()
+            return super().result(timeout=timeout)
+
+    async def resistant_operation():
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancellation_seen.set()
+            while not release_child.is_set():
+                await asyncio.sleep(0)
+            late_side_effects.append("child-finished-before-return")
+        finally:
+            child_exited.set()
+
+    def invoke():
+        try:
+            manager._run_async(
+                resistant_operation(), timeout=0, timeout_error=expected,
+            )
+        except Exception as exc:
+            return exc
+        raise AssertionError("timeout call unexpectedly succeeded")
+
+    monkeypatch.setattr(manager_mod, "Future", ObservedFuture)
+    try:
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            returned = executor.submit(invoke)
+            assert started.wait(timeout=1)
+            assert cancellation_seen.wait(timeout=1)
+            assert reconciler_waiting.wait(timeout=1)
+            assert not returned.done()
+            assert not child_exited.is_set()
+            assert late_side_effects == []
+
+            release_child.set()
+            raised = returned.result(timeout=1)
+
+        assert raised is expected
+        assert child_exited.is_set()
+        assert late_side_effects == ["child-finished-before-return"]
+    finally:
+        release_child.set()
+        loop.call_soon_threadsafe(loop.stop)
+        loop_thread.join(timeout=1)
+        loop.close()
+
+
+def test_run_async_timeout_before_task_start_cannot_launch_late_work(tmp_path):
+    manager = _manager(tmp_path)
+    late_effects: list[str] = []
+
+    class AcceptingStoppedLoop:
+        def is_running(self):
+            return True
+
+        def call_soon_threadsafe(self, callback):
+            self.callback = callback
+
+    loop = AcceptingStoppedLoop()
+    manager._loop = loop
+    expected = media.OutboundMediaError(
+        stage="media_operation_timeout",
+        message="The local WeChat media operation exceeded its deadline.",
+        retryable=False,
+        remote_acceptance="unknown",
+    )
+
+    async def operation():
+        late_effects.append("started")
+
+    with pytest.raises(media.OutboundMediaError) as raised:
+        manager._run_async(operation(), timeout=0, timeout_error=expected)
+
+    assert raised.value is expected
+    assert late_effects == []
+    loop.callback()
+    assert late_effects == []
+
+
+def test_run_async_task_start_winning_handshake_boundary_is_reconciled(
+    tmp_path, monkeypatch,
+):
+    manager = _manager(tmp_path)
+    loop = asyncio.new_event_loop()
+    loop_thread = threading.Thread(target=loop.run_forever, daemon=True)
+    loop_thread.start()
+    manager._loop = loop
+    expected = media.OutboundMediaError(
+        stage="media_operation_timeout",
+        message="The local WeChat media operation exceeded its deadline.",
+        retryable=False,
+        remote_acceptance="unknown",
+    )
+    task_started = threading.Event()
+    child_exited = threading.Event()
+    real_event = manager_mod.threading.Event
+
+    class BoundaryEvent(real_event):
+        def wait(self, timeout=None):
+            assert super().wait(timeout=1)
+            return False
+
+    async def operation():
+        task_started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            child_exited.set()
+
+    monkeypatch.setattr(manager_mod.threading, "Event", BoundaryEvent)
+    try:
+        with pytest.raises(media.OutboundMediaError) as raised:
+            manager._run_async(operation(), timeout=0, timeout_error=expected)
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+        loop_thread.join(timeout=1)
+        loop.close()
+
+    assert raised.value is expected
+    assert task_started.is_set()
+    assert child_exited.is_set()
 
 
 def _timeout_fake_run(calls: list[tuple[str, float, str | None]]):
@@ -764,12 +917,13 @@ def test_outer_timeout_after_text_delivery_persists_one_nonretryable_partial(
     assert result["status"] == "partial"
     assert result["partial_delivery"] is True
     assert result["text_status"] == "sent"
-    assert result["media_status"] == "failed"
+    assert result["media_status"] == "unknown"
     assert result["automatic_retry_allowed"] is False
     assert result["failure"] == {
         "stage": "media_operation_timeout",
         "message": "The local WeChat media operation exceeded its deadline.",
-        "retryable": True,
+        "retryable": False,
+        "remote_acceptance": "unknown",
     }
     assert calls == [
         ("send_message", 30, None),
@@ -804,13 +958,14 @@ def test_media_only_outer_timeout_is_not_persisted(tmp_path, monkeypatch):
     assert result == {
         "status": "failed",
         "error": "The local WeChat media operation exceeded its deadline.",
-        "media_status": "failed",
+        "media_status": "unknown",
         "failure": {
             "stage": "media_operation_timeout",
             "message": "The local WeChat media operation exceeded its deadline.",
-            "retryable": True,
+            "retryable": False,
+            "remote_acceptance": "unknown",
         },
-        "automatic_retry_allowed": True,
+        "automatic_retry_allowed": False,
     }
     assert manager._load_sent_messages() == []
     assert calls == [
@@ -894,8 +1049,10 @@ def test_final_media_message_failure_is_partial_and_redacted(tmp_path, monkeypat
     assert result["failure"] == {
         "stage": "media_message_transport",
         "message": "Could not reach WeChat iLink while sending the media message.",
-        "retryable": True,
+        "retryable": False,
+        "remote_acceptance": "unknown",
     }
+    assert result["media_status"] == "unknown"
     assert result["automatic_retry_allowed"] is False
     _assert_redacted(result, local_path=source)
 
@@ -915,7 +1072,8 @@ def test_final_media_message_failure_is_partial_and_redacted(tmp_path, monkeypat
             {
                 "stage": "media_message_http",
                 "message": "WeChat iLink rejected the media message (HTTP 503).",
-                "retryable": True,
+                "retryable": False,
+                "remote_acceptance": "unknown",
             },
         ),
         (
@@ -924,6 +1082,7 @@ def test_final_media_message_failure_is_partial_and_redacted(tmp_path, monkeypat
                 "stage": "media_message_response",
                 "message": "WeChat iLink did not accept the media message.",
                 "retryable": False,
+                "remote_acceptance": "rejected",
             },
         ),
     ],
@@ -932,6 +1091,226 @@ def test_final_media_message_http_and_response_stages_are_redacted(exc, expected
     failure = media.media_message_failure(exc).as_dict()
     assert failure == expected
     _assert_redacted(failure)
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        httpx.ConnectError(
+            "RAW_PROVIDER_BODY SECRET_QUERY",
+            request=httpx.Request("POST", "https://ilink.example.invalid/send"),
+        ),
+        httpx.HTTPStatusError(
+            "RAW_PROVIDER_BODY SECRET_QUERY",
+            request=httpx.Request("POST", "https://ilink.example.invalid/send"),
+            response=httpx.Response(
+                429,
+                request=httpx.Request("POST", "https://ilink.example.invalid/send"),
+            ),
+        ),
+        httpx.HTTPStatusError(
+            "RAW_PROVIDER_BODY SECRET_QUERY",
+            request=httpx.Request("POST", "https://ilink.example.invalid/send"),
+            response=httpx.Response(
+                503,
+                request=httpx.Request("POST", "https://ilink.example.invalid/send"),
+            ),
+        ),
+    ],
+)
+def test_media_only_final_message_ambiguous_outcome_forbids_automatic_retry(
+    exc, tmp_path, monkeypatch,
+):
+    source = _source(tmp_path, "report.html")
+    manager = _manager(tmp_path)
+
+    def fake_run(coro, *, timeout=30, timeout_error=None):
+        name = coro.cr_code.co_name
+        coro.close()
+        if name == "upload_media":
+            return object()
+        if name == "send_message":
+            raise exc
+        raise AssertionError(name)
+
+    monkeypatch.setattr(manager, "_run_async", fake_run)
+    monkeypatch.setattr(media, "make_media_item", lambda info, path: object())
+
+    result = manager._handle_send({
+        "user_id": "SECRET_USER",
+        "media_path": str(source),
+    })
+
+    assert result["status"] == "failed"
+    assert result["media_status"] == "unknown"
+    assert result["failure"]["remote_acceptance"] == "unknown"
+    assert result["failure"]["retryable"] is False
+    assert result["automatic_retry_allowed"] is False
+    assert manager._load_sent_messages() == []
+    _assert_redacted(result, local_path=source)
+
+
+def _install_text_send_sequence(manager, monkeypatch, *, failure_call: int | None):
+    calls: list[str] = []
+
+    def fake_run(coro, *, timeout=30, timeout_error=None):
+        name = coro.cr_code.co_name
+        text = None
+        if name == "send_message":
+            msg = coro.cr_frame.f_locals["msg"]
+            text = msg.item_list[0].text_item.text
+        coro.close()
+        if name != "send_message":
+            raise AssertionError(name)
+        calls.append(text)
+        if failure_call is not None and len(calls) == failure_call:
+            raise RuntimeError("RAW_PROVIDER_BODY SECRET_QUERY unsent suffix")
+        return None
+
+    monkeypatch.setattr(manager, "_run_async", fake_run)
+    return calls
+
+
+def test_later_text_chunk_failure_persists_safe_delivered_prefix(
+    tmp_path, monkeypatch,
+):
+    manager = _manager(tmp_path)
+    text = "A" * manager_mod.TEXT_CHUNK_LIMIT + "SECRET_UNSENT_SUFFIX"
+    calls = _install_text_send_sequence(manager, monkeypatch, failure_call=2)
+
+    result = manager._handle_send({"user_id": "SECRET_USER", "text": text})
+
+    assert len(calls) == 2
+    assert calls[0] == "A" * manager_mod.TEXT_CHUNK_LIMIT
+    assert calls[1] == "SECRET_UNSENT_SUFFIX"
+    assert result["status"] == "partial"
+    assert result["partial_delivery"] is True
+    assert result["text_status"] == "partial"
+    assert result["delivered_text_chunks"] == 1
+    assert result["total_text_chunks"] == 2
+    assert result["failed_text_chunk"] == 2
+    assert result["automatic_retry_allowed"] is False
+    assert result["failure"] == {
+        "stage": "text_message_response",
+        "message": "WeChat iLink did not accept text chunk 2.",
+        "retryable": False,
+        "remote_acceptance": "rejected",
+        "failed_text_chunk": 2,
+        "total_text_chunks": 2,
+    }
+    assert result["sent"] == [f"text ({manager_mod.TEXT_CHUNK_LIMIT} chars)"]
+
+    persisted = manager._load_sent_messages()
+    assert len(persisted) == 1
+    assert persisted[0]["text"] == "A" * manager_mod.TEXT_CHUNK_LIMIT
+    assert persisted[0]["text_status"] == "partial"
+    assert persisted[0]["delivered_text_chunks"] == 1
+    assert persisted[0]["total_text_chunks"] == 2
+    assert persisted[0]["failed_text_chunk"] == 2
+    assert persisted[0]["automatic_retry_allowed"] is False
+    rendered = json.dumps({"result": result, "persisted": persisted})
+    assert "SECRET_UNSENT_SUFFIX" not in rendered
+    assert "RAW_PROVIDER_BODY" not in rendered
+    assert "SECRET_QUERY" not in rendered
+
+
+def test_first_text_chunk_known_rejection_has_no_partial_record(
+    tmp_path, monkeypatch,
+):
+    manager = _manager(tmp_path)
+    request = httpx.Request("POST", "https://ilink.example.invalid/send")
+    calls: list[str] = []
+
+    def fake_run(coro, *, timeout=30, timeout_error=None):
+        msg = coro.cr_frame.f_locals["msg"]
+        calls.append(msg.item_list[0].text_item.text)
+        coro.close()
+        raise httpx.HTTPStatusError(
+            "RAW_PROVIDER_BODY SECRET_QUERY",
+            request=request,
+            response=httpx.Response(400, request=request),
+        )
+
+    monkeypatch.setattr(manager, "_run_async", fake_run)
+    result = manager._handle_send({
+        "user_id": "SECRET_USER",
+        "text": "B" * (manager_mod.TEXT_CHUNK_LIMIT + 1),
+    })
+
+    assert len(calls) == 1
+    assert result == {
+        "status": "failed",
+        "error": "WeChat iLink rejected text chunk 1 (HTTP 400).",
+        "text_status": "failed",
+        "failure": {
+            "stage": "text_message_http",
+            "message": "WeChat iLink rejected text chunk 1 (HTTP 400).",
+            "retryable": False,
+            "remote_acceptance": "rejected",
+            "failed_text_chunk": 1,
+            "total_text_chunks": 2,
+        },
+        "automatic_retry_allowed": False,
+    }
+    assert manager._load_sent_messages() == []
+    _assert_redacted(result)
+
+
+def test_first_text_chunk_ambiguous_transport_forbids_automatic_retry(
+    tmp_path, monkeypatch,
+):
+    manager = _manager(tmp_path)
+    request = httpx.Request("POST", "https://ilink.example.invalid/send")
+
+    def fake_run(coro, *, timeout=30, timeout_error=None):
+        coro.close()
+        raise httpx.ConnectError(
+            "RAW_PROVIDER_BODY SECRET_QUERY", request=request,
+        )
+
+    monkeypatch.setattr(manager, "_run_async", fake_run)
+    result = manager._handle_send({
+        "user_id": "SECRET_USER",
+        "text": "one chunk",
+    })
+
+    assert result["status"] == "failed"
+    assert result["text_status"] == "failed"
+    assert result["automatic_retry_allowed"] is False
+    assert result["failure"] == {
+        "stage": "text_message_transport",
+        "message": "Could not reach WeChat iLink while sending text chunk 1.",
+        "retryable": False,
+        "remote_acceptance": "unknown",
+        "failed_text_chunk": 1,
+        "total_text_chunks": 1,
+    }
+    assert manager._load_sent_messages() == []
+    _assert_redacted(result)
+
+
+def test_successful_multi_chunk_text_persists_complete_delivery(
+    tmp_path, monkeypatch,
+):
+    manager = _manager(tmp_path)
+    text = "C" * manager_mod.TEXT_CHUNK_LIMIT + "tail"
+    calls = _install_text_send_sequence(manager, monkeypatch, failure_call=None)
+
+    result = manager._handle_send({"user_id": "SECRET_USER", "text": text})
+
+    assert result["status"] == "ok"
+    assert calls == ["C" * manager_mod.TEXT_CHUNK_LIMIT, "tail"]
+    assert result["sent"] == [
+        f"text ({manager_mod.TEXT_CHUNK_LIMIT} chars)",
+        "text (4 chars)",
+    ]
+    persisted = manager._load_sent_messages()
+    assert len(persisted) == 1
+    assert persisted[0]["status"] == "sent"
+    assert persisted[0]["text"] == text
+    assert persisted[0]["delivered_text_chunks"] == 2
+    assert persisted[0]["total_text_chunks"] == 2
+    assert "failure" not in persisted[0]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- implement Tencent/OpenClaw-compatible encrypted WeChat media upload metadata and type-specific size fields;
- prefer the official static CDN upload construction when `upload_param` is present, while retaining the dynamic signed URL only as an absent-parameter compatibility fallback;
- retry only the encrypted CDN POST, at most three immediate attempts, for transport/TLS, HTTP 429/5xx, or a success response missing usable encrypted metadata;
- redact secret upload URLs, response bodies, local paths, recipient identifiers, unsent text suffixes, and raw provider errors from tool-visible failures;
- preserve truthful partial-delivery state for combined text+media and later text-chunk failures;
- treat final media transport/429/5xx outcomes as remote acceptance unknown and disable automatic retry, including media-only sends;
- make timeout cancellation task-owned: after a media task starts, wait for its real exit before returning; if scheduling is accepted but the task never starts, fail within a separate one-second handshake and prevent late launch;
- document the corrected retry, timeout, partial-delivery and manual-reconciliation behavior and add focused regressions.

## Why

The previous outbound path could report generic failures while exposing internal URLs or paths, could retry at the wrong layer, could lose the delivered prefix after a later text-chunk failure, could invite duplicate media sends when final acceptance was unknowable, and could return a terminal timeout while media work continued. It also did not follow the official static CDN upload route when `upload_param` was available.

This patch makes the protocol choice explicit, constrains retries to the encrypted CDN byte upload, preserves only redacted partial state, disables unsafe whole-message retries, and closes both post-start and pre-start task-detachment races.

## Evidence boundary

This is a source/regression fix, not proof of production media recovery. No real WeChat media upload was run. The actual dynamic signed upload host, exact failing substage and TLS root cause remain unknown. A cancellation-resistant child may extend wall-clock time beyond the nominal timeout because the caller now waits for its real exit rather than returning while it continues.

## Validation

- focused media-upload + outbound-containment tests: **59 passed**
- exact eight WeChat modules + outbound containment: **202 passed**
- architecture-document tests: **4 passed**
- no-bytecode compile of the changed runtime modules and affected test files: **passed**
- `git diff --check`: **passed**
- exact six-file scope, staged/untracked/debris and public-patch privacy gates: **passed**

## Out of scope

- merge, release, runtime/config/refresh or TLS-policy changes;
- real-media end-to-end acceptance;
- proving which dynamic signed hostname failed;
- Windows-style legacy basename display and inherited inbound/download exception redaction;
- the separate OpenAI/Anthropic read-timeout proposal.

Telegram: @wangrunyuansecbot | Nickname: 一心

Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai