### PR TITLE
fix(llm): align adapter read timeout with 300s retry watchdog for thinking models

### DIFF
--- a/ENVIRONMENT_VARIABLES.md
+++ b/ENVIRONMENT_VARIABLES.md
@@ -4,7 +4,7 @@ description: >
   Canonical registry for environment variables consumed by LingTai source,
   bundled MCPs, adapters, daemon composition, and focused tests.
 version: 1.0.0
-last_changed_at: "2026-08-10"
+last_changed_at: "2026-08-12"
 related_files:
 - ANATOMY.md
 - CONTRACT.md
@@ -22,6 +22,7 @@ related_files:
 - src/lingtai/kernel/nudge/ANATOMY.md
 - src/lingtai/kernel/refresh_watcher/ANATOMY.md
 - src/lingtai/llm/openai/ANATOMY.md
+- src/lingtai/llm/anthropic/ANATOMY.md
 - src/lingtai/mcp_servers/ANATOMY.md
 - src/lingtai/mcp_servers/local_commands/ANATOMY.md
 - src/lingtai/prompts/ANATOMY.md
@@ -92,6 +93,7 @@ reports, prompts, or this registry.
 | `LINGTAI_CODEX_WS_EPOCH_RESET_TURNS` | `0` | Non-negative integer | Codex diagnostic WebSocket epoch | Session construction; restart session | Invalid value falls back to the adapter default (`0`, turn-count reset disabled) | Codex adapter | Avoid values that cause unexpected session churn |
 | `LINGTAI_CODEX_RESPONSES_TRACE` | off | Adapter-recognized boolean | Bounded Codex Responses-wire diagnostics | Session construction; restart session | Invalid value is treated as off | Codex adapter | Traces remain local and redacted |
 | `LINGTAI_CODEX_RESPONSES_TRACE_PATH` | unset; adapter default | Local path | Codex Responses-wire diagnostics | Session construction; restart session | Unwritable or invalid path fails closed or disables tracing | Codex adapter | Trace files can contain sensitive prompts; restrict permissions |
+| `LINGTAI_LLM_READ_TIMEOUT` | `300` seconds | Positive finite numeric seconds | Per-phase HTTP read cap for OpenAI-compatible and Anthropic adapter SDK calls | Each `_build_http_timeout` call; no restart | Missing, blank, non-numeric, non-finite, zero, or negative values fall back to `300` | `src/lingtai/llm/openai/adapter.py`, `src/lingtai/llm/anthropic/adapter.py` | Tunes read tolerance only; the main-thread watchdog still bounds total request time and it grants no capability |
 | `LINGTAI_CLAUDE_MANAGED_ROOT` | Host-specific or unset | Local directory path | Claude launcher | Launch; relaunch after change | Invalid path fails closed | Claude adapter | Never widen the root from untrusted model text |
 | `LINGTAI_CLAUDE_INTERACTIVE_FIFO` | unset | Local FIFO or path | Claude interactive launch | Interactive launch; relaunch after change | Wrong type or permissions fail closed | Claude adapter | Protect the FIFO from other users and processes |
 | `LINGTAI_TASKCARD_POLL_INTERVAL` | `5.0` seconds | Positive numeric seconds (float) | Telegram automatic Task Card event-tail poll interval | Telegram manager load/start; restart after change | Non-numeric value fails manager load | `src/lingtai/mcp_servers/telegram/manager.py` | Display cadence only; no delivery or authorization effect |

--- a/src/lingtai/llm/anthropic/ANATOMY.md
+++ b/src/lingtai/llm/anthropic/ANATOMY.md
@@ -1,5 +1,6 @@
 ---
 related_files:
+  - ENVIRONMENT_VARIABLES.md
   - src/lingtai/llm/ANATOMY.md
   - src/lingtai/llm/anthropic/__init__.py
   - src/lingtai/llm/anthropic/adapter.py

--- a/src/lingtai/llm/anthropic/adapter.py
+++ b/src/lingtai/llm/anthropic/adapter.py
@@ -26,12 +26,18 @@ logger = get_logger()
 
 
 def _build_http_timeout(request_timeout: float | None):
-    """Build explicit per-phase HTTP timeout for SDK calls."""
+    """Build explicit per-phase HTTP timeout for SDK calls.
+
+    The read cap stays at least as long as the watchdog's ``retry_timeout``
+    (default 300s, config.py) so modern thinking models (DeepSeek/GLM
+    extended thinking, 60-180s) are not killed mid-thought before the
+    watchdog can decide.
+    """
     if request_timeout is None:
         return None
     return httpx.Timeout(
         connect=min(float(request_timeout), 30.0),
-        read=min(float(request_timeout), 60.0),
+        read=min(float(request_timeout), 300.0),
         write=min(float(request_timeout), 30.0),
         pool=10.0,
     )

--- a/src/lingtai/llm/anthropic/adapter.py
+++ b/src/lingtai/llm/anthropic/adapter.py
@@ -13,6 +13,8 @@ Key Anthropic API differences from OpenAI/Gemini:
 
 from __future__ import annotations
 
+import math
+import os
 import uuid
 from collections.abc import Callable
 from typing import Any
@@ -25,19 +27,42 @@ from lingtai.kernel.logging import get_logger
 logger = get_logger()
 
 
+_READ_TIMEOUT_ENV = "LINGTAI_LLM_READ_TIMEOUT"
+_READ_TIMEOUT_DEFAULT = 300.0
+
+
+def _read_timeout_cap() -> float:
+    """Resolve the per-phase HTTP read cap (seconds).
+
+    ``LINGTAI_LLM_READ_TIMEOUT`` overrides the default 300s cap so operators
+    can tune how long a thinking model may occupy a read phase before the
+    SDK gives up. Values must be positive and finite; anything else falls
+    back to the default.
+    """
+    raw = os.environ.get(_READ_TIMEOUT_ENV, "").strip()
+    if raw:
+        try:
+            value = float(raw)
+        except ValueError:
+            return _READ_TIMEOUT_DEFAULT
+        if math.isfinite(value) and value > 0:
+            return value
+    return _READ_TIMEOUT_DEFAULT
+
+
 def _build_http_timeout(request_timeout: float | None):
     """Build explicit per-phase HTTP timeout for SDK calls.
 
-    The read cap stays at least as long as the watchdog's ``retry_timeout``
-    (default 300s, config.py) so modern thinking models (DeepSeek/GLM
-    extended thinking, 60-180s) are not killed mid-thought before the
-    watchdog can decide.
+    The read cap defaults to the watchdog's ``retry_timeout`` (300s, config.py)
+    so modern thinking models (DeepSeek/GLM extended thinking, 60-180s) are not
+    killed mid-thought before the watchdog can decide. Operators may tune the
+    read cap with ``LINGTAI_LLM_READ_TIMEOUT`` (seconds).
     """
     if request_timeout is None:
         return None
     return httpx.Timeout(
         connect=min(float(request_timeout), 30.0),
-        read=min(float(request_timeout), 300.0),
+        read=min(float(request_timeout), _read_timeout_cap()),
         write=min(float(request_timeout), 30.0),
         pool=10.0,
     )

--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import copy
 import hashlib
 import json
+import math
 import os
 import threading
 import time
@@ -1088,21 +1089,45 @@ def _codex_responses_trace_record(
         logger.warning("Codex Responses trace write failed: %s", exc)
 
 
+_READ_TIMEOUT_ENV = "LINGTAI_LLM_READ_TIMEOUT"
+_READ_TIMEOUT_DEFAULT = 300.0
+
+
+def _read_timeout_cap() -> float:
+    """Resolve the per-phase HTTP read cap (seconds).
+
+    ``LINGTAI_LLM_READ_TIMEOUT`` overrides the default 300s cap so operators
+    can tune how long a thinking model may occupy a read phase before the
+    SDK gives up. Values must be positive and finite; anything else falls
+    back to the default.
+    """
+    raw = os.environ.get(_READ_TIMEOUT_ENV, "").strip()
+    if raw:
+        try:
+            value = float(raw)
+        except ValueError:
+            return _READ_TIMEOUT_DEFAULT
+        if math.isfinite(value) and value > 0:
+            return value
+    return _READ_TIMEOUT_DEFAULT
+
+
 def _build_http_timeout(request_timeout: float | None):
     """Build explicit per-phase HTTP timeout for SDK calls.
 
     The main-thread watchdog controls total wall-clock time. SDK/httpx
     timeout values are per phase, so cap read waits to keep wedged sockets
-    from occupying the worker indefinitely. The read cap must stay at least
-    as long as the watchdog's ``retry_timeout`` (default 300s, config.py) so
-    modern thinking models (DeepSeek/GLM extended thinking, 60-180s) are not
-    killed mid-thought before the watchdog can decide.
+    from occupying the worker indefinitely. The read cap defaults to the
+    watchdog's ``retry_timeout`` (300s, config.py) so modern thinking models
+    (DeepSeek/GLM extended thinking, 60-180s) are not killed mid-thought
+    before the watchdog can decide. Operators may tune the read cap with
+    ``LINGTAI_LLM_READ_TIMEOUT`` (seconds).
     """
     if request_timeout is None:
         return None
     return httpx.Timeout(
         connect=min(float(request_timeout), 30.0),
-        read=min(float(request_timeout), 300.0),
+        read=min(float(request_timeout), _read_timeout_cap()),
         write=min(float(request_timeout), 30.0),
         pool=10.0,
     )

--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -1093,13 +1093,16 @@ def _build_http_timeout(request_timeout: float | None):
 
     The main-thread watchdog controls total wall-clock time. SDK/httpx
     timeout values are per phase, so cap read waits to keep wedged sockets
-    from occupying the worker indefinitely.
+    from occupying the worker indefinitely. The read cap must stay at least
+    as long as the watchdog's ``retry_timeout`` (default 300s, config.py) so
+    modern thinking models (DeepSeek/GLM extended thinking, 60-180s) are not
+    killed mid-thought before the watchdog can decide.
     """
     if request_timeout is None:
         return None
     return httpx.Timeout(
         connect=min(float(request_timeout), 30.0),
-        read=min(float(request_timeout), 60.0),
+        read=min(float(request_timeout), 300.0),
         write=min(float(request_timeout), 30.0),
         pool=10.0,
     )

--- a/tests/test_llm_adapter_timeouts.py
+++ b/tests/test_llm_adapter_timeouts.py
@@ -2,9 +2,16 @@
 from __future__ import annotations
 
 import httpx
+import pytest
 
 from lingtai.llm.openai.adapter import _build_http_timeout as openai_timeout
 from lingtai.llm.anthropic.adapter import _build_http_timeout as anthropic_timeout
+
+
+@pytest.fixture(autouse=True)
+def _clear_read_timeout_env(monkeypatch):
+    """Default tests must be immune to a developer's local env var."""
+    monkeypatch.delenv("LINGTAI_LLM_READ_TIMEOUT", raising=False)
 
 
 def _assert_timeout(t: httpx.Timeout) -> None:
@@ -37,6 +44,38 @@ def test_timeout_read_cap_allows_thinking_models():
     # 60s cap that kills mid-thought.
     t = openai_timeout(300.0)
     assert t.read == 300.0
+    assert anthropic_timeout(300.0).read == 300.0
+
+
+def test_timeout_read_cap_default_when_env_unset():
+    assert openai_timeout(300.0).read == 300.0
+    assert anthropic_timeout(300.0).read == 300.0
+
+
+def test_timeout_read_cap_env_override():
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setenv("LINGTAI_LLM_READ_TIMEOUT", "120")
+    try:
+        assert openai_timeout(300.0).read == 120.0
+        assert anthropic_timeout(300.0).read == 120.0
+    finally:
+        monkeypatch.undo()
+
+
+def test_timeout_read_cap_env_cannot_exceed_request_timeout():
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setenv("LINGTAI_LLM_READ_TIMEOUT", "120")
+    try:
+        # request_timeout is the upper bound; the env cap only lowers it.
+        assert openai_timeout(60.0).read == 60.0
+        assert anthropic_timeout(60.0).read == 60.0
+    finally:
+        monkeypatch.undo()
+
+
+def test_timeout_read_cap_env_invalid_falls_back(monkeypatch):
+    monkeypatch.setenv("LINGTAI_LLM_READ_TIMEOUT", "not-a-number")
+    assert openai_timeout(300.0).read == 300.0
     assert anthropic_timeout(300.0).read == 300.0
 
 

--- a/tests/test_llm_adapter_timeouts.py
+++ b/tests/test_llm_adapter_timeouts.py
@@ -10,7 +10,7 @@ from lingtai.llm.anthropic.adapter import _build_http_timeout as anthropic_timeo
 def _assert_timeout(t: httpx.Timeout) -> None:
     assert isinstance(t, httpx.Timeout)
     assert t.connect == 30.0
-    assert t.read == 60.0
+    assert t.read == 300.0
     assert t.write == 30.0
     assert t.pool == 10.0
 
@@ -29,6 +29,15 @@ def test_timeout_respects_shorter_retry_timeout():
     assert t.read == 10.0
     assert t.write == 10.0
     assert t.pool == 10.0
+
+
+def test_timeout_read_cap_allows_thinking_models():
+    # Thinking models (DeepSeek/GLM extended thinking) can take 60-180s; the
+    # read phase must stay under the watchdog's retry_timeout (300s), not a
+    # 60s cap that kills mid-thought.
+    t = openai_timeout(300.0)
+    assert t.read == 300.0
+    assert anthropic_timeout(300.0).read == 300.0
 
 
 def test_timeout_none_passthrough():


### PR DESCRIPTION
## What

Raises the per-phase HTTP **read** timeout cap in both LLM adapters from 60s to 300s so it matches the main-thread watchdog's `retry_timeout` (`config.py` default 300s).

## Why

`config.retry_timeout` was bumped from 120s to 300s (2026-04-25) because modern thinking models (GLM-5.1, DeepSeek V4 thinking, Anthropic extended-thinking) routinely take 60-180s for high-context turns. But `_build_http_timeout` hard-caps the httpx read phase at 60s in both `openai/adapter.py` and `anthropic/adapter.py` (that 60s cap was added 2026-05-04, after the bump, silently reverting the intent). With the default non-streaming wire, a thinking turn exceeding 60s now dies with an `httpx.ReadTimeout`, is classified as a transient provider error, burns transient retries and AED budget, and triggers the AED cascade — instead of letting the 300s watchdog decide.

## Changes

- `src/lingtai/llm/openai/adapter.py`: `read=min(request_timeout, 300.0)` + docstring rationale
- `src/lingtai/llm/anthropic/adapter.py`: same
- `tests/test_llm_adapter_timeouts.py`: assert 300s cap; add `test_timeout_read_cap_allows_thinking_models`

## Validation

- `tests/test_llm_adapter_timeouts.py` + `tests/test_llm_utils.py`: 17 passed
- `git diff --check` clean

Telegram: @lingtaidev1bot | Nickname: 知微
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai