### PR TITLE
fix(wechat): diagnose outbound media TLS failures

### DIFF
--- a/src/lingtai/mcp_servers/wechat/manager.py
+++ b/src/lingtai/mcp_servers/wechat/manager.py
@@ -553,6 +553,37 @@ class WechatManager:
 
         results = []
 
+        def _persist_sent(status: str = "ok", media_error: dict | None = None) -> str:
+            """Persist an attempted outbound action for retry-safe inspection."""
+            msg_id = str(uuid.uuid4())
+            msg_dir = self._sent_dir / msg_id
+            msg_dir.mkdir(parents=True, exist_ok=True)
+            sent_data = {
+                "id": msg_id,
+                "to_user_id": user_id,
+                "text": text,
+                "media_path": media_path,
+                "status": status,
+                "date": datetime.now(timezone.utc).isoformat(),
+            }
+            if media_error is not None:
+                sent_data["media_error"] = media_error
+            (msg_dir / "message.json").write_text(
+                json.dumps(sent_data, ensure_ascii=False, indent=2), encoding="utf-8",
+            )
+            return msg_id
+
+        def _media_failure(error: media_mod.MediaUploadError) -> dict:
+            result = error.as_result()
+            result["sent"] = list(results)
+            if text and results:
+                result.update({
+                    "status": "partial",
+                    "partial_delivery": True,
+                    "message_id": _persist_sent("partial", result),
+                })
+            return result
+
         # Snapshot context token under lock (poll thread may update it)
         with self._lock:
             ctx_token = self._context_tokens.get(user_id)
@@ -581,9 +612,13 @@ class WechatManager:
         # Send media (already validated above)
         if media_path:
             path = Path(media_path)
-            upload_info = self._run_async(
-                media_mod.upload_media(path, self._base_url, self._token, user_id)
-            )
+            try:
+                upload_info = self._run_async(
+                    media_mod.upload_media(path, self._base_url, self._token, user_id)
+                )
+            except media_mod.MediaUploadError as exc:
+                return _media_failure(exc)
+
             media_item = media_mod.make_media_item(upload_info, path)
             msg = WeixinMessage(
                 from_user_id="",
@@ -594,26 +629,17 @@ class WechatManager:
                 context_token=ctx_token,
                 item_list=[media_item],
             )
-            self._run_async(
-                api.send_message(self._base_url, self._token, msg)
-            )
+            try:
+                self._run_async(
+                    api.send_message(self._base_url, self._token, msg)
+                )
+            except Exception as exc:
+                return _media_failure(media_mod.media_upload_error(
+                    "send_media_reference_failed", self._base_url, exc
+                ))
             results.append(f"media ({path.name})")
 
-        # Persist to sent
-        msg_id = str(uuid.uuid4())
-        msg_dir = self._sent_dir / msg_id
-        msg_dir.mkdir(parents=True, exist_ok=True)
-        sent_data = {
-            "id": msg_id,
-            "to_user_id": user_id,
-            "text": text,
-            "media_path": media_path,
-            "date": datetime.now(timezone.utc).isoformat(),
-        }
-        (msg_dir / "message.json").write_text(
-            json.dumps(sent_data, ensure_ascii=False, indent=2), encoding="utf-8",
-        )
-
+        msg_id = _persist_sent()
         return {"status": "ok", "sent": results, "message_id": msg_id}
 
     def _handle_check(self, args: dict) -> dict:

--- a/src/lingtai/mcp_servers/wechat/media.py
+++ b/src/lingtai/mcp_servers/wechat/media.py
@@ -4,10 +4,17 @@ from __future__ import annotations
 import base64
 import hashlib
 import logging
+import platform
 import secrets
+import ssl
+import sys
 from dataclasses import dataclass
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
 
+import httpcore
 import httpx
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
@@ -36,6 +43,167 @@ class UploadedMediaInfo:
     filekey: str
 
 log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class MediaUploadDiagnostic:
+    """Safe, structured context for a failed outbound media operation.
+
+    Upload URLs are pre-signed and may contain credentials in their query
+    strings. Keep only the public origin and a sanitized exception summary in
+    the diagnostic; never include the URL, token, recipient, or local path.
+    """
+
+    stage: str
+    endpoint: str | None
+    error_type: str
+    error_kind: str
+    error: str
+    runtime: dict[str, str]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "stage": self.stage,
+            "endpoint": self.endpoint,
+            "error_type": self.error_type,
+            "error_kind": self.error_kind,
+            "error": self.error,
+            "runtime": dict(self.runtime),
+        }
+
+
+class MediaUploadError(RuntimeError):
+    """A media-path failure with an actionable, secret-free diagnostic."""
+
+    def __init__(self, diagnostic: MediaUploadDiagnostic) -> None:
+        self.diagnostic = diagnostic
+        super().__init__(self._format_message())
+
+    @property
+    def stage(self) -> str:
+        return self.diagnostic.stage
+
+    def _format_message(self) -> str:
+        endpoint = self.diagnostic.endpoint or "unknown endpoint"
+        return (
+            f"WeChat media upload failed at {self.stage} "
+            f"({endpoint}): {self.diagnostic.error}"
+        )
+
+    def as_result(self) -> dict[str, Any]:
+        """Return a tool result without leaking transport secrets."""
+        message = str(self)
+        return {
+            "status": "failed",
+            "error_code": "MEDIA_UPLOAD_FAILED",
+            "error": message,
+            "message": message,
+            "stage": self.stage,
+            "media_upload": self.diagnostic.as_dict(),
+        }
+
+
+def _package_version(distribution: str) -> str:
+    try:
+        return version(distribution)
+    except PackageNotFoundError:
+        return "unknown"
+
+
+def _runtime_diagnostics() -> dict[str, str]:
+    """Return useful runtime versions without host paths or secrets."""
+    return {
+        "python": sys.version.split()[0],
+        "openssl": ssl.OPENSSL_VERSION,
+        "platform": f"{platform.system()} {platform.release()} {platform.machine()}".strip(),
+        "httpx": _package_version("httpx"),
+        "httpcore": _package_version("httpcore"),
+    }
+
+
+def _safe_endpoint(url: str | None) -> str | None:
+    """Reduce a URL to scheme/host/port; discard paths and query credentials."""
+    if not url:
+        return None
+    try:
+        parsed = urlsplit(url)
+        if not parsed.scheme or not parsed.hostname:
+            return None
+        host = parsed.hostname
+        port = parsed.port
+        if port is not None and not (
+            (parsed.scheme.lower() == "https" and port == 443)
+            or (parsed.scheme.lower() == "http" and port == 80)
+        ):
+            host = f"{host}:{port}"
+        return f"{parsed.scheme.lower()}://{host}"
+    except (TypeError, ValueError):
+        return None
+
+
+def _exception_chain(exc: BaseException):
+    current: BaseException | None = exc
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        yield current
+        current = current.__cause__ or current.__context__
+
+
+def _is_tls_handshake_error(exc: BaseException) -> bool:
+    """Recognize TLS failures wrapped by httpx/httpcore transport errors."""
+    markers = (
+        "ssl", "tls", "handshake", "certificate verify", "wrong version number",
+    )
+    for item in _exception_chain(exc):
+        if isinstance(item, ssl.SSLError):
+            return True
+        if isinstance(item, (httpx.ConnectError, httpcore.ConnectError)):
+            if any(marker in str(item).lower() for marker in markers):
+                return True
+        if any(marker in str(item).lower() for marker in markers):
+            return True
+    return False
+
+
+def _safe_exception_text(exc: BaseException) -> str:
+    """Sanitize exception text that may contain a pre-signed request URL."""
+    text = str(exc).strip() or type(exc).__name__
+    for marker in ("http://", "https://"):
+        while marker in text:
+            start = text.find(marker)
+            end = len(text)
+            for delimiter in ("'", '"', " ", ")", "]"):
+                candidate = text.find(delimiter, start)
+                if candidate >= 0:
+                    end = min(end, candidate)
+            text = text[:start] + "<redacted-url>" + text[end:]
+    return text[:240]
+
+
+def media_upload_error(
+    stage: str,
+    endpoint: str | None,
+    exc: BaseException,
+) -> MediaUploadError:
+    if _is_tls_handshake_error(exc):
+        kind = "tls_handshake"
+    elif isinstance(exc, httpx.HTTPStatusError):
+        kind = "http_status"
+    elif isinstance(exc, httpx.TimeoutException):
+        kind = "timeout"
+    else:
+        kind = "transport"
+    return MediaUploadError(
+        MediaUploadDiagnostic(
+            stage=stage,
+            endpoint=_safe_endpoint(endpoint),
+            error_type=type(exc).__name__,
+            error_kind=kind,
+            error=_safe_exception_text(exc),
+            runtime=_runtime_diagnostics(),
+        )
+    )
 
 
 # ── Magic-byte validation ──────────────────────────────────────────────────
@@ -331,34 +499,47 @@ async def upload_media(
     # Get upload URL. filesize is ciphertext size, rawsize is plaintext size.
     # Hermes/OpenClaw include filekey + no_need_thumb; without filekey iLink
     # may return HTTP 200 but omit upload_full_url.
-    upload_resp = await api.get_upload_url(
-        base_url, token,
-        media_type=int(media_type),
-        to_user_id=to_user_id,
-        rawsize=len(data),
-        rawfilemd5=md5,
-        filesize=len(ciphertext),
-        aeskey=aeskey_hex,
-        filekey=filekey,
-        no_need_thumb=True,
-    )
+    try:
+        upload_resp = await api.get_upload_url(
+            base_url, token,
+            media_type=int(media_type),
+            to_user_id=to_user_id,
+            rawsize=len(data),
+            rawfilemd5=md5,
+            filesize=len(ciphertext),
+            aeskey=aeskey_hex,
+            filekey=filekey,
+            no_need_thumb=True,
+        )
+    except Exception as exc:
+        raise media_upload_error("get_upload_url_failed", base_url, exc) from exc
 
     upload_url = upload_resp.upload_full_url
     if not upload_url:
-        raise RuntimeError("Server did not return an upload URL")
+        raise media_upload_error(
+            "get_upload_url_failed",
+            base_url,
+            RuntimeError("server did not return an upload URL"),
+        )
 
     # Upload encrypted bytes to CDN. OpenClaw uses POST (not PUT) and reads
     # the final download encrypted_query_param from the x-encrypted-param
     # response header. Some CDN responses also embed it in a JSON body.
-    async with httpx.AsyncClient() as client:
-        resp = await client.post(
-            upload_url,
-            content=ciphertext,
-            headers={"Content-Type": "application/octet-stream"},
-            timeout=120.0,
-        )
-        resp.raise_for_status()
-        raw = resp.text
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                upload_url,
+                content=ciphertext,
+                headers={"Content-Type": "application/octet-stream"},
+                timeout=120.0,
+            )
+            resp.raise_for_status()
+            raw = resp.text
+    except Exception as exc:
+        error = media_upload_error("cdn_upload_http_failed", upload_url, exc)
+        if error.diagnostic.error_kind == "tls_handshake":
+            error = media_upload_error("cdn_tls_handshake_failed", upload_url, exc)
+        raise error from exc
 
     header_param = resp.headers.get("x-encrypted-param")
     json_param: str | None = None
@@ -376,11 +557,15 @@ async def upload_media(
     if not download_param:
         # Be strict here. The prior code fell back to upload_param/filekey,
         # which made the function appear to succeed while producing media
-        # the WeChat client could not open. Better to raise loudly.
-        raise RuntimeError(
-            "CDN upload response missing x-encrypted-param header and "
-            "encrypt_query_param / download_param JSON field. The upload "
-            "may have failed silently — refusing to return media reference."
+        # the WeChat client could not open. Better to raise loudly, while
+        # preserving the stage in the structured result.
+        raise media_upload_error(
+            "cdn_response_metadata_missing",
+            upload_url,
+            RuntimeError(
+                "response missing x-encrypted-param header and "
+                "encrypt_query_param / download_param JSON field"
+            ),
         )
 
     cdn_media = CDNMedia(

--- a/src/lingtai/mcp_servers/wechat/server.py
+++ b/src/lingtai/mcp_servers/wechat/server.py
@@ -16,7 +16,7 @@ Config schemas (plaintext, no env-indirection):
 
     config.json:
         {
-          "cdn_base_url": "...",         // optional
+          "cdn_base_url": "...",         // legacy compatibility; not an upload override
           "poll_interval": 1.0,          // optional
           "allowed_users": ["wxid_..."]  // optional allow-list
         }
@@ -297,6 +297,12 @@ def _safe_status_payload(
     if startup_error_type:
         notes.append(f"Startup error: {startup_error_type}: {startup_error}")
 
+    notes.append(
+        "Outbound media uploads use the iLink-returned pre-signed upload_full_url; "
+        "cdn_base_url is retained for configuration compatibility and is not a "
+        "current upload destination override."
+    )
+
     return {
         "status": "ok" if manager is not None else "degraded",
         "manager_initialized": manager is not None,
@@ -411,7 +417,7 @@ reads `config.json` from the path in `LINGTAI_WECHAT_CONFIG` and reads sibling
 
 ```json
 {
-  "cdn_base_url": "https://...",
+  "cdn_base_url": "https://...",  // retained for compatibility; not an upload override
   "poll_interval": 1.0,
   "allowed_users": ["wxid_xxxxx"]
 }

--- a/tests/test_wechat_config_resolution.py
+++ b/tests/test_wechat_config_resolution.py
@@ -200,3 +200,4 @@ def test_status_payload_exposes_resolution_without_secrets(tmp_path, monkeypatch
     assert payload["has_bot_token"] is True
     # backward-compat resolution is flagged in notes
     assert any("backward-compat" in n for n in payload["notes"])
+    assert any("pre-signed upload_full_url" in n for n in payload["notes"])

--- a/tests/test_wechat_media_upload_diagnostics.py
+++ b/tests/test_wechat_media_upload_diagnostics.py
@@ -1,0 +1,128 @@
+"""Regression coverage for stage-aware WeChat outbound media failures."""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import httpx
+import pytest
+
+from lingtai.mcp_servers.wechat import api, media
+from lingtai.mcp_servers.wechat.manager import WechatManager
+from lingtai.mcp_servers.wechat.types import GetUploadUrlResp
+
+
+BASE_URL = "https://ilink.example.test"
+PRESIGNED_URL = (
+    "https://cdn.example.test/upload?token=secret-token&signature=secret-signature"
+)
+
+
+def test_safe_endpoint_discards_path_and_presigned_query() -> None:
+    assert media._safe_endpoint(PRESIGNED_URL) == "https://cdn.example.test"
+    assert media._safe_endpoint("https://cdn.example.test:8443/private/path") == (
+        "https://cdn.example.test:8443"
+    )
+
+
+def test_upload_url_tls_failure_has_stage_and_safe_runtime(monkeypatch, tmp_path: Path) -> None:
+    file_path = tmp_path / "attachment.txt"
+    file_path.write_text("attachment", encoding="utf-8")
+
+    async def fail_get_upload_url(*args, **kwargs):
+        raise httpx.ConnectError(
+            "[SSL: SSLV3_ALERT_HANDSHAKE_FAILURE] "
+            f"while connecting to {BASE_URL}/ilink/bot/getuploadurl?token=secret"
+        )
+
+    monkeypatch.setattr(api, "get_upload_url", fail_get_upload_url)
+
+    with pytest.raises(media.MediaUploadError) as exc_info:
+        asyncio.run(media.upload_media(file_path, BASE_URL, "bearer-secret", "wxid-secret"))
+
+    error = exc_info.value
+    payload = error.as_result()
+    assert error.stage == "get_upload_url_failed"
+    assert payload["media_upload"]["error_kind"] == "tls_handshake"
+    assert payload["media_upload"]["endpoint"] == BASE_URL
+    assert payload["media_upload"]["runtime"]["httpx"]
+    assert "bearer-secret" not in str(payload)
+    assert "wxid-secret" not in str(payload)
+    assert "secret" not in str(payload)
+
+
+def test_dynamic_cdn_tls_failure_reports_dynamic_host(monkeypatch, tmp_path: Path) -> None:
+    file_path = tmp_path / "attachment.txt"
+    file_path.write_text("attachment", encoding="utf-8")
+
+    async def fake_get_upload_url(*args, **kwargs):
+        return GetUploadUrlResp(upload_full_url=PRESIGNED_URL)
+
+    class FailingClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+        async def post(self, *args, **kwargs):
+            raise httpx.ConnectError(
+                "[SSL: SSLV3_ALERT_HANDSHAKE_FAILURE] "
+                f"while connecting to {PRESIGNED_URL}"
+            )
+
+    monkeypatch.setattr(api, "get_upload_url", fake_get_upload_url)
+    monkeypatch.setattr(media.httpx, "AsyncClient", lambda: FailingClient())
+
+    with pytest.raises(media.MediaUploadError) as exc_info:
+        asyncio.run(media.upload_media(file_path, BASE_URL, "bearer-secret", "wxid-secret"))
+
+    error = exc_info.value
+    assert error.stage == "cdn_tls_handshake_failed"
+    assert error.diagnostic.endpoint == "https://cdn.example.test"
+    assert error.diagnostic.error_kind == "tls_handshake"
+    assert "secret-token" not in str(error)
+
+
+def test_text_plus_media_returns_partial_result_and_persists_status(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    manager = WechatManager(
+        token="bearer-secret",
+        user_id="test-bot",
+        working_dir=tmp_path,
+        on_inbound=lambda event: None,
+    )
+    file_path = tmp_path / "attachment.txt"
+    file_path.write_text("attachment", encoding="utf-8")
+
+    async def send_text(*args, **kwargs):
+        return None
+
+    async def fail_upload(*args, **kwargs):
+        raise media.media_upload_error(
+            "cdn_tls_handshake_failed", PRESIGNED_URL,
+            httpx.ConnectError("[SSL: TLSV1_ALERT_HANDSHAKE_FAILURE]"),
+        )
+
+    monkeypatch.setattr(api, "send_message", send_text)
+    monkeypatch.setattr(media, "upload_media", fail_upload)
+    monkeypatch.setattr(manager, "_run_async", asyncio.run)
+
+    result = manager._handle_send({
+        "user_id": "wxid-recipient",
+        "text": "text control",
+        "media_path": str(file_path),
+    })
+
+    assert result["status"] == "partial"
+    assert result["partial_delivery"] is True
+    assert result["sent"] == ["text (12 chars)"]
+    assert result["stage"] == "cdn_tls_handshake_failed"
+    assert result["media_upload"]["endpoint"] == "https://cdn.example.test"
+    assert result["message_id"]
+    stored = tmp_path / "wechat" / "sent" / result["message_id"] / "message.json"
+    assert stored.is_file()
+    assert '"status": "partial"' in stored.read_text(encoding="utf-8")
+    assert "bearer-secret" not in stored.read_text(encoding="utf-8")
+    assert "wxid-recipient" in stored.read_text(encoding="utf-8")


### PR DESCRIPTION
Fixes #866

## Summary
- Root cause: outbound attachments use a distinct two-stage flow (iLink `getuploadurl`, then a dynamic pre-signed CDN POST), while the prior error flattened both stages and did not identify the dynamic host. The configured `cdn_base_url` was also retained but never used as an upload override.
- Added stage-aware, secret-free diagnostics for iLink URL acquisition, CDN TLS/HTTP transport, missing CDN response metadata, and media-reference send failures. Diagnostics include safe endpoint origin and Python/OpenSSL/httpx/httpcore runtime versions, never tokens, signed query strings, user IDs, or local paths.
- Text-plus-media now returns an explicit partial result and durable sent record when text was delivered but media failed; status diagnostics and configuration docs clarify the dynamic URL contract.

## Tests run
- `PYTHONPATH=... PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .../python -m pytest -q tests/test_wechat*.py tests/test_outbound_file_containment.py` (162 passed)
- Focused upload/media/config/family suite (109 passed)
- `python -m build --wheel --no-isolation` (passed; existing setuptools warnings only)
- Full `pytest -q` was attempted but exceeded the 120-second synchronous limit.

## Files changed
- `src/lingtai/mcp_servers/wechat/media.py`
- `src/lingtai/mcp_servers/wechat/manager.py`
- `src/lingtai/mcp_servers/wechat/server.py`
- `tests/test_wechat_media_upload_diagnostics.py`
- `tests/test_wechat_config_resolution.py`

Telegram: @lingtaidev1bot | Nickname: 知微

Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
