### PR TITLE
fix(wechat): retry transient QR fetch failures

### DIFF
--- a/src/lingtai/mcp_servers/wechat/login.py
+++ b/src/lingtai/mcp_servers/wechat/login.py
@@ -31,6 +31,8 @@ import webbrowser
 from collections.abc import Callable
 from pathlib import Path
 
+import httpx
+
 from . import api
 
 log = logging.getLogger(__name__)
@@ -38,6 +40,45 @@ log = logging.getLogger(__name__)
 LOGIN_TIMEOUT = 300  # 5 minutes per QR code
 POLL_INTERVAL = 2.0
 MAX_QR_REFRESHES = 3  # auto-refresh expired QR codes up to this many times
+QR_FETCH_MAX_ATTEMPTS = 3
+QR_FETCH_RETRY_DELAYS = (1.0, 2.0)
+QR_RETRYABLE_HTTP_STATUSES = frozenset({408, 429})
+
+
+async def _fetch_qr_with_retry(base_url: str) -> dict:
+    """Fetch a QR code, retrying transient endpoint failures with backoff.
+
+    The retry budget belongs to one QR acquisition and is independent of the
+    number of expired QR codes. Non-retryable HTTP responses fail immediately;
+    cancellation is intentionally not caught so callers can stop promptly.
+    """
+    for attempt in range(QR_FETCH_MAX_ATTEMPTS):
+        try:
+            return await api.get_qrcode(base_url)
+        except (httpx.TimeoutException, httpx.TransportError) as exc:
+            retryable = True
+            error = exc
+        except httpx.HTTPStatusError as exc:
+            status_code = exc.response.status_code if exc.response is not None else None
+            retryable = (
+                status_code in QR_RETRYABLE_HTTP_STATUSES
+                or (status_code is not None and 500 <= status_code < 600)
+            )
+            error = exc
+
+        if not retryable or attempt == QR_FETCH_MAX_ATTEMPTS - 1:
+            raise error
+        delay = QR_FETCH_RETRY_DELAYS[min(attempt, len(QR_FETCH_RETRY_DELAYS) - 1)]
+        log.debug(
+            "QR fetch failed (attempt %s/%s), retrying in %.1fs: %s",
+            attempt + 1,
+            QR_FETCH_MAX_ATTEMPTS,
+            delay,
+            error,
+        )
+        await asyncio.sleep(delay)
+
+    raise AssertionError("QR fetch retry loop exited unexpectedly")
 
 
 # ── Shared helpers ──────────────────────────────────────────────────
@@ -149,7 +190,7 @@ async def _login_flow(
     """
     print("Fetching QR code...")
     try:
-        qr_data = await api.get_qrcode(base_url)
+        qr_data = await _fetch_qr_with_retry(base_url)
     except Exception as e:
         print(f"Error fetching QR code: {e}")
         return None
@@ -208,14 +249,14 @@ async def _login_flow(
 
             await asyncio.sleep(POLL_INTERVAL)
 
-        qr_refresh_count += 1
-        if qr_refresh_count > MAX_QR_REFRESHES:
+        if qr_refresh_count >= MAX_QR_REFRESHES:
             print(f"\nQR code expired {MAX_QR_REFRESHES} times. Please try again later.")
             return None
 
-        print(f"\n⏳ QR code expired, refreshing... ({qr_refresh_count}/{MAX_QR_REFRESHES})")
+        next_refresh = qr_refresh_count + 1
+        print(f"\n⏳ QR code expired, refreshing... ({next_refresh}/{MAX_QR_REFRESHES})")
         try:
-            qr_data = await api.get_qrcode(base_url)
+            qr_data = await _fetch_qr_with_retry(base_url)
         except Exception as e:
             print(f"Failed to refresh QR code: {e}")
             return None
@@ -225,6 +266,8 @@ async def _login_flow(
             print("Failed to get new QR code from server.")
             return None
 
+        # Consume the refresh budget only after a usable replacement QR arrives.
+        qr_refresh_count = next_refresh
         current_base_url = base_url
         if on_new_qr is not None:
             try:

--- a/tests/test_wechat_login.py
+++ b/tests/test_wechat_login.py
@@ -1,0 +1,158 @@
+"""Regression tests for transient failures during WeChat QR acquisition."""
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from lingtai.mcp_servers.wechat import login
+
+
+@pytest.fixture
+def no_sleep(monkeypatch):
+    async def _sleep(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(login.asyncio, "sleep", _sleep)
+
+
+def _status_error(status_code: int) -> httpx.HTTPStatusError:
+    request = httpx.Request("GET", "https://example.test/qr")
+    response = httpx.Response(status_code, request=request)
+    return httpx.HTTPStatusError("QR fetch failed", request=request, response=response)
+
+
+@pytest.mark.asyncio
+async def test_qr_fetch_retries_transient_error_then_succeeds(monkeypatch, no_sleep):
+    responses = [httpx.ConnectError("temporary connection failure"), {"qrcode": "qr"}]
+    calls = 0
+
+    async def fake_get_qrcode(_base_url: str) -> dict:
+        nonlocal calls
+        calls += 1
+        response = responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    monkeypatch.setattr(login.api, "get_qrcode", fake_get_qrcode)
+
+    assert await login._fetch_qr_with_retry("https://example.test") == {"qrcode": "qr"}
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_login_initial_fetch_retries_transient_error(monkeypatch, no_sleep):
+    responses = [httpx.ConnectError("temporary connection failure"), {"qrcode": "qr"}]
+    statuses = iter([{"status": "confirmed", "bot_token": "token"}])
+
+    async def fake_get_qrcode(_base_url: str) -> dict:
+        response = responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    async def fake_poll_qr_status(_base_url: str, qrcode: str) -> dict:
+        assert qrcode == "qr"
+        return next(statuses)
+
+    monkeypatch.setattr(login.api, "get_qrcode", fake_get_qrcode)
+    monkeypatch.setattr(login.api, "poll_qr_status", fake_poll_qr_status)
+    monkeypatch.setattr(login, "_display_qr", lambda _qr_data: None)
+
+    assert await login._login_flow("https://example.test") == {
+        "bot_token": "token",
+        "user_id": "",
+        "base_url": "https://example.test",
+    }
+
+
+@pytest.mark.asyncio
+async def test_login_refresh_retries_transient_qr_fetch(monkeypatch, no_sleep):
+    responses = [
+        {"qrcode": "first-qr"},
+        httpx.ReadTimeout("temporary read timeout"),
+        {"qrcode": "replacement-qr"},
+    ]
+    fetched = []
+    statuses = iter([{"status": "expired"}, {"status": "confirmed", "bot_token": "token"}])
+
+    async def fake_get_qrcode(_base_url: str) -> dict:
+        response = responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        fetched.append(response["qrcode"])
+        return response
+
+    async def fake_poll_qr_status(_base_url: str, qrcode: str) -> dict:
+        assert qrcode in {"first-qr", "replacement-qr"}
+        return next(statuses)
+
+    monkeypatch.setattr(login.api, "get_qrcode", fake_get_qrcode)
+    monkeypatch.setattr(login.api, "poll_qr_status", fake_poll_qr_status)
+    monkeypatch.setattr(login, "_display_qr", lambda _qr_data: None)
+
+    result = await login._login_flow("https://example.test")
+
+    assert result == {
+        "bot_token": "token",
+        "user_id": "",
+        "base_url": "https://example.test",
+    }
+    assert fetched == ["first-qr", "replacement-qr"]
+
+
+@pytest.mark.asyncio
+async def test_qr_fetch_exhaustion_is_bounded(monkeypatch, no_sleep):
+    calls = 0
+
+    async def always_timeout(_base_url: str) -> dict:
+        nonlocal calls
+        calls += 1
+        raise httpx.ReadTimeout("temporary read timeout")
+
+    monkeypatch.setattr(login.api, "get_qrcode", always_timeout)
+
+    with pytest.raises(httpx.ReadTimeout):
+        await login._fetch_qr_with_retry("https://example.test")
+
+    assert calls == login.QR_FETCH_MAX_ATTEMPTS
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status_code", [408, 429, 503])
+async def test_qr_fetch_retries_selected_http_statuses(
+    monkeypatch, no_sleep, status_code: int,
+):
+    responses = [_status_error(status_code), {"qrcode": "qr"}]
+    calls = 0
+
+    async def fake_get_qrcode(_base_url: str) -> dict:
+        nonlocal calls
+        calls += 1
+        response = responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    monkeypatch.setattr(login.api, "get_qrcode", fake_get_qrcode)
+
+    assert await login._fetch_qr_with_retry("https://example.test") == {"qrcode": "qr"}
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_qr_fetch_does_not_retry_non_retryable_http_status(monkeypatch, no_sleep):
+    calls = 0
+    error = _status_error(401)
+
+    async def fail_auth(_base_url: str) -> dict:
+        nonlocal calls
+        calls += 1
+        raise error
+
+    monkeypatch.setattr(login.api, "get_qrcode", fail_auth)
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await login._fetch_qr_with_retry("https://example.test")
+
+    assert calls == 1


### PR DESCRIPTION
## Summary

- Root cause: the initial and replacement WeChat QR fetches made one request; `_login_flow` treated any transient timeout, transport, connection, or retryable HTTP failure as terminal.
- Fix: add a shared bounded async retry helper (three attempts with backoff) for timeouts, transport failures, HTTP 408/429, and 5xx responses; fail fast for ordinary 4xx responses.
- Preserve the QR refresh budget until a valid replacement QR is received.

Fixes #1374

## Tests run

- `env -u PYTHONPATH .venv/bin/python -m pytest -q tests/test_wechat_login.py` (8 passed)
- `ruff check src/lingtai/mcp_servers/wechat/login.py tests/test_wechat_login.py`
- `env -u PYTHONPATH .venv/bin/python -m compileall -q src/lingtai/mcp_servers/wechat/login.py tests/test_wechat_login.py`
- `env -u PYTHONPATH .venv/bin/python -m build --wheel --no-isolation`

## Files changed

- `src/lingtai/mcp_servers/wechat/login.py`
- `tests/test_wechat_login.py`

## Standing lines

Telegram: @lingtaidev1bot | Nickname: 知微

Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
