### PR TITLE
feat(telegram): default rendering_mode to Markdown for agent messages

### DIFF
--- a/src/lingtai/mcp_servers/telegram/SKILL.md
+++ b/src/lingtai/mcp_servers/telegram/SKILL.md
@@ -131,14 +131,14 @@ setup readiness checklist are **not** here — they belong to `mcp-manual`
   non-numeric value the schema accepts) to `read`/`search` to recover them;
   `send`/`reply` still require a real numeric chat ID.
 
-## RENDERING MODE: explicit per-message choice
+## RENDERING MODE: Markdown default for agent messages
 
-- Every content-bearing `send`, `reply`, and `edit` must include
-  `rendering_mode`; there is no default. Choose exactly one of `plain_text`,
-  `HTML`, `Markdown`, `MarkdownV2`, `entities`, or `rich`.
+- Content-bearing `send`, `reply`, and `edit` default to `rendering_mode='Markdown'`; the
+  agent may omit it for agent messages. Choose exactly one of `plain_text`, `HTML`,
+  `Markdown`, `MarkdownV2`, `entities`, or `rich` when needed. Internal manager-owned
+  sends (such as progress/typing) still use the plain-text fallback when they omit it.
 - `plain_text` maps to an omitted Bot API `parse_mode`; the other three named
-  formats map to Telegram `parse_mode`. The agent must still provide the label
-  even when no formatting is wanted.
+  formats map to Telegram `parse_mode`. Choose it explicitly when no formatting is wanted.
 - `entities` selects explicit `MessageEntity[]` formatting. Pass `entities` for
   message text or `caption_entities` for media captions; do not combine entity
   fields with a parse-mode rendering choice.
@@ -158,8 +158,8 @@ setup readiness checklist are **not** here — they belong to `mcp-manual`
   actions. Ordinary conversational prose should remain ordinary text rather
   than being forced into a card.
 - For `send` with only `chat_action` and no text/media, use `plain_text` because
-  no message body is rendered. `rendering_mode` is still required by the strict
-  public branch.
+  no message body is rendered. The public branch defaults to Markdown if the
+  agent omits `rendering_mode`; internal manager-owned sends still use plain text.
 
 ## CHAT ACTION
 

--- a/src/lingtai/mcp_servers/telegram/_family.py
+++ b/src/lingtai/mcp_servers/telegram/_family.py
@@ -108,6 +108,7 @@ def _telegram_input_schemas() -> dict[str, dict[str, Any]]:
             }),
             "rendering_mode": {
                 "type": "string", "enum": list(_RENDERING_MODES),
+                "default": "Markdown",
             },
             "entities": _nullable({"type": "array"}),
             "caption_entities": _nullable({"type": "array"}),
@@ -122,7 +123,7 @@ def _telegram_input_schemas() -> dict[str, dict[str, Any]]:
             "link_preview_options": _nullable({"type": "object"}),
             "disable_web_page_preview": _nullable({"type": "boolean"}),
         },
-        required=["chat_id", "rendering_mode"],
+        required=["chat_id"],
         any_of=[
             {"required": ["text"]},
             {"required": ["media"]},
@@ -139,10 +140,10 @@ def _telegram_input_schemas() -> dict[str, dict[str, Any]]:
         "file paths in message text as a substitute for attaching the file."
     )
     send["properties"]["rendering_mode"]["description"] = (
-        "Required rendering choice for every send. Choose plain_text for unformatted "
-        "text or chat actions, HTML/Markdown/MarkdownV2 for Telegram parse_mode, "
+        "Default is Markdown for the agent's messages. Choose plain_text for "
+        "unformatted text/chat actions, HTML/MarkdownV2 for other parse modes, "
         "entities when supplying MessageEntity data, or rich for a native structured "
-        "message. There is no default; do not combine the modes."
+        "message; you may omit it to use Markdown; do not combine modes."
     )
     send["properties"]["entities"]["anyOf"][0]["description"] = (
         "Telegram MessageEntity[] for rendering_mode='entities' on message text."
@@ -173,15 +174,13 @@ def _telegram_input_schemas() -> dict[str, dict[str, Any]]:
                 "text": {"type": "string"},
                 "rendering_mode": {
                     "type": "string", "enum": list(_RENDERING_MODES),
-                    "description": (
-                        "Required rendering choice: plain_text, HTML, Markdown, "
-                        "MarkdownV2, entities, or rich. There is no default."
-                    ),
+                    "default": "Markdown",
+                    "description": "Default is Markdown; you may omit rendering_mode.",
                 },
                 "entities": _nullable({"type": "array"}),
                 "structured_message": _nullable(structured_message),
             },
-            required=["message_id", "rendering_mode"],
+            required=["message_id"],
             any_of=[{"required": ["text"]}, {"required": ["structured_message"]}],
         ),
         "search": _object(
@@ -200,15 +199,13 @@ def _telegram_input_schemas() -> dict[str, dict[str, Any]]:
                 "reply_markup": _nullable({"type": "object"}),
                 "rendering_mode": {
                     "type": "string", "enum": list(_RENDERING_MODES),
-                    "description": (
-                        "Required rendering choice: plain_text, HTML, Markdown, "
-                        "MarkdownV2, entities, or rich. There is no default."
-                    ),
+                    "default": "Markdown",
+                    "description": "Default is Markdown; you may omit rendering_mode.",
                 },
                 "entities": _nullable({"type": "array"}),
                 "structured_message": _nullable(structured_message),
             },
-            required=["message_id", "rendering_mode"],
+            required=["message_id"],
             any_of=[{"required": ["text"]}, {"required": ["structured_message"]}],
         ),
         "contacts": _object({"account": _nullable({"type": "string"})}),
@@ -257,8 +254,9 @@ def telegram_schema() -> dict[str, Any]:
     schema["properties"]["input"]["anyOf"] = schema["properties"]["input"].pop("oneOf")
     schema["properties"]["action"]["description"] = (
         "Telegram action. Each action owns a strict input branch. Content-bearing "
-        "send/reply/edit calls must provide rendering_mode explicitly: plain_text, "
-        "HTML, Markdown, MarkdownV2, entities, or rich; there is no default. For charts, "
+        "send/reply/edit calls default to rendering_mode=\"Markdown\"; the agent may omit "
+        "rendering_mode and it will render as Markdown. Choose plain_text/HTML/MarkdownV2/"
+        "entities/rich only when needed. For charts, "
         "reports, generated artifacts, and other files the user should open intact, "
         "prefer media.type='document'; use media.type='photo' only for an inline "
         "preview because photo previews may crop or compress text-heavy graphics. "

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -493,16 +493,16 @@ SCHEMA = {
                 "accounts", "manual",
             ],
             "description": (
-                "send: send message to a chat (chat_id, rendering_mode, and text or structured_message; optional media, reply_markup, placeholder, chat_action, entities). "
+                "send: send message to a chat (chat_id and text or structured_message; rendering_mode defaults to Markdown; optional media, reply_markup, placeholder, chat_action, entities). "
                 "For charts, reports, generated artifacts, and other files the user should open intact, prefer media.type='document'; use media.type='photo' only when an inline Telegram photo preview is desired, because photo previews may crop, compress, or display poorly for text-heavy graphics. "
                 "If chat_action is set and no text/media is provided, sends a typing "
                 "indicator (auto-expires after 5s) instead of a message. "
                 "check: list recent conversations with unread counts (optional account). "
                 "read: read messages from a chat (chat_id; optional limit). "
-                "reply: reply to a specific message (message_id from read results, rendering_mode, and text or structured_message; optional entities). "
+                "reply: reply to a specific message (message_id from read results and text or structured_message; rendering_mode defaults to Markdown; optional entities). "
                 "search: search messages (query; optional account, chat_id). "
                 "delete: delete a bot message (message_id). "
-                "edit: edit a bot message (message_id, rendering_mode, and text or structured_message; optional reply_markup, entities). "
+                "edit: edit a bot message (message_id and text or structured_message; rendering_mode defaults to Markdown; optional reply_markup, entities). "
                 "contacts: list saved contacts. "
                 "add_contact: save a chat alias (chat_id, alias); this does not grant inbound permission. "
                 "To receive messages from that user, their Telegram user ID must also be in allowed_users. "
@@ -561,11 +561,12 @@ SCHEMA = {
         "rendering_mode": {
             "type": "string",
             "enum": ["plain_text", "HTML", "MarkdownV2", "Markdown", "entities"],
+            "default": "Markdown",
             "description": (
-                "Required for every content-bearing send/reply/edit. Choose "
-                "plain_text, HTML, Markdown, MarkdownV2, or entities; there is no "
-                "default. The runtime maps the choice to Telegram parse_mode or "
-                "MessageEntity data."
+                "Defaults to Markdown for agent messages; the agent may omit it. Choose "
+                "plain_text, HTML, MarkdownV2, or entities when needed. The runtime "
+                "maps the choice to Telegram parse_mode or MessageEntity data; "
+                "internal manager-owned sends without it remain plain text."
             ),
         },
         "entities": {
@@ -893,6 +894,9 @@ class TelegramManager:
         if chat_id_error is not None:
             return chat_id_error
         try:
+            if action in {"send", "reply", "edit"}:
+                args = {**args}
+                args.setdefault("rendering_mode", "Markdown")
             if action == "send":
                 return self._send(args)
             elif action == "check":
@@ -3819,12 +3823,12 @@ class TelegramManager:
 
     @classmethod
     def _rendering_mode(cls, args: dict) -> str:
-        """Return the explicit rendering choice, with an internal plain fallback.
+        """Return the rendering choice, with an internal plain-text fallback.
 
-        The public ToolFamily requires ``rendering_mode``.  Manager internals
-        also send text (for example automatic progress) without passing through
-        that model-facing schema, so those internal calls retain plain-text
-        behavior without creating a public default.
+        The public ToolFamily now defaults to Markdown at dispatch. The
+        ``None`` to ``plain_text`` fallback remains only for internal
+        manager-owned sends (for example automatic progress) that do not pass
+        through that model-facing boundary.
         """
         value = args.get("rendering_mode")
         return "plain_text" if value is None else value
@@ -3853,9 +3857,9 @@ class TelegramManager:
     def _rich_text_options(self, args: dict) -> tuple[dict[str, Any], str | None]:
         """Extract Bot API options for a text message from rendering_mode.
 
-        ``rendering_mode`` is required at the public family boundary.  Missing
-        values here are only for manager-owned internal sends and mean plain
-        text; the model-facing schema never relies on that fallback.
+        The public ToolFamily defaults ``rendering_mode`` to Markdown at its
+        dispatch boundary. Missing values here are only for manager-owned
+        internal sends and mean plain text.
         """
         opts: dict[str, Any] = {}
         entities = args.get("entities")

--- a/tests/test_telegram_rich_formatting.py
+++ b/tests/test_telegram_rich_formatting.py
@@ -124,7 +124,8 @@ def test_schema_exposes_explicit_rendering_fields():
     for field in ("rendering_mode", "entities", "caption_entities", "link_preview_options", "disable_web_page_preview"):
         assert field in props
     assert _schema_enum(props["rendering_mode"]) == ["plain_text", "HTML", "MarkdownV2", "Markdown", "entities", "rich"]
-    assert "no default" in _schema_description(props["rendering_mode"])
+    assert props["rendering_mode"]["default"] == "Markdown"
+    assert "default is markdown" in _schema_description(props["rendering_mode"]).lower()
     assert "parse_mode" not in props
 
 
@@ -324,6 +325,27 @@ def test_send_reply_target_precedence_prefers_private_field(tmp_path):
 
     read_result = manager._read({"account": "mybot", "chat_id": 123, "limit": 1})
     assert read_result["messages"][0]["reply_to_message_id"] == 111
+
+
+def test_public_send_without_rendering_mode_defaults_to_markdown(tmp_path):
+    manager, account = _manager(tmp_path)
+
+    result = manager.handle({
+        "action": "send",
+        "account": "mybot",
+        "chat_id": 123,
+        "text": "formatted",
+    })
+
+    assert result == {"status": "sent", "message_id": "mybot:123:111"}
+    assert account.calls == [(
+        "send_message",
+        123,
+        "formatted",
+        None,
+        None,
+        {"parse_mode": "Markdown"},
+    )]
 
 
 def test_internal_send_without_rendering_mode_keeps_plain_fallback(tmp_path):

--- a/tests/test_telegram_toolfamily_ltpv2.py
+++ b/tests/test_telegram_toolfamily_ltpv2.py
@@ -58,28 +58,33 @@ def test_family_dispatch_rejects_root_and_cross_branch_before_manager_io():
     assert len(manager.calls) == 1
 
 
-def test_telegram_send_requires_rendering_mode_before_manager_io():
+def test_telegram_send_without_rendering_mode_passes_family_validation():
     manager = _CountingManager()
     for input_ in (
         {"chat_id": 2, "text": "x"},
-        {"chat_id": 2, "text": "x", "parse_mode": "HTML"},
         {"chat_id": 2, "chat_action": "typing"},
     ):
         result = handle_telegram(manager, {"action": "send", "input": input_, "reasoning": "schema probe"})
-        assert result["status"] == "failed", input_
-        assert result["error_code"] == "INVALID_ARGUMENT"
-        assert manager.calls == []
+        assert result["status"] == "ok", input_
+    result = handle_telegram(manager, {"action": "send", "input": {"chat_id": 2, "text": "x", "parse_mode": "HTML"}, "reasoning": "schema probe"})
+    assert result["status"] == "failed"
+    assert result["error_code"] == "INVALID_ARGUMENT"
 
-def test_telegram_send_schema_requires_rendering_mode_and_preserves_content_alternatives():
-    send = _branches(TELEGRAM_SCHEMA)["send"]
-    assert "rendering_mode" in send["required"]
+def test_telegram_send_schema_defaults_rendering_mode_and_preserves_content_alternatives():
+    branches = _branches(TELEGRAM_SCHEMA)
+    send = branches["send"]
+    assert "rendering_mode" not in send["required"]
+    assert send["properties"]["rendering_mode"]["default"] == "Markdown"
     assert send["properties"]["rendering_mode"]["enum"] == ["plain_text", "HTML", "MarkdownV2", "Markdown", "entities", "rich"]
+    for action in ("reply", "edit"):
+        assert "rendering_mode" not in branches[action]["required"]
+        assert branches[action]["properties"]["rendering_mode"]["default"] == "Markdown"
     assert send["anyOf"] == [{"required": ["text"]}, {"required": ["media"]}, {"required": ["chat_action"]}, {"required": ["structured_message"]}]
     assert _basic_validate({"chat_id": 3, "rendering_mode": "plain_text", "text": "hello"}, send)
     assert _basic_validate({"chat_id": 3, "rendering_mode": "plain_text", "media": {"type": "photo", "path": "x"}}, send)
     assert _basic_validate({"chat_id": 3, "rendering_mode": "plain_text", "chat_action": "typing"}, send)
     assert _basic_validate({"chat_id": 3, "rendering_mode": "rich", "structured_message": {"title": "✅ Done"}}, send)
-    assert not _basic_validate({"chat_id": 3, "text": "hello"}, send)
+    assert _basic_validate({"chat_id": 3, "text": "hello"}, send)
     assert not _basic_validate({"chat_id": 3, "rendering_mode": "plain_text"}, send)
     assert not _basic_validate({"text": "missing chat", "rendering_mode": "plain_text"}, send)
     assert not _basic_validate({"chat_id": 3, "rendering_mode": "plain_text", "text": 17}, send)


### PR DESCRIPTION
## Summary
- Make Telegram agent-facing send/reply/edit rendering default to Markdown while allowing the field to be omitted.
- Inject the Markdown default only at public manager dispatch; internal manager-owned progress and typing sends retain their plain-text fallback.
- Update schemas, documentation, and regression coverage for the new contract.

## Tests
- `PYTHONPATH=src /opt/homebrew/bin/python3 -m pytest tests/test_telegram_toolfamily_ltpv2.py tests/test_telegram_rich_formatting.py tests/test_telegram_structured_rendering.py -x -q` (64 passed)
- `PYTHONPATH=src /opt/homebrew/bin/python3 -m compileall -q src/lingtai/mcp_servers/telegram tests/test_telegram_toolfamily_ltpv2.py tests/test_telegram_rich_formatting.py`

Telegram: @lingtaidev1bot | Nickname: 知微
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai