### PR TITLE
feat(taskcard): show daemon backend distribution on resident card

### DIFF
--- a/src/lingtai/mcp_servers/task_card/event_projection.py
+++ b/src/lingtai/mcp_servers/task_card/event_projection.py
@@ -792,7 +792,13 @@ class TaskCardEventProjection:
             if stats_parts:
                 line4 = "daemon stats · " + " · ".join(stats_parts)
 
-        lines = [ln for ln in (line1, line2, line3, line3b, line4) if ln]
+        daemon_lines = [ln for ln in (line3, line3b, line4) if ln]
+        lines = [ln for ln in (line1, line2) if ln]
+        if daemon_lines:
+            # Visually separate the daemon block from the session/identity
+            # lines so it stands out on the resident card.
+            lines.append("────────────────")
+            lines.extend(daemon_lines)
         if not lines:
             return []
         joined = "\n".join(lines)

--- a/src/lingtai/mcp_servers/task_card/event_projection.py
+++ b/src/lingtai/mcp_servers/task_card/event_projection.py
@@ -792,13 +792,26 @@ class TaskCardEventProjection:
             if stats_parts:
                 line4 = "daemon stats · " + " · ".join(stats_parts)
 
-        daemon_lines = [ln for ln in (line3, line3b, line4) if ln]
-        lines = [ln for ln in (line1, line2) if ln]
-        if daemon_lines:
-            # Visually separate the daemon block from the session/identity
-            # lines so it stands out on the resident card.
-            lines.append("────────────────")
-            lines.extend(daemon_lines)
+        # Metadata is organized into three sections — Session (line1),
+        # Identity (line2), Daemon (line3/backends/stats) — with a horizontal
+        # divider between adjacent sections that are both present, so the
+        # daemon block stands out and each section is scannable on its own.
+        sections: list[tuple[str, str | None]] = [
+            ("session", line1),
+            ("identity", line2),
+            ("daemon", line3),
+            ("daemon", line3b),
+            ("daemon", line4),
+        ]
+        lines: list[str] = []
+        prev_section: str | None = None
+        for section, text in sections:
+            if text is None:
+                continue
+            if prev_section is not None and section != prev_section:
+                lines.append("────────────────")
+            lines.append(text)
+            prev_section = section
         if not lines:
             return []
         joined = "\n".join(lines)

--- a/src/lingtai/mcp_servers/task_card/event_projection.py
+++ b/src/lingtai/mcp_servers/task_card/event_projection.py
@@ -11,6 +11,9 @@ from lingtai.kernel.state import AgentState
 from lingtai.kernel.trace_redaction import redact_text
 
 
+_ASYNC_STATUS_KEYS = ("running", "done", "failed", "cancelled", "timeout", "unknown")
+
+
 class TaskCardEventProjection:
     """Shared, transport-free event grouping, redaction, and rendering core."""
 
@@ -28,7 +31,6 @@ class TaskCardEventProjection:
     )
     DEFAULT_NORMAL_ROWS = 1
     METADATA_MAX_CHARS = 500
-    METADATA_MAX_LINES = 2
     TIME_PREFIX = "Last Updated: "
     AGENT_STATES = frozenset(state.value for state in AgentState)
 
@@ -48,6 +50,13 @@ class TaskCardEventProjection:
             "failed": "failed",
             "retrying": "retrying",
             "retrying_attempt": "retrying (attempt {n})",
+            "session": "Session",
+            "identity": "Identity",
+            "async_work": "Async Work",
+            "daemons": "Daemons",
+            "backends": "Backends",
+            "shell": "Shell",
+            "daemon_stats": "Daemon stats",
         },
         "zh": {
             "header": "📋 活动",
@@ -63,6 +72,13 @@ class TaskCardEventProjection:
             "failed": "失败",
             "retrying": "重试中",
             "retrying_attempt": "重试中 (第 {n} 次)",
+            "session": "会话",
+            "identity": "身份",
+            "async_work": "异步工作",
+            "daemons": "守护进程",
+            "backends": "后端",
+            "shell": "Shell",
+            "daemon_stats": "守护进程统计",
         },
     }
 
@@ -98,6 +114,7 @@ class TaskCardEventProjection:
     # old full-width run so section breaks read as compact separators
     # (Jason 2026-08-13).
     METADATA_DIVIDER = "────────"
+    _ASYNC_STATUS_KEYS = _ASYNC_STATUS_KEYS
 
     @classmethod
     def footer(cls, normal_rows: int, locale: str = "en") -> str:
@@ -653,18 +670,27 @@ class TaskCardEventProjection:
 
     @classmethod
     def format_metadata(cls, metadata: object, locale: str = "en") -> list[str]:
+        """Render bounded resident-card metadata as explicit semantic sections.
+
+        The manager supplies ``async_work`` as a render-time, read-only snapshot.
+        This method deliberately knows nothing about the filesystem or providers;
+        it only sanitizes and arranges the already validated payload.
+        """
         if not isinstance(metadata, dict):
             return []
 
+        def label(key: str) -> str:
+            return cls._locale_text(key, locale)
+
         session_parts: list[str] = []
         model = metadata.get("model")
-        if isinstance(model, str) and model.strip():
+        if isinstance(model, str) and model.strip() and len(model.strip()) <= 128:
             session_parts.append(model.strip())
         thinking = metadata.get("thinking")
-        if isinstance(thinking, str) and thinking.strip():
+        if isinstance(thinking, str) and thinking.strip() and len(thinking.strip()) <= 48:
             session_parts.append(thinking.strip())
         endpoint = metadata.get("endpoint")
-        if isinstance(endpoint, str) and endpoint.strip():
+        if isinstance(endpoint, str) and endpoint.strip() and len(endpoint.strip()) <= 96:
             session_parts.append(f"@{endpoint.strip()}")
         context = cls.format_count(metadata.get("context_tokens"))
         window = cls.format_count(metadata.get("context_window"))
@@ -672,6 +698,7 @@ class TaskCardEventProjection:
         if (
             type(usage) in {int, float}
             and not isinstance(usage, bool)
+            and math.isfinite(float(usage))
             and 0 <= usage <= 1
         ):
             if context is not None:
@@ -690,6 +717,7 @@ class TaskCardEventProjection:
         if (
             type(cache_rate) in {int, float}
             and not isinstance(cache_rate, bool)
+            and math.isfinite(float(cache_rate))
             and 0 <= cache_rate <= 1
         ):
             session_parts.append(f"cache {float(cache_rate):.1%}")
@@ -712,6 +740,7 @@ class TaskCardEventProjection:
             if (
                 type(active_seconds) in {int, float}
                 and not isinstance(active_seconds, bool)
+                and math.isfinite(float(active_seconds))
                 and active_seconds >= 0
             ):
                 agent_part = f"active ({float(active_seconds):.0f}s)"
@@ -720,126 +749,225 @@ class TaskCardEventProjection:
         elif lifecycle in cls.AGENT_STATES:
             agent_part = f"agent · {lifecycle}"
 
-        # Line 1 = running state: agent lifecycle + session identity/usage,
-        # compact (no per-part prefixes; effort/endpoint/ctx/cache/miss are
-        # self-evident from position). Line 2 = identity: device + short path.
         line1_parts: list[str] = []
         if agent_part:
             line1_parts.append(agent_part)
         line1_parts.extend(session_parts)
-        line1 = " · ".join(line1_parts) if line1_parts else None
-
-        device = cls.machine_identifier(
-            metadata.get("device_short_name"), limit=64
+        session_line = (
+            f"{label('session')} · {' · '.join(line1_parts)}"
+            if line1_parts
+            else None
         )
+
+        # Keep all identity values behind the strict machine_identifier allowlist.
+        # In particular, working_dir is never rendered from an arbitrary string.
+        device = cls.machine_identifier(metadata.get("device_short_name"), limit=64)
         shell_name = cls.machine_identifier(metadata.get("shell_name"), limit=48)
-        line2_parts: list[str] = []
+        identity_parts: list[str] = []
         if device is not None or shell_name is not None:
             parts: list[str] = []
             if device is not None:
                 parts.append(device)
             if shell_name is not None:
                 parts.append(f"shell {shell_name}")
-            line2_parts.append("device · " + " · ".join(parts))
+            identity_parts.append("device · " + " · ".join(parts))
         working_dir = cls.machine_identifier(metadata.get("working_dir"), limit=220)
         if working_dir is not None:
-            line2_parts.append(f"path · {working_dir}")
-        line2 = " | ".join(line2_parts) if line2_parts else None
+            identity_parts.append(f"path · {working_dir}")
+        identity_payload = " | ".join(identity_parts) if identity_parts else None
+        identity_line = (
+            f"{label('identity')} · {identity_payload}"
+            if identity_payload
+            else None
+        )
 
-        # Daemon status + statistics: active runs plus terminal runs finished
-        # within the last ten minutes. Counts and backend distribution only
-        # (no id lists); the stats line aggregates token input/output/cached
-        # and call counts over the same window. Nothing renders when no daemon
-        # is in scope.
-        daemons = metadata.get("daemons")
-        line3: str | None = None
-        line3b: str | None = None
-        line4: str | None = None
-        if isinstance(daemons, dict):
-            status_parts: list[str] = []
-            active = daemons.get("active")
-            if isinstance(active, int) and active > 0:
-                status_parts.append(f"active {active}")
-            for key in ("failed", "done", "cancelled", "timeout"):
-                count = daemons.get(key)
-                if isinstance(count, int) and count > 0:
-                    status_parts.append(f"{key} {count}")
-            if status_parts:
-                line3 = "daemons · " + " · ".join(status_parts)
-            backend_counts = daemons.get("backend_counts")
-            if isinstance(backend_counts, dict) and backend_counts:
-                backend_parts: list[str] = []
-                for backend in sorted(backend_counts):
-                    count = backend_counts.get(backend)
-                    if isinstance(count, int) and count > 0:
-                        backend_parts.append(f"{backend} {count}")
-                if backend_parts:
-                    line3b = "backends · " + " · ".join(backend_parts)
+        def count(value: object) -> int | None:
+            if type(value) is int and value >= 0:
+                return value
+            return None
+
+        def status_parts(source: object) -> list[str]:
+            if not isinstance(source, dict):
+                return []
+            out: list[str] = []
+            for key in cls._ASYNC_STATUS_KEYS:
+                value = count(source.get(key))
+                if value is not None and value > 0:
+                    out.append(f"{key} {value}")
+            return out
+
+        async_work = metadata.get("async_work")
+        async_sections: list[tuple[str, str, int]] = []
+        if isinstance(async_work, dict):
+            daemon = async_work.get("daemon")
+            shell = async_work.get("shell")
+            daemon_parts = status_parts(daemon)
+            shell_parts = status_parts(shell)
+            # The adapter normally supplies validated combined counts. When a
+            # carrier is hand-built or stale, prefer the two lane truths so the
+            # visible unified kanban cannot contradict its detail rows.
+            if isinstance(daemon, dict) or isinstance(shell, dict):
+                totals = []
+                for key in cls._ASYNC_STATUS_KEYS:
+                    value = 0
+                    for lane in (daemon, shell):
+                        if isinstance(lane, dict):
+                            lane_value = count(lane.get(key))
+                            if lane_value is not None:
+                                value += lane_value
+                    if value > 0:
+                        totals.append(f"{key} {value}")
+            else:
+                totals = status_parts(async_work)
+            backend_parts: list[str] = []
+            if isinstance(daemon, dict) and isinstance(daemon.get("backend_counts"), dict):
+                safe_backends: list[tuple[str, int]] = []
+                for raw_backend, raw_count in daemon["backend_counts"].items():
+                    backend = cls.machine_identifier(raw_backend, limit=48)
+                    value = count(raw_count)
+                    if backend is None:
+                        backend = "unknown"
+                    if value is not None and value > 0:
+                        safe_backends.append((backend, value))
+                for backend, value in sorted(safe_backends):
+                    backend_parts.append(f"{backend} {value}")
+
             stats_parts: list[str] = []
-            input_tokens = daemons.get("input_tokens")
-            output_tokens = daemons.get("output_tokens")
-            cached_tokens = daemons.get("cached_tokens")
-            calls = daemons.get("calls")
-            if isinstance(input_tokens, int) and input_tokens > 0:
-                stats_parts.append(f"in {cls.format_count(input_tokens)}")
-            if isinstance(output_tokens, int) and output_tokens > 0:
-                stats_parts.append(f"out {cls.format_count(output_tokens)}")
-            if (
-                isinstance(cached_tokens, int)
-                and isinstance(input_tokens, int)
-                and input_tokens > 0
-                and cached_tokens > 0
-            ):
-                stats_parts.append(f"cache {min(cached_tokens / input_tokens, 1.0):.1%}")
-            if isinstance(calls, int) and calls > 0:
-                stats_parts.append(f"calls {calls}")
-            if stats_parts:
-                line4 = "daemon stats · " + " · ".join(stats_parts)
+            if isinstance(daemon, dict):
+                input_tokens = count(daemon.get("input_tokens"))
+                output_tokens = count(daemon.get("output_tokens"))
+                cached_tokens = count(daemon.get("cached_tokens"))
+                cli_calls = count(daemon.get("cli_calls"))
+                if input_tokens is not None and input_tokens > 0:
+                    stats_parts.append(f"in {cls.format_count(input_tokens)}")
+                if output_tokens is not None and output_tokens > 0:
+                    stats_parts.append(f"out {cls.format_count(output_tokens)}")
+                if (
+                    cached_tokens is not None
+                    and input_tokens is not None
+                    and input_tokens > 0
+                    and cached_tokens > 0
+                ):
+                    stats_parts.append(
+                        f"cache {min(cached_tokens / input_tokens, 1.0):.1%}"
+                    )
+                if cli_calls is not None and cli_calls > 0:
+                    stats_parts.append(f"CLI calls {cli_calls}")
 
-        # Metadata is organized into three sections — Session (line1),
-        # Identity (line2), Daemon (line3/backends/stats) — with a horizontal
-        # divider between adjacent sections that are both present, so the
-        # daemon block stands out and each section is scannable on its own.
-        sections: list[tuple[str, str | None]] = [
-            ("session", line1),
-            ("identity", line2),
-            ("daemon", line3),
-            ("daemon", line3b),
-            ("daemon", line4),
+            # All rows belong to one Async Work section. The priority value is
+            # used only by the whole-line 500-character budget below.
+            if totals:
+                async_sections.append(("totals", f"{label('async_work')} · {' · '.join(totals)}", 2))
+            if daemon_parts:
+                async_sections.append(("daemon", f"{label('daemons')} · {' · '.join(daemon_parts)}", 3))
+            if backend_parts:
+                async_sections.append(("backend", f"{label('backends')} · {' · '.join(backend_parts)}", 4))
+            if shell_parts:
+                async_sections.append(("shell", f"{label('shell')} · {' · '.join(shell_parts)}", 3))
+            if stats_parts:
+                async_sections.append(("stats", f"{label('daemon_stats')} · {' · '.join(stats_parts)}", 4))
+
+        # ``sections`` is intentionally list[list[str]]: a section is either
+        # present or absent, and dividers are inserted only between present
+        # adjacent sections (never after Identity or inside Async Work).
+        sections: list[list[str]] = []
+        priorities: list[list[int]] = []
+        if session_line is not None:
+            sections.append([session_line])
+            priorities.append([0])
+        if identity_line is not None:
+            sections.append([identity_line])
+            priorities.append([1])
+        if async_sections:
+            sections.append([line for _, line, _ in async_sections])
+            priorities.append([priority for _, _, priority in async_sections])
+
+        def render_selected(selected: list[list[tuple[str, int]]]) -> list[str]:
+            result: list[str] = []
+            previous = False
+            for section in selected:
+                present = [line for line, _ in section if line]
+                if not present:
+                    continue
+                if previous:
+                    result.append(cls.METADATA_DIVIDER)
+                result.extend(present)
+                previous = True
+            return result
+
+        def total_length(lines: list[str]) -> int:
+            return len("\n".join(lines))
+
+        selected: list[list[tuple[str, int]]] = [
+            [(line, priority) for line, priority in zip(lines, section_priorities)]
+            for lines, section_priorities in zip(sections, priorities)
         ]
-        lines: list[str] = []
-        prev_section: str | None = None
-        for section, text in sections:
-            if text is None:
-                continue
-            if prev_section is not None and section != prev_section:
-                lines.append(cls.METADATA_DIVIDER)
-            lines.append(text)
-            prev_section = section
-        # Close the identity section with a divider even when no daemon block
-        # follows, so the resident card keeps a stable sectioned look while
-        # idle (Jason 2026-08-13).
-        if prev_section == "identity":
-            lines.append(cls.METADATA_DIVIDER)
-        if not lines:
-            return []
-        joined = "\n".join(lines)
-        if len(joined) <= cls.METADATA_MAX_CHARS:
-            return lines
-        # Prefer preserving the session line; truncate from the identity line
-        # and keep as many trailing lines as fit, each cut at its share.
-        first = lines[0][: cls.METADATA_MAX_CHARS]
-        remaining = cls.METADATA_MAX_CHARS - len(first) - 1
-        if remaining <= 0:
-            return [first]
-        kept = [first]
-        for extra in lines[1:]:
-            if remaining <= 0:
+
+        # Remove lower-priority complete rows before touching Identity. Session
+        # and Identity are section rows, while Async totals outrank lane detail.
+        for priority_to_drop in (4, 3, 2):
+            if total_length(render_selected(selected)) <= cls.METADATA_MAX_CHARS:
                 break
-            take = min(len(extra), remaining)
-            kept.append(extra[:take])
-            remaining -= take + 1
-        return kept
+            for section in selected:
+                section[:] = [item for item in section if item[1] != priority_to_drop]
+
+        # If necessary, shorten only the Identity payload. The label and its
+        # separator remain atomic, and the ellipsis is added only to a shortened
+        # payload (never to a divider or a partial label).
+        if total_length(render_selected(selected)) > cls.METADATA_MAX_CHARS:
+            identity_location: tuple[int, int] | None = None
+            for section_index, section in enumerate(selected):
+                for item_index, (_, priority) in enumerate(section):
+                    if priority == 1:
+                        identity_location = (section_index, item_index)
+                        break
+                if identity_location is not None:
+                    break
+            if identity_location is not None:
+                section_index, item_index = identity_location
+                original, priority = selected[section_index][item_index]
+                marker = " · "
+                marker_index = original.find(marker)
+                if marker_index >= 0:
+                    prefix = original[: marker_index + len(marker)]
+                    payload = original[marker_index + len(marker) :]
+                    low, high = 0, len(payload)
+                    best: str | None = None
+                    while low <= high:
+                        mid = (low + high) // 2
+                        candidate_payload = payload if mid == len(payload) else (
+                            payload[: max(0, mid - 1)] + "…"
+                        )
+                        candidate = prefix + candidate_payload
+                        trial = [list(section) for section in selected]
+                        trial[section_index][item_index] = (candidate, priority)
+                        if total_length(render_selected(trial)) <= cls.METADATA_MAX_CHARS:
+                            best = candidate
+                            low = mid + 1
+                        else:
+                            high = mid - 1
+                    if best is not None:
+                        selected[section_index][item_index] = (best, priority)
+                    else:
+                        selected[section_index].pop(item_index)
+
+        # A pathological session payload may itself exceed the budget. There is
+        # no safe partial Session representation; retain the higher-priority
+        # whole line and discard lower-priority whole lines rather than splitting
+        # a label/separator. Normal session fields are bounded well below this.
+        while total_length(render_selected(selected)) > cls.METADATA_MAX_CHARS:
+            removable = [
+                (priority, section_index, item_index)
+                for section_index, section in enumerate(selected)
+                for item_index, (_, priority) in enumerate(section)
+                if priority > 0
+            ]
+            if not removable:
+                break
+            _, section_index, item_index = max(removable)
+            selected[section_index].pop(item_index)
+
+        return render_selected(selected)
 
     @classmethod
     def _short_working_dir(cls, working_dir: str) -> str:
@@ -916,7 +1044,7 @@ class TaskCardEventProjection:
         metadata_lines = cls.format_metadata(metadata, locale)
         time_line = f"{cls.time_prefix(locale)}{cls.render_time(now)}"
         if not tool_prepared and not text_prepared and not api_prepared:
-            lines = [cls.header(locale), "", footer]
+            lines = [cls.header(locale), "", footer, cls.METADATA_DIVIDER]
             lines.extend(metadata_lines)
             lines.append(time_line)
             return "\n".join(lines)
@@ -940,6 +1068,8 @@ class TaskCardEventProjection:
             + 1
             + 1
             + len(footer)
+            + len(cls.METADATA_DIVIDER)
+            + 1
             + sum(len(line) + 1 for line in metadata_lines)
             + len(time_line)
             + 1
@@ -971,6 +1101,7 @@ class TaskCardEventProjection:
         lines.extend(by_idx[index] for index in sorted(by_idx))
         lines.append("")
         lines.append(footer)
+        lines.append(cls.METADATA_DIVIDER)
         lines.extend(metadata_lines)
         lines.append(time_line)
         return "\n".join(lines)

--- a/src/lingtai/mcp_servers/task_card/event_projection.py
+++ b/src/lingtai/mcp_servers/task_card/event_projection.py
@@ -743,11 +743,13 @@ class TaskCardEventProjection:
         line2 = " | ".join(line2_parts) if line2_parts else None
 
         # Daemon status + statistics: active runs plus terminal runs finished
-        # within the last ten minutes. Counts only (no id lists); the stats
-        # line aggregates token input/output/cached and call counts over the
-        # same window. Nothing renders when no daemon is in scope.
+        # within the last ten minutes. Counts and backend distribution only
+        # (no id lists); the stats line aggregates token input/output/cached
+        # and call counts over the same window. Nothing renders when no daemon
+        # is in scope.
         daemons = metadata.get("daemons")
         line3: str | None = None
+        line3b: str | None = None
         line4: str | None = None
         if isinstance(daemons, dict):
             status_parts: list[str] = []
@@ -760,6 +762,15 @@ class TaskCardEventProjection:
                     status_parts.append(f"{key} {count}")
             if status_parts:
                 line3 = "daemons · " + " · ".join(status_parts)
+            backend_counts = daemons.get("backend_counts")
+            if isinstance(backend_counts, dict) and backend_counts:
+                backend_parts: list[str] = []
+                for backend in sorted(backend_counts):
+                    count = backend_counts.get(backend)
+                    if isinstance(count, int) and count > 0:
+                        backend_parts.append(f"{backend} {count}")
+                if backend_parts:
+                    line3b = "backends · " + " · ".join(backend_parts)
             stats_parts: list[str] = []
             input_tokens = daemons.get("input_tokens")
             output_tokens = daemons.get("output_tokens")
@@ -781,7 +792,7 @@ class TaskCardEventProjection:
             if stats_parts:
                 line4 = "daemon stats · " + " · ".join(stats_parts)
 
-        lines = [ln for ln in (line1, line2, line3, line4) if ln]
+        lines = [ln for ln in (line1, line2, line3, line3b, line4) if ln]
         if not lines:
             return []
         joined = "\n".join(lines)

--- a/src/lingtai/mcp_servers/task_card/event_projection.py
+++ b/src/lingtai/mcp_servers/task_card/event_projection.py
@@ -94,6 +94,10 @@ class TaskCardEventProjection:
     # the divider becomes a log-style section header `──── 00:22:02 U-7 ────`
     # (Jason 2026-08-09).
     API_CALL_DIVIDER = "────"
+    # Section divider on the resident card — deliberately shorter than the
+    # old full-width run so section breaks read as compact separators
+    # (Jason 2026-08-13).
+    METADATA_DIVIDER = "────────"
 
     @classmethod
     def footer(cls, normal_rows: int, locale: str = "en") -> str:
@@ -809,9 +813,14 @@ class TaskCardEventProjection:
             if text is None:
                 continue
             if prev_section is not None and section != prev_section:
-                lines.append("────────────────")
+                lines.append(cls.METADATA_DIVIDER)
             lines.append(text)
             prev_section = section
+        # Close the identity section with a divider even when no daemon block
+        # follows, so the resident card keeps a stable sectioned look while
+        # idle (Jason 2026-08-13).
+        if prev_section == "identity":
+            lines.append(cls.METADATA_DIVIDER)
         if not lines:
             return []
         joined = "\n".join(lines)

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -33,6 +33,7 @@ from lingtai.adapters.posix.agent_presence import PosixAgentPresenceStoreAdapter
 from lingtai.kernel._frontmatter import strip_frontmatter
 from lingtai.kernel.agent_presence import observe_alive
 from lingtai.kernel.state import AgentState
+from lingtai.tools.bash._async_supervisor import load_state
 from lingtai.mcp_servers.task_card import (
     TaskCardEventProjection,
     TaskCardResident,
@@ -141,7 +142,9 @@ _TASK_CARD_DELETE_NONDELETABLE_DESCRIPTIONS = frozenset({
 _TASK_CARD_FOOTER = TaskCardEventProjection.FOOTER
 _TASK_CARD_DEFAULT_NORMAL_ROWS = TaskCardEventProjection.DEFAULT_NORMAL_ROWS
 _TASK_CARD_METADATA_MAX_CHARS = TaskCardEventProjection.METADATA_MAX_CHARS
-_TASK_CARD_METADATA_MAX_LINES = TaskCardEventProjection.METADATA_MAX_LINES
+_TASK_CARD_ASYNC_TERMINAL_WINDOW_SECONDS = 600
+_TASK_CARD_ASYNC_STATUS_KEYS = ("running", "done", "failed", "cancelled", "timeout", "unknown")
+_TASK_CARD_DAEMON_TERMINAL_STATUS = frozenset({"done", "failed", "cancelled", "timeout"})
 
 # Canonical AgentState values that render without a /refresh hint; "stuck" is
 # the exact same enum plus the hint, and "offline" is not an AgentState value
@@ -156,6 +159,77 @@ _TASK_CARD_AGENT_STATES = TaskCardEventProjection.AGENT_STATES
 # always present — unlike the retired started_at-derived line, it never
 # depends on any row carrying a stamp.
 _TASK_CARD_TIME_PREFIX = TaskCardEventProjection.TIME_PREFIX
+
+
+def _task_card_nonnegative_count(value: object) -> int:
+    """Coerce finite non-negative numeric counters without accepting bool."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return 0
+    try:
+        number = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return 0
+    if not math.isfinite(number) or number < 0:
+        return 0
+    return int(number)
+
+
+def _task_card_parse_daemon_finished_at(value: object, now: datetime) -> bool:
+    """Return whether an ISO daemon terminal timestamp is in the strict window."""
+    if not isinstance(value, str) or not value.strip():
+        return False
+    try:
+        text = value.strip()
+        if text.endswith("Z"):
+            text = text[:-1] + "+00:00"
+        finished = datetime.fromisoformat(text)
+        if finished.tzinfo is None:
+            finished = finished.replace(tzinfo=timezone.utc)
+        else:
+            finished = finished.astimezone(timezone.utc)
+        age = (now.astimezone(timezone.utc) - finished).total_seconds()
+    except (TypeError, ValueError, OverflowError, OSError):
+        return False
+    return math.isfinite(age) and 0 <= age <= _TASK_CARD_ASYNC_TERMINAL_WINDOW_SECONDS
+
+
+def _task_card_shell_status(state: object) -> str | None:
+    """Classify durable async-shell truth without probing processes or mutating state."""
+    if not isinstance(state, dict):
+        return None
+    raw = state.get("status")
+    if raw in ("launching", "running"):
+        return "running"
+    if raw == "unrecoverable":
+        return "failed"
+    if raw == "completed":
+        if state.get("cancellation_outcome") == "group_cancelled":
+            return "cancelled"
+        if state.get("exit_status_known") is True:
+            exit_code = state.get("exit_code")
+            if type(exit_code) is int:
+                return "done" if exit_code == 0 else "failed"
+        return "unknown"
+    # A non-empty status other than the known nonterminal states is terminal
+    # truth we cannot explain exactly; retain it as unknown inside its window.
+    if isinstance(raw, str) and raw.strip():
+        return "unknown"
+    return None
+
+
+def _task_card_shell_in_window(state: object, now_epoch: float) -> bool:
+    """Nonterminal shell jobs are always visible; terminal jobs need epoch time."""
+    if not isinstance(state, dict):
+        return False
+    if state.get("status") in ("launching", "running"):
+        return True
+    finished = state.get("finished_at")
+    if isinstance(finished, bool) or not isinstance(finished, (int, float)):
+        return False
+    if not math.isfinite(float(finished)) or not math.isfinite(float(now_epoch)):
+        return False
+    age = float(now_epoch) - float(finished)
+    return 0 <= age <= _TASK_CARD_ASYNC_TERMINAL_WINDOW_SECONDS
 
 
 def _task_card_footer(normal_rows: int, locale: str = "en") -> str:
@@ -2352,13 +2426,6 @@ class TelegramManager:
                 snapshot["endpoint"] = llm_extra["endpoint"]
             if "thinking" in llm_extra:
                 snapshot["thinking"] = llm_extra["thinking"]
-        # Physical path + device short name make the card self-identifying:
-        # the reader can tell exactly which agent on which machine produced
-        # this card, and where its durable state lives. ``socket.gethostname``
-        # returns the short host name (no FQDN suffix); failures degrade to
-        # omitting the key so no line is fabricated. ``shell_kind`` is carried
-        # from the agent's resolved dialect when available so the card also
-        # shows which shell the agent runs on.
         try:
             snapshot["device_short_name"] = socket.gethostname()
         except (OSError, ValueError):
@@ -2381,102 +2448,150 @@ class TelegramManager:
                 shell_kind = ""
         if shell_kind:
             snapshot["shell_name"] = shell_kind
-        daemon_snapshot = self._task_card_daemon_snapshot()
-        if daemon_snapshot:
-            snapshot["daemons"] = daemon_snapshot
+        snapshot.pop("daemons", None)
+        snapshot.pop("async_work", None)
+        async_work = self._task_card_async_work_snapshot()
+        if async_work is not None:
+            snapshot["async_work"] = async_work
         return snapshot or None
 
     def _task_card_daemon_snapshot(self) -> dict | None:
-        """Read-only daemon status/statistics for the resident Task Card.
-
-        Scans ``<working_dir>/daemons/*`` state files (``daemon.json``, falling
-        back to legacy ``n``) and returns counts plus token statistics over the
-        active runs plus terminal runs finished within the last ten minutes.
-        Terminal runs older than the window are excluded so the card does not
-        accumulate a permanent daemon history. Missing/invalid state files
-        degrade silently; an empty scan returns ``None`` so no line renders.
-        """
+        """Read-only daemon lane snapshot over the strict terminal window."""
         daemons_dir = self._working_dir / "daemons"
-        if not daemons_dir.is_dir():
+        try:
+            if daemons_dir.is_symlink() or not daemons_dir.is_dir():
+                return None
+        except OSError:
             return None
         now = datetime.now(timezone.utc)
-        active = 0
-        terminal_counts: dict[str, int] = {
-            "done": 0,
-            "failed": 0,
-            "cancelled": 0,
-            "timeout": 0,
-        }
-        totals = {"input": 0, "output": 0, "cached": 0, "calls": 0}
+        counts = {key: 0 for key in _TASK_CARD_ASYNC_STATUS_KEYS}
+        totals = {"input": 0, "output": 0, "cached": 0}
+        cli_calls = 0
         backend_counts: dict[str, int] = {}
         included = False
-        for run_path in daemons_dir.iterdir():
-            if not run_path.is_dir():
-                continue
-            state: dict | None = None
-            for candidate in ("daemon.json",):
-                state_path = run_path / candidate
-                if not state_path.is_file():
+        try:
+            children = list(daemons_dir.iterdir())
+        except OSError:
+            return None
+        for run_path in children:
+            try:
+                if run_path.is_symlink() or not run_path.is_dir():
                     continue
-                try:
-                    loaded = json.loads(state_path.read_text(encoding="utf-8"))
-                except (OSError, ValueError, json.JSONDecodeError, UnicodeDecodeError):
+                state_path = run_path / "daemon.json"
+                if state_path.is_symlink() or not state_path.is_file():
                     continue
-                if isinstance(loaded, dict):
-                    state = loaded
-                    break
-            if not state:
+                state = json.loads(state_path.read_text(encoding="utf-8"))
+                if not isinstance(state, dict):
+                    continue
+                raw_status = state.get("state")
+                if raw_status in ("running", "active"):
+                    status = "running"
+                    in_window = True
+                elif raw_status in _TASK_CARD_DAEMON_TERMINAL_STATUS:
+                    status = raw_status
+                    in_window = _task_card_parse_daemon_finished_at(
+                        state.get("finished_at"), now
+                    )
+                else:
+                    continue
+                if not in_window:
+                    continue
+                included = True
+                counts[status] += 1
+                backend = state.get("backend")
+                backend = (
+                    backend.strip()
+                    if isinstance(backend, str) and backend.strip()
+                    else "unknown"
+                )
+                backend = TaskCardEventProjection.machine_identifier(backend, limit=48) or "unknown"
+                backend_counts[backend] = backend_counts.get(backend, 0) + 1
+
+                tokens = state.get("tokens")
+                cli_tokens = state.get("cli_tokens")
+                if not isinstance(tokens, dict):
+                    tokens = None
+                if not isinstance(cli_tokens, dict):
+                    cli_tokens = None
+                backend_name = state.get("backend")
+                if backend_name == "lingtai":
+                    usage = tokens
+                elif isinstance(backend_name, str) and backend_name.strip():
+                    usage = cli_tokens or tokens
+                else:
+                    # Legacy records had no backend marker. Prefer a non-zero
+                    # external CLI ledger, then fall back to kernel tokens.
+                    cli_nonzero = (
+                        cli_tokens is not None
+                        and any(_task_card_nonnegative_count(cli_tokens.get(k)) > 0
+                                for k in ("input", "output", "thinking", "cached", "calls"))
+                    )
+                    usage = cli_tokens if cli_nonzero else (tokens or cli_tokens)
+                if isinstance(usage, dict):
+                    for source_key, total_key in (("input", "input"), ("output", "output"), ("cached", "cached")):
+                        totals[total_key] += _task_card_nonnegative_count(usage.get(source_key))
+                # API call statistics are meaningful only for the external CLI
+                # ledger; daemon tool_call_count is deliberately not substituted.
+                cli_calls += _task_card_nonnegative_count(
+                    cli_tokens.get("calls") if cli_tokens is not None else None
+                )
+            except (OSError, ValueError, TypeError, UnicodeDecodeError, json.JSONDecodeError):
                 continue
-            status = state.get("state")
-            in_window = False
-            if status in ("running", "active"):
-                active += 1
-                in_window = True
-            elif status in terminal_counts:
-                finished_at = state.get("finished_at")
-                if isinstance(finished_at, str):
-                    try:
-                        finished_dt = datetime.fromisoformat(
-                            finished_at[:-1] + "+00:00"
-                            if finished_at.endswith("Z")
-                            else finished_at
-                        )
-                        if finished_dt.tzinfo is None:
-                            finished_dt = finished_dt.replace(tzinfo=timezone.utc)
-                        age = (now - finished_dt).total_seconds()
-                        if 0 <= age <= 600:
-                            terminal_counts[status] += 1
-                            in_window = True
-                    except ValueError:
-                        pass
-            if not in_window:
-                continue
-            included = True
-            backend = state.get("backend")
-            if not isinstance(backend, str) or not backend.strip():
-                backend = "unknown"
-            else:
-                backend = backend.strip()
-            backend_counts[backend] = backend_counts.get(backend, 0) + 1
-            tokens = state.get("tokens")
-            if not isinstance(tokens, dict):
-                tokens = state.get("cli_tokens")
-            if isinstance(tokens, dict):
-                for key in ("input", "output", "cached", "calls"):
-                    value = tokens.get(key)
-                    if isinstance(value, (int, float)) and not isinstance(value, bool):
-                        totals[key] += int(value)
-        if not included and active == 0 and not any(terminal_counts.values()):
+        if not included:
             return None
         return {
-            "active": active,
-            **terminal_counts,
+            **counts,
             "backend_counts": backend_counts,
             "input_tokens": totals["input"],
             "output_tokens": totals["output"],
             "cached_tokens": totals["cached"],
-            "calls": totals["calls"],
+            "cli_calls": cli_calls,
         }
+
+    def _task_card_async_shell_snapshot(self) -> dict | None:
+        """Read-only async-shell lane using only durable ``state.json`` files."""
+        jobs_dir = self._working_dir / "system" / "jobs"
+        try:
+            if jobs_dir.is_symlink() or not jobs_dir.is_dir():
+                return None
+            children = list(jobs_dir.iterdir())
+        except OSError:
+            return None
+        now_epoch = time.time()
+        counts = {key: 0 for key in _TASK_CARD_ASYNC_STATUS_KEYS}
+        included = False
+        for job_dir in children:
+            try:
+                if job_dir.is_symlink() or not job_dir.is_dir():
+                    continue
+                state = load_state(job_dir)
+                if not isinstance(state, dict):
+                    continue
+                status = _task_card_shell_status(state)
+                if status is None or not _task_card_shell_in_window(state, now_epoch):
+                    continue
+                counts[status] += 1
+                included = True
+            except (OSError, ValueError, TypeError, UnicodeDecodeError):
+                continue
+        return counts if included else None
+
+    def _task_card_async_work_snapshot(self) -> dict | None:
+        daemon = self._task_card_daemon_snapshot()
+        shell = self._task_card_async_shell_snapshot()
+        if daemon is None and shell is None:
+            return None
+        lanes = [lane for lane in (daemon, shell) if lane is not None]
+        combined = {
+            key: sum(_task_card_nonnegative_count(lane.get(key)) for lane in lanes)
+            for key in _TASK_CARD_ASYNC_STATUS_KEYS
+        }
+        result: dict = {**combined}
+        if daemon is not None:
+            result["daemon"] = daemon
+        if shell is not None:
+            result["shell"] = shell
+        return result
 
     def _task_card_current_model(self) -> str | None:
         """Read the agent's current LLM model from ``.agent.json``.
@@ -3757,7 +3872,7 @@ class TelegramManager:
 
     @classmethod
     def _format_task_card_metadata(cls, metadata: object, locale: str = "en") -> list[str]:
-        """Render at most two compact session lines within a 150-char budget."""
+        """Render bounded semantic resident-card sections."""
         return TaskCardEventProjection.format_metadata(metadata, locale)
 
     @classmethod

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -2408,12 +2408,13 @@ class TelegramManager:
             "timeout": 0,
         }
         totals = {"input": 0, "output": 0, "cached": 0, "calls": 0}
+        backend_counts: dict[str, int] = {}
         included = False
         for run_path in daemons_dir.iterdir():
             if not run_path.is_dir():
                 continue
             state: dict | None = None
-            for candidate in ("daemon.json", "n"):
+            for candidate in ("daemon.json",):
                 state_path = run_path / candidate
                 if not state_path.is_file():
                     continue
@@ -2451,6 +2452,12 @@ class TelegramManager:
             if not in_window:
                 continue
             included = True
+            backend = state.get("backend")
+            if not isinstance(backend, str) or not backend.strip():
+                backend = "unknown"
+            else:
+                backend = backend.strip()
+            backend_counts[backend] = backend_counts.get(backend, 0) + 1
             tokens = state.get("tokens")
             if not isinstance(tokens, dict):
                 tokens = state.get("cli_tokens")
@@ -2464,6 +2471,7 @@ class TelegramManager:
         return {
             "active": active,
             **terminal_counts,
+            "backend_counts": backend_counts,
             "input_tokens": totals["input"],
             "output_tokens": totals["output"],
             "cached_tokens": totals["cached"],

--- a/tests/test_feishu_automatic_task_cards.py
+++ b/tests/test_feishu_automatic_task_cards.py
@@ -225,7 +225,7 @@ def test_journal_rehydrates_complete_lines_and_consumes_partial_later(
     assert groups[0]["events"][0]["elapsed_s"] == 1.25
     assert all(row.get("text") != "done" for row in groups[0]["events"])
     assert changed is True
-    assert completed_groups[-1]["events"] == [{"kind": "text", "text": "done"}]
+    assert completed_groups[-1]["events"] == [{"kind": "text", "text": "done", "_api_call_id": "api-2"}]
     assert len(changes) == 2
 
 

--- a/tests/test_task_card_event_projection_shared.py
+++ b/tests/test_task_card_event_projection_shared.py
@@ -131,7 +131,8 @@ def test_shared_render_is_byte_identical_to_telegram_golden_surface() -> None:
         "\n"
         "Don't reply to this Task Card. Use /taskcard on|off to toggle; "
         "/taskcard N sets normal rows (1-10, current: 1).\n"
-        "active · calls 2\n"
+        "────────\n"
+        "Session · active · calls 2\n"
         "Last Updated: 02:30:00 U+8"
     )
 
@@ -188,14 +189,13 @@ def test_metadata_renders_device_and_working_dir_lines() -> None:
         "working_dir": "C:\\Users\\zhuang\\.lingtai\\deepseek-1",
     }
     lines = TaskCardEventProjection.format_metadata(metadata)
-    # Session + identity + the identity-closing divider (stable sectioned look).
-    assert len(lines) == 4
-    assert lines[0] == "active · calls 2"
+    # Explicit Session and Identity sections, with no identity closing divider.
+    assert len(lines) == 3
+    assert lines[0] == "Session · active · calls 2"
     # Session and identity are separate sections with a divider between them.
     assert lines[1] == "────────"
     identity = lines[2]
-    # Identity section is closed with a divider even without a daemon block.
-    assert lines[3] == "────────"
+    assert lines[-1].startswith("Identity · ")
     assert "device · zesen-desktop · shell powershell" in identity
     assert "path · C:\\Users\\zhuang" in identity
     assert " | " in identity

--- a/tests/test_task_card_event_projection_shared.py
+++ b/tests/test_task_card_event_projection_shared.py
@@ -188,9 +188,11 @@ def test_metadata_renders_device_and_working_dir_lines() -> None:
         "working_dir": "C:\\Users\\zhuang\\.lingtai\\deepseek-1",
     }
     lines = TaskCardEventProjection.format_metadata(metadata)
-    assert len(lines) == 2
+    assert len(lines) == 3
     assert lines[0] == "active · calls 2"
-    identity = lines[1]
+    # Session and identity are separate sections with a divider between them.
+    assert lines[1] == "────────────────"
+    identity = lines[2]
     assert "device · zesen-desktop · shell powershell" in identity
     assert "path · C:\\Users\\zhuang" in identity
     assert " | " in identity

--- a/tests/test_task_card_event_projection_shared.py
+++ b/tests/test_task_card_event_projection_shared.py
@@ -188,11 +188,14 @@ def test_metadata_renders_device_and_working_dir_lines() -> None:
         "working_dir": "C:\\Users\\zhuang\\.lingtai\\deepseek-1",
     }
     lines = TaskCardEventProjection.format_metadata(metadata)
-    assert len(lines) == 3
+    # Session + identity + the identity-closing divider (stable sectioned look).
+    assert len(lines) == 4
     assert lines[0] == "active · calls 2"
     # Session and identity are separate sections with a divider between them.
-    assert lines[1] == "────────────────"
+    assert lines[1] == "────────"
     identity = lines[2]
+    # Identity section is closed with a divider even without a daemon block.
+    assert lines[3] == "────────"
     assert "device · zesen-desktop · shell powershell" in identity
     assert "path · C:\\Users\\zhuang" in identity
     assert " | " in identity

--- a/tests/test_telegram_task_card_event_tail.py
+++ b/tests/test_telegram_task_card_event_tail.py
@@ -245,10 +245,11 @@ def test_provider_groups_count_calls_and_exclude_unprojected_fields(tmp_path):
     manager._poll_event_tail()
     rendered = [call for call in acct.calls if call[0] == "edit_message"][-1][3]
     divider = manager._TASK_CARD_API_CALL_DIVIDER
-    # Two API groups → two symmetric divider header lines, plus one resident
-    # identity-closing metadata divider (each line carries the dash run once or
-    # twice, so count lines, not substring occurrences).
-    assert sum(ln.startswith(divider) for ln in rendered.splitlines()) == 3
+    api_dividers = [ln for ln in rendered.splitlines()
+                    if ln == divider or (ln.startswith(divider + " ") and ln.endswith(" " + divider))]
+    footer_idx = next(i for i, ln in enumerate(rendered.splitlines()) if "Don't reply to this Task Card." in ln)
+    assert len(api_dividers) == 2
+    assert rendered.splitlines()[footer_idx + 1] == TaskCardEventProjection.METADATA_DIVIDER
     assert all(value in rendered for value in ("text one", "• bash.run:", "text two", "• read.read:"))
     assert len(rendered) <= manager._TASK_CARD_TEXT_LIMIT
     assert all(secret not in rendered for secret in (
@@ -258,7 +259,11 @@ def test_provider_groups_count_calls_and_exclude_unprojected_fields(tmp_path):
     service.normal_rows = 1
     manager._broadcast_task_card_event_window()
     latest = acct.calls[-1][3]
-    assert sum(ln.startswith(divider) for ln in latest.splitlines()) == 2 and "text two" in latest and "• read.read:" in latest
+    latest_lines = latest.splitlines()
+    latest_api_dividers = [ln for ln in latest_lines
+                           if ln == divider or (ln.startswith(divider + " ") and ln.endswith(" " + divider))]
+    latest_footer_idx = next(i for i, ln in enumerate(latest_lines) if "Don't reply to this Task Card." in ln)
+    assert len(latest_api_dividers) == 1 and latest_lines[latest_footer_idx + 1] == TaskCardEventProjection.METADATA_DIVIDER and "text two" in latest and "• read.read:" in latest
     assert "text one" not in latest and "• bash.run:" not in latest
 
 

--- a/tests/test_telegram_task_card_event_tail.py
+++ b/tests/test_telegram_task_card_event_tail.py
@@ -245,9 +245,10 @@ def test_provider_groups_count_calls_and_exclude_unprojected_fields(tmp_path):
     manager._poll_event_tail()
     rendered = [call for call in acct.calls if call[0] == "edit_message"][-1][3]
     divider = manager._TASK_CARD_API_CALL_DIVIDER
-    # Two API groups → two symmetric divider header lines (each line carries the
-    # dash run twice, once per side, so count lines, not substring occurrences).
-    assert sum(ln.startswith(divider) for ln in rendered.splitlines()) == 2
+    # Two API groups → two symmetric divider header lines, plus one resident
+    # identity-closing metadata divider (each line carries the dash run once or
+    # twice, so count lines, not substring occurrences).
+    assert sum(ln.startswith(divider) for ln in rendered.splitlines()) == 3
     assert all(value in rendered for value in ("text one", "• bash.run:", "text two", "• read.read:"))
     assert len(rendered) <= manager._TASK_CARD_TEXT_LIMIT
     assert all(secret not in rendered for secret in (
@@ -257,7 +258,7 @@ def test_provider_groups_count_calls_and_exclude_unprojected_fields(tmp_path):
     service.normal_rows = 1
     manager._broadcast_task_card_event_window()
     latest = acct.calls[-1][3]
-    assert sum(ln.startswith(divider) for ln in latest.splitlines()) == 1 and "text two" in latest and "• read.read:" in latest
+    assert sum(ln.startswith(divider) for ln in latest.splitlines()) == 2 and "text two" in latest and "• read.read:" in latest
     assert "text one" not in latest and "• bash.run:" not in latest
 
 

--- a/tests/test_telegram_task_card_rows.py
+++ b/tests/test_telegram_task_card_rows.py
@@ -9,9 +9,15 @@ can never survive a length-pressure trim.
 
 from __future__ import annotations
 
+import json
+import os
+import time
+
 from lingtai.mcp_servers.telegram.manager import (
     TelegramManager,
     _TASK_CARD_FOOTER,
+    _task_card_shell_status,
+    _task_card_shell_in_window,
 )
 from tests._notification_store_helpers import FakeNotificationStore
 
@@ -337,9 +343,10 @@ def test_metadata_is_two_lines_bounded_and_between_footer_and_timestamp():
     lines = text.splitlines()
     footer_idx = next(i for i, line in enumerate(lines) if _TASK_CARD_FOOTER in line)
     time_idx = next(i for i, line in enumerate(lines) if line.startswith("Last Updated: "))
-    metadata_lines = lines[footer_idx + 1:time_idx]
+    assert lines[footer_idx + 1] == "────────"
+    metadata_lines = lines[footer_idx + 2:time_idx]
     assert metadata_lines == [
-        "ctx 63% · 171.2k/272.0k · cache 87.8% · miss 170.6k/1.0M · calls 13",
+        "Session · ctx 63% · 171.2k/272.0k · cache 87.8% · miss 170.6k/1.0M · calls 13",
     ]
     assert len(metadata_lines) == 1
     assert len(metadata_lines[0]) <= 500
@@ -380,10 +387,7 @@ def test_metadata_pathological_counts_never_overflow_or_break_budget():
 def test_metadata_renders_compact_normal_lifecycle_states():
     for state in ("active", "idle", "asleep", "suspended"):
         lines = TelegramManager._format_task_card_metadata({"agent_lifecycle": state})
-        if state == "active":
-            assert lines == ["active"]
-        else:
-            assert lines == [f"agent · {state}"]
+        assert lines == [f"Session · {'active' if state == 'active' else 'agent · ' + state}"]
 
 
 def test_metadata_renders_active_seconds_only_when_active():
@@ -392,36 +396,36 @@ def test_metadata_renders_active_seconds_only_when_active():
         "agent_lifecycle": "active",
         "agent_active_seconds": 12.0,
     })
-    assert lines == ["active (12s)"]
+    assert lines == ["Session · active (12s)"]
     # Non-active states never render the suffix even if the field is present.
     lines = TelegramManager._format_task_card_metadata({
         "agent_lifecycle": "idle",
         "agent_active_seconds": 12.0,
     })
-    assert lines == ["agent · idle"]
+    assert lines == ["Session · agent · idle"]
     # Missing/invalid age degrades to the plain lifecycle line.
     lines = TelegramManager._format_task_card_metadata({"agent_lifecycle": "active"})
-    assert lines == ["active"]
+    assert lines == ["Session · active"]
     lines = TelegramManager._format_task_card_metadata({
         "agent_lifecycle": "active",
         "agent_active_seconds": "secret",
     })
-    assert lines == ["active"]
+    assert lines == ["Session · active"]
 
 
 def test_metadata_renders_stuck_with_refresh_hint():
     lines = TelegramManager._format_task_card_metadata({"agent_lifecycle": "stuck"})
-    assert lines == ["agent · stuck · try /refresh"]
+    assert lines == ["Session · agent · stuck · try /refresh"]
 
 
 def test_metadata_renders_offline_with_refresh_hint():
     lines = TelegramManager._format_task_card_metadata({"agent_lifecycle": "offline"})
-    assert lines == ["agent · offline · try /refresh"]
+    assert lines == ["Session · agent · offline · try /refresh"]
 
 
 def test_metadata_suspended_never_gets_refresh_hint():
     lines = TelegramManager._format_task_card_metadata({"agent_lifecycle": "suspended"})
-    assert lines == ["agent · suspended"]
+    assert lines == ["Session · agent · suspended"]
     assert "/refresh" not in lines[0]
 
 
@@ -430,7 +434,7 @@ def test_metadata_ignores_unrecognized_lifecycle_value():
         "agent_lifecycle": "haunted",
         "session_cache_rate": 0.5,
     })
-    assert lines == ["cache 50.0%"]
+    assert lines == ["Session · cache 50.0%"]
 
 
 def test_metadata_agent_and_session_combine_on_line_one_ctx_preserved():
@@ -446,7 +450,7 @@ def test_metadata_agent_and_session_combine_on_line_one_ctx_preserved():
         "context_usage": 0.62958,
     })
     assert lines == [
-        "active · ctx 63% · 171.2k/272.0k · cache 87.8% · miss 170.6k/1.0M · calls 13",
+        "Session · active · ctx 63% · 171.2k/272.0k · cache 87.8% · miss 170.6k/1.0M · calls 13",
     ]
     assert len(lines) == 1
     assert len(lines[0]) <= 500
@@ -466,9 +470,9 @@ def test_metadata_stuck_hint_and_ctx_both_survive_full_metadata():
     # The 2-line cap holds; the hint leads line 1 (safe from end-truncation)
     # and ctx survives as line 2 instead of being dropped by the cap.
     assert lines == [
-        "agent · stuck · try /refresh · ctx 63% · 171.2k/272.0k · cache 87.8% · miss 170.6k/1.0M · calls 13",
+        "Session · agent · stuck · try /refresh · ctx 63% · 171.2k/272.0k · cache 87.8% · miss 170.6k/1.0M · calls 13",
     ]
-    assert lines[0].startswith("agent · stuck · try /refresh ·")
+    assert lines[0].startswith("Session · agent · stuck · try /refresh ·")
     assert len(lines) == 1
     assert len(lines[0]) <= 500
 
@@ -485,7 +489,7 @@ def test_metadata_unchanged_when_no_agent_lifecycle_present():
         "context_usage": 0.62958,
     })
     assert lines == [
-        "ctx 63% · 171.2k/272.0k · cache 87.8% · miss 170.6k/1.0M · calls 13",
+        "Session · ctx 63% · 171.2k/272.0k · cache 87.8% · miss 170.6k/1.0M · calls 13",
     ]
 
 
@@ -648,7 +652,7 @@ def test_metadata_renders_current_model_first():
         "model": "deepseek-v4-flash",
         "session_cache_rate": 0.5,
     })
-    assert lines == ["deepseek-v4-flash · cache 50.0%"]
+    assert lines == ["Session · deepseek-v4-flash · cache 50.0%"]
 
 
 def test_event_metadata_snapshot_adds_current_model(tmp_path):
@@ -671,52 +675,48 @@ def test_metadata_renders_absolute_path_not_shortened():
         "working_dir": "/Users/huangzesen/work/projects/lingtai-dev/dev-2/.lingtai/mimo-1",
         "device_short_name": "MacStudio",
     })
-    assert len(lines) == 2
-    assert "device · MacStudio | path · /Users/huangzesen/work/projects/lingtai-dev/dev-2/.lingtai/mimo-1" in lines[0]
+    assert len(lines) == 1
+    assert "Identity · device · MacStudio | path · /Users/huangzesen/work/projects/lingtai-dev/dev-2/.lingtai/mimo-1" in lines[0]
     assert "dev-2/.lingtai/mimo-1" not in lines[0].replace("dev-2/.lingtai/mimo-1", "")
-    assert lines[1] == "────────"
 
 
 def test_metadata_renders_daemon_status_and_stats():
     lines = TelegramManager._format_task_card_metadata({
-        "daemons": {
-            "active": 3,
-            "failed": 1,
-            "done": 2,
-            "cancelled": 0,
-            "timeout": 0,
-            "backend_counts": {"lingtai": 2, "claude-p": 1},
-            "input_tokens": 1_234_567,
-            "output_tokens": 340_000,
-            "cached_tokens": 1_049_382,
-            "calls": 12,
+        "async_work": {
+            "running": 3, "failed": 1, "done": 2,
+            "daemon": {"running": 3, "failed": 1, "done": 2,
+                        "backend_counts": {"lingtai": 2, "claude-p": 1},
+                        "input_tokens": 1_234_567, "output_tokens": 340_000,
+                        "cached_tokens": 1_049_382, "cli_calls": 12},
         },
     })
     assert lines == [
-        "daemons · active 3 · failed 1 · done 2",
-        "backends · claude-p 1 · lingtai 2",
-        "daemon stats · in 1.2M · out 340.0k · cache 85.0% · calls 12",
+        "Async Work · running 3 · done 2 · failed 1",
+        "Daemons · running 3 · done 2 · failed 1",
+        "Backends · claude-p 1 · lingtai 2",
+        "Daemon stats · in 1.2M · out 340.0k · cache 85.0% · CLI calls 12",
     ]
 
 
 def test_metadata_renders_backend_stats_only_when_present():
     # No backend_counts -> no backends line.
     lines = TelegramManager._format_task_card_metadata({
-        "daemons": {"active": 1},
+        "async_work": {"running": 1, "daemon": {"running": 1}},
     })
-    assert lines == ["daemons · active 1"]
+    assert lines == ["Async Work · running 1", "Daemons · running 1"]
     # Empty backend_counts -> no backends line.
     lines = TelegramManager._format_task_card_metadata({
-        "daemons": {"active": 1, "backend_counts": {}},
+        "async_work": {"running": 1, "daemon": {"running": 1, "backend_counts": {}}},
     })
-    assert lines == ["daemons · active 1"]
+    assert lines == ["Async Work · running 1", "Daemons · running 1"]
     # Populated backend_counts -> sorted backends line.
     lines = TelegramManager._format_task_card_metadata({
-        "daemons": {"active": 1, "backend_counts": {"claude-p": 2, "lingtai": 1}},
+        "async_work": {"running": 1, "daemon": {"running": 1, "backend_counts": {"claude-p": 2, "lingtai": 1}}},
     })
     assert lines == [
-        "daemons · active 1",
-        "backends · claude-p 2 · lingtai 1",
+        "Async Work · running 1",
+        "Daemons · running 1",
+        "Backends · claude-p 2 · lingtai 1",
     ]
 
 
@@ -727,58 +727,50 @@ def test_metadata_section_dividers_between_present_sections():
         "working_dir": "/Users/huangzesen/work/projects/lingtai-dev/dev-2/.lingtai/mimo-1",
     })
     assert lines == [
-        "active",
+        "Session · active",
         "────────",
-        "path · /Users/huangzesen/work/projects/lingtai-dev/dev-2/.lingtai/mimo-1",
-        "────────",
+        "Identity · path · /Users/huangzesen/work/projects/lingtai-dev/dev-2/.lingtai/mimo-1",
     ]
     # Session + Identity + Daemon -> dividers between all adjacent sections.
     lines = TelegramManager._format_task_card_metadata({
         "agent_lifecycle": "active",
         "working_dir": "/Users/huangzesen/work/projects/lingtai-dev/dev-2/.lingtai/mimo-1",
-        "daemons": {"active": 1, "backend_counts": {"lingtai": 1}},
+        "async_work": {"running": 1, "daemon": {"running": 1, "backend_counts": {"lingtai": 1}}},
     })
     assert lines == [
-        "active",
+        "Session · active",
         "────────",
-        "path · /Users/huangzesen/work/projects/lingtai-dev/dev-2/.lingtai/mimo-1",
+        "Identity · path · /Users/huangzesen/work/projects/lingtai-dev/dev-2/.lingtai/mimo-1",
         "────────",
-        "daemons · active 1",
-        "backends · lingtai 1",
+        "Async Work · running 1",
+        "Daemons · running 1",
+        "Backends · lingtai 1",
     ]
     # A single daemon section alone stays clean with no divider.
     lines = TelegramManager._format_task_card_metadata({
-        "daemons": {"active": 2},
+        "async_work": {"running": 2, "daemon": {"running": 2}},
     })
-    assert lines == ["daemons · active 2"]
+    assert lines == ["Async Work · running 2", "Daemons · running 2"]
 
 
 def test_metadata_omits_daemon_lines_when_no_daemons():
     lines = TelegramManager._format_task_card_metadata({
         "working_dir": "/Users/huangzesen/work/projects/lingtai-dev/dev-2/.lingtai/mimo-1",
-        "daemons": {"active": 0, "failed": 0, "done": 0, "cancelled": 0, "timeout": 0},
+        "async_work": {"running": 0, "failed": 0, "done": 0, "cancelled": 0, "timeout": 0},
     })
-    assert len(lines) == 2
-    assert "daemons" not in lines[0]
-    assert "daemon stats" not in lines[0]
-    assert lines[1] == "────────"
+    assert len(lines) == 1
+    assert "Async Work" not in lines[0]
+    assert "Daemon stats" not in lines[0]
 
 
 def test_metadata_daemon_stats_require_positive_counts():
     lines = TelegramManager._format_task_card_metadata({
-        "daemons": {
-            "active": 1,
-            "failed": 0,
-            "done": 0,
-            "cancelled": 0,
-            "timeout": 0,
-            "input_tokens": 0,
-            "output_tokens": 0,
-            "cached_tokens": 0,
-            "calls": 0,
-        },
+        "async_work": {"running": 1, "daemon": {
+            "running": 1, "failed": 0, "done": 0, "cancelled": 0,
+            "input_tokens": 0, "output_tokens": 0, "cached_tokens": 0, "cli_calls": 0,
+        }},
     })
-    assert lines == ["daemons · active 1"]
+    assert lines == ["Async Work · running 1", "Daemons · running 1"]
 
 
 def test_daemon_snapshot_scans_daemons_dir_and_windows(tmp_path):
@@ -803,14 +795,14 @@ def test_daemon_snapshot_scans_daemons_dir_and_windows(tmp_path):
 
     mgr, _ = _integration_manager(tmp_path)
     snap = mgr._task_card_daemon_snapshot()
-    assert snap["active"] == 1
+    assert snap["running"] == 1
     assert snap["done"] == 1
     assert snap["failed"] == 1
     # em-4 outside the 10-minute window is excluded entirely.
     assert snap["input_tokens"] == 1000 + 2000 + 3000
     assert snap["output_tokens"] == 500 + 700 + 100
     assert snap["cached_tokens"] == 800 + 1500 + 0
-    assert snap["calls"] == 3 + 4 + 1
+    assert snap["cli_calls"] == 1
     # Backend distribution counts only in-window runs; em-3 without a backend
     # falls back to "unknown".
     assert snap["backend_counts"] == {"lingtai": 1, "claude-p": 1, "unknown": 1}
@@ -819,3 +811,106 @@ def test_daemon_snapshot_scans_daemons_dir_and_windows(tmp_path):
 def test_daemon_snapshot_returns_none_when_no_daemons(tmp_path):
     mgr, _ = _integration_manager(tmp_path)
     assert mgr._task_card_daemon_snapshot() is None
+
+
+# ---------------------------------------------------------------------------
+# Unified async-work lanes: shell classification, mixed arithmetic, and RO scan
+# ---------------------------------------------------------------------------
+
+
+def test_shell_status_classification_matrix() -> None:
+    now = time.time()
+    cases = [
+        ({"status": "launching"}, "running"),
+        ({"status": "running", "cancel_requested_at": now}, "running"),
+        ({"status": "completed", "cancellation_outcome": "group_cancelled"}, "cancelled"),
+        ({"status": "completed", "exit_status_known": True, "exit_code": 0}, "done"),
+        ({"status": "completed", "exit_status_known": True, "exit_code": 7}, "failed"),
+        ({"status": "completed", "exit_status_known": True, "exit_code": False}, "unknown"),
+        ({"status": "completed", "exit_status_known": False}, "unknown"),
+        ({"status": "unrecoverable"}, "failed"),
+    ]
+    for state, expected in cases:
+        assert _task_card_shell_status(state) == expected
+    assert _task_card_shell_in_window({"status": "running"}, now) is True
+    assert _task_card_shell_in_window(
+        {"status": "completed", "finished_at": now - 600}, now
+    ) is True
+    assert _task_card_shell_in_window(
+        {"status": "completed", "finished_at": now - 601}, now
+    ) is False
+    assert _task_card_shell_in_window(
+        {"status": "completed", "finished_at": float("nan")}, now
+    ) is False
+
+
+def test_shell_snapshot_is_read_only_and_skips_legacy_jobs(tmp_path):
+    jobs = tmp_path / "system" / "jobs"
+    jobs.mkdir(parents=True)
+    state_dir = jobs / "job-1"
+    state_dir.mkdir()
+    state_path = state_dir / "state.json"
+    state_path.write_text(json.dumps({
+        "status": "completed", "finished_at": time.time(),
+        "exit_status_known": True, "exit_code": 0,
+    }), encoding="utf-8")
+    legacy = jobs / "legacy"
+    legacy.mkdir()
+    before = state_path.read_bytes()
+    before_mtime = state_path.stat().st_mtime_ns
+    mgr, _ = _integration_manager(tmp_path)
+    assert mgr._task_card_async_shell_snapshot() == {
+        "running": 0, "done": 1, "failed": 0,
+        "cancelled": 0, "timeout": 0, "unknown": 0,
+    }
+    assert state_path.read_bytes() == before
+    assert state_path.stat().st_mtime_ns == before_mtime
+
+
+def test_async_work_snapshot_mixes_daemon_and_shell_lanes(tmp_path, monkeypatch):
+    mgr, _ = _integration_manager(tmp_path)
+    monkeypatch.setattr(mgr, "_task_card_daemon_snapshot", lambda: {
+        "running": 2, "done": 1, "failed": 0, "cancelled": 0,
+        "timeout": 0, "unknown": 1, "backend_counts": {"lingtai": 2},
+        "input_tokens": 4, "output_tokens": 5, "cached_tokens": 3,
+        "cli_calls": 2,
+    })
+    monkeypatch.setattr(mgr, "_task_card_async_shell_snapshot", lambda: {
+        "running": 1, "done": 0, "failed": 1, "cancelled": 1,
+        "timeout": 0, "unknown": 0,
+    })
+    snapshot = mgr._task_card_async_work_snapshot()
+    assert snapshot["running"] == 3
+    assert snapshot["done"] == 1
+    assert snapshot["failed"] == 1
+    assert snapshot["cancelled"] == 1
+    assert snapshot["unknown"] == 1
+    assert "daemon" in snapshot and "shell" in snapshot
+
+
+def test_daemon_real_schema_cli_ledger_not_shadowed_and_kernel_calls_not_fabricated(tmp_path):
+    import datetime as _datetime
+    daemons = tmp_path / "daemons"
+    daemons.mkdir()
+    recent = (_datetime.datetime.now(_datetime.timezone.utc) - _datetime.timedelta(seconds=2)).isoformat()
+    cli = daemons / "cli"
+    cli.mkdir()
+    (cli / "daemon.json").write_text(json.dumps({
+        "state": "done", "backend": "codex", "finished_at": recent,
+        "tokens": {"input": 0, "output": 0, "cached": 0},
+        "cli_tokens": {"input": 100, "output": 40, "cached": 20, "calls": 3},
+        "tool_call_count": 99,
+    }), encoding="utf-8")
+    kernel = daemons / "kernel"
+    kernel.mkdir()
+    (kernel / "daemon.json").write_text(json.dumps({
+        "state": "running", "backend": "lingtai",
+        "tokens": {"input": 9, "output": 4, "cached": 2},
+        "tool_call_count": 17,
+    }), encoding="utf-8")
+    mgr, _ = _integration_manager(tmp_path)
+    snapshot = mgr._task_card_daemon_snapshot()
+    assert snapshot["input_tokens"] == 109
+    assert snapshot["output_tokens"] == 44
+    assert snapshot["cached_tokens"] == 22
+    assert snapshot["cli_calls"] == 3

--- a/tests/test_telegram_task_card_rows.py
+++ b/tests/test_telegram_task_card_rows.py
@@ -684,6 +684,7 @@ def test_metadata_renders_daemon_status_and_stats():
             "done": 2,
             "cancelled": 0,
             "timeout": 0,
+            "backend_counts": {"lingtai": 2, "claude-p": 1},
             "input_tokens": 1_234_567,
             "output_tokens": 340_000,
             "cached_tokens": 1_049_382,
@@ -692,8 +693,27 @@ def test_metadata_renders_daemon_status_and_stats():
     })
     assert lines == [
         "daemons · active 3 · failed 1 · done 2",
+        "backends · claude-p 1 · lingtai 2",
         "daemon stats · in 1.2M · out 340.0k · cache 85.0% · calls 12",
     ]
+
+
+def test_metadata_renders_backend_stats_only_when_present():
+    # No backend_counts -> no backends line.
+    lines = TelegramManager._format_task_card_metadata({
+        "daemons": {"active": 1},
+    })
+    assert lines == ["daemons · active 1"]
+    # Empty backend_counts -> no backends line.
+    lines = TelegramManager._format_task_card_metadata({
+        "daemons": {"active": 1, "backend_counts": {}},
+    })
+    assert lines == ["daemons · active 1"]
+    # Populated backend_counts -> sorted backends line.
+    lines = TelegramManager._format_task_card_metadata({
+        "daemons": {"active": 1, "backend_counts": {"claude-p": 2, "lingtai": 1}},
+    })
+    assert lines == ["daemons · active 1", "backends · claude-p 2 · lingtai 1"]
 
 
 def test_metadata_omits_daemon_lines_when_no_daemons():
@@ -736,10 +756,10 @@ def test_daemon_snapshot_scans_daemons_dir_and_windows(tmp_path):
     recent = (now - timedelta(minutes=2)).strftime("%Y-%m-%dT%H:%M:%SZ")
     old = (now - timedelta(minutes=30)).strftime("%Y-%m-%dT%H:%M:%SZ")
     for name, state in [
-        ("em-1", {"state": "running", "tokens": {"input": 1000, "output": 500, "cached": 800, "calls": 3}}),
-        ("em-2", {"state": "done", "finished_at": recent, "tokens": {"input": 2000, "output": 700, "cached": 1500, "calls": 4}}),
+        ("em-1", {"state": "running", "backend": "lingtai", "tokens": {"input": 1000, "output": 500, "cached": 800, "calls": 3}}),
+        ("em-2", {"state": "done", "backend": "claude-p", "finished_at": recent, "tokens": {"input": 2000, "output": 700, "cached": 1500, "calls": 4}}),
         ("em-3", {"state": "failed", "finished_at": recent, "cli_tokens": {"input": 3000, "output": 100, "cached": 0, "calls": 1}}),
-        ("em-4", {"state": "done", "finished_at": old, "tokens": {"input": 9999, "output": 9999, "cached": 9999, "calls": 99}}),
+        ("em-4", {"state": "done", "backend": "codex", "finished_at": old, "tokens": {"input": 9999, "output": 9999, "cached": 9999, "calls": 99}}),
     ]:
         (daemons / name / "daemon.json").write_text(_json.dumps(state), encoding="utf-8")
 
@@ -753,6 +773,9 @@ def test_daemon_snapshot_scans_daemons_dir_and_windows(tmp_path):
     assert snap["output_tokens"] == 500 + 700 + 100
     assert snap["cached_tokens"] == 800 + 1500 + 0
     assert snap["calls"] == 3 + 4 + 1
+    # Backend distribution counts only in-window runs; em-3 without a backend
+    # falls back to "unknown".
+    assert snap["backend_counts"] == {"lingtai": 1, "claude-p": 1, "unknown": 1}
 
 
 def test_daemon_snapshot_returns_none_when_no_daemons(tmp_path):

--- a/tests/test_telegram_task_card_rows.py
+++ b/tests/test_telegram_task_card_rows.py
@@ -692,7 +692,6 @@ def test_metadata_renders_daemon_status_and_stats():
         },
     })
     assert lines == [
-        "────────────────",
         "daemons · active 3 · failed 1 · done 2",
         "backends · claude-p 1 · lingtai 2",
         "daemon stats · in 1.2M · out 340.0k · cache 85.0% · calls 12",
@@ -704,30 +703,52 @@ def test_metadata_renders_backend_stats_only_when_present():
     lines = TelegramManager._format_task_card_metadata({
         "daemons": {"active": 1},
     })
-    assert lines == ["────────────────", "daemons · active 1"]
+    assert lines == ["daemons · active 1"]
     # Empty backend_counts -> no backends line.
     lines = TelegramManager._format_task_card_metadata({
         "daemons": {"active": 1, "backend_counts": {}},
     })
-    assert lines == ["────────────────", "daemons · active 1"]
+    assert lines == ["daemons · active 1"]
     # Populated backend_counts -> sorted backends line.
     lines = TelegramManager._format_task_card_metadata({
         "daemons": {"active": 1, "backend_counts": {"claude-p": 2, "lingtai": 1}},
     })
     assert lines == [
-        "────────────────",
         "daemons · active 1",
         "backends · claude-p 2 · lingtai 1",
     ]
 
 
-def test_metadata_no_divider_without_daemon_block():
-    # A session/identity-only card never renders the divider.
+def test_metadata_section_dividers_between_present_sections():
+    # Session + Identity -> one divider between the two sections.
     lines = TelegramManager._format_task_card_metadata({
         "agent_lifecycle": "active",
         "working_dir": "/Users/huangzesen/work/projects/lingtai-dev/dev-2/.lingtai/mimo-1",
     })
-    assert all("─" not in line for line in lines)
+    assert lines == [
+        "active",
+        "────────────────",
+        "path · /Users/huangzesen/work/projects/lingtai-dev/dev-2/.lingtai/mimo-1",
+    ]
+    # Session + Identity + Daemon -> dividers between all adjacent sections.
+    lines = TelegramManager._format_task_card_metadata({
+        "agent_lifecycle": "active",
+        "working_dir": "/Users/huangzesen/work/projects/lingtai-dev/dev-2/.lingtai/mimo-1",
+        "daemons": {"active": 1, "backend_counts": {"lingtai": 1}},
+    })
+    assert lines == [
+        "active",
+        "────────────────",
+        "path · /Users/huangzesen/work/projects/lingtai-dev/dev-2/.lingtai/mimo-1",
+        "────────────────",
+        "daemons · active 1",
+        "backends · lingtai 1",
+    ]
+    # A single daemon section alone stays clean with no divider.
+    lines = TelegramManager._format_task_card_metadata({
+        "daemons": {"active": 2},
+    })
+    assert lines == ["daemons · active 2"]
 
 
 def test_metadata_omits_daemon_lines_when_no_daemons():
@@ -754,7 +775,7 @@ def test_metadata_daemon_stats_require_positive_counts():
             "calls": 0,
         },
     })
-    assert lines == ["────────────────", "daemons · active 1"]
+    assert lines == ["daemons · active 1"]
 
 
 def test_daemon_snapshot_scans_daemons_dir_and_windows(tmp_path):

--- a/tests/test_telegram_task_card_rows.py
+++ b/tests/test_telegram_task_card_rows.py
@@ -692,6 +692,7 @@ def test_metadata_renders_daemon_status_and_stats():
         },
     })
     assert lines == [
+        "────────────────",
         "daemons · active 3 · failed 1 · done 2",
         "backends · claude-p 1 · lingtai 2",
         "daemon stats · in 1.2M · out 340.0k · cache 85.0% · calls 12",
@@ -703,17 +704,30 @@ def test_metadata_renders_backend_stats_only_when_present():
     lines = TelegramManager._format_task_card_metadata({
         "daemons": {"active": 1},
     })
-    assert lines == ["daemons · active 1"]
+    assert lines == ["────────────────", "daemons · active 1"]
     # Empty backend_counts -> no backends line.
     lines = TelegramManager._format_task_card_metadata({
         "daemons": {"active": 1, "backend_counts": {}},
     })
-    assert lines == ["daemons · active 1"]
+    assert lines == ["────────────────", "daemons · active 1"]
     # Populated backend_counts -> sorted backends line.
     lines = TelegramManager._format_task_card_metadata({
         "daemons": {"active": 1, "backend_counts": {"claude-p": 2, "lingtai": 1}},
     })
-    assert lines == ["daemons · active 1", "backends · claude-p 2 · lingtai 1"]
+    assert lines == [
+        "────────────────",
+        "daemons · active 1",
+        "backends · claude-p 2 · lingtai 1",
+    ]
+
+
+def test_metadata_no_divider_without_daemon_block():
+    # A session/identity-only card never renders the divider.
+    lines = TelegramManager._format_task_card_metadata({
+        "agent_lifecycle": "active",
+        "working_dir": "/Users/huangzesen/work/projects/lingtai-dev/dev-2/.lingtai/mimo-1",
+    })
+    assert all("─" not in line for line in lines)
 
 
 def test_metadata_omits_daemon_lines_when_no_daemons():
@@ -740,7 +754,7 @@ def test_metadata_daemon_stats_require_positive_counts():
             "calls": 0,
         },
     })
-    assert lines == ["daemons · active 1"]
+    assert lines == ["────────────────", "daemons · active 1"]
 
 
 def test_daemon_snapshot_scans_daemons_dir_and_windows(tmp_path):

--- a/tests/test_telegram_task_card_rows.py
+++ b/tests/test_telegram_task_card_rows.py
@@ -671,9 +671,10 @@ def test_metadata_renders_absolute_path_not_shortened():
         "working_dir": "/Users/huangzesen/work/projects/lingtai-dev/dev-2/.lingtai/mimo-1",
         "device_short_name": "MacStudio",
     })
-    assert len(lines) == 1
+    assert len(lines) == 2
     assert "device · MacStudio | path · /Users/huangzesen/work/projects/lingtai-dev/dev-2/.lingtai/mimo-1" in lines[0]
     assert "dev-2/.lingtai/mimo-1" not in lines[0].replace("dev-2/.lingtai/mimo-1", "")
+    assert lines[1] == "────────"
 
 
 def test_metadata_renders_daemon_status_and_stats():
@@ -727,8 +728,9 @@ def test_metadata_section_dividers_between_present_sections():
     })
     assert lines == [
         "active",
-        "────────────────",
+        "────────",
         "path · /Users/huangzesen/work/projects/lingtai-dev/dev-2/.lingtai/mimo-1",
+        "────────",
     ]
     # Session + Identity + Daemon -> dividers between all adjacent sections.
     lines = TelegramManager._format_task_card_metadata({
@@ -738,9 +740,9 @@ def test_metadata_section_dividers_between_present_sections():
     })
     assert lines == [
         "active",
-        "────────────────",
+        "────────",
         "path · /Users/huangzesen/work/projects/lingtai-dev/dev-2/.lingtai/mimo-1",
-        "────────────────",
+        "────────",
         "daemons · active 1",
         "backends · lingtai 1",
     ]
@@ -756,9 +758,10 @@ def test_metadata_omits_daemon_lines_when_no_daemons():
         "working_dir": "/Users/huangzesen/work/projects/lingtai-dev/dev-2/.lingtai/mimo-1",
         "daemons": {"active": 0, "failed": 0, "done": 0, "cancelled": 0, "timeout": 0},
     })
-    assert len(lines) == 1
+    assert len(lines) == 2
     assert "daemons" not in lines[0]
     assert "daemon stats" not in lines[0]
+    assert lines[1] == "────────"
 
 
 def test_metadata_daemon_stats_require_positive_counts():


### PR DESCRIPTION
## Summary

The resident Telegram Task Card currently shows only aggregate daemon counts (`daemons · active 2 · failed 1`) and token stats (`daemon stats · in … · out … · cache …% · calls N`). This PR adds a per-backend distribution line so operators can see at a glance which daemon backends (lingtai / claude-p / codex / opencode / …) are active or finished in the recent window.

Example rendered metadata:
```
daemons · active 3 · failed 1 · done 2
backends · claude-p 1 · lingtai 2
daemon stats · in 1.2M · out 340.0k · cache 85.0% · calls 12
```

Also drops the dead `daemon.json` state-candidate name `"n"` introduced in #1369 so the scan only reads the real `daemon.json` state file.

## Changes
- `mcp_servers/telegram/manager.py` — `_task_card_daemon_snapshot` now collects `backend_counts` (per-backend distribution over active plus recent-terminal runs; missing backend falls back to `unknown`) and returns it in the metadata dict.
- `mcp_servers/task_card/event_projection.py` — renders the `backends` line between the daemon counts and the token-stats line; nothing renders when the distribution is absent/empty. Cache precision stays at one decimal (`85.0%`).
- `tests/test_telegram_task_card_rows.py` — updated daemon-status assertions and added coverage for backend rendering and snapshot backend distribution.

## Validation
- `PYTHONPATH=src python -m pytest tests/test_telegram_task_card_rows.py tests/test_task_card_event_projection_shared.py tests/test_telegram_task_card_in_place.py` → **66 passed**
- `python -m py_compile` on both changed source files → ok
- `git diff --check` → clean

Telegram: @lingtaidev2bot | Nickname: 观一
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
