### PR TITLE
fix(wechat): prefer official static CDN upload with bounded retry

### DIFF
--- a/src/lingtai/mcp_servers/wechat/media.py
+++ b/src/lingtai/mcp_servers/wechat/media.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlsplit
+from urllib.parse import quote, urlsplit
 
 import httpcore
 import httpx
@@ -23,6 +23,22 @@ from .types import (
     CDNMedia, UploadMediaType, MessageItemType,
     ImageItem, VoiceItem, FileItem, VideoItem, MessageItem,
 )
+
+
+CDN_UPLOAD_TIMEOUT_SECONDS = 120.0
+CDN_UPLOAD_MAX_ATTEMPTS = 3
+
+
+def _official_cdn_upload_url(
+    cdn_base_url: str, upload_param: str, filekey: str,
+) -> str:
+    """Build the official Tencent v1.0.3 static CDN upload URL."""
+    encode_uri_component_safe = "-_.!~*'()"
+    return (
+        f"{cdn_base_url.rstrip('/')}/upload?encrypted_query_param="
+        f"{quote(upload_param, safe=encode_uri_component_safe)}&filekey="
+        f"{quote(filekey, safe=encode_uri_component_safe)}"
+    )
 
 
 @dataclass
@@ -460,6 +476,8 @@ async def upload_media(
     base_url: str,
     token: str,
     to_user_id: str,
+    *,
+    cdn_base_url: str = api.CDN_BASE_URL,
 ) -> UploadedMediaInfo:
     """Upload a file to WeChat CDN.
 
@@ -514,8 +532,18 @@ async def upload_media(
     except Exception as exc:
         raise media_upload_error("get_upload_url_failed", base_url, exc) from exc
 
-    upload_url = upload_resp.upload_full_url
-    if not upload_url:
+    # Official Tencent v1.0.3 constructs the upload URL from upload_param + a
+    # configured CDN base. Keep the dynamic upload_full_url only as fallback
+    # when upload_param is absent.
+    raw_upload_param = getattr(upload_resp, "upload_param", None)
+    upload_full_url = getattr(upload_resp, "upload_full_url", "")
+    if raw_upload_param:
+        upload_url = _official_cdn_upload_url(
+            cdn_base_url, str(raw_upload_param), filekey,
+        )
+    elif upload_full_url:
+        upload_url = upload_full_url
+    else:
         raise media_upload_error(
             "get_upload_url_failed",
             base_url,
@@ -525,47 +553,71 @@ async def upload_media(
     # Upload encrypted bytes to CDN. OpenClaw uses POST (not PUT) and reads
     # the final download encrypted_query_param from the x-encrypted-param
     # response header. Some CDN responses also embed it in a JSON body.
-    try:
-        async with httpx.AsyncClient() as client:
-            resp = await client.post(
-                upload_url,
-                content=ciphertext,
-                headers={"Content-Type": "application/octet-stream"},
-                timeout=120.0,
-            )
-            resp.raise_for_status()
-            raw = resp.text
-    except Exception as exc:
-        error = media_upload_error("cdn_upload_http_failed", upload_url, exc)
-        if error.diagnostic.error_kind == "tls_handshake":
-            error = media_upload_error("cdn_tls_handshake_failed", upload_url, exc)
-        raise error from exc
-
-    header_param = resp.headers.get("x-encrypted-param")
-    json_param: str | None = None
-    if raw and raw.strip().startswith("{"):
+    # Retry only this encrypted CDN POST (transport/HTTP 429/5xx/HTTP 200
+    # missing metadata), at most three immediate attempts, never the whole
+    # surrounding text+media send.
+    download_param: str | None = None
+    last_error: BaseException | None = None
+    for attempt in range(1, CDN_UPLOAD_MAX_ATTEMPTS + 1):
         try:
-            body = resp.json()
-            json_param = (
-                body.get("encrypt_query_param")
-                or body.get("download_param")
-            )
-        except Exception:
-            json_param = None
+            async with httpx.AsyncClient() as client:
+                resp = await client.post(
+                    upload_url,
+                    content=ciphertext,
+                    headers={"Content-Type": "application/octet-stream"},
+                    timeout=CDN_UPLOAD_TIMEOUT_SECONDS,
+                )
+                resp.raise_for_status()
+                raw = resp.text
+        except httpx.HTTPStatusError as exc:
+            retryable = exc.response.status_code == 429 or exc.response.status_code >= 500
+            if attempt < CDN_UPLOAD_MAX_ATTEMPTS and retryable:
+                last_error = exc
+                continue
+            error = media_upload_error("cdn_upload_http_failed", upload_url, exc)
+            if error.diagnostic.error_kind == "tls_handshake":
+                error = media_upload_error("cdn_tls_handshake_failed", upload_url, exc)
+            raise error from exc
+        except (httpx.TransportError, httpx.TimeoutException) as exc:
+            if attempt < CDN_UPLOAD_MAX_ATTEMPTS:
+                last_error = exc
+                continue
+            error = media_upload_error("cdn_upload_http_failed", upload_url, exc)
+            if error.diagnostic.error_kind == "tls_handshake":
+                error = media_upload_error("cdn_tls_handshake_failed", upload_url, exc)
+            raise error from exc
+        except Exception as exc:
+            error = media_upload_error("cdn_upload_http_failed", upload_url, exc)
+            if error.diagnostic.error_kind == "tls_handshake":
+                error = media_upload_error("cdn_tls_handshake_failed", upload_url, exc)
+            raise error from exc
 
-    download_param = header_param or json_param
+        header_param = resp.headers.get("x-encrypted-param")
+        json_param: str | None = None
+        if raw and raw.strip().startswith("{"):
+            try:
+                body = resp.json()
+                json_param = (
+                    body.get("encrypt_query_param")
+                    or body.get("download_param")
+                )
+            except Exception:
+                json_param = None
+
+        download_param = header_param or json_param
+        if download_param:
+            break
+        # HTTP 200 without usable metadata: not a usable completion; retry.
+        last_error = RuntimeError(
+            "response missing x-encrypted-param header and "
+            "encrypt_query_param / download_param JSON field"
+        )
+
     if not download_param:
-        # Be strict here. The prior code fell back to upload_param/filekey,
-        # which made the function appear to succeed while producing media
-        # the WeChat client could not open. Better to raise loudly, while
-        # preserving the stage in the structured result.
         raise media_upload_error(
             "cdn_response_metadata_missing",
             upload_url,
-            RuntimeError(
-                "response missing x-encrypted-param header and "
-                "encrypt_query_param / download_param JSON field"
-            ),
+            last_error or RuntimeError("no usable CDN response"),
         )
 
     cdn_media = CDNMedia(

--- a/tests/test_wechat_media_official_cdn.py
+++ b/tests/test_wechat_media_official_cdn.py
@@ -1,0 +1,183 @@
+"""Focused regression coverage for official CDN URL + bounded retry."""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import httpx
+import pytest
+
+from lingtai.mcp_servers.wechat import api, media
+from lingtai.mcp_servers.wechat.types import GetUploadUrlResp
+
+
+BASE_URL = "https://ilink.example.test"
+CDN_BASE = "https://cdn.example.test/c2c"
+UPLOAD_PARAM = "secret-upload-param"
+FILEKEY = "abcdef0123456789"
+
+
+def _attachment(tmp_path: Path) -> Path:
+    p = tmp_path / "attachment.txt"
+    p.write_text("attachment", encoding="utf-8")
+    return p
+
+
+class _StaticClient:
+    """In-memory httpx AsyncClient stand-in returning a fixed sequence."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.posts: list[tuple[str, bytes]] = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    async def post(self, url, *, content, headers=None, timeout=None):
+        self.posts.append((url, content))
+        if not self._responses:
+            raise AssertionError("more posts than canned responses")
+        item = self._responses.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+
+class _Resp:
+    def __init__(self, status_code=200, headers=None, text=""):
+        self.status_code = status_code
+        self.headers = headers or {}
+        self.text = text
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError(
+                f"HTTP {self.status_code}",
+                request=httpx.Request("POST", "https://cdn.example.test/"),
+                response=httpx.Response(self.status_code, request=httpx.Request("POST", "https://cdn.example.test/")),
+            )
+
+    def json(self):
+        import json
+        return json.loads(self.text)
+
+
+def test_official_cdn_url_preferred_when_upload_param_present(
+    monkeypatch, tmp_path: Path
+) -> None:
+    file_path = _attachment(tmp_path)
+
+    async def fake_get_upload_url(*args, **kwargs):
+        return GetUploadUrlResp(
+            upload_param=UPLOAD_PARAM,
+            upload_full_url="https://dynamic.example.test/upload?token=leak",
+        )
+
+    client = _StaticClient([
+        _Resp(headers={"x-encrypted-param": "download-param"}),
+    ])
+    monkeypatch.setattr(api, "get_upload_url", fake_get_upload_url)
+    monkeypatch.setattr(media.httpx, "AsyncClient", lambda: client)
+
+    info = asyncio.run(media.upload_media(
+        file_path, BASE_URL, "bearer-secret", "wxid-secret",
+        cdn_base_url=CDN_BASE,
+    ))
+
+    # Official static CDN URL was used, never the dynamic presigned fallback.
+    assert len(client.posts) == 1
+    url, _ = client.posts[0]
+    assert url.startswith(f"{CDN_BASE}/upload?encrypted_query_param=")
+    assert "token=leak" not in url
+    assert info.cdn_media.encrypt_query_param == "download-param"
+
+
+def test_fallback_dynamic_url_when_no_upload_param(monkeypatch, tmp_path: Path) -> None:
+    file_path = _attachment(tmp_path)
+
+    async def fake_get_upload_url(*args, **kwargs):
+        return GetUploadUrlResp(upload_full_url="https://dynamic.example.test/upload?token=leak")
+
+    client = _StaticClient([
+        _Resp(headers={"x-encrypted-param": "download-param"}),
+    ])
+    monkeypatch.setattr(api, "get_upload_url", fake_get_upload_url)
+    monkeypatch.setattr(media.httpx, "AsyncClient", lambda: client)
+
+    info = asyncio.run(media.upload_media(file_path, BASE_URL, "bearer-secret", "wxid-secret"))
+    assert info.cdn_media.encrypt_query_param == "download-param"
+
+
+def test_cdn_upload_retries_transport_failure_then_succeeds(
+    monkeypatch, tmp_path: Path
+) -> None:
+    file_path = _attachment(tmp_path)
+
+    async def fake_get_upload_url(*args, **kwargs):
+        return GetUploadUrlResp(upload_param=UPLOAD_PARAM)
+
+    client = _StaticClient([
+        httpx.ConnectError("boom one"),
+        _Resp(headers={"x-encrypted-param": "download-param"}),
+    ])
+    monkeypatch.setattr(api, "get_upload_url", fake_get_upload_url)
+    monkeypatch.setattr(media.httpx, "AsyncClient", lambda: client)
+
+    info = asyncio.run(media.upload_media(
+        file_path, BASE_URL, "bearer-secret", "wxid-secret",
+        cdn_base_url=CDN_BASE,
+    ))
+    assert info.cdn_media.encrypt_query_param == "download-param"
+    assert len(client.posts) == 2  # one failure, one retry
+
+
+def test_cdn_upload_retries_missing_metadata_then_succeeds(
+    monkeypatch, tmp_path: Path
+) -> None:
+    file_path = _attachment(tmp_path)
+
+    async def fake_get_upload_url(*args, **kwargs):
+        return GetUploadUrlResp(upload_param=UPLOAD_PARAM)
+
+    client = _StaticClient([
+        _Resp(headers={}, text=""),          # HTTP 200 but no encrypted metadata
+        _Resp(headers={"x-encrypted-param": "download-param"}),
+    ])
+    monkeypatch.setattr(api, "get_upload_url", fake_get_upload_url)
+    monkeypatch.setattr(media.httpx, "AsyncClient", lambda: client)
+
+    info = asyncio.run(media.upload_media(
+        file_path, BASE_URL, "bearer-secret", "wxid-secret",
+        cdn_base_url=CDN_BASE,
+    ))
+    assert info.cdn_media.encrypt_query_param == "download-param"
+    assert len(client.posts) == 2
+
+
+def test_cdn_upload_gives_up_after_max_attempts(monkeypatch, tmp_path: Path) -> None:
+    file_path = _attachment(tmp_path)
+
+    async def fake_get_upload_url(*args, **kwargs):
+        return GetUploadUrlResp(upload_param=UPLOAD_PARAM)
+
+    client = _StaticClient([
+        httpx.ConnectError("boom one"),
+        httpx.ConnectError("boom two"),
+        httpx.ConnectError("boom three"),
+    ])
+    monkeypatch.setattr(api, "get_upload_url", fake_get_upload_url)
+    monkeypatch.setattr(media.httpx, "AsyncClient", lambda: client)
+
+    with pytest.raises(media.MediaUploadError) as exc_info:
+        asyncio.run(media.upload_media(
+            file_path, BASE_URL, "bearer-secret", "wxid-secret",
+            cdn_base_url=CDN_BASE,
+        ))
+    payload = exc_info.value.as_result()
+    assert payload["media_upload"]["stage"] == "cdn_upload_http_failed"
+    assert "bearer-secret" not in str(payload)
+    assert "wxid-secret" not in str(payload)
+    assert len(client.posts) == 3


### PR DESCRIPTION
fix(wechat): prefer official static CDN upload with bounded retry

## Summary
- Prefer the official Tencent v1.0.3 static CDN upload construction when `upload_param` is present (`{cdn_base_url}/upload?encrypted_query_param=...&filekey=...`), retaining the dynamic signed URL only as an absent-parameter compatibility fallback.
- Retry only the encrypted CDN POST, at most three immediate attempts, for transport/TLS, HTTP 429/5xx, or a success response missing usable encrypted metadata.
- Reuses the existing `MediaUploadError` redaction path: failures never leak the presigned URL, local path, recipient ID, or token.
- Manager unchanged: the baseline already preserves simple partial-delivery state and stage-aware error classification.

## Why
Previous outbound path could report generic failures while exposing internal URLs/paths, could retry at the wrong layer (inviting duplicate media sends), and did not follow the official static CDN upload route when `upload_param` was available.

This patch keeps the minimal production seam: protocol choice explicit, retries bounded to the encrypted CDN byte upload, and existing redacted diagnostics.

## Validation
- New focused regressions: `tests/test_wechat_media_official_cdn.py` (5 passed)
- Existing media diagnostics + validation suites: 33 passed, no regression
- `git diff --check`: clean
- Scope: 2 files (+274/-39) — production change only in `media.py` (91+/39-)

## Out of scope
- merge, release, runtime/config/refresh changes
- real-media end-to-end acceptance
- manager partial-delivery chunk persistence, timeout task ownership (kept simple)

Telegram: @lingtaidev2bot | Nickname: 观一

Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
