### PR TITLE
feat(daemon): add supervisor return observer

### DIFF
--- a/src/lingtai/kernel/daemon_supervisor/manifest.py
+++ b/src/lingtai/kernel/daemon_supervisor/manifest.py
@@ -265,9 +265,10 @@ def build_manifest(
     backend_argv: list[str] | None = None, language: str = "en",
     preset_name: str | None = None, preset_llm: dict | None = None,
     preset_capabilities: dict | None = None,
+    return_observer_enabled: bool = False,
 ) -> dict:
     """Build the supervisor input record without resolved credentials."""
-    return {
+    manifest = {
         "schema": MANIFEST_SCHEMA,
         "run_id": run_id,
         "backend": backend,
@@ -288,6 +289,9 @@ def build_manifest(
         "preset_llm": _safe_llm(preset_llm),
         "preset_capabilities": _safe_json(preset_capabilities) if isinstance(preset_capabilities, dict) else None,
     }
+    if return_observer_enabled:
+        manifest["return_observer_enabled"] = True
+    return manifest
 
 
 def write_manifest(run_dir: Path, manifest: dict) -> Path:
@@ -327,6 +331,8 @@ def read_manifest(path: Path) -> dict:
         raise ValueError("manifest max_turns must be a positive integer")
     if isinstance(data["timeout_s"], bool) or not isinstance(data["timeout_s"], (int, float)) or data["timeout_s"] <= 0:
         raise ValueError("manifest timeout_s must be positive")
+    if "return_observer_enabled" in data and not isinstance(data["return_observer_enabled"], bool):
+        raise ValueError("manifest return_observer_enabled must be a boolean")
     run_dir = Path(data["run_dir"]).resolve()
     if run_dir != path.parent or run_dir.name == "":
         raise ValueError("manifest run_dir does not match its canonical parent directory")

--- a/src/lingtai/tools/daemon/ANATOMY.md
+++ b/src/lingtai/tools/daemon/ANATOMY.md
@@ -50,6 +50,8 @@ related_files:
   - src/lingtai/adapters/posix/process_identity.py
   - src/lingtai/adapters/windows/daemon_supervisor.py
   - src/lingtai/tools/daemon/runtime.py
+  - src/lingtai/tools/daemon/return_observer_hook.py
+  - src/lingtai/tools/daemon/return_observer_helper.py
   - src/lingtai/tools/daemon/glossary-en.md
   - src/lingtai/tools/daemon/glossary-zh.md
   - src/lingtai/tools/daemon/glossary-wen.md
@@ -154,6 +156,7 @@ remains deferred until ConPTY has its own accepted adapter. `ClaudeInteractiveBr
 - `adapters/posix/daemon_execution_child_entrypoint.py` — fresh-interpreter execution boundary launched by the supervisor before its watcher. It registers exact execution PID/PGID/start identity and composes the existing production host; it does not duplicate backend parsers. `daemon_resume_owner_entrypoint.py` provides the bounded detached owner for one terminal supported-CLI resume generation. Durable `resume-claims/` records enforce one writer, and `followups/` plus `daemon.json` expose follow-up truth to `daemon(check)`.
 - `adapters/posix/process_identity.py` — shared POSIX process-incarnation helper. Linux identities combine boot ID and `/proc/<pid>/stat` start ticks; Darwin/BSD identities use bounded `ps` start time plus PPID. It returns `None` when observation is unavailable, and all ownership-sensitive signal paths refuse unknown or mismatched identities.
 - `daemon/runtime.py` — stateless daemon backend runtime primitives shared by the LingTai in-process loop and transitional CLI runners. Port-owned Codex, Cursor, OpenCode-family, Qwen, and Kimi runners use the daemon-local process Port for stderr draining and stdout iteration; only ask workers use a local deadline, while initial streams remain watchdog-owned. The historical private names remain for unmigrated paths and compatibility tests.
+- `daemon/return_observer_hook.py` and `daemon/return_observer_helper.py` — default-off supervisor return observation. The hook is a fail-open wrapper called from `supervisor_runtime.py` after terminal notification claim and before publication; the helper is a separate stdlib-only process that reads bounded files beneath the run directory and writes only `.supervisor/return-observation/g*.{host,portable,status}.json`.
 - `daemon/CONTRACT.md` — maintained daemon contract for the public tool surface, selected skills catalog/path semantics, MCP registration redaction/native mounting, `daemon_common` completion enforcement, backend implementation status, run artifacts, review triggers, and the acceptance gate for new backend or contract-impacting changes.
 
 - `daemon/interactive_terminal/` — capability-local immutable command/exit values and the

--- a/src/lingtai/tools/daemon/__init__.py
+++ b/src/lingtai/tools/daemon/__init__.py
@@ -81,6 +81,12 @@ from .process_port import (
 from .posix_process import PosixDaemonProcessPort
 
 PROVIDERS = {"providers": [], "default": "builtin"}
+_RETURN_OBSERVER_ENV = "LINGTAI_DAEMON_RETURN_OBSERVER_ENABLED"
+
+
+def _return_observer_feature_enabled() -> bool:
+    value = os.environ.get(_RETURN_OBSERVER_ENV, "")
+    return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _kill_process_group(proc, *, term_timeout: float = 5.0, kill_timeout: float = 3.0) -> None:
@@ -3102,8 +3108,15 @@ class DaemonManager:
             preset_name=preset_name,
             preset_llm=preset_llm,
             preset_capabilities=preset_capabilities,
+            return_observer_enabled=_return_observer_feature_enabled(),
         )
         write_manifest(run_dir.path, manifest)
+        if manifest.get("return_observer_enabled") is True:
+            try:
+                from .return_observer_hook import write_dispatch_intent_receipt
+                write_dispatch_intent_receipt(run_dir, manifest)
+            except BaseException:
+                pass
 
         from lingtai.kernel.daemon_supervisor.manifest import manifest_path_for
         from .supervisor_runtime import select_daemon_supervisor_adapter
@@ -5066,9 +5079,20 @@ class DaemonManager:
         self._log("daemon_emanate", ids=ids, group_id=group_id, count=len(tasks),
                   tasks=[{"task": s["task"][:80], "tools": s["tools"]} for s in tasks])
 
-        return {"status": "dispatched", "count": len(tasks), "ids": ids,
-                "group_id": group_id,
-                "handoff": self._emanate_handoff(len(tasks), requested_timeout)}
+        result = {"status": "dispatched", "count": len(tasks), "ids": ids,
+                  "group_id": group_id,
+                  "handoff": self._emanate_handoff(len(tasks), requested_timeout)}
+        if _return_observer_feature_enabled():
+            try:
+                from .return_observer_hook import write_dispatch_result_receipt
+                for em_id in ids:
+                    entry = self._emanations.get(em_id)
+                    run_dir = entry.get("run_dir") if isinstance(entry, dict) else None
+                    if run_dir is not None:
+                        write_dispatch_result_receipt(run_dir, result)
+            except BaseException:
+                pass
+        return result
 
     def _emanate_handoff(self, count: int, requested_timeout_s: float | None) -> str:
         """Async handoff line, plus a Task Card nudge for fleet-scale dispatch.

--- a/src/lingtai/tools/daemon/return_observer_helper.py
+++ b/src/lingtai/tools/daemon/return_observer_helper.py
@@ -1,0 +1,669 @@
+"""One-shot daemon return observation helper."""
+from __future__ import annotations
+
+import argparse
+import errno
+import hashlib
+import json
+import os
+import re
+import secrets
+import sys
+from pathlib import Path, PurePosixPath
+
+SCHEMA_VERSION = "lingtai.daemon-return-observation.v0"
+STATUS_SCHEMA_VERSION = "lingtai.daemon-return-observation-status.v0"
+SIDE_DIR = Path(".supervisor/return-observation")
+GENERATION_RE = re.compile(r"(?:g0000|g[1-9][0-9]*-[0-9a-f]{16})\Z")
+# Bounded local sample on 2026-08-14: 80 existing daemon run dirs / 309
+# candidate files had max daemon.json=2194B, artifacts.json=1268B,
+# supervisor_manifest.json=810B, result.txt=15B.  These caps leave room for
+# real result previews/events while keeping the helper unable to scan arbitrary
+# large artifacts.
+MAX_FILES = 32
+MAX_FILE_BYTES = 256 * 1024
+MAX_TOTAL_BYTES = 1024 * 1024
+KNOWN_FILES = (
+    ("state", "daemon.json"),
+    ("result", "result.txt"),
+    ("artifacts_manifest", "artifacts.json"),
+    ("events", "events.jsonl"),
+    ("supervisor_manifest", "supervisor_manifest.json"),
+)
+DISPATCH_INTENT_NAME = "dispatch-intent.v0.json"
+DISPATCH_RESULT_NAME = "dispatch-result.v0.json"
+
+
+class Unavailable(Exception):
+    def __init__(self, reason_code: str, details: dict | None = None):
+        super().__init__(reason_code)
+        self.reason_code = reason_code
+        self.details = details or {}
+
+
+def _is_regular(mode: int) -> bool:
+    return (mode & 0o170000) == 0o100000
+
+
+def _safe_rel(value: str) -> str:
+    rel = PurePosixPath(value)
+    if rel.is_absolute() or not rel.parts or any(part in {"", ".", ".."} for part in rel.parts):
+        raise Unavailable("path_escape")
+    return rel.as_posix()
+
+
+def _open_beneath(root_fd: int, rel: str) -> int:
+    flags_no_follow = getattr(os, "O_NOFOLLOW", 0)
+    parts = _safe_rel(rel).split("/")
+    current_fd = os.dup(root_fd)
+    try:
+        for part in parts[:-1]:
+            try:
+                next_fd = os.open(
+                    part,
+                    os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | flags_no_follow,
+                    dir_fd=current_fd,
+                )
+            except OSError as exc:
+                if exc.errno in {errno.ELOOP, errno.ENOTDIR, errno.EACCES, errno.EPERM}:
+                    raise Unavailable("path_escape")
+                raise
+            os.close(current_fd)
+            current_fd = next_fd
+        try:
+            return os.open(parts[-1], os.O_RDONLY | flags_no_follow, dir_fd=current_fd)
+        except OSError as exc:
+            if exc.errno in {errno.ELOOP, errno.EACCES, errno.EPERM}:
+                raise Unavailable("path_escape")
+            raise
+    finally:
+        os.close(current_fd)
+
+
+def _open_or_create_dir(parent_fd: int, name: str) -> int:
+    if "/" in name or name in {"", ".", ".."}:
+        raise Unavailable("path_escape")
+    flags_no_follow = getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(
+            name,
+            os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | flags_no_follow,
+            dir_fd=parent_fd,
+        )
+        os.fchmod(fd, 0o700)
+        return fd
+    except FileNotFoundError:
+        try:
+            os.mkdir(name, 0o700, dir_fd=parent_fd)
+        except FileExistsError:
+            pass
+        fd = os.open(
+            name,
+            os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | flags_no_follow,
+            dir_fd=parent_fd,
+        )
+        try:
+            os.fchmod(fd, 0o700)
+        except OSError:
+            pass
+        return fd
+    except OSError as exc:
+        if exc.errno in {errno.ELOOP, errno.ENOTDIR, errno.EACCES, errno.EPERM}:
+            raise Unavailable("unsafe_sidecar")
+        raise
+
+
+def _read_fd_stable(fd: int, *, cap: int = MAX_FILE_BYTES, chmod_mode: int | None = None) -> tuple[bytes, os.stat_result]:
+    if chmod_mode is not None:
+        os.fchmod(fd, chmod_mode)
+    first = os.fstat(fd)
+    if not _is_regular(first.st_mode):
+        raise Unavailable("not_regular_file")
+    if first.st_size > cap:
+        raise Unavailable("per_file_cap")
+    chunks: list[bytes] = []
+    remaining = first.st_size
+    while remaining > 0:
+        chunk = os.read(fd, min(64 * 1024, remaining))
+        if not chunk:
+            raise Unavailable("short_read")
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    data = b"".join(chunks)
+    second = os.fstat(fd)
+    if (
+        first.st_dev != second.st_dev
+        or first.st_ino != second.st_ino
+        or first.st_size != second.st_size
+        or first.st_mtime_ns != second.st_mtime_ns
+        or first.st_ctime_ns != second.st_ctime_ns
+    ):
+        raise Unavailable("mutation_detected")
+    return data, first
+
+
+def _read_file_beneath(root_fd: int, rel: str) -> tuple[bytes, os.stat_result]:
+    fd = _open_beneath(root_fd, rel)
+    try:
+        return _read_fd_stable(fd)
+    finally:
+        os.close(fd)
+
+
+def _row_for_bytes(rel: str, data: bytes, st: os.stat_result) -> dict:
+    return {
+        "relative_ref": rel,
+        "size": st.st_size,
+        "sha256": "sha256:" + hashlib.sha256(data).hexdigest(),
+        "stability": "stable",
+        "mtime_ns": st.st_mtime_ns,
+        "ctime_ns": st.st_ctime_ns,
+    }
+
+
+def _hash_file_with_bytes(root_fd: int, rel: str) -> tuple[dict, bytes]:
+    data, st = _read_file_beneath(root_fd, rel)
+    return _row_for_bytes(rel, data, st), data
+
+
+def _hash_file(root_fd: int, rel: str) -> dict:
+    row, _ = _hash_file_with_bytes(root_fd, rel)
+    return row
+
+
+def _exists_beneath(root_fd: int, rel: str) -> bool:
+    try:
+        fd = _open_beneath(root_fd, rel)
+    except FileNotFoundError:
+        return False
+    except NotADirectoryError:
+        return False
+    else:
+        os.close(fd)
+        return True
+
+
+def _read_json_file(root_fd: int, rel: str) -> dict:
+    raw, _ = _read_file_beneath(root_fd, rel)
+    return _json_object_from_bytes(raw)
+
+
+def _json_object_from_bytes(raw: bytes) -> dict:
+    data = json.loads(raw.decode("utf-8"))
+    return data if isinstance(data, dict) else {}
+
+
+def _json_bytes(payload: dict) -> bytes:
+    return json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _atomic_json_at(dir_fd: int, name: str, payload: dict) -> bytes:
+    if "/" in name or name.startswith(".tmp-"):
+        raise Unavailable("path_escape")
+    data = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    tmp = f".tmp-{name}-{os.getpid()}-{secrets.token_hex(4)}"
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600, dir_fd=dir_fd)
+    try:
+        view = memoryview(data)
+        written = 0
+        while written < len(data):
+            count = os.write(fd, view[written:])
+            if count <= 0:
+                raise Unavailable("short_write")
+            written += count
+        os.fsync(fd)
+        os.fchmod(fd, 0o600)
+    finally:
+        os.close(fd)
+    try:
+        try:
+            os.link(tmp, name, src_dir_fd=dir_fd, dst_dir_fd=dir_fd)
+        except FileExistsError:
+            existing = _read_file_at(dir_fd, name)
+            if existing == data:
+                return data
+            raise Unavailable("receipt_conflict")
+        return data
+    finally:
+        try:
+            os.unlink(tmp, dir_fd=dir_fd)
+        except FileNotFoundError:
+            pass
+
+
+def _read_file_at(dir_fd: int, name: str) -> bytes | None:
+    try:
+        fd = os.open(name, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0), dir_fd=dir_fd)
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        if exc.errno in {errno.ELOOP, errno.EACCES, errno.EPERM}:
+            raise Unavailable("unsafe_sidecar")
+        raise
+    try:
+        data, _ = _read_fd_stable(fd, chmod_mode=0o600)
+        return data
+    finally:
+        os.close(fd)
+
+
+def _digest_sidecar_if_present(side_fd: int, name: str) -> dict:
+    data = _read_file_at(side_fd, name)
+    if data is None:
+        return {"status": "missing_binding"}
+    return {
+        "status": "observed",
+        "relative_ref": f".supervisor/return-observation/{name}",
+        "sha256": "sha256:" + hashlib.sha256(data).hexdigest(),
+    }
+
+
+def _read_sidecar_json_if_present(side_fd: int, name: str) -> tuple[dict | None, dict]:
+    data = _read_file_at(side_fd, name)
+    if data is None:
+        return None, {"status": "missing_binding"}
+    try:
+        payload = json.loads(data.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        raise Unavailable("dispatch_binding_unreadable")
+    if not isinstance(payload, dict):
+        raise Unavailable("dispatch_binding_unreadable")
+    return payload, {
+        "status": "observed",
+        "relative_ref": f".supervisor/return-observation/{name}",
+        "sha256": "sha256:" + hashlib.sha256(data).hexdigest(),
+    }
+
+
+def _generation_index(generation: str) -> int:
+    if generation == "g0000":
+        return 0
+    return int(generation[1:].split("-", 1)[0])
+
+
+def _predecessor_ref(side_fd: int, generation: str) -> dict | None:
+    index = _generation_index(generation)
+    if index == 0:
+        return None
+    if index == 1:
+        candidates = ["g0000.status.json"]
+    else:
+        prefix = f"g{index - 1}-"
+        suffix = ".status.json"
+        candidates = [
+            name for name in os.listdir(side_fd)
+            if name.startswith(prefix)
+            and name.endswith(suffix)
+            and GENERATION_RE.fullmatch(name.removesuffix(suffix))
+        ]
+    if not candidates:
+        raise Unavailable("missing_predecessor")
+    if len(candidates) != 1:
+        raise Unavailable("conflicting_predecessor")
+    status_name = candidates[0]
+    status_data = _read_file_at(side_fd, status_name)
+    if status_data is None:
+        raise Unavailable("missing_predecessor")
+    try:
+        payload = json.loads(status_data.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        raise Unavailable("conflicting_predecessor")
+    predecessor_generation = status_name.removesuffix(".status.json")
+    portable_name = f"{predecessor_generation}.portable.json"
+    if not isinstance(payload, dict):
+        raise Unavailable("conflicting_predecessor")
+    if payload.get("generation") != predecessor_generation:
+        raise Unavailable("conflicting_predecessor")
+    if payload.get("portable_ref") != f".supervisor/return-observation/{portable_name}":
+        raise Unavailable("conflicting_predecessor")
+    digest = payload.get("portable_digest") if isinstance(payload, dict) else None
+    if (
+        not isinstance(digest, str)
+        or not digest.startswith("sha256:")
+        or len(digest) != 71
+        or any(ch not in "0123456789abcdef" for ch in digest.removeprefix("sha256:"))
+    ):
+        raise Unavailable("conflicting_predecessor")
+    portable_bytes = _read_file_at(side_fd, portable_name)
+    if portable_bytes is None:
+        raise Unavailable("missing_predecessor")
+    current_digest = "sha256:" + hashlib.sha256(portable_bytes).hexdigest()
+    if current_digest != digest:
+        raise Unavailable("predecessor_tamper")
+    try:
+        portable_payload = json.loads(portable_bytes.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        raise Unavailable("predecessor_tamper")
+    if not isinstance(portable_payload, dict) or portable_payload.get("generation_key") != predecessor_generation:
+        raise Unavailable("predecessor_tamper")
+    return {
+        "generation": predecessor_generation,
+        "portable_digest": digest,
+        "status_ref": f".supervisor/return-observation/{status_name}",
+        "portable_ref": f".supervisor/return-observation/{portable_name}",
+    }
+
+
+def _declared_artifact_rows(
+    root_fd: int, artifacts_data: dict, observed: list[dict], total: int
+) -> tuple[list[dict], list[dict], int]:
+    if not isinstance(artifacts_data, dict):
+        return [], [], total
+    declared = artifacts_data.get("artifacts")
+    if declared is None:
+        return [], [], total
+    if artifacts_data.get("truncated") is True:
+        raise Unavailable("artifact_manifest_truncated")
+    if not isinstance(declared, list):
+        raise Unavailable("artifact_manifest_invalid")
+    rows: list[dict] = []
+    differences: list[dict] = []
+    seen = {row["relative_ref"] for row in observed}
+    for item in declared:
+        if not isinstance(item, dict) or not isinstance(item.get("path"), str):
+            raise Unavailable("artifact_manifest_invalid")
+        rel = _safe_rel(item["path"])
+        if not _exists_beneath(root_fd, rel):
+            raise Unavailable("artifact_missing")
+        row = _hash_file(root_fd, rel)
+        row["role"] = item.get("role") if isinstance(item.get("role"), str) else "declared_artifact"
+        row["declared_path"] = rel
+        manifest_size = item.get("size")
+        if isinstance(manifest_size, int) and manifest_size != row["size"]:
+            differences.append({
+                "path": rel,
+                "field": "size",
+                "declared": manifest_size,
+                "observed": row["size"],
+            })
+        rows.append(row)
+        if rel not in seen:
+            observed.append(row)
+            seen.add(rel)
+            total += int(row["size"])
+            if len(observed) > MAX_FILES:
+                raise Unavailable("file_count_cap")
+            if total > MAX_TOTAL_BYTES:
+                raise Unavailable("total_byte_cap")
+    return rows, differences, total
+
+
+def _expected_intent_from_manifest(manifest: dict, manifest_digest: str) -> dict:
+    call_parameters = {
+        "backend": manifest.get("backend"),
+        "task": manifest.get("task"),
+        "tools": manifest.get("tools"),
+        "mcp": manifest.get("mcp"),
+        "max_turns": manifest.get("max_turns"),
+        "timeout_s": manifest.get("timeout_s"),
+        "context_token_limit": manifest.get("context_token_limit"),
+        "llm": manifest.get("llm"),
+        "backend_argv": manifest.get("backend_argv"),
+        "language": manifest.get("language"),
+        "preset_name": manifest.get("preset_name"),
+        "preset_llm": manifest.get("preset_llm"),
+        "preset_capabilities": manifest.get("preset_capabilities"),
+        "group_id": manifest.get("group_id"),
+    }
+    return {
+        "schema_version": "lingtai.daemon-dispatch-intent.v0",
+        "run_id": manifest.get("run_id"),
+        "group_id": manifest.get("group_id"),
+        "task": manifest.get("task"),
+        "tools": manifest.get("tools"),
+        "call_parameters": call_parameters,
+        "manifest": manifest,
+        "manifest_sha256": manifest_digest,
+        "authority": "parent_owned",
+    }
+
+
+def _dispatch_mismatches(
+    *, side_fd: int, manifest: dict, manifest_digest: str, state_data: dict
+) -> tuple[dict, dict, list[dict]]:
+    intent_payload, intent_ref = _read_sidecar_json_if_present(side_fd, DISPATCH_INTENT_NAME)
+    result_payload, result_ref = _read_sidecar_json_if_present(side_fd, DISPATCH_RESULT_NAME)
+    mismatches: list[dict] = []
+    if intent_payload is not None:
+        expected = _expected_intent_from_manifest(manifest, manifest_digest)
+        for key, expected_value in expected.items():
+            if intent_payload.get(key) != expected_value:
+                mismatches.append({"receipt": "dispatch_intent", "field": key})
+    if result_payload is not None:
+        result = result_payload.get("dispatch_result")
+        if not isinstance(result, dict):
+            mismatches.append({"receipt": "dispatch_result", "field": "dispatch_result"})
+        else:
+            ids = result.get("ids")
+            if not isinstance(ids, list) or manifest.get("run_id") not in ids:
+                mismatches.append({"receipt": "dispatch_result", "field": "ids"})
+            if result.get("group_id") != manifest.get("group_id"):
+                mismatches.append({"receipt": "dispatch_result", "field": "group_id"})
+            if result.get("status") != "dispatched":
+                mismatches.append({"receipt": "dispatch_result", "field": "status"})
+        if result_payload.get("run_id") != manifest.get("run_id"):
+            mismatches.append({"receipt": "dispatch_result", "field": "run_id"})
+    if state_data.get("run_id") not in {None, manifest.get("run_id")}:
+        mismatches.append({"receipt": "daemon_state", "field": "run_id"})
+    return intent_ref, result_ref, mismatches
+
+
+def _ensure_final_at(dir_fd: int, name: str, payload: dict) -> bytes:
+    desired = _json_bytes(payload)
+    existing = _read_file_at(dir_fd, name)
+    if existing is None:
+        return _atomic_json_at(dir_fd, name, payload)
+    if existing == desired:
+        return desired
+    raise Unavailable("receipt_conflict")
+
+
+def _write_generation(side_fd: int, generation: str, host: dict, portable: dict, status: dict) -> tuple[str, str]:
+    host_name = f"{generation}.host.json"
+    portable_name = f"{generation}.portable.json"
+    status_name = f"{generation}.status.json"
+    portable_bytes = _json_bytes(portable)
+    digest = "sha256:" + hashlib.sha256(portable_bytes).hexdigest()
+    status["portable_digest"] = digest
+
+    existing_status = _read_file_at(side_fd, status_name)
+    if existing_status is not None:
+        if (
+            _read_file_at(side_fd, host_name) == _json_bytes(host)
+            and _read_file_at(side_fd, portable_name) == portable_bytes
+            and existing_status == _json_bytes(status)
+        ):
+            return "available", digest
+        raise Unavailable("receipt_conflict")
+    _ensure_final_at(side_fd, host_name, host)
+    _ensure_final_at(side_fd, portable_name, portable)
+    _atomic_json_at(side_fd, status_name, status)
+    return "available", digest
+
+
+def _validate_generation(generation: str) -> str:
+    if not isinstance(generation, str) or not GENERATION_RE.fullmatch(generation):
+        raise Unavailable("invalid_generation")
+    return generation
+
+
+def _check_authoritative_state(state_data: dict, *, generation: str, terminal_state: str) -> None:
+    if generation == "g0000":
+        if state_data.get("state") != terminal_state:
+            raise Unavailable("terminal_state_mismatch")
+        return
+    if not str(terminal_state).startswith("follow-up "):
+        raise Unavailable("generation_state_mismatch")
+    expected_status = terminal_state.removeprefix("follow-up ")
+    if state_data.get("followup_generation") != generation:
+        raise Unavailable("generation_state_mismatch")
+    if state_data.get("followup_status") != expected_status:
+        raise Unavailable("terminal_state_mismatch")
+
+
+def observe(run_dir: Path, manifest_path: Path, generation: str, terminal_state: str) -> dict:
+    generation = _validate_generation(generation)
+    run_dir_abs = os.path.abspath(os.fspath(run_dir))
+    expected_manifest_path = os.path.join(run_dir_abs, "supervisor_manifest.json")
+    if os.path.abspath(os.fspath(manifest_path)) != expected_manifest_path:
+        raise Unavailable("manifest_path_mismatch")
+    root_fd = os.open(
+        run_dir,
+        os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0),
+    )
+    try:
+        supervisor_fd = _open_or_create_dir(root_fd, ".supervisor")
+        try:
+            side_fd = _open_or_create_dir(supervisor_fd, "return-observation")
+        finally:
+            os.close(supervisor_fd)
+        keep_side_fd = False
+        try:
+            _read_file_at(side_fd, f"{generation}.host.json")
+            observed = []
+            stable_bytes: dict[str, bytes] = {}
+            total = 0
+            for role, rel in KNOWN_FILES:
+                if not _exists_beneath(root_fd, rel):
+                    continue
+                row, raw = _hash_file_with_bytes(root_fd, rel)
+                row["role"] = role
+                observed.append(row)
+                stable_bytes[rel] = raw
+                total += int(row["size"])
+                if len(observed) > MAX_FILES:
+                    raise Unavailable("file_count_cap")
+                if total > MAX_TOTAL_BYTES:
+                    raise Unavailable("total_byte_cap")
+            state_data = _json_object_from_bytes(stable_bytes["daemon.json"]) if "daemon.json" in stable_bytes else {}
+            artifacts_data = _json_object_from_bytes(stable_bytes["artifacts.json"]) if "artifacts.json" in stable_bytes else {}
+            if "supervisor_manifest.json" not in stable_bytes:
+                raise Unavailable("manifest_missing")
+            manifest_data = _json_object_from_bytes(stable_bytes["supervisor_manifest.json"])
+            if manifest_data.get("run_dir") != run_dir_abs or manifest_data.get("run_id") != os.path.basename(run_dir_abs):
+                raise Unavailable("manifest_identity_mismatch")
+            manifest_row = next((row for row in observed if row["relative_ref"] == "supervisor_manifest.json"), None)
+            if manifest_row is None:
+                raise Unavailable("manifest_missing")
+            declared_rows, artifact_differences, total = _declared_artifact_rows(
+                root_fd, artifacts_data, observed, total
+            )
+            _check_authoritative_state(state_data, generation=generation, terminal_state=terminal_state)
+            dispatch_intent_ref, dispatch_result_ref, dispatch_mismatches = _dispatch_mismatches(
+                side_fd=side_fd,
+                manifest=manifest_data,
+                manifest_digest=manifest_row["sha256"],
+                state_data=state_data,
+            )
+            if dispatch_mismatches:
+                raise Unavailable("dispatch_binding_mismatch", {"mismatches": dispatch_mismatches})
+            predecessor = _predecessor_ref(side_fd, generation)
+            side_fd_for_write = side_fd
+            keep_side_fd = True
+        finally:
+            if not keep_side_fd:
+                os.close(side_fd)
+    finally:
+        os.close(root_fd)
+
+    host = {
+        "schema_version": SCHEMA_VERSION + ".host",
+        "run_dir": str(run_dir),
+        "manifest_path": str(manifest_path),
+        "observed_files": observed,
+        "declared_artifact_files": declared_rows,
+    }
+    host_digest = "sha256:" + hashlib.sha256(
+        json.dumps(host, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    declared_artifacts = artifacts_data.get("artifacts") if isinstance(artifacts_data, dict) else None
+    portable = {
+        "schema_version": SCHEMA_VERSION,
+        "safe_observation_id": "return-observation:" + hashlib.sha256(
+            f"{generation}:{terminal_state}:{host_digest}".encode("utf-8")
+        ).hexdigest()[:24],
+        "host_mapping_digest": host_digest,
+        "dispatch_intent_ref": dispatch_intent_ref,
+        "dispatch_result_ref": dispatch_result_ref,
+        "generation_key": generation,
+        "terminal_state": terminal_state,
+        "snapshot_status": "stable",
+        "observed_files": [
+            {k: row[k] for k in ("role", "relative_ref", "size", "sha256", "stability")}
+            for row in observed
+        ],
+        "declared_artifacts": {
+            "status": "observed" if isinstance(declared_artifacts, list) else "missing_or_unavailable",
+            "count": len(declared_artifacts) if isinstance(declared_artifacts, list) else 0,
+            "truncated": bool(artifacts_data.get("truncated")) if isinstance(artifacts_data, dict) else False,
+            "differences": artifact_differences,
+        },
+        "observed_artifacts": {
+            "roles": [row["role"] for row in observed],
+            "count": len(observed),
+            "declared_file_count": len(declared_rows),
+            "caps": {
+                "max_files": MAX_FILES,
+                "max_file_bytes": MAX_FILE_BYTES,
+                "max_total_bytes": MAX_TOTAL_BYTES,
+            },
+        },
+        "mechanically_observed": ["terminal_state", "observed_file_size_sha256_stability", "artifact_manifest_presence"],
+        "daemon_declared": [
+            key for key in ("task", "result_preview", "error", "followup_status", "followup_generation")
+            if key in state_data
+        ],
+        "parent_verification_required": ["semantic_truth", "source_completeness", "side_effect_completeness", "remaining_gates"],
+        "raw_fallback_refs": [
+            {"role": row["role"], "relative_ref": row["relative_ref"]}
+            for row in observed
+        ],
+        "supersedes": predecessor,
+        "superseded_by": None,
+        "notification_publication_state": "not_yet_attempted",
+        "authority": "advisory_only",
+        "raw_result_unchanged": True,
+    }
+    status = {
+        "schema_version": STATUS_SCHEMA_VERSION,
+        "state": "available",
+        "generation": generation,
+        "reason_code": None,
+        "portable_ref": f".supervisor/return-observation/{generation}.portable.json",
+        "authority": "advisory_only",
+    }
+    try:
+        state, digest = _write_generation(side_fd_for_write, generation, host, portable, status)
+    finally:
+        os.close(side_fd_for_write)
+    return {
+        "state": state,
+        "generation": generation,
+        "receipt_digest": digest,
+        "portable_ref": status["portable_ref"],
+        "authority": "advisory_only",
+        "raw_result_unchanged": True,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--run-dir", required=True)
+    parser.add_argument("--manifest-path", required=True)
+    parser.add_argument("--generation", required=True)
+    parser.add_argument("--terminal-state", required=True)
+    args = parser.parse_args(argv)
+    try:
+        result = observe(Path(args.run_dir), Path(args.manifest_path), args.generation, args.terminal_state)
+    except Unavailable as exc:
+        result = {"state": "unavailable", "reason_code": exc.reason_code}
+        if exc.details:
+            result["details"] = exc.details
+    except BaseException:
+        result = {"state": "unavailable", "reason_code": "unexpected_exception"}
+    sys.stdout.write(json.dumps(result, sort_keys=True, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/lingtai/tools/daemon/return_observer_helper.py
+++ b/src/lingtai/tools/daemon/return_observer_helper.py
@@ -150,6 +150,18 @@ def _read_file_beneath(root_fd: int, rel: str) -> tuple[bytes, os.stat_result]:
         os.close(fd)
 
 
+def _stat_regular_file_beneath(root_fd: int, rel: str) -> os.stat_result:
+    """Return no-follow metadata without reading file content."""
+    fd = _open_beneath(root_fd, rel)
+    try:
+        st = os.fstat(fd)
+        if not _is_regular(st.st_mode):
+            raise Unavailable("not_regular_file")
+        return st
+    finally:
+        os.close(fd)
+
+
 def _row_for_bytes(rel: str, data: bytes, st: os.stat_result) -> dict:
     return {
         "relative_ref": rel,
@@ -365,10 +377,42 @@ def _declared_artifact_rows(
         rel = _safe_rel(item["path"])
         if not _exists_beneath(root_fd, rel):
             raise Unavailable("artifact_missing")
+        metadata = _stat_regular_file_beneath(root_fd, rel)
+        manifest_size = item.get("size")
+        omission_reason = None
+        omission_cap = None
+        omission_remaining = None
+        if metadata.st_size > MAX_FILE_BYTES:
+            omission_reason = "per_file_cap"
+            omission_cap = MAX_FILE_BYTES
+        elif rel not in seen and total + int(metadata.st_size) > MAX_TOTAL_BYTES:
+            omission_reason = "total_byte_cap"
+            omission_cap = MAX_TOTAL_BYTES
+            omission_remaining = max(MAX_TOTAL_BYTES - total, 0)
+        if omission_reason is not None:
+            if isinstance(manifest_size, int) and manifest_size != metadata.st_size:
+                differences.append({
+                    "path": rel,
+                    "field": "size",
+                    "declared": manifest_size,
+                    "observed": metadata.st_size,
+                })
+            omission = {
+                "path": rel,
+                "field": "content_observation",
+                "declared": "present",
+                "observed": "omitted",
+                "reason_code": omission_reason,
+                "size_bytes": metadata.st_size,
+                "cap_bytes": omission_cap,
+            }
+            if omission_remaining is not None:
+                omission["remaining_bytes"] = omission_remaining
+            differences.append(omission)
+            continue
         row = _hash_file(root_fd, rel)
         row["role"] = item.get("role") if isinstance(item.get("role"), str) else "declared_artifact"
         row["declared_path"] = rel
-        manifest_size = item.get("size")
         if isinstance(manifest_size, int) and manifest_size != row["size"]:
             differences.append({
                 "path": rel,

--- a/src/lingtai/tools/daemon/return_observer_hook.py
+++ b/src/lingtai/tools/daemon/return_observer_hook.py
@@ -1,0 +1,195 @@
+"""Fail-open wrapper for the daemon return observer helper."""
+from __future__ import annotations
+
+import json
+import os
+import re
+import hashlib
+import subprocess
+import sys
+from pathlib import Path
+
+HELPER_DEADLINE_S = 1.5
+SHA256_RE = re.compile(r"sha256:[0-9a-f]{64}\Z")
+GENERATION_RE = re.compile(r"(?:g0000|g[1-9][0-9]*-[0-9a-f]{16})\Z")
+SAFE_ENV = {
+    "LANG": "C",
+    "LC_ALL": "C",
+    "PYTHONIOENCODING": "utf-8",
+}
+
+
+def _generation_for(status: str, state: dict) -> str:
+    if str(status).startswith("follow-up"):
+        generation = state.get("followup_generation")
+        if isinstance(generation, str) and GENERATION_RE.fullmatch(generation):
+            return generation
+        return ""
+    return "g0000"
+
+
+def observe_return_bounded(run_dir, manifest: dict, *, status: str, state: dict) -> dict | None:
+    """Return a safe notification block, or ``None`` on any observer failure."""
+    if manifest.get("return_observer_enabled") is not True:
+        return None
+    try:
+        expected_generation = _generation_for(status, state)
+        if not expected_generation:
+            return None
+        env = dict(SAFE_ENV)
+        if os.environ.get("PYTHONPATH"):
+            env["PYTHONPATH"] = os.environ["PYTHONPATH"]
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "lingtai.tools.daemon.return_observer_helper",
+                "--run-dir",
+                str(run_dir.path),
+                "--manifest-path",
+                str(Path(manifest["run_dir"]) / "supervisor_manifest.json"),
+                "--generation",
+                expected_generation,
+                "--terminal-state",
+                str(status),
+            ],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=HELPER_DEADLINE_S,
+            env=env,
+            check=False,
+        )
+        if proc.returncode != 0:
+            return None
+        if len(proc.stdout or "") > 8192:
+            return None
+        data = json.loads(proc.stdout or "{}")
+        if not isinstance(data, dict) or data.get("state") != "available":
+            return None
+        digest = data.get("receipt_digest")
+        generation = data.get("generation")
+        if not (isinstance(digest, str) and SHA256_RE.fullmatch(digest)):
+            return None
+        if not isinstance(generation, str) or not GENERATION_RE.fullmatch(generation):
+            return None
+        if generation != expected_generation:
+            return None
+        return {
+            "schema_version": "lingtai.return-observation-notice.v0",
+            "state": "available",
+            "generation": generation,
+            "receipt_digest": digest,
+            "authority": "advisory_only",
+            "raw_result_unchanged": True,
+        }
+    except BaseException:
+        return None
+
+
+def _write_sidecar_json(run_dir, name: str, payload: dict) -> str | None:
+    try:
+        from lingtai.tools.daemon import return_observer_helper as helper
+
+        root_fd = helper.os.open(
+            run_dir.path,
+            helper.os.O_RDONLY
+            | getattr(helper.os, "O_DIRECTORY", 0)
+            | getattr(helper.os, "O_NOFOLLOW", 0),
+        )
+        try:
+            supervisor_fd = helper._open_or_create_dir(root_fd, ".supervisor")
+            try:
+                side_fd = helper._open_or_create_dir(supervisor_fd, "return-observation")
+            finally:
+                helper.os.close(supervisor_fd)
+            try:
+                helper._ensure_final_at(side_fd, name, payload)
+                data = helper._json_bytes(payload)
+                return "sha256:" + hashlib.sha256(data).hexdigest()
+            finally:
+                helper.os.close(side_fd)
+        finally:
+            helper.os.close(root_fd)
+    except BaseException:
+        return None
+
+
+def write_dispatch_intent_receipt(run_dir, manifest: dict) -> str | None:
+    """Best-effort parent-owned pre-launch receipt for enabled observation."""
+    try:
+        if manifest.get("return_observer_enabled") is not True:
+            return None
+        try:
+            manifest_bytes = (Path(manifest["run_dir"]) / "supervisor_manifest.json").read_bytes()
+        except BaseException:
+            manifest_bytes = json.dumps(
+                manifest, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+            ).encode("utf-8")
+        call_parameters = {
+            "backend": manifest.get("backend"),
+            "task": manifest.get("task"),
+            "tools": manifest.get("tools"),
+            "mcp": manifest.get("mcp"),
+            "max_turns": manifest.get("max_turns"),
+            "timeout_s": manifest.get("timeout_s"),
+            "context_token_limit": manifest.get("context_token_limit"),
+            "llm": manifest.get("llm"),
+            "backend_argv": manifest.get("backend_argv"),
+            "language": manifest.get("language"),
+            "preset_name": manifest.get("preset_name"),
+            "preset_llm": manifest.get("preset_llm"),
+            "preset_capabilities": manifest.get("preset_capabilities"),
+            "group_id": manifest.get("group_id"),
+        }
+        payload = {
+            "schema_version": "lingtai.daemon-dispatch-intent.v0",
+            "run_id": run_dir.run_id,
+            "group_id": manifest.get("group_id"),
+            "task": manifest.get("task"),
+            "call_parameters": call_parameters,
+            "task_sha256": "sha256:" + hashlib.sha256(str(manifest.get("task", "")).encode("utf-8")).hexdigest(),
+            "tools": list(manifest.get("tools") or []),
+            "manifest": manifest,
+            "manifest_sha256": "sha256:" + hashlib.sha256(manifest_bytes).hexdigest(),
+            "authority": "parent_owned",
+        }
+        return _write_sidecar_json(run_dir, "dispatch-intent.v0.json", payload)
+    except BaseException:
+        return None
+
+
+def write_dispatch_result_receipt(run_dir, result: dict) -> str | None:
+    """Best-effort parent-owned immediate dispatch result receipt."""
+    try:
+        try:
+            state = run_dir.read_state_from_disk(run_dir.path)
+        except BaseException:
+            state = {}
+        if state.get("return_observer_enabled") is not True:
+            manifest_path = Path(run_dir.path) / "supervisor_manifest.json"
+            try:
+                manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            except BaseException:
+                manifest = {}
+            if manifest.get("return_observer_enabled") is not True:
+                return None
+        data = {
+            "status": result.get("status"),
+            "count": result.get("count"),
+            "ids": result.get("ids"),
+            "group_id": result.get("group_id"),
+        }
+        payload = {
+            "schema_version": "lingtai.daemon-dispatch-result.v0",
+            "run_id": run_dir.run_id,
+            "dispatch_result_sha256": "sha256:" + hashlib.sha256(
+                json.dumps(data, sort_keys=True, separators=(",", ":")).encode("utf-8")
+            ).hexdigest(),
+            "dispatch_result": data,
+            "authority": "parent_owned",
+        }
+        return _write_sidecar_json(run_dir, "dispatch-result.v0.json", payload)
+    except BaseException:
+        return None

--- a/src/lingtai/tools/daemon/supervisor_runtime.py
+++ b/src/lingtai/tools/daemon/supervisor_runtime.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import signal
 import subprocess
 import sys
@@ -230,9 +231,13 @@ def run_resume_owner(manifest_path: str, run_id: str, generation: str,
         )
         try:
             state = run_dir.read_state_from_disk(run_dir.path)
+            observation = _return_observation_if_available(
+                run_dir, manifest, status=f"follow-up {status}", state=state,
+            )
             _publish_daemon_notification(
                 run_dir, manifest, status=f"follow-up {status}",
                 state=state, idempotency_key=f"daemon-followup:{run_id}:{generation}",
+                return_observation=observation,
             )
         except Exception:
             pass
@@ -480,7 +485,11 @@ def _publish_terminal_notification_if_needed(run_dir, manifest: dict) -> None:
     idempotency_key = run_dir.claim_terminal_notification(status)
     if idempotency_key is None:
         return  # already claimed/published by a concurrent path
-    published = _publish_daemon_notification(run_dir, manifest, status=status, state=state, idempotency_key=idempotency_key)
+    observation = _return_observation_if_available(run_dir, manifest, status=status, state=state)
+    published = _publish_daemon_notification(
+        run_dir, manifest, status=status, state=state, idempotency_key=idempotency_key,
+        return_observation=observation,
+    )
     if published:
         run_dir.mark_terminal_notification_published(idempotency_key)
     else:
@@ -490,7 +499,50 @@ def _publish_terminal_notification_if_needed(run_dir, manifest: dict) -> None:
 _NOTIFICATION_PREVIEW_MAX = 500
 
 
-def _publish_daemon_notification(run_dir, manifest: dict, *, status: str, state: dict, idempotency_key: str) -> bool:
+def _return_observation_if_available(run_dir, manifest: dict, *, status: str, state: dict) -> dict | None:
+    if manifest.get("return_observer_enabled") is not True:
+        return None
+    def _expected_generation() -> str:
+        if str(status).startswith("follow-up"):
+            value = state.get("followup_generation")
+            if isinstance(value, str) and re.fullmatch(r"(?:g0000|g[1-9][0-9]*-[0-9a-f]{16})", value):
+                return value
+            return ""
+        return "g0000"
+    try:
+        from lingtai.tools.daemon.return_observer_hook import observe_return_bounded
+        observation = observe_return_bounded(run_dir, manifest, status=status, state=state)
+        if not isinstance(observation, dict):
+            return None
+        if observation.get("schema_version") != "lingtai.return-observation-notice.v0":
+            return None
+        if observation.get("state") != "available":
+            return None
+        digest = observation.get("receipt_digest")
+        if not (isinstance(digest, str) and len(digest) == 71 and digest.startswith("sha256:")):
+            return None
+        if any(ch not in "0123456789abcdef" for ch in digest.removeprefix("sha256:")):
+            return None
+        generation = observation.get("generation")
+        if not isinstance(generation, str):
+            return None
+        if not (generation == "g0000" or re.fullmatch(r"g[1-9][0-9]*-[0-9a-f]{16}", generation)):
+            return None
+        if generation != _expected_generation():
+            return None
+        if observation.get("authority") != "advisory_only":
+            return None
+        if observation.get("raw_result_unchanged") is not True:
+            return None
+        return observation
+    except BaseException:
+        return None
+
+
+def _publish_daemon_notification(
+    run_dir, manifest: dict, *, status: str, state: dict, idempotency_key: str,
+    return_observation: dict | None = None,
+) -> bool:
     """Publish the terminal event directly via the notification store Port.
 
     Mirrors ``DaemonManager._publish_daemon_notification``'s body/text
@@ -572,6 +624,8 @@ def _publish_daemon_notification(run_dir, manifest: dict, *, status: str, state:
             "at": received_at,
             "idempotency_key": idempotency_key,
         }
+        if isinstance(return_observation, dict):
+            event["return_observation"] = return_observation
         events.append(event)
         events = events[-20:]
         envelope_priority = (

--- a/tests/test_daemon_return_observer.py
+++ b/tests/test_daemon_return_observer.py
@@ -733,14 +733,63 @@ def test_atomic_json_zero_write_fails_certificate(tmp_path, monkeypatch, capsys)
     assert json.loads(capsys.readouterr().out) == {"reason_code": "short_write", "state": "unavailable"}
 
 
-def test_per_file_cap_breach_fails_certificate_only(tmp_path, capsys):
+@pytest.mark.parametrize("oversized_bytes", [530_042, 892_071])
+def test_oversized_declared_artifact_is_omitted_but_notice_remains_exactly_once(
+    tmp_path, oversized_bytes
+):
+    """Regression for the two real failed transcript sizes.
+
+    A declared artifact beyond the read cap is explicitly not content-observed;
+    it must not disable the bounded generation or the additive terminal notice.
+    """
+    run_dir = _make_run_dir(tmp_path)
+    manifest = _manifest(run_dir, enabled=True)
+    private_marker = b"PRIVATE-OVERSIZED-CONTENT-MUST-NOT-BE-READ"
+    too_large = run_dir.path / "too-large.bin"
+    too_large.write_bytes(private_marker + b"x" * (oversized_bytes - len(private_marker)))
+    run_dir.mark_done("raw survives")
+    run_dir.manifest_path.write_text(
+        json.dumps({"artifacts": [{"path": "too-large.bin", "size": oversized_bytes}], "truncated": False}),
+        encoding="utf-8",
+    )
+
+    _publish_terminal_notification_if_needed(run_dir, manifest)
+    _publish_terminal_notification_if_needed(run_dir, manifest)
+
+    events = _matching_events(run_dir)
+    assert len(events) == 1
+    assert events[0]["return_observation"]["generation"] == "g0000"
+    side = run_dir.path / ".supervisor" / "return-observation"
+    assert sorted(path.name for path in side.glob("g0000.*.json")) == [
+        "g0000.host.json",
+        "g0000.portable.json",
+        "g0000.status.json",
+    ]
+    portable = json.loads((side / "g0000.portable.json").read_text(encoding="utf-8"))
+    assert {
+        "path": "too-large.bin",
+        "field": "content_observation",
+        "declared": "present",
+        "observed": "omitted",
+        "reason_code": "per_file_cap",
+        "size_bytes": oversized_bytes,
+        "cap_bytes": 256 * 1024,
+    } in portable["declared_artifacts"]["differences"]
+    assert "too-large.bin" not in {row["relative_ref"] for row in portable["observed_files"]}
+    rendered_receipts = b"".join(path.read_bytes() for path in side.glob("g0000.*.json"))
+    assert private_marker not in rendered_receipts
+    assert run_dir.result_path.read_text(encoding="utf-8") == "raw survives"
+    assert DaemonRunDir.read_state_from_disk(run_dir.path)["state"] == "done"
+
+
+def test_oversized_declared_artifact_preserves_manifest_size_difference(tmp_path, capsys):
     run_dir = _make_run_dir(tmp_path)
     _manifest(run_dir, enabled=True)
-    run_dir.mark_done("raw")
     too_large = run_dir.path / "too-large.bin"
-    too_large.write_bytes(b"x" * (256 * 1024 + 1))
+    too_large.write_bytes(b"x" * 530_042)
+    run_dir.mark_done("raw")
     run_dir.manifest_path.write_text(
-        json.dumps({"artifacts": [{"path": "too-large.bin", "size": too_large.stat().st_size}], "truncated": False}),
+        json.dumps({"artifacts": [{"path": "too-large.bin", "size": 1}], "truncated": False}),
         encoding="utf-8",
     )
 
@@ -751,8 +800,108 @@ def test_per_file_cap_breach_fails_certificate_only(tmp_path, capsys):
         "--terminal-state", "done",
     ])
 
-    assert json.loads(capsys.readouterr().out) == {"reason_code": "per_file_cap", "state": "unavailable"}
-    assert run_dir.result_path.read_text(encoding="utf-8") == "raw"
+    assert json.loads(capsys.readouterr().out)["state"] == "available"
+    portable = json.loads(
+        (run_dir.path / ".supervisor" / "return-observation" / "g0000.portable.json").read_text(encoding="utf-8")
+    )
+    differences = portable["declared_artifacts"]["differences"]
+    assert {
+        "path": "too-large.bin",
+        "field": "size",
+        "declared": 1,
+        "observed": 530_042,
+    } in differences
+    assert any(
+        row.get("path") == "too-large.bin"
+        and row.get("field") == "content_observation"
+        and row.get("reason_code") == "per_file_cap"
+        and row.get("size_bytes") == 530_042
+        for row in differences
+    )
+
+
+def test_declared_artifact_total_budget_omits_content_without_disabling_generation(tmp_path, capsys):
+    run_dir = _make_run_dir(tmp_path)
+    _manifest(run_dir, enabled=True)
+    private_marker = b"PRIVATE-TOTAL-BUDGET-CONTENT-MUST-NOT-BE-READ"
+    declared = []
+    for index in range(5):
+        path = run_dir.path / f"budget-{index}.bin"
+        path.write_bytes(private_marker + b"x" * (250_000 - len(private_marker)))
+        declared.append({"path": path.name, "size": path.stat().st_size})
+    run_dir.mark_done("raw total survives")
+    run_dir.manifest_path.write_text(
+        json.dumps({"artifacts": declared, "truncated": False}),
+        encoding="utf-8",
+    )
+
+    helper_main([
+        "--run-dir", str(run_dir.path),
+        "--manifest-path", str(run_dir.path / "supervisor_manifest.json"),
+        "--generation", "g0000",
+        "--terminal-state", "done",
+    ])
+
+    assert json.loads(capsys.readouterr().out)["state"] == "available"
+    side = run_dir.path / ".supervisor" / "return-observation"
+    portable = json.loads((side / "g0000.portable.json").read_text(encoding="utf-8"))
+    omissions = [
+        row for row in portable["declared_artifacts"]["differences"]
+        if row.get("field") == "content_observation" and row.get("reason_code") == "total_byte_cap"
+    ]
+    assert omissions
+    observed = {row["relative_ref"] for row in portable["observed_files"]}
+    assert all(row["path"] not in observed for row in omissions)
+    assert all(row["size_bytes"] == 250_000 for row in omissions)
+    rendered_receipts = b"".join(path.read_bytes() for path in side.glob("g0000.*.json"))
+    assert private_marker not in rendered_receipts
+    assert run_dir.result_path.read_text(encoding="utf-8") == "raw total survives"
+
+
+def test_concurrent_bounded_invocations_share_one_oversized_generation(tmp_path):
+    import lingtai.tools.daemon.return_observer_hook as hook
+
+    run_dir = _make_run_dir(tmp_path)
+    manifest = _manifest(run_dir, enabled=True)
+    too_large = run_dir.path / "too-large.bin"
+    too_large.write_bytes(b"x" * 530_042)
+    run_dir.mark_done("raw concurrent")
+    run_dir.manifest_path.write_text(
+        json.dumps({"artifacts": [{"path": "too-large.bin", "size": too_large.stat().st_size}], "truncated": False}),
+        encoding="utf-8",
+    )
+    state = DaemonRunDir.read_state_from_disk(run_dir.path)
+    barrier = threading.Barrier(3)
+    blocks: list[dict | None] = []
+    errors: list[BaseException] = []
+
+    def invoke():
+        try:
+            barrier.wait(timeout=5)
+            blocks.append(hook.observe_return_bounded(run_dir, manifest, status="done", state=state))
+        except BaseException as exc:  # test thread must report, not disappear
+            errors.append(exc)
+
+    threads = [threading.Thread(target=invoke) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    barrier.wait(timeout=5)
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert not errors
+    assert all(not thread.is_alive() for thread in threads)
+    assert len(blocks) == 2
+    assert all(isinstance(block, dict) for block in blocks)
+    assert blocks[0] == blocks[1]
+    assert blocks[0]["generation"] == "g0000"
+    side = run_dir.path / ".supervisor" / "return-observation"
+    assert sorted(path.name for path in side.glob("g0000.*.json")) == [
+        "g0000.host.json",
+        "g0000.portable.json",
+        "g0000.status.json",
+    ]
+    assert run_dir.result_path.read_text(encoding="utf-8") == "raw concurrent"
 
 
 def test_dispatch_intent_manifest_mismatch_is_explicit_unavailable(tmp_path, capsys):

--- a/tests/test_daemon_return_observer.py
+++ b/tests/test_daemon_return_observer.py
@@ -1,0 +1,1032 @@
+from __future__ import annotations
+
+import builtins
+import errno
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+from lingtai.adapters.posix.notification_store import PosixNotificationStoreAdapter
+from lingtai.kernel.daemon_supervisor.manifest import build_manifest, write_manifest
+from lingtai.tools.daemon.return_observer_helper import main as helper_main
+from lingtai.tools.daemon.return_observer_helper import observe as helper_observe
+from lingtai.tools.daemon.return_observer_hook import (
+    write_dispatch_intent_receipt,
+    write_dispatch_result_receipt,
+)
+from lingtai.tools.daemon.run_dir import DaemonRunDir
+from lingtai.tools.daemon.supervisor_runtime import (
+    _publish_terminal_notification_if_needed,
+    _return_observation_if_available,
+)
+
+
+def _make_run_dir(tmp_path: Path, *, run_id: str = "em-test") -> DaemonRunDir:
+    parent = tmp_path / "agent"
+    parent.mkdir(parents=True, exist_ok=True)
+    return DaemonRunDir(
+        parent_working_dir=parent,
+        handle=run_id,
+        run_id=run_id,
+        task="observe me",
+        tools=[],
+        model="fake-model",
+        max_turns=5,
+        timeout_s=30,
+        parent_addr=parent.name,
+        parent_pid=os.getpid(),
+        system_prompt="You are a test daemon.",
+        call_parameters={"task": "observe me", "tools": []},
+    )
+
+
+def _manifest(run_dir: DaemonRunDir, *, enabled: bool) -> dict:
+    manifest = build_manifest(
+        run_id=run_dir.run_id,
+        backend="lingtai",
+        parent_working_dir=str(run_dir.path.parent.parent),
+        run_dir=str(run_dir.path),
+        task="observe me",
+        tools=[],
+        max_turns=5,
+        timeout_s=30,
+        group_id=None,
+        llm={"provider": "fake", "model": "fake", "api_key": None, "base_url": None},
+        return_observer_enabled=enabled,
+    )
+    write_manifest(run_dir.path, manifest)
+    return manifest
+
+
+def _matching_events(run_dir: DaemonRunDir) -> list[dict]:
+    store = PosixNotificationStoreAdapter(run_dir.path.parent.parent)
+    snap = store.snapshot(lambda ch: ch == "system")
+    events = snap.get("system", {}).get("data", {}).get("events", [])
+    return [ev for ev in events if ev.get("ref_id") == run_dir.handle]
+
+
+def test_disabled_observer_does_not_import_spawn_or_write_sidecar(tmp_path, monkeypatch):
+    run_dir = _make_run_dir(tmp_path)
+    manifest = _manifest(run_dir, enabled=False)
+    run_dir.mark_done("baseline result")
+
+    real_import = builtins.__import__
+
+    def guarded_import(name, *args, **kwargs):
+        if name == "lingtai.tools.daemon.return_observer_hook":
+            raise AssertionError("observer hook imported while disabled")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+    _publish_terminal_notification_if_needed(run_dir, manifest)
+
+    assert not (run_dir.path / ".supervisor" / "return-observation").exists()
+    events = _matching_events(run_dir)
+    assert len(events) == 1
+    assert "return_observation" not in events[0]
+    assert run_dir.result_path.read_text(encoding="utf-8") == "baseline result"
+
+
+def test_enabled_observer_adds_safe_notification_block_and_sidecar(tmp_path):
+    run_dir = _make_run_dir(tmp_path)
+    manifest = _manifest(run_dir, enabled=True)
+    run_dir.mark_done("observed result")
+
+    _publish_terminal_notification_if_needed(run_dir, manifest)
+
+    events = _matching_events(run_dir)
+    assert len(events) == 1
+    block = events[0]["return_observation"]
+    assert block == {
+        "schema_version": "lingtai.return-observation-notice.v0",
+        "state": "available",
+        "generation": "g0000",
+        "receipt_digest": block["receipt_digest"],
+        "authority": "advisory_only",
+        "raw_result_unchanged": True,
+    }
+    assert block["receipt_digest"].startswith("sha256:")
+    side_dir = run_dir.path / ".supervisor" / "return-observation"
+    portable = json.loads((side_dir / "g0000.portable.json").read_text(encoding="utf-8"))
+    assert portable["notification_publication_state"] == "not_yet_attempted"
+    assert portable["authority"] == "advisory_only"
+    assert str(run_dir.path) not in json.dumps(portable)
+
+
+def test_helper_binds_parent_dispatch_receipts_when_present(tmp_path):
+    run_dir = _make_run_dir(tmp_path)
+    manifest = _manifest(run_dir, enabled=True)
+    intent_digest = write_dispatch_intent_receipt(run_dir, manifest)
+    result_digest = write_dispatch_result_receipt(
+        run_dir,
+        {"status": "dispatched", "count": 1, "ids": [run_dir.run_id], "group_id": None},
+    )
+    run_dir.mark_done("observed result")
+
+    observed = helper_observe(run_dir.path, run_dir.path / "supervisor_manifest.json", "g0000", "done")
+    assert observed["state"] == "available"
+    portable = json.loads(
+        (run_dir.path / ".supervisor" / "return-observation" / "g0000.portable.json").read_text(encoding="utf-8")
+    )
+    assert portable["dispatch_intent_ref"]["status"] == "observed"
+    assert portable["dispatch_intent_ref"]["sha256"] == intent_digest
+    assert portable["dispatch_result_ref"]["status"] == "observed"
+    assert portable["dispatch_result_ref"]["sha256"] == result_digest
+
+
+@pytest.mark.parametrize(
+    "fault",
+    [
+        "import_error",
+        "unexpected_exception",
+        "keyboard_interrupt",
+        "unavailable",
+        "bad_schema",
+    ],
+)
+def test_observer_failures_leave_terminal_notification_exactly_once(tmp_path, monkeypatch, fault):
+    run_dir = _make_run_dir(tmp_path)
+    manifest = _manifest(run_dir, enabled=True)
+    run_dir.mark_done("raw survives")
+
+    if fault == "import_error":
+        real_import = builtins.__import__
+
+        def guarded_import(name, *args, **kwargs):
+            if name == "lingtai.tools.daemon.return_observer_hook":
+                raise ImportError("boom")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", guarded_import)
+    else:
+        import lingtai.tools.daemon.return_observer_hook as hook
+
+        if fault == "unexpected_exception":
+            monkeypatch.setattr(hook, "observe_return_bounded", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")))
+        elif fault == "keyboard_interrupt":
+            monkeypatch.setattr(hook, "observe_return_bounded", lambda *a, **k: (_ for _ in ()).throw(KeyboardInterrupt()))
+        elif fault == "unavailable":
+            monkeypatch.setattr(hook, "observe_return_bounded", lambda *a, **k: None)
+        else:
+            monkeypatch.setattr(hook, "observe_return_bounded", lambda *a, **k: {"state": "available", "receipt_digest": "not-a-digest"})
+
+    _publish_terminal_notification_if_needed(run_dir, manifest)
+
+    events = _matching_events(run_dir)
+    assert len(events) == 1
+    assert "return_observation" not in events[0]
+    assert run_dir.result_path.read_text(encoding="utf-8") == "raw survives"
+    assert DaemonRunDir.read_state_from_disk(run_dir.path)["state"] == "done"
+
+
+def test_helper_rejects_symlink_escape_without_notification_exception(tmp_path, capsys):
+    run_dir = _make_run_dir(tmp_path)
+    manifest = _manifest(run_dir, enabled=True)
+    run_dir.mark_done("raw survives")
+    (run_dir.path / "result.txt").unlink()
+    (run_dir.path / "result.txt").symlink_to(tmp_path / "outside.txt")
+
+    rc = helper_main([
+        "--run-dir",
+        str(run_dir.path),
+        "--manifest-path",
+        str(run_dir.path / "supervisor_manifest.json"),
+        "--generation",
+        "g0000",
+        "--terminal-state",
+        "done",
+    ])
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["state"] == "unavailable"
+    assert payload["reason_code"] in {"unsafe_sidecar", "not_regular_file", "path_escape"}
+
+
+def test_helper_reuses_identical_generation_and_refuses_conflict(tmp_path, capsys):
+    run_dir = _make_run_dir(tmp_path)
+    _manifest(run_dir, enabled=True)
+    run_dir.mark_done("first")
+    argv = [
+        "--run-dir",
+        str(run_dir.path),
+        "--manifest-path",
+        str(run_dir.path / "supervisor_manifest.json"),
+        "--generation",
+        "g0000",
+        "--terminal-state",
+        "done",
+    ]
+
+    assert helper_main(argv) == 0
+    first = json.loads(capsys.readouterr().out)
+    assert first["state"] == "available"
+    assert helper_main(argv) == 0
+    second = json.loads(capsys.readouterr().out)
+    assert second == first
+
+    portable = run_dir.path / ".supervisor" / "return-observation" / "g0000.portable.json"
+    portable.write_text("{}", encoding="utf-8")
+    assert helper_main(argv) == 0
+    third = json.loads(capsys.readouterr().out)
+    assert third == {"reason_code": "receipt_conflict", "state": "unavailable"}
+
+
+@pytest.mark.parametrize("component", [".supervisor", "return-observation"])
+def test_helper_rejects_sidecar_directory_symlinks(tmp_path, capsys, component):
+    run_dir = _make_run_dir(tmp_path)
+    _manifest(run_dir, enabled=True)
+    run_dir.mark_done("raw")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    if component == ".supervisor":
+        (run_dir.path / ".supervisor").symlink_to(outside, target_is_directory=True)
+    else:
+        (run_dir.path / ".supervisor").mkdir()
+        (run_dir.path / ".supervisor" / "return-observation").symlink_to(outside, target_is_directory=True)
+
+    helper_main([
+        "--run-dir", str(run_dir.path),
+        "--manifest-path", str(run_dir.path / "supervisor_manifest.json"),
+        "--generation", "g0000",
+        "--terminal-state", "done",
+    ])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {"reason_code": "unsafe_sidecar", "state": "unavailable"}
+    assert not any(outside.iterdir())
+
+
+def test_helper_rejects_final_file_symlink(tmp_path, capsys):
+    run_dir = _make_run_dir(tmp_path)
+    _manifest(run_dir, enabled=True)
+    run_dir.mark_done("raw")
+    side = run_dir.path / ".supervisor" / "return-observation"
+    side.mkdir(parents=True)
+    outside = tmp_path / "outside-host.json"
+    outside.write_text("{}", encoding="utf-8")
+    (side / "g0000.host.json").symlink_to(outside)
+
+    helper_main([
+        "--run-dir", str(run_dir.path),
+        "--manifest-path", str(run_dir.path / "supervisor_manifest.json"),
+        "--generation", "g0000",
+        "--terminal-state", "done",
+    ])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {"reason_code": "unsafe_sidecar", "state": "unavailable"}
+    assert outside.read_text(encoding="utf-8") == "{}"
+
+
+def test_same_snapshot_receipt_is_deterministic_across_time_change(tmp_path, monkeypatch):
+    run_dir = _make_run_dir(tmp_path)
+    _manifest(run_dir, enabled=True)
+    run_dir.mark_done("stable")
+    manifest_path = run_dir.path / "supervisor_manifest.json"
+
+    monkeypatch.setattr("lingtai.tools.daemon.return_observer_helper.time", None, raising=False)
+    first = helper_observe(run_dir.path, manifest_path, "g0000", "done")
+    second = helper_observe(run_dir.path, manifest_path, "g0000", "done")
+
+    assert second == first
+
+
+@pytest.mark.parametrize("fail_name", ["g0000.host.json", "g0000.portable.json", "g0000.status.json"])
+def test_status_last_partial_write_recovers_matching_files(tmp_path, monkeypatch, fail_name):
+    import lingtai.tools.daemon.return_observer_helper as helper
+
+    run_dir = _make_run_dir(tmp_path)
+    _manifest(run_dir, enabled=True)
+    run_dir.mark_done("recover")
+    real_atomic = helper._atomic_json_at
+    seen = {"failed": False}
+
+    def flaky(dir_fd, name, payload):
+        if name == fail_name and not seen["failed"]:
+            seen["failed"] = True
+            raise OSError("injected write failure")
+        return real_atomic(dir_fd, name, payload)
+
+    monkeypatch.setattr(helper, "_atomic_json_at", flaky)
+    with pytest.raises(OSError):
+        helper_observe(run_dir.path, run_dir.path / "supervisor_manifest.json", "g0000", "done")
+
+    monkeypatch.setattr(helper, "_atomic_json_at", real_atomic)
+    recovered = helper_observe(run_dir.path, run_dir.path / "supervisor_manifest.json", "g0000", "done")
+    assert recovered["state"] == "available"
+
+
+@pytest.mark.parametrize("generation", ["", "../x", "g1/evil", "g1-XYZ", "g01-1234567890abcdef"])
+def test_helper_rejects_unsafe_generation_names(tmp_path, capsys, generation):
+    run_dir = _make_run_dir(tmp_path)
+    _manifest(run_dir, enabled=True)
+    run_dir.mark_done("raw")
+
+    helper_main([
+        "--run-dir", str(run_dir.path),
+        "--manifest-path", str(run_dir.path / "supervisor_manifest.json"),
+        "--generation", generation,
+        "--terminal-state", "done",
+    ])
+
+    assert json.loads(capsys.readouterr().out) == {
+        "reason_code": "invalid_generation",
+        "state": "unavailable",
+    }
+
+
+def test_helper_rejects_terminal_state_mismatch(tmp_path, capsys):
+    run_dir = _make_run_dir(tmp_path)
+    _manifest(run_dir, enabled=True)
+    run_dir.mark_done("raw")
+
+    helper_main([
+        "--run-dir", str(run_dir.path),
+        "--manifest-path", str(run_dir.path / "supervisor_manifest.json"),
+        "--generation", "g0000",
+        "--terminal-state", "failed",
+    ])
+
+    assert json.loads(capsys.readouterr().out) == {
+        "reason_code": "terminal_state_mismatch",
+        "state": "unavailable",
+    }
+
+
+def test_followup_generation_uses_authoritative_state(tmp_path):
+    run_dir = _make_run_dir(tmp_path)
+    manifest = _manifest(run_dir, enabled=True)
+    run_dir.mark_done("initial")
+    helper_observe(run_dir.path, run_dir.path / "supervisor_manifest.json", "g0000", "done")
+    generation = "g1-1234567890abcdef"
+    run_dir.record_followup(generation, status="done", output="follow")
+    state = DaemonRunDir.read_state_from_disk(run_dir.path)
+
+    block = _return_observation_if_available(
+        run_dir, manifest, status="follow-up done", state=state,
+    )
+
+    assert block is not None
+    assert block["generation"] == generation
+
+
+@pytest.mark.parametrize(
+    "block",
+    [
+        {"schema_version": "lingtai.return-observation-notice.v0", "state": "available", "generation": "g0000", "receipt_digest": "sha256:abc", "authority": "advisory_only", "raw_result_unchanged": True},
+        {"schema_version": "lingtai.return-observation-notice.v0", "state": "available", "generation": "../x", "receipt_digest": "sha256:" + "a" * 64, "authority": "advisory_only", "raw_result_unchanged": True},
+        {"schema_version": "lingtai.return-observation-notice.v0", "state": "available", "generation": "g0000", "receipt_digest": "sha256:" + "a" * 64, "authority": "advisory_only", "raw_result_unchanged": False},
+    ],
+)
+def test_supervisor_rejects_malformed_observation_blocks(tmp_path, monkeypatch, block):
+    run_dir = _make_run_dir(tmp_path)
+    manifest = _manifest(run_dir, enabled=True)
+    run_dir.mark_done("raw")
+
+    import lingtai.tools.daemon.return_observer_hook as hook
+
+    monkeypatch.setattr(hook, "observe_return_bounded", lambda *a, **k: block)
+    assert _return_observation_if_available(
+        run_dir, manifest, status="done", state=DaemonRunDir.read_state_from_disk(run_dir.path),
+    ) is None
+
+
+@pytest.mark.parametrize("terminal", ["failed", "cancelled", "timeout"])
+def test_observer_preserves_non_done_terminal_states(tmp_path, terminal):
+    run_dir = _make_run_dir(tmp_path)
+    manifest = _manifest(run_dir, enabled=True)
+    if terminal == "failed":
+        run_dir.mark_failed(RuntimeError("boom"))
+    elif terminal == "cancelled":
+        run_dir.mark_cancelled()
+    else:
+        run_dir.mark_timeout()
+
+    _publish_terminal_notification_if_needed(run_dir, manifest)
+
+    state = DaemonRunDir.read_state_from_disk(run_dir.path)
+    assert state["state"] == terminal
+    events = _matching_events(run_dir)
+    assert len(events) == 1
+    assert events[0]["return_observation"]["generation"] == "g0000"
+
+
+def test_missing_finish_physical_result_is_not_upgraded(tmp_path):
+    run_dir = _make_run_dir(tmp_path)
+    _manifest(run_dir, enabled=True)
+    run_dir.result_path.write_text("physical failure evidence", encoding="utf-8")
+    run_dir.mark_failed(RuntimeError("missing finish"))
+
+    result = helper_observe(run_dir.path, run_dir.path / "supervisor_manifest.json", "g0000", "failed")
+    portable = json.loads(
+        (run_dir.path / ".supervisor" / "return-observation" / "g0000.portable.json").read_text(encoding="utf-8")
+    )
+
+    assert result["state"] == "available"
+    assert portable["terminal_state"] == "failed"
+    assert DaemonRunDir.read_state_from_disk(run_dir.path)["state"] == "failed"
+
+
+def test_artifact_manifest_missing_and_truncated_are_explicit(tmp_path, capsys):
+    run_dir = _make_run_dir(tmp_path)
+    _manifest(run_dir, enabled=True)
+    run_dir.mark_done("raw")
+    run_dir.manifest_path.unlink()
+    first = helper_observe(run_dir.path, run_dir.path / "supervisor_manifest.json", "g0000", "done")
+    assert first["state"] == "available"
+    portable = json.loads(
+        (run_dir.path / ".supervisor" / "return-observation" / "g0000.portable.json").read_text(encoding="utf-8")
+    )
+    assert portable["declared_artifacts"]["status"] == "missing_or_unavailable"
+
+    run_dir2 = _make_run_dir(tmp_path, run_id="em-test-truncated")
+    _manifest(run_dir2, enabled=True)
+    run_dir2.mark_done("raw")
+    run_dir2.manifest_path.write_text(
+        json.dumps({"artifacts": [], "truncated": True}),
+        encoding="utf-8",
+    )
+    helper_main([
+        "--run-dir", str(run_dir2.path),
+        "--manifest-path", str(run_dir2.path / "supervisor_manifest.json"),
+        "--generation", "g0000",
+        "--terminal-state", "done",
+    ])
+    assert json.loads(capsys.readouterr().out) == {
+        "reason_code": "artifact_manifest_truncated",
+        "state": "unavailable",
+    }
+
+
+@pytest.mark.parametrize(
+    "fault",
+    ["spawn_failure", "nonzero_exit", "timeout", "invalid_json", "oversized_stdout"],
+)
+def test_hook_subprocess_faults_fail_open(tmp_path, monkeypatch, fault):
+    import lingtai.tools.daemon.return_observer_hook as hook
+
+    run_dir = _make_run_dir(tmp_path)
+    manifest = _manifest(run_dir, enabled=True)
+    run_dir.mark_done("raw")
+    state = DaemonRunDir.read_state_from_disk(run_dir.path)
+
+    if fault == "spawn_failure":
+        monkeypatch.setattr(hook.subprocess, "run", lambda *a, **k: (_ for _ in ()).throw(OSError("spawn failed")))
+    elif fault == "timeout":
+        monkeypatch.setattr(
+            hook.subprocess,
+            "run",
+            lambda *a, **k: (_ for _ in ()).throw(subprocess.TimeoutExpired("helper", 1.5)),
+        )
+    elif fault == "nonzero_exit":
+        monkeypatch.setattr(hook.subprocess, "run", lambda *a, **k: subprocess.CompletedProcess(a[0], 2, "{}", ""))
+    elif fault == "invalid_json":
+        monkeypatch.setattr(hook.subprocess, "run", lambda *a, **k: subprocess.CompletedProcess(a[0], 0, "{", ""))
+    else:
+        monkeypatch.setattr(hook.subprocess, "run", lambda *a, **k: subprocess.CompletedProcess(a[0], 0, "x" * 9000, ""))
+
+    assert hook.observe_return_bounded(run_dir, manifest, status="done", state=state) is None
+    assert run_dir.result_path.read_text(encoding="utf-8") == "raw"
+    assert DaemonRunDir.read_state_from_disk(run_dir.path)["state"] == "done"
+
+
+@pytest.mark.parametrize(
+    "reason",
+    ["permission_denied", "enospc", "atomic_replace_failure", "mutation_detected", "file_count_cap", "total_byte_cap"],
+)
+def test_helper_injected_unavailable_reasons_do_not_mutate_raw_result(tmp_path, monkeypatch, reason):
+    import lingtai.tools.daemon.return_observer_helper as helper
+
+    run_dir = _make_run_dir(tmp_path)
+    _manifest(run_dir, enabled=True)
+    run_dir.mark_done("raw")
+    if reason in {"permission_denied", "enospc", "atomic_replace_failure"}:
+        monkeypatch.setattr(helper, "_atomic_json_at", lambda *a, **k: (_ for _ in ()).throw(helper.Unavailable(reason)))
+    elif reason == "mutation_detected":
+        monkeypatch.setattr(helper, "_hash_file", lambda *a, **k: (_ for _ in ()).throw(helper.Unavailable(reason)))
+    elif reason == "file_count_cap":
+        monkeypatch.setattr(helper, "MAX_FILES", 0)
+    else:
+        monkeypatch.setattr(helper, "MAX_TOTAL_BYTES", 1)
+
+    with pytest.raises(helper.Unavailable) as exc:
+        helper_observe(run_dir.path, run_dir.path / "supervisor_manifest.json", "g0000", "done")
+
+    assert exc.value.reason_code == reason
+    assert run_dir.result_path.read_text(encoding="utf-8") == "raw"
+    assert DaemonRunDir.read_state_from_disk(run_dir.path)["state"] == "done"
+
+
+def test_stale_tmp_file_does_not_block_observation(tmp_path):
+    run_dir = _make_run_dir(tmp_path)
+    _manifest(run_dir, enabled=True)
+    run_dir.mark_done("raw")
+    side = run_dir.path / ".supervisor" / "return-observation"
+    side.mkdir(parents=True)
+    (side / ".tmp-g0000.host.json-stale").write_text("stale", encoding="utf-8")
+
+    result = helper_observe(run_dir.path, run_dir.path / "supervisor_manifest.json", "g0000", "done")
+
+    assert result["state"] == "available"
+    assert (side / ".tmp-g0000.host.json-stale").read_text(encoding="utf-8") == "stale"
+
+
+def test_hook_keyboard_interrupt_and_generation_mismatch_fail_open(tmp_path, monkeypatch):
+    import lingtai.tools.daemon.return_observer_hook as hook
+
+    run_dir = _make_run_dir(tmp_path)
+    manifest = _manifest(run_dir, enabled=True)
+    run_dir.mark_done("raw")
+    state = DaemonRunDir.read_state_from_disk(run_dir.path)
+
+    monkeypatch.setattr(hook.subprocess, "run", lambda *a, **k: (_ for _ in ()).throw(KeyboardInterrupt()))
+    assert hook.observe_return_bounded(run_dir, manifest, status="done", state=state) is None
+
+    generation = "g1-1234567890abcdef"
+    state["followup_generation"] = generation
+    state["followup_status"] = "done"
+    stdout = json.dumps({
+        "state": "available",
+        "generation": "g0000",
+        "receipt_digest": "sha256:" + "a" * 64,
+    })
+    monkeypatch.setattr(hook.subprocess, "run", lambda *a, **k: subprocess.CompletedProcess(a[0], 0, stdout, ""))
+    assert hook.observe_return_bounded(run_dir, manifest, status="follow-up done", state=state) is None
+
+
+def test_dispatch_writers_fail_open_on_baseexception(tmp_path, monkeypatch):
+    import lingtai.tools.daemon.return_observer_hook as hook
+
+    run_dir = _make_run_dir(tmp_path)
+    manifest = _manifest(run_dir, enabled=True)
+    monkeypatch.setattr(hook, "_write_sidecar_json", lambda *a, **k: (_ for _ in ()).throw(KeyboardInterrupt()))
+
+    assert write_dispatch_intent_receipt(run_dir, manifest) is None
+    assert write_dispatch_result_receipt(run_dir, {"status": "dispatched", "count": 1, "ids": [run_dir.run_id]}) is None
+
+
+def test_existing_real_sidecar_dirs_are_chmodded_and_receipts_are_0600(tmp_path):
+    run_dir = _make_run_dir(tmp_path)
+    _manifest(run_dir, enabled=True)
+    run_dir.mark_done("raw")
+    side = run_dir.path / ".supervisor" / "return-observation"
+    side.mkdir(parents=True)
+    (run_dir.path / ".supervisor").chmod(0o777)
+    side.chmod(0o777)
+
+    helper_observe(run_dir.path, run_dir.path / "supervisor_manifest.json", "g0000", "done")
+
+    assert ((run_dir.path / ".supervisor").stat().st_mode & 0o777) == 0o700
+    assert (side.stat().st_mode & 0o777) == 0o700
+    for name in ("g0000.host.json", "g0000.portable.json", "g0000.status.json"):
+        assert ((side / name).stat().st_mode & 0o777) == 0o600
+
+
+def test_declared_artifact_bytes_are_hashed_and_same_generation_changes_conflict(tmp_path, capsys):
+    run_dir = _make_run_dir(tmp_path)
+    _manifest(run_dir, enabled=True)
+    declared = run_dir.path / "declared.bin"
+    declared.write_bytes(b"AAAA")
+    run_dir.mark_done("raw")
+    run_dir.manifest_path.write_text(
+        json.dumps({"artifacts": [{"path": "declared.bin", "size": 4, "role": "declared"}], "truncated": False}),
+        encoding="utf-8",
+    )
+
+    first = helper_observe(run_dir.path, run_dir.path / "supervisor_manifest.json", "g0000", "done")
+    assert first["state"] == "available"
+    portable = json.loads(
+        (run_dir.path / ".supervisor" / "return-observation" / "g0000.portable.json").read_text(encoding="utf-8")
+    )
+    declared_row = next(row for row in portable["observed_files"] if row["relative_ref"] == "declared.bin")
+    assert declared_row["sha256"] == "sha256:" + hashlib.sha256(b"AAAA").hexdigest()
+
+    declared.write_bytes(b"BBBB")
+    helper_main([
+        "--run-dir", str(run_dir.path),
+        "--manifest-path", str(run_dir.path / "supervisor_manifest.json"),
+        "--generation", "g0000",
+        "--terminal-state", "done",
+    ])
+    assert json.loads(capsys.readouterr().out) == {"reason_code": "receipt_conflict", "state": "unavailable"}
+
+
+@pytest.mark.parametrize(
+    ("artifact_path", "reason"),
+    [
+        ("missing.bin", "artifact_missing"),
+        ("../escape.bin", "path_escape"),
+    ],
+)
+def test_bad_declared_artifacts_fail_certificate_only(tmp_path, capsys, artifact_path, reason):
+    run_dir = _make_run_dir(tmp_path)
+    _manifest(run_dir, enabled=True)
+    run_dir.mark_done("raw")
+    run_dir.manifest_path.write_text(
+        json.dumps({"artifacts": [{"path": artifact_path, "size": 4}], "truncated": False}),
+        encoding="utf-8",
+    )
+
+    helper_main([
+        "--run-dir", str(run_dir.path),
+        "--manifest-path", str(run_dir.path / "supervisor_manifest.json"),
+        "--generation", "g0000",
+        "--terminal-state", "done",
+    ])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["state"] == "unavailable"
+    assert payload["reason_code"] == reason
+    assert run_dir.result_path.read_text(encoding="utf-8") == "raw"
+
+
+def test_symlinked_declared_artifact_fails_certificate_only(tmp_path, capsys):
+    run_dir = _make_run_dir(tmp_path)
+    _manifest(run_dir, enabled=True)
+    outside = tmp_path / "outside.bin"
+    outside.write_bytes(b"AAAA")
+    (run_dir.path / "declared.bin").symlink_to(outside)
+    run_dir.mark_done("raw")
+    run_dir.manifest_path.write_text(
+        json.dumps({"artifacts": [{"path": "declared.bin", "size": 4}], "truncated": False}),
+        encoding="utf-8",
+    )
+
+    helper_main([
+        "--run-dir", str(run_dir.path),
+        "--manifest-path", str(run_dir.path / "supervisor_manifest.json"),
+        "--generation", "g0000",
+        "--terminal-state", "done",
+    ])
+
+    assert json.loads(capsys.readouterr().out) == {"reason_code": "path_escape", "state": "unavailable"}
+    assert run_dir.result_path.read_text(encoding="utf-8") == "raw"
+
+
+def test_followup_supersedes_initial_generation_and_requires_predecessor(tmp_path, capsys):
+    run_dir = _make_run_dir(tmp_path)
+    _manifest(run_dir, enabled=True)
+    run_dir.mark_done("initial")
+    initial = helper_observe(run_dir.path, run_dir.path / "supervisor_manifest.json", "g0000", "done")
+    generation = "g1-1234567890abcdef"
+    run_dir.record_followup(generation, status="done", output="follow")
+    follow = helper_observe(run_dir.path, run_dir.path / "supervisor_manifest.json", generation, "follow-up done")
+    assert follow["state"] == "available"
+    portable = json.loads(
+        (run_dir.path / ".supervisor" / "return-observation" / f"{generation}.portable.json").read_text(encoding="utf-8")
+    )
+    assert portable["supersedes"]["generation"] == "g0000"
+    assert portable["supersedes"]["portable_digest"] == initial["receipt_digest"]
+
+    run_dir2 = _make_run_dir(tmp_path, run_id="em-follow-missing")
+    _manifest(run_dir2, enabled=True)
+    run_dir2.mark_done("initial")
+    run_dir2.record_followup(generation, status="done", output="follow")
+    helper_main([
+        "--run-dir", str(run_dir2.path),
+        "--manifest-path", str(run_dir2.path / "supervisor_manifest.json"),
+        "--generation", generation,
+        "--terminal-state", "follow-up done",
+    ])
+    assert json.loads(capsys.readouterr().out) == {"reason_code": "missing_predecessor", "state": "unavailable"}
+
+
+def test_atomic_json_loops_over_short_writes(tmp_path, monkeypatch):
+    import lingtai.tools.daemon.return_observer_helper as helper
+
+    run_dir = _make_run_dir(tmp_path)
+    _manifest(run_dir, enabled=True)
+    run_dir.mark_done("raw")
+    real_write = helper.os.write
+
+    def short_write(fd, data):
+        return real_write(fd, data[: max(1, len(data) // 3)])
+
+    monkeypatch.setattr(helper.os, "write", short_write)
+    result = helper_observe(run_dir.path, run_dir.path / "supervisor_manifest.json", "g0000", "done")
+    assert result["state"] == "available"
+    json.loads((run_dir.path / ".supervisor" / "return-observation" / "g0000.portable.json").read_text(encoding="utf-8"))
+
+
+def test_atomic_json_zero_write_fails_certificate(tmp_path, monkeypatch, capsys):
+    import lingtai.tools.daemon.return_observer_helper as helper
+
+    run_dir = _make_run_dir(tmp_path)
+    _manifest(run_dir, enabled=True)
+    run_dir.mark_done("raw")
+    monkeypatch.setattr(helper.os, "write", lambda *a, **k: 0)
+
+    helper_main([
+        "--run-dir", str(run_dir.path),
+        "--manifest-path", str(run_dir.path / "supervisor_manifest.json"),
+        "--generation", "g0000",
+        "--terminal-state", "done",
+    ])
+
+    assert json.loads(capsys.readouterr().out) == {"reason_code": "short_write", "state": "unavailable"}
+
+
+def test_per_file_cap_breach_fails_certificate_only(tmp_path, capsys):
+    run_dir = _make_run_dir(tmp_path)
+    _manifest(run_dir, enabled=True)
+    run_dir.mark_done("raw")
+    too_large = run_dir.path / "too-large.bin"
+    too_large.write_bytes(b"x" * (256 * 1024 + 1))
+    run_dir.manifest_path.write_text(
+        json.dumps({"artifacts": [{"path": "too-large.bin", "size": too_large.stat().st_size}], "truncated": False}),
+        encoding="utf-8",
+    )
+
+    helper_main([
+        "--run-dir", str(run_dir.path),
+        "--manifest-path", str(run_dir.path / "supervisor_manifest.json"),
+        "--generation", "g0000",
+        "--terminal-state", "done",
+    ])
+
+    assert json.loads(capsys.readouterr().out) == {"reason_code": "per_file_cap", "state": "unavailable"}
+    assert run_dir.result_path.read_text(encoding="utf-8") == "raw"
+
+
+def test_dispatch_intent_manifest_mismatch_is_explicit_unavailable(tmp_path, capsys):
+    run_dir = _make_run_dir(tmp_path)
+    manifest = _manifest(run_dir, enabled=True)
+    write_dispatch_intent_receipt(run_dir, manifest)
+    mutated = dict(manifest)
+    mutated["task"] = "changed by parent after intent"
+    (run_dir.path / "supervisor_manifest.json").write_text(json.dumps(mutated), encoding="utf-8")
+    run_dir.mark_done("raw")
+
+    helper_main([
+        "--run-dir", str(run_dir.path),
+        "--manifest-path", str(run_dir.path / "supervisor_manifest.json"),
+        "--generation", "g0000",
+        "--terminal-state", "done",
+    ])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["state"] == "unavailable"
+    assert payload["reason_code"] == "dispatch_binding_mismatch"
+    assert payload["details"]["mismatches"]
+
+
+def test_manifest_path_must_be_confined_supervisor_manifest(tmp_path, capsys):
+    run_dir = _make_run_dir(tmp_path)
+    _manifest(run_dir, enabled=True)
+    run_dir.mark_done("raw")
+    outside = tmp_path / "supervisor_manifest.json"
+    outside.write_text("{}", encoding="utf-8")
+
+    helper_main([
+        "--run-dir", str(run_dir.path),
+        "--manifest-path", str(outside),
+        "--generation", "g0000",
+        "--terminal-state", "done",
+    ])
+
+    assert json.loads(capsys.readouterr().out) == {"reason_code": "manifest_path_mismatch", "state": "unavailable"}
+
+
+def test_parse_uses_same_stable_bytes_as_hashed_snapshot(tmp_path, monkeypatch, capsys):
+    import lingtai.tools.daemon.return_observer_helper as helper
+
+    run_dir = _make_run_dir(tmp_path)
+    _manifest(run_dir, enabled=True)
+    run_dir.mark_done("raw")
+    real_hash = helper._hash_file_with_bytes
+    flipped = {"done": False}
+
+    def hash_then_flip(root_fd, rel):
+        row, raw = real_hash(root_fd, rel)
+        if rel == "daemon.json" and not flipped["done"]:
+            flipped["done"] = True
+            state = json.loads((run_dir.path / "daemon.json").read_text(encoding="utf-8"))
+            state["state"] = "failed"
+            (run_dir.path / "daemon.json").write_text(json.dumps(state), encoding="utf-8")
+        return row, raw
+
+    monkeypatch.setattr(helper, "_hash_file_with_bytes", hash_then_flip)
+    helper_main([
+        "--run-dir", str(run_dir.path),
+        "--manifest-path", str(run_dir.path / "supervisor_manifest.json"),
+        "--generation", "g0000",
+        "--terminal-state", "failed",
+    ])
+
+    assert json.loads(capsys.readouterr().out) == {"reason_code": "terminal_state_mismatch", "state": "unavailable"}
+
+
+def test_followup_rejects_tampered_predecessor_portable_bytes(tmp_path, capsys):
+    run_dir = _make_run_dir(tmp_path)
+    _manifest(run_dir, enabled=True)
+    run_dir.mark_done("initial")
+    helper_observe(run_dir.path, run_dir.path / "supervisor_manifest.json", "g0000", "done")
+    side = run_dir.path / ".supervisor" / "return-observation"
+    (side / "g0000.portable.json").write_text("{}", encoding="utf-8")
+    generation = "g1-1234567890abcdef"
+    run_dir.record_followup(generation, status="done", output="follow")
+
+    helper_main([
+        "--run-dir", str(run_dir.path),
+        "--manifest-path", str(run_dir.path / "supervisor_manifest.json"),
+        "--generation", generation,
+        "--terminal-state", "follow-up done",
+    ])
+
+    assert json.loads(capsys.readouterr().out) == {"reason_code": "predecessor_tamper", "state": "unavailable"}
+
+
+def test_sidecar_read_loops_over_short_reads(tmp_path, monkeypatch):
+    import lingtai.tools.daemon.return_observer_helper as helper
+
+    side = tmp_path / "side"
+    side.mkdir()
+    target = side / "receipt.json"
+    target.write_bytes(b"0123456789abcde")
+    side_fd = os.open(side, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    real_read = helper.os.read
+
+    def one_byte_read(fd, count):
+        return real_read(fd, min(count, 1))
+
+    try:
+        monkeypatch.setattr(helper.os, "read", one_byte_read)
+        assert helper._read_file_at(side_fd, "receipt.json") == b"0123456789abcde"
+    finally:
+        os.close(side_fd)
+
+
+def test_sidecar_read_detects_same_size_mutation(tmp_path, monkeypatch):
+    import lingtai.tools.daemon.return_observer_helper as helper
+
+    side = tmp_path / "side"
+    side.mkdir()
+    target = side / "receipt.json"
+    target.write_bytes(b"AAAA")
+    side_fd = os.open(side, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    real_read = helper.os.read
+    changed = {"done": False}
+
+    def mutating_read(fd, count):
+        data = real_read(fd, count)
+        if data and not changed["done"]:
+            changed["done"] = True
+            target.write_bytes(b"BBBB")
+        return data
+
+    try:
+        monkeypatch.setattr(helper.os, "read", mutating_read)
+        with pytest.raises(helper.Unavailable) as exc:
+            helper._read_file_at(side_fd, "receipt.json")
+        assert exc.value.reason_code == "mutation_detected"
+    finally:
+        os.close(side_fd)
+
+
+def test_conflicting_concurrent_final_writers_do_not_overwrite(tmp_path, monkeypatch):
+    import lingtai.tools.daemon.return_observer_helper as helper
+
+    side = tmp_path / "side"
+    side.mkdir()
+    side_fd = os.open(side, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    real_link = helper.os.link
+    barrier = threading.Barrier(2)
+    results: list[str] = []
+
+    def racing_link(*args, **kwargs):
+        barrier.wait(timeout=5)
+        return real_link(*args, **kwargs)
+
+    def writer(payload):
+        try:
+            helper._ensure_final_at(side_fd, "receipt.json", payload)
+            results.append("available")
+        except helper.Unavailable as exc:
+            results.append(exc.reason_code)
+
+    try:
+        monkeypatch.setattr(helper.os, "link", racing_link)
+        threads = [
+            threading.Thread(target=writer, args=({"writer": "a"},)),
+            threading.Thread(target=writer, args=({"writer": "b"},)),
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=5)
+        assert sorted(results) == ["available", "receipt_conflict"]
+        final = json.loads((side / "receipt.json").read_text(encoding="utf-8"))
+        assert final in [{"writer": "a"}, {"writer": "b"}]
+    finally:
+        os.close(side_fd)
+
+
+def _assert_fail_open_notification_invariants(run_dir: DaemonRunDir, expected_result: str) -> None:
+    events = _matching_events(run_dir)
+    assert len(events) == 1
+    assert "return_observation" not in events[0]
+    assert run_dir.result_path.read_text(encoding="utf-8") == expected_result
+    assert DaemonRunDir.read_state_from_disk(run_dir.path)["state"] == "done"
+
+
+@pytest.mark.parametrize(
+    "fault",
+    ["permission_denied", "enospc", "finalize_link_failure"],
+)
+def test_syscall_faults_fail_open_through_terminal_notification(tmp_path, monkeypatch, fault):
+    import lingtai.tools.daemon.return_observer_helper as helper
+    import lingtai.tools.daemon.return_observer_hook as hook
+
+    run_dir = _make_run_dir(tmp_path)
+    manifest = _manifest(run_dir, enabled=True)
+    run_dir.mark_done(f"raw {fault}")
+
+    if fault == "permission_denied":
+        real_open = helper.os.open
+
+        def denied_open(path, flags, *args, **kwargs):
+            if isinstance(path, str) and path.startswith(".tmp-"):
+                raise PermissionError(errno.EACCES, "permission denied", path)
+            return real_open(path, flags, *args, **kwargs)
+
+        monkeypatch.setattr(helper.os, "open", denied_open)
+        expected = "unexpected_exception"
+    elif fault == "enospc":
+        real_write = helper.os.write
+        injected = {"done": False}
+
+        def enospc_write(fd, data):
+            if not injected["done"]:
+                injected["done"] = True
+                raise OSError(errno.ENOSPC, "no space left on device")
+            return real_write(fd, data)
+
+        monkeypatch.setattr(helper.os, "write", enospc_write)
+        expected = "unexpected_exception"
+    else:
+        def failing_link(*args, **kwargs):
+            raise OSError(errno.EIO, "link failed")
+
+        monkeypatch.setattr(helper.os, "link", failing_link)
+        expected = "unexpected_exception"
+
+    def in_process_observer(*args, **kwargs):
+        try:
+            helper_observe(run_dir.path, run_dir.path / "supervisor_manifest.json", "g0000", "done")
+        except helper.Unavailable as exc:
+            assert exc.reason_code == expected
+        except OSError:
+            assert expected == "unexpected_exception"
+        return None
+
+    monkeypatch.setattr(hook, "observe_return_bounded", in_process_observer)
+    _publish_terminal_notification_if_needed(run_dir, manifest)
+    _assert_fail_open_notification_invariants(run_dir, f"raw {fault}")
+
+
+def test_killed_helper_fail_open_through_terminal_notification(tmp_path, monkeypatch):
+    import lingtai.tools.daemon.return_observer_hook as hook
+
+    run_dir = _make_run_dir(tmp_path)
+    manifest = _manifest(run_dir, enabled=True)
+    run_dir.mark_done("raw killed")
+    monkeypatch.setattr(
+        hook.subprocess,
+        "run",
+        lambda *a, **k: subprocess.CompletedProcess(a[0], -9, "", ""),
+    )
+
+    _publish_terminal_notification_if_needed(run_dir, manifest)
+
+    _assert_fail_open_notification_invariants(run_dir, "raw killed")
+
+
+def test_safe_notification_block_construction_failure_keeps_ordinary_notification(tmp_path, monkeypatch):
+    import lingtai.tools.daemon.return_observer_hook as hook
+
+    run_dir = _make_run_dir(tmp_path)
+    manifest = _manifest(run_dir, enabled=True)
+    run_dir.mark_done("raw malformed block")
+    monkeypatch.setattr(
+        hook,
+        "observe_return_bounded",
+        lambda *a, **k: {
+            "schema_version": "lingtai.return-observation-notice.v0",
+            "state": "available",
+            "generation": "g0000",
+            "receipt_digest": "sha256:" + "z" * 64,
+            "authority": "advisory_only",
+            "raw_result_unchanged": True,
+        },
+    )
+
+    _publish_terminal_notification_if_needed(run_dir, manifest)
+
+    _assert_fail_open_notification_invariants(run_dir, "raw malformed block")


### PR DESCRIPTION
## Summary

Add an opt-in **Supervisor Return Observer** at the daemon terminal return seam.

When enabled for a newly dispatched daemon, the supervisor invokes a short isolated helper after terminal state/notification ownership is claimed and before terminal publication. The helper validates the exact dispatch/return generation, freezes source-bound receipt files, and returns a bounded advisory block that may be attached to the terminal notification.

The raw daemon result and ordinary terminal notification remain authoritative.

## What changed

- Snapshot `return_observer_enabled` into the immutable supervisor manifest at dispatch time.
- Add a thin fail-open supervisor hook and isolated no-network helper subprocess.
- Write bounded `host`, `portable`, and `status` receipts under the daemon supervisor directory with restrictive modes.
- Validate generation identity, result/artifact bytes, predecessor linkage, read completeness, supersession, path containment, and concurrent same-key publication.
- Keep bounded generations available when declared advisory artifacts exceed the per-file or total receipt-byte budget by recording explicit metadata-only omission instead of reading or hashing omitted content.
- Add only a privacy-safe additive `return_observation` notification block when a valid receipt is available.
- Document the seam and invariants in the daemon anatomy.
- Add focused fault-injection, integrity, concurrency, recovery, privacy, notification, terminal-state, and oversized-artifact regressions.

## Safety and compatibility

- **Default off.** Only `1`, `true`, `yes`, or `on` enable the observer.
- **Fail open to the raw result.** Import, spawn, timeout, crash, malformed output, receipt, or validation failures never suppress normal daemon delivery.
- **Raw first / additive only.** No daemon result bytes, completion state, `daemon.check` behavior, or public tool schema are replaced.
- **Advisory, not semantic judgment.** A valid receipt proves binding/integrity properties; it does not prove that the daemon's conclusion is correct.
- **Bounded omission is explicit.** An oversized or over-total-budget declared artifact is represented by relative reference, reason, observed size and cap (plus any declared-versus-observed size difference); it is absent from content-observed files and receives no content-digest claim.
- **No scheduler/resource claim.** This does not throttle or accelerate high-concurrency daemon execution.
- **Per-dispatch snapshot.** Existing daemon manifests are unchanged; the flag applies to new dispatches.

Operational rollback for an ordinary refresh should set `LINGTAI_DAEMON_RETURN_OBSERVER_ENABLED=0` explicitly. Deleting the key is not a reliable rollback when a parent process already inherited a truthy value. A cold launcher must likewise avoid exporting the flag as true when the observer should be off.

## Sanitized real-use reliability evidence

Two genuine same-batch concurrent daemon returns invoked the helper successfully (exit 0, empty stderr), but their declared transcript and event artifacts were each above the unchanged 262,144-byte per-file observation cap. Raw terminal delivery remained correct while the additive `g0000` generation was absent.

The correction preserves the cap. For oversized or over-total-budget advisory artifacts it records metadata-only omission, preserves declared-versus-observed size differences, does not read or claim a content digest for omitted files, and leaves raw results, terminal state, and exactly-one logical terminal notification unchanged.

Final local gates passed: **71 focused observer tests + 1 parent metadata-mismatch probe + 12 adjacent terminal tests**. Three copied real fixtures produced nine portable receipts in diagnostic/direct/wrapper paths, and `g0000` was restored for all three. This is bounded real-use reliability evidence for the observer seam, not an optimization, token-benefit, general quality, semantic-truth, security, authorization, or production-fitness claim.

No private transcript/event content, local path, daemon identifier, internal message identifier, credential, receipt body, or hidden-file content is included here.

## Validation

- Focused observer regressions: **71 passed**.
- Parent oversized-metadata mismatch probe: **1 passed**.
- Adjacent terminal suites: **12 passed** (1 detached exactly-once publication + 5 daemon notification/receipt + 6 run-directory terminal tests).
- Copied real-fixture reproduction: **3 fixtures**, direct and wrapper observation available for each, **9 portable receipts**, and `g0000` restored for all three.
- Disposable copied canary: OFF / ON / ON-helper-failure, repeated twice: **6/6 passed** with one ordinary terminal notification per run and unchanged raw results.
- Changed Python files: `py_compile` passed.
- `git diff --check` passed.
- Architecture-document test: candidate and frozen base have the exact same pre-existing result (**3 passed, 1 failed** in the same graph-coverage test); this patch adds no architecture-test regression.
- Wider adjacent daemon run from the accepted migration: **286 passed, 14 failed**; the exact same 14 failures reproduced on the frozen base from existing optional-MCP/default-max environment conditions.

## Scope

Exactly seven files are changed in the PR: the supervisor manifest/runtime seam, daemon anatomy/export surface, two observer modules, and one focused test module. The oversized-artifact correction changes only the existing helper and focused test files. No runtime configuration, deployment, live-channel behavior, merge, or release is included in this PR.

Telegram: @wangrunyuansecbot | Nickname: 一心
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
