### PR TITLE
feat(telegram): surface inbound media absolute path + vision hint

### DIFF
--- a/src/lingtai/mcp_servers/telegram/SKILL.md
+++ b/src/lingtai/mcp_servers/telegram/SKILL.md
@@ -81,6 +81,21 @@ setup readiness checklist are **not** here — they belong to `mcp-manual`
 - Do not paste a local file path into message text as a substitute for
   attaching the file; attach it with `media={type, path}`.
 
+## INBOUND MEDIA: reading what the user sends you
+
+- When a user sends a photo or document, the message's `media` object includes
+  an absolute local `path` to the downloaded attachment (under the agent's
+  `telegram/<account>/inbox/<uuid>/attachments/` directory) plus
+  `type`, `filename`, and `size`.
+- Use the `vision` capability to read images: `vision(action='analyze',
+  image_path=<absolute path>)`. Do not try to infer image content from the
+  filename or size alone.
+- If `media.view_with_vision` is present, the attachment is an image-like
+  file and the manager explicitly suggests the vision route.
+- If `media.download_error` is present, the download failed; the metadata is
+  preserved without a path, so read the message text and ask the user to
+  resend if the attachment matters.
+
 ## PLACEHOLDER / LIVE-STATUS
 
 - For responses that take more than ~5s, send `action='send'` with

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -1764,9 +1764,17 @@ class TelegramManager:
             media = message["media"] or {}
             item["media"] = {
                 key: media[key]
-                for key in ("type", "filename", "size", "duration", "mime_type")
+                for key in ("type", "filename", "path", "size", "duration", "mime_type")
                 if key in media and media[key] is not None
             }
+            # Inbound photo/document attachments carry an absolute local path
+            # (from _download_media). Surface an explicit hint so the agent
+            # knows to open the image with the vision capability instead of
+            # treating it as an opaque filename.
+            media_path = item["media"].get("path")
+            media_type = item["media"].get("type")
+            if media_path and media_type in ("photo", "document", "image"):
+                item["media"]["view_with_vision"] = True
         reply_id_raw = message.get("reply_to_message_id")
         if reply_id_raw:
             item["reply_to_message_id"] = reply_id_raw

--- a/tests/test_telegram_structured_rendering.py
+++ b/tests/test_telegram_structured_rendering.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -291,6 +292,45 @@ def test_account_uses_send_rich_message_and_reply_parameters():
         "reply_markup": {"inline_keyboard": []},
         "reply_parameters": {"message_id": 456},
     }
+
+
+def test_structured_message_carries_media_path_and_vision_hint():
+    manager, _ = _manager(Path("/tmp/telegram-media-vision-test"))
+    item = manager._structured_message(
+        {
+            "id": "acct:chat:1",
+            "date": "2026-08-14T00:00:00Z",
+            "media": {
+                "type": "photo",
+                "filename": "shot.jpg",
+                "path": "/abs/path/telegram/bot/inbox/uuid/attachments/shot.jpg",
+                "size": 2048,
+            },
+        },
+        now=datetime(2026, 8, 14, 0, 0, 0, tzinfo=timezone.utc),
+    )
+    assert item["media"]["path"] == (
+        "/abs/path/telegram/bot/inbox/uuid/attachments/shot.jpg"
+    )
+    assert item["media"]["view_with_vision"] is True
+
+
+def test_structured_message_omits_path_when_media_has_none():
+    manager, _ = _manager(Path("/tmp/telegram-media-vision-test"))
+    item = manager._structured_message(
+        {
+            "id": "acct:chat:2",
+            "date": "2026-08-14T00:00:00Z",
+            "media": {
+                "type": "document",
+                "filename": "doc.pdf",
+                "download_error": "failed",
+            },
+        },
+        now=datetime(2026, 8, 14, 0, 0, 0, tzinfo=timezone.utc),
+    )
+    assert "path" not in item["media"]
+    assert "view_with_vision" not in item["media"]
 
 
 def test_account_edits_rich_message_without_text():


### PR DESCRIPTION
## What
When a human sends a photo/document, the downloaded attachment already exists at an absolute local path under `telegram/<account>/inbox/<uuid>/attachments/`, but the structured message in `_meta.agent_meta.notifications.persistent` only carried `type/filename/size` — the agent could not find the file to view it.

This PR surfaces the absolute `path` in the structured media object and adds an explicit `view_with_vision` flag so agents know to open images with the `vision` capability instead of guessing from the filename.

## Changes
- `manager.py` `_structured_message`: media projection now includes `path`; photo/document/image attachments with a path get `view_with_vision: true`
- `SKILL.md`: new INBOUND MEDIA section explaining the vision route
- Tests: 2 focused tests (path+flag present; path absent when download_error)

## Validation
- `tests/test_telegram_structured_rendering.py`: 16 passed
- Related telegram suites (inbound media download failure, lossless envelope, notification read state): 82 passed
- `git diff --check` clean