### PR TITLE
docs: require explicit bidirectional related_files for capability mentions in ANATOMY

### DIFF
--- a/ANATOMY.md
+++ b/ANATOMY.md
@@ -63,6 +63,8 @@ maintenance: |
   stale navigation in the same change that moves files, symbols, connections,
   composition, or state. Preserve the child template and its maintenance rule;
   validate the distributed graph before merge.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see ## Maintenance).
   Follow the root Anatomy/Contract pairing rule, report mismatches, and do not duplicate or auto-fix the rule here.
 ---
 # LingTai Distributed Code Navigation Convention
@@ -319,6 +321,15 @@ Maintenance is part of reading:
 - Keep parent/child and Anatomy/Contract pair or owner links reciprocal. Update
   the root convention, its validator, root development skill, README entry,
   and bundled anatomy router together when this system changes.
+- **Capability mentions require explicit related files.** Whenever any
+  repository document (README, guides, skills, release notes, blogs, or this
+  anatomy's own prose) names a capability, behavior, or feature, the owning
+  component anatomy MUST list in `related_files` the repo-relative code files
+  that implement it, and the link MUST be bidirectional: the anatomy entry
+  maps the mention to code, and the owning anatomy is reachable from that
+  mention's document via the navigation graph. A prose mention without a
+  `related_files` mapping is drift, not documentation; repair it in the same
+  change that introduces the mention.
 - Follow the root Anatomy/Contract pairing rule, report mismatches, and do not duplicate or auto-fix the rule here.
 
 ## Template
@@ -337,6 +348,8 @@ maintenance: |
   truth: update this anatomy in the same change that moves files, symbols,
   connections, composition, or state. Verify every changed citation and run the
   architecture-document validation before merge.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
   Follow the root Anatomy/Contract pairing rule, report mismatches, and do not duplicate or auto-fix the rule here.
 ---
 # <Component Name> Anatomy

--- a/crates/lingtai-search-sidecar/ANATOMY.md
+++ b/crates/lingtai-search-sidecar/ANATOMY.md
@@ -23,6 +23,8 @@ maintenance: |
   setup.py, or the resolver order. Keep the README's runtime-selection table and
   this map consistent, and run the architecture-document validation before merge.
   Follow the root Anatomy/Contract pairing rule, report mismatches, and do not duplicate or auto-fix the rule here.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # lingtai-search-sidecar (Rust)
 

--- a/reports/ANATOMY.md
+++ b/reports/ANATOMY.md
@@ -59,6 +59,8 @@ maintenance: |
   the tree. Keep the parent link to the root anatomy, and run the
   architecture-document validation before merge.
   Follow the root Anatomy/Contract pairing rule, report mismatches, and do not duplicate or auto-fix the rule here.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # reports/
 

--- a/src/lingtai/ANATOMY.md
+++ b/src/lingtai/ANATOMY.md
@@ -59,6 +59,8 @@ maintenance: |
   anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
   maintenance field. If you notice drift between this anatomy and the code,
   report it. See lingtai-dev-guide for details.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # lingtai
 

--- a/src/lingtai/adapters/posix/ANATOMY.md
+++ b/src/lingtai/adapters/posix/ANATOMY.md
@@ -44,6 +44,8 @@ maintenance: |
   connections, composition, or state. Verify every changed citation and run the
   architecture-document validation before merge.
   Follow the root Anatomy/Contract pairing rule, report mismatches, and do not duplicate or auto-fix the rule here.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # POSIX Adapter Anatomy
 

--- a/src/lingtai/adapters/windows/ANATOMY.md
+++ b/src/lingtai/adapters/windows/ANATOMY.md
@@ -38,6 +38,8 @@ maintenance: |
   connections, composition, or state. Verify every changed citation and run the
   architecture-document validation before merge.
   Follow the root Anatomy/Contract pairing rule, report mismatches, and do not duplicate or auto-fix the rule here.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # Windows Adapter Anatomy
 

--- a/src/lingtai/auth/ANATOMY.md
+++ b/src/lingtai/auth/ANATOMY.md
@@ -14,6 +14,8 @@ maintenance: |
   anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
   maintenance field. If you notice drift between this anatomy and the code,
   report it. See lingtai-dev-guide for details.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # src/lingtai/auth/
 

--- a/src/lingtai/intrinsic_skills/ANATOMY.md
+++ b/src/lingtai/intrinsic_skills/ANATOMY.md
@@ -52,6 +52,8 @@ maintenance: |
   src/lingtai/ANATOMY.md bidirectional and run the architecture-document
   validation before merge.
   Follow the root Anatomy/Contract pairing rule, report mismatches, and do not duplicate or auto-fix the rule here.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # src/lingtai/intrinsic_skills/
 

--- a/src/lingtai/intrinsic_skills/lingtai-kernel-anatomy/SKILL.md
+++ b/src/lingtai/intrinsic_skills/lingtai-kernel-anatomy/SKILL.md
@@ -15,7 +15,7 @@ related_files:
 - src/lingtai/intrinsic_skills/lingtai-kernel-anatomy/scripts/bench_agent_session_rebuild.py
 - src/lingtai/intrinsic_skills/lingtai-kernel-anatomy/reference/mcp-protocol.md
 maintenance: |
-  Tracks the ANATOMY.md/CONTRACT.md convention it routes into; update when the root anatomy-of-anatomy or the pairing/link rules it summarizes change.
+  Tracks the ANATOMY.md/CONTRACT.md convention it routes into; update when the root anatomy-of-anatomy or the pairing/link rules it summarizes change. Capability mentions in any repository document require explicit bidirectional related_files mapping to the implementing code (root ANATOMY.md ## Maintenance); update this router when that rule or its summary changes.
 ---
 
 # LingTai Kernel Anatomy — Navigation Router
@@ -56,8 +56,11 @@ Who repairs drift depends on which agent you are:
   silently fix.
 
 Root `ANATOMY.md` → "## Maintenance" owns the repair rules for code-vs-anatomy
-and code-vs-contract, and the requirement to verify every touched citation. Run
-the repository's architecture-document validator and the drift checker below.
+and code-vs-contract, and the requirement to verify every touched citation. It
+also requires that any capability mention in any repository document be mapped
+to implementing code via explicit bidirectional `related_files` entries in the
+owning anatomy — a prose mention without a mapping is drift, not documentation.
+Run the repository's architecture-document validator and the drift checker below.
 
 ## Drift checker
 

--- a/src/lingtai/kernel/ANATOMY.md
+++ b/src/lingtai/kernel/ANATOMY.md
@@ -90,6 +90,8 @@ maintenance: |
   anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
   maintenance field. If you notice drift between this anatomy and the code,
   report it. See lingtai-dev-guide for details.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # lingtai.kernel
 

--- a/src/lingtai/kernel/agent_presence/ANATOMY.md
+++ b/src/lingtai/kernel/agent_presence/ANATOMY.md
@@ -21,6 +21,8 @@ maintenance: |
   connections, composition, or state. Verify every changed citation and run the
   architecture-document validation before merge.
   Follow the root Anatomy/Contract pairing rule, report mismatches, and do not duplicate or auto-fix the rule here.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # Agent Presence Store Anatomy
 

--- a/src/lingtai/kernel/agent_readme/ANATOMY.md
+++ b/src/lingtai/kernel/agent_readme/ANATOMY.md
@@ -11,6 +11,8 @@ maintenance: |
   the idempotent writer and pure renderer, and the behavior-test loop. When
   CONTRACT or BEHAVIORS change, update this anatomy together and revalidate
   the architecture-document graph before merge.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # agent_readme ANATOMY
 

--- a/src/lingtai/kernel/base_agent/ANATOMY.md
+++ b/src/lingtai/kernel/base_agent/ANATOMY.md
@@ -31,6 +31,8 @@ maintenance: |
   anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
   maintenance field. If you notice drift between this anatomy and the code,
   report it. See lingtai-dev-guide for details.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # base_agent
 

--- a/src/lingtai/kernel/daemon_supervisor/ANATOMY.md
+++ b/src/lingtai/kernel/daemon_supervisor/ANATOMY.md
@@ -22,6 +22,8 @@ maintenance: |
   connections, composition, or state. Verify every changed citation and run the
   architecture-document validation before merge.
   Follow the root Anatomy/Contract pairing rule, report mismatches, and do not duplicate or auto-fix the rule here.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # Detached daemon supervisor
 

--- a/src/lingtai/kernel/event_journal/ANATOMY.md
+++ b/src/lingtai/kernel/event_journal/ANATOMY.md
@@ -20,6 +20,8 @@ maintenance: |
   connections, composition, or state. Verify every changed citation and run the
   architecture-document validation before merge.
   Follow the root Anatomy/Contract pairing rule, report mismatches, and do not duplicate or auto-fix the rule here.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # Structured Event Journal Anatomy
 

--- a/src/lingtai/kernel/i18n/ANATOMY.md
+++ b/src/lingtai/kernel/i18n/ANATOMY.md
@@ -11,6 +11,8 @@ maintenance: |
   anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
   maintenance field. If you notice drift between this anatomy and the code,
   report it. See lingtai-dev-guide for details.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # i18n
 

--- a/src/lingtai/kernel/lifecycle_clock/ANATOMY.md
+++ b/src/lingtai/kernel/lifecycle_clock/ANATOMY.md
@@ -18,6 +18,8 @@ maintenance: |
   connections, composition, or state. Verify every changed citation and run the
   architecture-document validation before merge.
   Follow the root Anatomy/Contract pairing rule, report mismatches, and do not duplicate or auto-fix the rule here.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # Lifecycle Clock Port Anatomy
 

--- a/src/lingtai/kernel/llm/ANATOMY.md
+++ b/src/lingtai/kernel/llm/ANATOMY.md
@@ -17,6 +17,8 @@ maintenance: |
   anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
   maintenance field. If you notice drift between this anatomy and the code,
   report it. See lingtai-dev-guide for details.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # llm
 

--- a/src/lingtai/kernel/mail_transport/ANATOMY.md
+++ b/src/lingtai/kernel/mail_transport/ANATOMY.md
@@ -16,6 +16,8 @@ maintenance: |
   connections, composition, or state. Verify every changed citation and run the
   architecture-document validation before merge.
   Follow the root Anatomy/Contract pairing rule, report mismatches, and do not duplicate or auto-fix the rule here.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # Mail Transport Port Anatomy
 

--- a/src/lingtai/kernel/maintenance/ANATOMY.md
+++ b/src/lingtai/kernel/maintenance/ANATOMY.md
@@ -9,6 +9,8 @@ maintenance: |
   anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
   maintenance field. If you notice drift between this anatomy and the code,
   report it. See lingtai-dev-guide for details.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # maintenance
 

--- a/src/lingtai/kernel/migrate/ANATOMY.md
+++ b/src/lingtai/kernel/migrate/ANATOMY.md
@@ -24,6 +24,8 @@ maintenance: |
   connections, composition, or state. Verify every changed citation and run the
   architecture-document validation before merge.
   Follow the root Anatomy/Contract pairing rule, report mismatches, and do not duplicate or auto-fix the rule here.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # migrate
 

--- a/src/lingtai/kernel/notification_store/ANATOMY.md
+++ b/src/lingtai/kernel/notification_store/ANATOMY.md
@@ -24,6 +24,8 @@ maintenance: |
   connections, composition, or state. Verify every changed citation and run the
   architecture-document validation before merge.
   Follow the root Anatomy/Contract pairing rule, report mismatches, and do not duplicate or auto-fix the rule here.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # Notification Store Anatomy
 

--- a/src/lingtai/kernel/nudge/ANATOMY.md
+++ b/src/lingtai/kernel/nudge/ANATOMY.md
@@ -23,6 +23,8 @@ maintenance: |
   anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
   maintenance field. If you notice drift between this anatomy and the code,
   report it. See lingtai-dev-guide for details.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # Nudge
 

--- a/src/lingtai/kernel/refresh_watcher/ANATOMY.md
+++ b/src/lingtai/kernel/refresh_watcher/ANATOMY.md
@@ -30,6 +30,8 @@ maintenance: |
   connections, composition, or state. Verify every changed citation and run the
   architecture-document validation before merge.
   Follow the root Anatomy/Contract pairing rule, report mismatches, and do not duplicate or auto-fix the rule here.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # Refresh Watcher Port Anatomy
 

--- a/src/lingtai/kernel/reminders/ANATOMY.md
+++ b/src/lingtai/kernel/reminders/ANATOMY.md
@@ -14,6 +14,8 @@ maintenance: |
   anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
   maintenance field. If you notice drift between this anatomy and the code,
   report it. See lingtai-dev-guide for details.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # Reminders
 

--- a/src/lingtai/kernel/services/ANATOMY.md
+++ b/src/lingtai/kernel/services/ANATOMY.md
@@ -17,6 +17,8 @@ maintenance: |
   anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
   maintenance field. If you notice drift between this anatomy and the code,
   report it. See lingtai-dev-guide for details.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # services
 

--- a/src/lingtai/kernel/snapshot/ANATOMY.md
+++ b/src/lingtai/kernel/snapshot/ANATOMY.md
@@ -22,6 +22,8 @@ maintenance: |
   connections, composition, or state. Verify every changed citation and run the
   architecture-document validation before merge.
   Follow the root Anatomy/Contract pairing rule, report mismatches, and do not duplicate or auto-fix the rule here.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # Snapshot + Source Revision Port Anatomy
 

--- a/src/lingtai/kernel/workdir_lease/ANATOMY.md
+++ b/src/lingtai/kernel/workdir_lease/ANATOMY.md
@@ -15,6 +15,8 @@ maintenance: |
   connections, composition, or state. Verify every changed citation and run the
   architecture-document validation before merge.
   Follow the root Anatomy/Contract pairing rule, report mismatches, and do not duplicate or auto-fix the rule here.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # Workdir Lease Port Anatomy
 

--- a/src/lingtai/llm/ANATOMY.md
+++ b/src/lingtai/llm/ANATOMY.md
@@ -37,6 +37,8 @@ maintenance: |
   anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
   maintenance field. If you notice drift between this anatomy and the code,
   report it. See lingtai-dev-guide for details.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # src/lingtai/llm/
 

--- a/src/lingtai/llm/anthropic/ANATOMY.md
+++ b/src/lingtai/llm/anthropic/ANATOMY.md
@@ -10,6 +10,8 @@ maintenance: |
   anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
   maintenance field. If you notice drift between this anatomy and the code,
   report it. See lingtai-dev-guide for details.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # src/lingtai/llm/anthropic
 

--- a/src/lingtai/llm/custom/ANATOMY.md
+++ b/src/lingtai/llm/custom/ANATOMY.md
@@ -10,6 +10,8 @@ maintenance: |
   anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
   maintenance field. If you notice drift between this anatomy and the code,
   report it. See lingtai-dev-guide for details.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # src/lingtai/llm/custom
 

--- a/src/lingtai/llm/gemini/ANATOMY.md
+++ b/src/lingtai/llm/gemini/ANATOMY.md
@@ -9,6 +9,8 @@ maintenance: |
   anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
   maintenance field. If you notice drift between this anatomy and the code,
   report it. See lingtai-dev-guide for details.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # src/lingtai/llm/gemini
 

--- a/src/lingtai/llm/mimo/ANATOMY.md
+++ b/src/lingtai/llm/mimo/ANATOMY.md
@@ -14,6 +14,8 @@ maintenance: |
   anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
   maintenance field. If you notice drift between this anatomy and the code,
   report it. See lingtai-dev-guide for details.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # src/lingtai/llm/mimo
 

--- a/src/lingtai/llm/minimax/ANATOMY.md
+++ b/src/lingtai/llm/minimax/ANATOMY.md
@@ -11,6 +11,8 @@ maintenance: |
   anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
   maintenance field. If you notice drift between this anatomy and the code,
   report it. See lingtai-dev-guide for details.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # src/lingtai/llm/minimax
 

--- a/src/lingtai/llm/openai/ANATOMY.md
+++ b/src/lingtai/llm/openai/ANATOMY.md
@@ -30,6 +30,8 @@ maintenance: |
   anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
   maintenance field. If you notice drift between this anatomy and the code,
   report it. See lingtai-dev-guide for details.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # src/lingtai/llm/openai/
 

--- a/src/lingtai/llm/openrouter/ANATOMY.md
+++ b/src/lingtai/llm/openrouter/ANATOMY.md
@@ -10,6 +10,8 @@ maintenance: |
   anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
   maintenance field. If you notice drift between this anatomy and the code,
   report it. See lingtai-dev-guide for details.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # src/lingtai/llm/openrouter
 

--- a/src/lingtai/mcp_servers/ANATOMY.md
+++ b/src/lingtai/mcp_servers/ANATOMY.md
@@ -125,6 +125,8 @@ maintenance: |
   anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
   maintenance field. If you notice drift between this anatomy and the code,
   report it. See lingtai-dev-guide for details.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # lingtai.mcp_servers
 

--- a/src/lingtai/mcp_servers/local_commands/ANATOMY.md
+++ b/src/lingtai/mcp_servers/local_commands/ANATOMY.md
@@ -16,6 +16,8 @@ maintenance: |
   Keep related_files repo-relative, duplicate-free, and linked to real files.
   Update this Anatomy with changes to command ownership, workdir reads, signal
   semantics, or the boundary between shared command results and channel UI.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # Local Messaging Command Core Anatomy
 

--- a/src/lingtai/mcp_servers/telegram/task_card/ANATOMY.md
+++ b/src/lingtai/mcp_servers/telegram/task_card/ANATOMY.md
@@ -23,6 +23,8 @@ maintenance: |
   Keep this Anatomy reciprocal with its paired CONTRACT.md and packaged manual.
   Update it when resident ownership, programmable projection, or the relation to
   the intrinsic producer changes.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # Telegram Task Card Projection Anatomy
 

--- a/src/lingtai/prompts/ANATOMY.md
+++ b/src/lingtai/prompts/ANATOMY.md
@@ -40,6 +40,8 @@ maintenance: |
   anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
   maintenance field. If you notice drift between this anatomy and the code,
   report it. See lingtai-dev-guide for details.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # lingtai/prompts
 

--- a/src/lingtai/services/ANATOMY.md
+++ b/src/lingtai/services/ANATOMY.md
@@ -34,6 +34,8 @@ maintenance: |
   anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
   maintenance field. If you notice drift between this anatomy and the code,
   report it. See lingtai-dev-guide for details.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # src/lingtai/services/
 

--- a/src/lingtai/services/vision/ANATOMY.md
+++ b/src/lingtai/services/vision/ANATOMY.md
@@ -14,6 +14,8 @@ maintenance: |
   ANATOMY.md files so the anatomy graph stays connected rather than isolated;
   anatomy links must be bidirectional. If code or citations drift, update this
   map with the code change and run the architecture/document checks.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # src/lingtai/services/vision/
 

--- a/src/lingtai/services/websearch/ANATOMY.md
+++ b/src/lingtai/services/websearch/ANATOMY.md
@@ -13,6 +13,8 @@ maintenance: |
   anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
   maintenance field. If you notice drift between this anatomy and the code,
   report it. See lingtai-dev-guide for details.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # src/lingtai/services/websearch/
 

--- a/src/lingtai/tools/ANATOMY.md
+++ b/src/lingtai/tools/ANATOMY.md
@@ -56,6 +56,8 @@ maintenance: |
   future family migration may adopt, not a second registry. context is its
   thirteenth consumer and the fifth migrated intrinsic. Update
   structural claims with code and keep reciprocal graph edges valid.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # src/lingtai/tools/
 

--- a/src/lingtai/tools/avatar/ANATOMY.md
+++ b/src/lingtai/tools/avatar/ANATOMY.md
@@ -21,6 +21,8 @@ maintenance: |
   anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
   maintenance field. If you notice drift between this anatomy and the code,
   report it. See lingtai-dev-guide for details.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # core/avatar
 

--- a/src/lingtai/tools/bash/ANATOMY.md
+++ b/src/lingtai/tools/bash/ANATOMY.md
@@ -43,6 +43,8 @@ maintenance: |
   anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
   maintenance field. If you notice drift between this anatomy and the code,
   report it. See lingtai-dev-guide for details.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # core/shell (retained implementation: bash)
 

--- a/src/lingtai/tools/browser/ANATOMY.md
+++ b/src/lingtai/tools/browser/ANATOMY.md
@@ -22,6 +22,8 @@ maintenance: |
   This map describes only the internal browse subcomponent of unified web.
   Keep its Contract edge and parent/child links reciprocal. Browser files are
   retained implementation truth, not a public capability or manual owner.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # Internal browse subcomponent Anatomy
 

--- a/src/lingtai/tools/context/ANATOMY.md
+++ b/src/lingtai/tools/context/ANATOMY.md
@@ -24,6 +24,8 @@ maintenance: |
   Keep paths real, repo-relative, duplicate-free, and reciprocal with the paired
   Contract and connected anatomies. Update this graph with schema, lifecycle,
   composition-path, summary-engine, or state-ownership changes.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # tools/context
 

--- a/src/lingtai/tools/daemon/ANATOMY.md
+++ b/src/lingtai/tools/daemon/ANATOMY.md
@@ -73,6 +73,8 @@ maintenance: |
   anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
   maintenance field. If you notice drift between this anatomy and the code,
   report it. See lingtai-dev-guide for details.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # core/daemon
 

--- a/src/lingtai/tools/daemon/interactive_terminal/ANATOMY.md
+++ b/src/lingtai/tools/daemon/interactive_terminal/ANATOMY.md
@@ -16,6 +16,8 @@ maintenance: |
   Keep related_files repo-relative and bidirectional with the capability
   Contract and neighboring adapter/daemon Anatomy files. This document maps
   local ownership; behavioral promises live in CONTRACT.md.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # Interactive terminal capability Anatomy
 

--- a/src/lingtai/tools/email/ANATOMY.md
+++ b/src/lingtai/tools/email/ANATOMY.md
@@ -20,6 +20,8 @@ maintenance: |
   anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
   maintenance field. If you notice drift between this anatomy and the code,
   report it. See lingtai-dev-guide for details.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # intrinsics/email
 

--- a/src/lingtai/tools/file/ANATOMY.md
+++ b/src/lingtai/tools/file/ANATOMY.md
@@ -25,6 +25,8 @@ maintenance: |
   when the five pre-migration packages were deleted. tool_family is generic
   optional infrastructure this package composes onto. Update this map with
   structural code changes and verify citations.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # Unified file capability Anatomy
 

--- a/src/lingtai/tools/knowledge/ANATOMY.md
+++ b/src/lingtai/tools/knowledge/ANATOMY.md
@@ -20,6 +20,8 @@ maintenance: |
   anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
   maintenance field. If you notice drift between this anatomy and the code,
   report it. See lingtai-dev-guide for details.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # core/knowledge
 

--- a/src/lingtai/tools/lingtai/ANATOMY.md
+++ b/src/lingtai/tools/lingtai/ANATOMY.md
@@ -15,6 +15,8 @@ maintenance: |
   Keep paths real, repo-relative, duplicate-free, and reciprocal with the paired
   Contract and parent/neighbor anatomies. Update this graph when symbols,
   connections, state ownership, or composition move.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # tools/lingtai
 

--- a/src/lingtai/tools/mcp/ANATOMY.md
+++ b/src/lingtai/tools/mcp/ANATOMY.md
@@ -28,6 +28,8 @@ maintenance: |
   anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
   maintenance field. If you notice drift between this anatomy and the code,
   report it. See lingtai-dev-guide for details.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # lingtai/tools/mcp + lingtai/services/mcp_* (split)
 

--- a/src/lingtai/tools/notification/ANATOMY.md
+++ b/src/lingtai/tools/notification/ANATOMY.md
@@ -32,6 +32,8 @@ maintenance: |
   connections, composition, or state. Verify every changed citation and run the
   architecture-document validation before merge.
   Follow the root Anatomy/Contract pairing rule, report mismatches, and do not duplicate or auto-fix the rule here.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # Notification Tool Anatomy
 

--- a/src/lingtai/tools/pad/ANATOMY.md
+++ b/src/lingtai/tools/pad/ANATOMY.md
@@ -15,6 +15,8 @@ maintenance: |
   Keep paths real, repo-relative, duplicate-free, and reciprocal with the paired
   Contract and parent/neighbor anatomies. Update this graph when symbols,
   connections, state ownership, or composition move.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # tools/pad
 

--- a/src/lingtai/tools/plugin/ANATOMY.md
+++ b/src/lingtai/tools/plugin/ANATOMY.md
@@ -31,6 +31,8 @@ maintenance: |
   family composition, manual adaptation, or unknown-action envelope changes,
   re-check this one; when its addon decompression changes, re-check the
   registration half here, which mirrors it. See lingtai-dev-guide for details.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # lingtai/tools/plugin + lingtai/services/plugin_registry (split)
 

--- a/src/lingtai/tools/psyche/ANATOMY.md
+++ b/src/lingtai/tools/psyche/ANATOMY.md
@@ -15,6 +15,8 @@ maintenance: |
   truth: update this graph when symbols, connections, state ownership, or
   composition move.
   Follow the root Anatomy/Contract pairing rule, report mismatches, and do not duplicate or auto-fix the rule here.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # tools/psyche
 

--- a/src/lingtai/tools/skills/ANATOMY.md
+++ b/src/lingtai/tools/skills/ANATOMY.md
@@ -25,6 +25,8 @@ maintenance: |
   anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
   maintenance field. If you notice drift between this anatomy and the code,
   report it. See lingtai-dev-guide for details.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # core/skills
 

--- a/src/lingtai/tools/soul/ANATOMY.md
+++ b/src/lingtai/tools/soul/ANATOMY.md
@@ -21,6 +21,8 @@ maintenance: |
   anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
   maintenance field. If you notice drift between this anatomy and the code,
   report it. See lingtai-dev-guide for details.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # intrinsics/soul
 

--- a/src/lingtai/tools/system/ANATOMY.md
+++ b/src/lingtai/tools/system/ANATOMY.md
@@ -25,6 +25,8 @@ maintenance: |
   anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
   maintenance field. If you notice drift between this anatomy and the code,
   report it. See lingtai-dev-guide for details.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # intrinsics/system
 

--- a/src/lingtai/tools/task_card/ANATOMY.md
+++ b/src/lingtai/tools/task_card/ANATOMY.md
@@ -23,6 +23,8 @@ maintenance: |
   Keep this Anatomy reciprocal with its paired CONTRACT.md and manual. Update
   this file in the same change as any ownership, file-path, lifecycle, or
   projection-boundary change.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # Intrinsic Task Card Anatomy
 

--- a/src/lingtai/tools/tool_family/ANATOMY.md
+++ b/src/lingtai/tools/tool_family/ANATOMY.md
@@ -32,6 +32,8 @@ maintenance: |
   connections, composition, or state. Verify every changed citation and run the
   architecture-document validation before merge.
   Follow the root Anatomy/Contract pairing rule, report mismatches, and do not duplicate or auto-fix the rule here.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # src/lingtai/tools/tool_family/ Anatomy
 

--- a/src/lingtai/tools/vision/ANATOMY.md
+++ b/src/lingtai/tools/vision/ANATOMY.md
@@ -17,6 +17,8 @@ maintenance: |
   validators after edits. tool_family is generic optional infrastructure this
   package composes onto; vision's own provider routing and result shapes stay
   here.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # src/lingtai/tools/vision/
 

--- a/src/lingtai/tools/web_search/ANATOMY.md
+++ b/src/lingtai/tools/web_search/ANATOMY.md
@@ -52,6 +52,8 @@ maintenance: |
   tool_family is generic optional infrastructure this package composes onto;
   web's own instance-bound diagnostics and dispatch wrapper remain here.
   Update this map with structural code changes and verify citations.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # Unified web capability Anatomy
 

--- a/tests/ANATOMY.md
+++ b/tests/ANATOMY.md
@@ -452,6 +452,8 @@ maintenance: |
   under tests/ must appear above, so adding or deleting a test file updates
   this list in the same change; test_architecture_documents.py enforces that.
   Follow the root Anatomy/Contract pairing rule, report mismatches, and do not duplicate or auto-fix the rule here.
+  Capability mentions in any document require explicit bidirectional
+  related_files mapping to the implementing code (see root ## Maintenance).
 ---
 # tests/
 


### PR DESCRIPTION
## What

Strengthens the **anatomy-of-anatomy maintenance rule** so that any capability mention in any repository document MUST be mapped to implementing code via explicit bidirectional `related_files` entries in the owning anatomy — a prose mention without a mapping is drift, not documentation.

This is **phase 1** of Jason's two-phase plan: first update the mechanical maintenance rule, then (phase 2, follow-up PR) apply the rule to update all ANATOMY files across repos.

## Changes

- `ANATOMY.md` — root `## Maintenance` adds the capability-mention → related_files bidirectional rule; frontmatter `maintenance` and child `Template` maintenance note sync it.
- `src/lingtai/intrinsic_skills/lingtai-kernel-anatomy/SKILL.md` — router maintenance + Maintenance direction point to the new root rule.

## Validation

- `git diff --check` clean.
- `tests/test_architecture_documents.py`: 3 passed; the 4th (`test_every_tracked_file_climbs_the_anatomy_graph`) fails **identically on baseline main 6e8dc29c** (verified via stash) — 9 tracked files already orphaned before this PR (wechat media #1387, daemon_manager #1366, etc.). This PR does not introduce that failure; phase 2 fixes it by applying the new rule.

Telegram: @lingtaidev2bot | Nickname: 观一
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
