### PR TITLE
fix(telegram): enforce per-target edit throttle on Task Card resident

### DIFF
--- a/src/lingtai/mcp_servers/task_card/resident.py
+++ b/src/lingtai/mcp_servers/task_card/resident.py
@@ -44,6 +44,10 @@ class TaskCardResident:
     EDIT_OK = "ok"
     EDIT_IMPOSSIBLE = "edit_impossible"
     EDIT_FAILED = "failed"
+    # The provider accepted the logical projection, but its hard edit interval
+    # deferred transport.  The provider adapter owns the pending-latest retry;
+    # resident commits the channel slot so later compositions cannot lose it.
+    EDIT_THROTTLED = "throttled"
 
     DELETE_OK = "ok"
     DELETE_MISSING = "missing"
@@ -187,31 +191,8 @@ class TaskCardResident:
         empty_fallback: str | None = None,
         thread_id: str | int | None = None,
     ) -> dict[str, Any]:
-        if channel not in self.CHANNELS:
-            return {"status": "error", "error": f"Unknown channel: {channel}"}
         with self.delivery_lock(account, chat_id, thread_id):
-            if not self.enabled():
-                if channel == "programmable" and frame is None:
-                    self.set_frame(
-                        account,
-                        chat_id,
-                        channel,
-                        None,
-                        thread_id=thread_id,
-                    )
-                return {"status": "ok", "suppressed": True, "taskcard": False}
-            if self._transport is None:
-                assert self._legacy_deliver is not None
-                return self._legacy_deliver(
-                    account,
-                    chat_id,
-                    channel,
-                    frame,
-                    error=error,
-                    resident_id=resident_id,
-                    empty_fallback=empty_fallback,
-                )
-            return self.deliver_locked(
+            return self.project_locked(
                 account,
                 chat_id,
                 channel,
@@ -221,6 +202,53 @@ class TaskCardResident:
                 empty_fallback=empty_fallback,
                 thread_id=thread_id,
             )
+
+    def project_locked(
+        self,
+        account: str,
+        chat_id: str | int,
+        channel: str,
+        frame: str | None,
+        *,
+        error: str,
+        resident_id: str | None = None,
+        empty_fallback: str | None = None,
+        thread_id: str | int | None = None,
+    ) -> dict[str, Any]:
+        """Project while the caller already owns this route's delivery lock."""
+        if channel not in self.CHANNELS:
+            return {"status": "error", "error": f"Unknown channel: {channel}"}
+        if not self.enabled():
+            if channel == "programmable" and frame is None:
+                self.set_frame(
+                    account,
+                    chat_id,
+                    channel,
+                    None,
+                    thread_id=thread_id,
+                )
+            return {"status": "ok", "suppressed": True, "taskcard": False}
+        if self._transport is None:
+            assert self._legacy_deliver is not None
+            return self._legacy_deliver(
+                account,
+                chat_id,
+                channel,
+                frame,
+                error=error,
+                resident_id=resident_id,
+                empty_fallback=empty_fallback,
+            )
+        return self.deliver_locked(
+            account,
+            chat_id,
+            channel,
+            frame,
+            error=error,
+            resident_id=resident_id,
+            empty_fallback=empty_fallback,
+            thread_id=thread_id,
+        )
 
     def deliver_locked(
         self,
@@ -272,7 +300,7 @@ class TaskCardResident:
                 return outcome
 
             edit_outcome, edit_error = transport.edit(resident_id, text)
-            if edit_outcome == self.EDIT_OK:
+            if edit_outcome in (self.EDIT_OK, self.EDIT_THROTTLED):
                 self.set_frame(
                     account,
                     chat_id,
@@ -280,7 +308,13 @@ class TaskCardResident:
                     frame,
                     thread_id=thread_id,
                 )
-                return {"status": "ok", "message_id": resident_id}
+                outcome: dict[str, Any] = {
+                    "status": "ok",
+                    "message_id": resident_id,
+                }
+                if edit_outcome == self.EDIT_THROTTLED:
+                    outcome["pending"] = True
+                return outcome
             if edit_outcome == self.EDIT_FAILED:
                 return {"status": "error", "error": edit_error or error}
 
@@ -340,6 +374,14 @@ class TaskCardResident:
             probe_outcome, probe_error = transport.edit(stale_id, committed_text)
             if probe_outcome == self.EDIT_FAILED:
                 return {"status": "error", "error": probe_error or error}
+            if probe_outcome == self.EDIT_THROTTLED:
+                # The provider adapter retries the whole latest projection, not
+                # this existence-probe text, once the route becomes eligible.
+                return {
+                    "status": "ok",
+                    "message_id": stale_id,
+                    "pending": True,
+                }
         return self.replace_after_probe(route, stale_id, text, error=error)
 
     def replace_after_probe(
@@ -363,12 +405,15 @@ class TaskCardResident:
         current = transport.get_resident(route)
         if current and current != stale_id:
             adopt_outcome, adopt_error = transport.edit(current, text)
-            if adopt_outcome == self.EDIT_OK:
-                return {
+            if adopt_outcome in (self.EDIT_OK, self.EDIT_THROTTLED):
+                outcome = {
                     "status": "ok",
                     "message_id": current,
                     "adopted_resident": True,
                 }
+                if adopt_outcome == self.EDIT_THROTTLED:
+                    outcome["pending"] = True
+                return outcome
             if adopt_outcome == self.EDIT_FAILED:
                 return {"status": "error", "error": adopt_error or error}
 

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -115,6 +115,7 @@ _TELEGRAM_API_ERROR_PREFIX = "Telegram API error: "
 _TASK_CARD_EDIT_OK = TaskCardResident.EDIT_OK
 _TASK_CARD_EDIT_IMPOSSIBLE = TaskCardResident.EDIT_IMPOSSIBLE
 _TASK_CARD_EDIT_FAILED = TaskCardResident.EDIT_FAILED
+_TASK_CARD_EDIT_THROTTLED = TaskCardResident.EDIT_THROTTLED
 _TASK_CARD_EDIT_UNCHANGED = "bad request: message is not modified"
 _TASK_CARD_EDIT_IMPOSSIBLE_DESCRIPTIONS = frozenset({
     "bad request: message to edit not found",
@@ -762,7 +763,27 @@ class TelegramManager:
         # one Bot API edit during a poll interval.
         self._task_card_last_edit_at: dict[tuple[str, int], float] = {}
         self._task_card_edit_gate_lock = threading.Lock()
+        self._task_card_edit_gate_condition = threading.Condition(
+            self._task_card_edit_gate_lock
+        )
         self._task_card_edit_clock: Callable[[], float] = time.monotonic
+        # A throttled edit is an accepted logical projection, not a transport
+        # failure.  Keep only the newest channel transaction for each target;
+        # because throttled slots are committed by TaskCardResident, retrying the
+        # newest proposal recomposes every intervening automatic/programmable
+        # change rather than dropping one producer's intent.
+        self._task_card_pending_edits: dict[
+            tuple[str, int],
+            tuple[str, str | None, str, str | None, str | None],
+        ] = {}
+        # Retry backoff for failures that happen before an edit can claim the
+        # provider gate (for example a temporarily unreadable resident route).
+        # Without this separate deadline, such a retained pending intent would
+        # spin the worker because ``last_edit_at`` correctly remains unchanged.
+        self._task_card_pending_retry_at: dict[tuple[str, int], float] = {}
+        self._task_card_pending_force: set[tuple[str, int]] = set()
+        self._task_card_pending_edit_thread: threading.Thread | None = None
+        self._task_card_pending_edit_stop = threading.Event()
         self._resident = TaskCardResident(
             enabled=self._raw_taskcard_enabled(),
             transport=TaskCardResidentTransport(
@@ -848,7 +869,11 @@ class TelegramManager:
 
     def _on_taskcard_changed(self, enabled: bool) -> None:
         """Apply one durable setting transition; reproject once when enabled."""
-        if self._resident.set_enabled(enabled) and enabled:
+        changed = self._resident.set_enabled(enabled)
+        if changed:
+            with self._task_card_edit_gate_condition:
+                self._task_card_edit_gate_condition.notify_all()
+        if changed and enabled:
             self._broadcast_task_card_event_window()
             self._broadcast_programmable_task_card_file()
 
@@ -913,12 +938,14 @@ class TelegramManager:
 
     def start(self) -> None:
         self._service.start()
+        self._start_pending_task_card_edit_worker()
         self._start_task_card_tail()
         self._start_programmable_task_card_poller()
 
     def stop(self) -> None:
         self._stop_programmable_task_card_poller()
         self._stop_task_card_tail()
+        self._stop_pending_task_card_edit_worker()
         # lingtai#672: quiesce the producers FIRST (service.stop() signals and
         # joins every account poll thread, so no in-flight callback can start
         # a new typing lease), then stop_all() signals and boundedly joins
@@ -2254,7 +2281,7 @@ class TelegramManager:
                     last_edit_at is not None
                     and now - last_edit_at < self._TASK_CARD_EVENT_POLL_INTERVAL
                 ):
-                    return _TASK_CARD_EDIT_FAILED, "Task card edit throttled"
+                    return _TASK_CARD_EDIT_THROTTLED, None
                 self._task_card_last_edit_at[key] = now
             acct = self._service.get_account(account)
             acct.edit_message(chat_id, tg_msg_id, text)
@@ -2282,7 +2309,7 @@ class TelegramManager:
         compound_id: str,
         text: str,
     ) -> bool:
-        """Compatibility bool: true for an applied edit or identical-content no-op."""
+        """Compatibility bool: true only when the provider edit was applied."""
         outcome, _reason = self._try_update_progress_message(compound_id, text)
         return outcome == _TASK_CARD_EDIT_OK
 
@@ -2338,19 +2365,69 @@ class TelegramManager:
         *, error: str, resident_id: str | None = None,
         empty_fallback: str | None = None,
     ) -> dict:
-        """Project via the single resident owner."""
-        return self._resident.project(
-            account, chat_id, channel, frame, error=error,
-            resident_id=resident_id, empty_fallback=empty_fallback,
-        )
+        """Project once and retain a throttled projection as pending-latest.
+
+        The route lock intentionally spans both the shared resident transaction
+        and pending bookkeeping.  Without that outer acquisition, an older
+        caller could return from ``project`` after a newer caller and overwrite
+        the newer pending record.
+        """
+        key = (account, chat_id)
+        with self._task_card_delivery_lock(account, chat_id):
+            with self._task_card_edit_gate_lock:
+                had_pending = key in self._task_card_pending_edits
+            result = self._resident.project_locked(
+                account, chat_id, channel, frame, error=error,
+                resident_id=resident_id, empty_fallback=empty_fallback,
+            )
+            result = dict(result)
+            pending = bool(result.pop("pending", False))
+            # A hidden programmable finalize is the one suppressed transition
+            # that still commits logical state.  It must supersede any older
+            # queued body, otherwise re-enable could resurrect a stopped watch.
+            accepted_pending = pending or (
+                had_pending
+                and result.get("suppressed")
+                and channel == "programmable"
+                and frame is None
+            )
+            with self._task_card_edit_gate_condition:
+                if accepted_pending:
+                    self._task_card_pending_edits[key] = (
+                        channel,
+                        frame,
+                        error,
+                        resident_id,
+                        empty_fallback,
+                    )
+                    # A newer accepted intent gets the earliest legal gate slot;
+                    # any prior non-provider failure backoff belonged to the old
+                    # transaction.
+                    self._task_card_pending_retry_at.pop(key, None)
+                elif result.get("status") == "ok" and not result.get("suppressed"):
+                    # Any successful projection sends the current composition,
+                    # including all logically committed slots, so it supersedes
+                    # an older pending transaction for this target.
+                    self._task_card_pending_edits.pop(key, None)
+                    self._task_card_pending_retry_at.pop(key, None)
+                self._task_card_edit_gate_condition.notify_all()
+
+            if (
+                had_pending
+                and not accepted_pending
+                and result.get("status") == "ok"
+                and not result.get("suppressed")
+            ):
+                self._sync_task_card_fingerprint_after_delivery(account, chat_id)
+            return result
 
     def _deliver_channel_frame_locked(
         self, account: str, chat_id: int, channel: str, frame: str | None,
         *, error: str, resident_id: str | None = None,
         empty_fallback: str | None = None,
     ) -> dict:
-        """Compatibility wrapper around the shared serialized state machine."""
-        return self._resident.deliver_locked(
+        """Compatibility wrapper around the pending-aware serialized path."""
+        return self._deliver_channel_frame(
             account,
             chat_id,
             channel,
@@ -2359,6 +2436,147 @@ class TelegramManager:
             resident_id=resident_id,
             empty_fallback=empty_fallback,
         )
+
+    def _sync_task_card_fingerprint_after_delivery(
+        self, account: str, chat_id: int,
+    ) -> None:
+        """Record the automatic slot that the latest real projection composed."""
+        key = (account, chat_id)
+        automatic = self._task_card_channels.get(
+            self._channel_key(account, chat_id), {}
+        ).get("automatic")
+        if automatic is not None:
+            self._task_card_automatic_fingerprints[key] = (
+                self._task_card_automatic_fingerprint(automatic)
+            )
+            # A real composed edit also delivers any forced rehydrated automatic
+            # slot, even when a programmable transaction happened to be the
+            # latest coalesced producer.
+            self._task_card_pending_force.discard(key)
+
+    def _task_card_edit_is_pending(self, account: str, chat_id: int) -> bool:
+        with self._task_card_edit_gate_lock:
+            return (account, chat_id) in self._task_card_pending_edits
+
+    def _pending_task_card_edit_is_eligible(
+        self, key: tuple[str, int], *, now: float | None = None,
+    ) -> bool:
+        """Check one target's hard interval; caller holds the gate lock."""
+        if key not in self._task_card_pending_edits:
+            return False
+        last_edit_at = self._task_card_last_edit_at.get(key)
+        if now is None:
+            now = self._task_card_edit_clock()
+        retry_at = self._task_card_pending_retry_at.get(key)
+        if retry_at is not None and now < retry_at:
+            return False
+        if last_edit_at is None:
+            return True
+        return now - last_edit_at >= self._TASK_CARD_EVENT_POLL_INTERVAL
+
+    def _flush_pending_task_card_edit(self, key: tuple[str, int]) -> bool:
+        """Retry one eligible pending-latest projection through full recovery."""
+        account, chat_id = key
+        with self._task_card_delivery_lock(account, chat_id):
+            with self._task_card_edit_gate_lock:
+                if not self._pending_task_card_edit_is_eligible(key):
+                    return False
+                pending = self._task_card_pending_edits.get(key)
+            if pending is None:
+                return False
+            channel, frame, error, resident_id, empty_fallback = pending
+            result = self._deliver_channel_frame(
+                account,
+                chat_id,
+                channel,
+                frame,
+                error=error,
+                resident_id=resident_id,
+                empty_fallback=empty_fallback,
+            )
+            delivered = (
+                result.get("status") == "ok"
+                and not self._task_card_edit_is_pending(account, chat_id)
+            )
+            if not delivered:
+                with self._task_card_edit_gate_condition:
+                    if key in self._task_card_pending_edits:
+                        self._task_card_pending_retry_at[key] = (
+                            self._task_card_edit_clock()
+                            + max(self._TASK_CARD_EVENT_POLL_INTERVAL, 0.1)
+                        )
+                        self._task_card_edit_gate_condition.notify_all()
+            return delivered
+
+    def _flush_pending_task_card_edits(self) -> None:
+        """Opportunistically drain every currently eligible target.
+
+        Blanket callers use this deterministic hook too, so fake-monotonic tests
+        and a manager that has not started its worker exercise the same retry path.
+        """
+        with self._task_card_edit_gate_lock:
+            keys = list(self._task_card_pending_edits)
+        for key in keys:
+            self._flush_pending_task_card_edit(key)
+
+    def _start_pending_task_card_edit_worker(self) -> None:
+        """Start the one manager-owned pending-latest retry worker."""
+        thread = self._task_card_pending_edit_thread
+        if thread is not None and thread.is_alive():
+            return
+        self._task_card_pending_edit_stop.clear()
+
+        def _loop() -> None:
+            while not self._task_card_pending_edit_stop.is_set():
+                if not self._resident.enabled():
+                    # Keep accepted intent while hidden; re-enable notifies the
+                    # condition and reprojects the current logical composition.
+                    with self._task_card_edit_gate_condition:
+                        self._task_card_edit_gate_condition.wait(timeout=1.0)
+                    continue
+                key: tuple[str, int] | None = None
+                with self._task_card_edit_gate_condition:
+                    if self._task_card_pending_edit_stop.is_set():
+                        return
+                    now = self._task_card_edit_clock()
+                    wait_for: float | None = None
+                    for candidate in self._task_card_pending_edits:
+                        last_edit_at = self._task_card_last_edit_at.get(candidate)
+                        due_at = (
+                            now
+                            if last_edit_at is None
+                            else last_edit_at + self._TASK_CARD_EVENT_POLL_INTERVAL
+                        )
+                        retry_at = self._task_card_pending_retry_at.get(candidate)
+                        if retry_at is not None:
+                            due_at = max(due_at, retry_at)
+                        remaining = due_at - now
+                        if remaining <= 0:
+                            key = candidate
+                            break
+                        if wait_for is None or remaining < wait_for:
+                            wait_for = remaining
+                    if key is None:
+                        self._task_card_edit_gate_condition.wait(timeout=wait_for)
+                        continue
+                self._flush_pending_task_card_edit(key)
+
+        thread = threading.Thread(
+            target=_loop,
+            name="telegram-task-card-pending-edit",
+            daemon=True,
+        )
+        self._task_card_pending_edit_thread = thread
+        thread.start()
+
+    def _stop_pending_task_card_edit_worker(self) -> None:
+        self._task_card_pending_edit_stop.set()
+        with self._task_card_edit_gate_condition:
+            self._task_card_edit_gate_condition.notify_all()
+        thread = self._task_card_pending_edit_thread
+        if thread is not None:
+            thread.join(timeout=5.0)
+        self._task_card_pending_edit_thread = None
 
     @classmethod
     def _format_programmable_card_text(
@@ -3315,6 +3533,12 @@ class TelegramManager:
         """
         if not self._taskcard_enabled():
             return
+        # A normal blanket tick is also the deterministic retry point for tests
+        # and for callers racing just before the background worker wakes.  An
+        # explicit force call itself supersedes the queued automatic proposal, so
+        # let that one projection consume the newly eligible gate instead.
+        if not force:
+            self._flush_pending_task_card_edits()
         normal_rows = self._taskcard_normal_rows()
         automatic = TaskCardEventProjection.render_event_groups(
             self._task_card_event_groups_snapshot(),
@@ -3326,12 +3550,16 @@ class TelegramManager:
         for account, chat_id in self._resident_task_card_targets():
             key = (account, chat_id)
             # Check + deliver + store are atomic per route (RLock is reentrant,
-            # so the nested acquisition inside project() is free). This keeps the
-            # fingerprint cache consistent with the actually-delivered frame even
+            # so the nested pending-aware delivery wrapper is free). This keeps
+            # the fingerprint cache consistent with the delivered frame even
             # when the 5s blanket loop, the re-enable listener, and a rehydrate
             # race on the same route.
             with self._task_card_delivery_lock(account, chat_id):
-                if not force and self._task_card_automatic_fingerprints.get(key) == fingerprint:
+                effective_force = force or key in self._task_card_pending_force
+                if (
+                    not effective_force
+                    and self._task_card_automatic_fingerprints.get(key) == fingerprint
+                ):
                     # Skip only when the tracked resident still exists. This guard
                     # catches tracked-map clears (e.g. a peer process rotating the
                     # resident in state.json); it does NOT probe whether a user
@@ -3341,17 +3569,29 @@ class TelegramManager:
                     resident_id = self._get_resident_task_card(account, chat_id)
                     if resident_id is not None:
                         continue
+                if effective_force:
+                    # Persist the one-shot force contract until a real composed
+                    # transport succeeds.  A throttled projection leaves this set,
+                    # so the next ordinary eligible blanket bypasses the old
+                    # fingerprint without requiring its caller to repeat force=True.
+                    self._task_card_pending_force.add(key)
                 try:
                     result = self._deliver_channel_frame(
                         account, chat_id, "automatic", automatic,
                         error="Failed to broadcast task card",
                     )
                     # Cache only when a frame was actually delivered. A suppressed
-                    # project (toggle flipped off mid-broadcast) delivers nothing,
-                    # so caching its fingerprint would pin a stale frame once the
-                    # card is re-enabled.
-                    if result.get("status") == "ok" and not result.get("suppressed"):
+                    # or pending project has not touched Telegram, so caching its
+                    # fingerprint would pin stale content.  The delivery wrapper
+                    # clears pending force and syncs this same fingerprint after a
+                    # real success (including a background retry).
+                    if (
+                        result.get("status") == "ok"
+                        and not result.get("suppressed")
+                        and not self._task_card_edit_is_pending(account, chat_id)
+                    ):
                         self._task_card_automatic_fingerprints[key] = fingerprint
+                        self._task_card_pending_force.discard(key)
                 except Exception as e:
                     log.debug(
                         "Automatic task card broadcast failed for %s:%s: %s",
@@ -3484,8 +3724,12 @@ class TelegramManager:
             normal_rows=self._taskcard_normal_rows(),
             locale=self._taskcard_locale(),
         )
-        return self._resident.ensure(
-            account, chat_id, automatic, error="Failed to ensure task card resident",
+        return self._deliver_channel_frame(
+            account,
+            chat_id,
+            "automatic",
+            automatic,
+            error="Failed to ensure task card resident",
         )
 
     def _task_card_create(self, args: dict) -> dict:

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -2575,7 +2575,7 @@ class TelegramManager:
             self._task_card_edit_gate_condition.notify_all()
         thread = self._task_card_pending_edit_thread
         if thread is not None:
-            thread.join(timeout=5.0)
+            thread.join()
         self._task_card_pending_edit_thread = None
 
     @classmethod

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -754,9 +754,15 @@ class TelegramManager:
         # target per account+chat, composed from two fully independent channels —
         # "automatic" (the agent-event-tail broadcast) and "programmable" (the
         # intrinsic taskcard/ artifact projected read-only by Telegram).
-        # ``TaskCardResident`` owns the
-        # frames, per-route locks, and atomic enablement. Updating one channel
-        # never reads, advances, or overrides the other's frame.
+        # ``TaskCardResident`` owns the frames, per-route locks, and atomic
+        # enablement. Telegram adds one resident-scoped edit gate at its transport
+        # boundary: every path (tail broadcasts, inbound ensure, enablement
+        # callbacks, and programmable recomposition) shares the same per-target
+        # last-attempt timestamp, so concurrent producers cannot issue more than
+        # one Bot API edit during a poll interval.
+        self._task_card_last_edit_at: dict[tuple[str, int], float] = {}
+        self._task_card_edit_gate_lock = threading.Lock()
+        self._task_card_edit_clock: Callable[[], float] = time.monotonic
         self._resident = TaskCardResident(
             enabled=self._raw_taskcard_enabled(),
             transport=TaskCardResidentTransport(
@@ -815,10 +821,9 @@ class TelegramManager:
         self._task_card_event_metadata: dict | None = None
         self._task_card_event_lock = threading.Lock()
         # Blanket-delivery dedupe: the last automatic frame fingerprint seen per
-        # resident target. A 5s blanket rebuild only edits Telegram when the
-        # frame actually changed (excluding the volatile ``Last Updated`` line),
-        # so bursty event tails coalesce into at most one edit every 5s
-        # instead of hammering the per-chat edit rate limit.
+        # resident target. It excludes wall-clock-only Last Updated/active-seconds
+        # ticks; the transport gate above independently enforces the hard minimum
+        # interval when meaningful content does change.
         self._task_card_automatic_fingerprints: dict[tuple[str, int], str] = {}
         self._task_card_tail_thread: threading.Thread | None = None
         self._task_card_tail_stop = threading.Event()
@@ -2229,9 +2234,28 @@ class TelegramManager:
         compound_id: str,
         text: str,
     ) -> tuple[str, str | None]:
-        """Edit once; return its semantic outcome and a safe failure reason."""
+        """Gate and attempt one resident edit; return its semantic outcome.
+
+        The gate is keyed by resident target, not message id, so replacement or
+        peer-process rotation cannot reset it. The timestamp is claimed before
+        calling Telegram: failed/unchanged edit requests still consume provider
+        edit capacity and therefore count toward the hard interval.
+        """
         try:
             account, chat_id, tg_msg_id = self._parse_compound_id(compound_id)
+            # Resident projections are route-serialized already. The narrow gate
+            # lock also covers direct compatibility callers without re-entering or
+            # extending the provider request under the resident delivery lock.
+            with self._task_card_edit_gate_lock:
+                now = self._task_card_edit_clock()
+                key = (account, chat_id)
+                last_edit_at = self._task_card_last_edit_at.get(key)
+                if (
+                    last_edit_at is not None
+                    and now - last_edit_at < self._TASK_CARD_EVENT_POLL_INTERVAL
+                ):
+                    return _TASK_CARD_EDIT_FAILED, "Task card edit throttled"
+                self._task_card_last_edit_at[key] = now
             acct = self._service.get_account(account)
             acct.edit_message(chat_id, tg_msg_id, text)
             return _TASK_CARD_EDIT_OK, None
@@ -2991,10 +3015,9 @@ class TelegramManager:
 
         Detects truncation/replacement (current size smaller than the tracked
         offset, or a changed inode) and reinitializes from the new tail rather
-        than seeking into now-invalid byte positions. The blanket 1s loop also
-        re-renders every tick; this method only fires when the file itself
-        changed, so bursty appends still coalesce through the fingerprint
-        dedupe in ``_broadcast_task_card_event_window``.
+        than seeking into now-invalid byte positions. The blanket loop also
+        re-renders every tick; if both paths broadcast, the shared resident edit
+        gate admits at most one request for each target during the interval.
         """
         with self._task_card_event_lock:
             path = self._task_card_event_path
@@ -3251,22 +3274,31 @@ class TelegramManager:
                 )
 
     def _task_card_automatic_fingerprint(self, automatic: str) -> str:
-        """Stable fingerprint of an automatic frame for edit dedupe.
+        """Stable fingerprint of meaningful automatic-frame content.
 
-        The volatile ``Last Updated:`` line is excluded — it changes on every
-        render and must not force a Telegram edit when the actual content
-        (events, footer, metadata) is unchanged. Every supported locale prefix
-        is excluded so the dedupe stays correct after ``/taskcard lang`` flips.
+        ``Last Updated:`` (in every locale) and the numeric seconds in the
+        structured ``agent active (Ns)`` session field advance solely because
+        time passed. Exclude those ticks while retaining the active lifecycle
+        itself and every other event/footer/metadata change.
         """
-        prefixes = tuple(
+        time_prefixes = tuple(
             TaskCardEventProjection.time_prefix(locale)
             for locale in sorted(TaskCardEventProjection.SUPPORTED_LOCALES)
         )
-        stable = "\n".join(
-            line
-            for line in automatic.splitlines()
-            if not line.startswith(prefixes)
-        )
+        session_prefixes = ("Session · ", "会话 · ")
+        stable_lines: list[str] = []
+        for line in automatic.splitlines():
+            if line.startswith(time_prefixes):
+                continue
+            if line.startswith(session_prefixes):
+                line = re.sub(
+                    r"(?<= · )active \(\d+s\)(?= · |$)",
+                    "active",
+                    line,
+                    count=1,
+                )
+            stable_lines.append(line)
+        stable = "\n".join(stable_lines)
         return hashlib.sha256(stable.encode("utf-8", "replace")).hexdigest()
 
     def _broadcast_task_card_event_window(self, *, force: bool = False) -> None:
@@ -3344,10 +3376,10 @@ class TelegramManager:
                     self._poll_event_tail()
                 except Exception as e:
                     log.debug("Automatic task card event tail poll failed: %s", e)
-                # Blanket rebuild: every tick re-renders the current window and
-                # the fingerprint dedupe inside the broadcast decides whether a
-                # Telegram edit is actually needed. This coalesces bursty event
-                # tails into at most one edit every 5 seconds.
+                # Blanket rebuild: every tick re-renders the current window.
+                # Fingerprints reject time-only/unchanged renders; the resident
+                # transport gate enforces the hard per-target edit interval when
+                # this follows a changed-tail broadcast in the same tick.
                 try:
                     self._broadcast_task_card_event_window()
                 except Exception as e:

--- a/tests/test_task_card_resident_shared.py
+++ b/tests/test_task_card_resident_shared.py
@@ -128,6 +128,34 @@ def test_initial_send_and_in_place_slot_compose_commit_after_success() -> None:
     ) in harness.calls
 
 
+def test_throttled_edit_commits_logical_frame_for_provider_retry() -> None:
+    harness = _Harness(
+        resident_id="main:chat#1",
+        edit_results=[(TaskCardResident.EDIT_THROTTLED, None)],
+    )
+    resident = _resident(harness)
+    resident.set_frame("main", "chat", "automatic", "automatic-v1")
+
+    outcome = resident.project(
+        "main",
+        "chat",
+        "programmable",
+        "watch-v2",
+        error="failed",
+    )
+
+    assert outcome == {
+        "status": "ok",
+        "message_id": "main:chat#1",
+        "pending": True,
+    }
+    assert resident.frames["main:chat"] == {
+        "automatic": "automatic-v1",
+        "programmable": "watch-v2",
+    }
+    assert not any(call[0] in {"delete", "send", "persist"} for call in harness.calls)
+
+
 def test_failed_edit_preserves_committed_frame_and_never_sends() -> None:
     harness = _Harness(
         resident_id="main:chat#1",

--- a/tests/test_telegram_task_card.py
+++ b/tests/test_telegram_task_card.py
@@ -379,6 +379,8 @@ def test_full_routing_chain_create_update_finalize(tmp_path):
     manager = TelegramManager(service, working_dir=Path(tmp_path),
                               on_inbound=lambda _: None, notification_store=notification_store_for(Path(tmp_path)))
     account = service.default_account
+    now = [100.0]
+    manager._task_card_edit_clock = lambda: now[0]
 
     # — Create via manager.handle (real dispatch) —
     create_args = {
@@ -431,6 +433,10 @@ def test_full_routing_chain_create_update_finalize(tmp_path):
     }
     r3 = manager.handle(finalize_args)
     assert r3["status"] == "ok"
+    # Finalize is the pending-latest transition while the update edit owns the
+    # interval.  It must be accepted synchronously and delivered once eligible.
+    now[0] += manager._TASK_CARD_EVENT_POLL_INTERVAL
+    manager._flush_pending_task_card_edits()
     final_edit_calls = [c for c in account.calls if c[0] == "edit_message"]
     assert any("✅ TASK CARD · DONE" in c[3] for c in final_edit_calls)
 

--- a/tests/test_telegram_task_card_event_tail.py
+++ b/tests/test_telegram_task_card_event_tail.py
@@ -111,6 +111,10 @@ def _manager(tmp_path, *accounts):
         on_inbound=lambda _: None,
         notification_store=FakeNotificationStore(),
     )
+    # Most projection tests intentionally perform several semantic transitions
+    # synchronously; disable wall-clock throttling unless a test explicitly opts
+    # into the production interval with a deterministic fake clock.
+    manager._TASK_CARD_EVENT_POLL_INTERVAL = 0.0
     return manager, service
 
 
@@ -1333,12 +1337,17 @@ def test_blanket_rebuild_skips_unchanged_frame(tmp_path):
     assert len([c for c in acct.calls if c[0] == "edit_message"]) == 1
 
 
-def test_blanket_force_bypasses_fingerprint_dedupe(tmp_path):
-    """Truncation/replacement uses force=True so identical rehydrated frames
-    still re-edit rather than being suppressed by the unchanged-fingerprint
-    fast path."""
+def test_blanket_force_bypasses_fingerprint_but_not_edit_gate(tmp_path):
+    """Truncation/replacement remains a legal forced re-render after the gate.
+
+    ``force=True`` bypasses only unchanged-fingerprint dedupe; it cannot violate
+    the per-target hard edit interval.
+    """
     acct = FakeAccount()
     manager, service = _manager(tmp_path, acct)
+    manager._TASK_CARD_EVENT_POLL_INTERVAL = 5.0
+    now = [100.0]
+    manager._task_card_edit_clock = lambda: now[0]
     _pre_resident(acct, 555, manager)
 
     events_path = _events_path(tmp_path)
@@ -1347,8 +1356,10 @@ def test_blanket_force_bypasses_fingerprint_dedupe(tmp_path):
     assert len([c for c in acct.calls if c[0] == "edit_message"]) == 1
     acct.calls.clear()
 
-    # Force broadcast (the truncation path) must edit even though the frame
-    # fingerprint is unchanged.
+    manager._broadcast_task_card_event_window(force=True)
+    assert acct.calls == []
+
+    now[0] += manager._TASK_CARD_EVENT_POLL_INTERVAL
     manager._broadcast_task_card_event_window(force=True)
     assert len([c for c in acct.calls if c[0] == "edit_message"]) == 1
 
@@ -1419,14 +1430,161 @@ def test_pure_tool_turn_renders_api_usage_from_llm_response_group(tmp_path):
     assert "85.0%" in rendered
 
 
-def test_fingerprint_ignores_last_updated_line_only(tmp_path):
-    """The volatile Last Updated line must not change the fingerprint; any
-    other content change must."""
+def test_changed_poll_and_blanket_share_per_target_edit_gate(
+    tmp_path, monkeypatch,
+):
+    """A changed poll plus its same-tick blanket may issue one edit per target.
+
+    The metadata mutation between renders models async state changing in the
+    narrow gap that used to make both broadcasts perform real Telegram edits.
+    """
+    acct = FakeAccount()
+    manager, _ = _manager(tmp_path, acct)
+    manager._TASK_CARD_EVENT_POLL_INTERVAL = 5.0
+    now = [100.0]
+    manager._task_card_edit_clock = lambda: now[0]
+    _pre_resident(acct, 111, manager)
+    _pre_resident(acct, 222, manager)
+    live_metadata = {"api_calls": 1}
+    monkeypatch.setattr(
+        manager,
+        "_task_card_event_metadata_snapshot",
+        lambda: dict(live_metadata),
+    )
+
+    _write_lines(_events_path(tmp_path), [_tool_call_line()])
+    manager._poll_event_tail()
+    edits = [call for call in acct.calls if call[0] == "edit_message"]
+    assert [call[1] for call in edits] == [111, 222]
+
+    # The blanket sees genuinely different content, not a fingerprint no-op,
+    # but both target-local gates are still closed in this tick.
+    live_metadata["api_calls"] = 2
+    manager._broadcast_task_card_event_window()
+    assert len([call for call in acct.calls if call[0] == "edit_message"]) == 2
+
+    now[0] += 4.999
+    manager._broadcast_task_card_event_window()
+    assert len([call for call in acct.calls if call[0] == "edit_message"]) == 2
+
+    now[0] += 0.001
+    manager._broadcast_task_card_event_window()
+    edits = [call for call in acct.calls if call[0] == "edit_message"]
+    assert [call[1] for call in edits] == [111, 222, 111, 222]
+    assert all("calls 2" in call[3] for call in edits[-2:])
+
+
+def test_inbound_ensure_and_enable_callback_use_same_resident_gate(
+    tmp_path, monkeypatch,
+):
+    """Both loop-external automatic update paths share the edit timestamp."""
+    acct = FakeAccount()
+    manager, _ = _manager(tmp_path, acct)
+    manager._TASK_CARD_EVENT_POLL_INTERVAL = 5.0
+    now = [200.0]
+    manager._task_card_edit_clock = lambda: now[0]
+    _pre_resident(acct, 555, manager)
+    live_metadata = {"api_calls": 1}
+    monkeypatch.setattr(
+        manager,
+        "_task_card_event_metadata_snapshot",
+        lambda: dict(live_metadata),
+    )
+
+    manager._broadcast_task_card_event_window()
+    assert len([call for call in acct.calls if call[0] == "edit_message"]) == 1
+
+    # Real inbound handling calls _ensure_task_card_resident outside the tail
+    # loop. It must not edit the same resident again inside the interval.
+    manager.on_incoming("mybot", {"message": {
+        "message_id": 8,
+        "date": 1781600000,
+        "from": {"username": "alice"},
+        "chat": {"id": 555, "type": "private"},
+        "text": "hello",
+    }})
+    assert len([call for call in acct.calls if call[0] == "edit_message"]) == 1
+
+    # Re-enable sees changed automatic content and therefore reaches delivery;
+    # the same resident gate, rather than fingerprint dedupe, suppresses it.
+    live_metadata["api_calls"] = 2
+    manager._on_taskcard_changed(False)
+    manager._on_taskcard_changed(True)
+    assert len([call for call in acct.calls if call[0] == "edit_message"]) == 1
+
+    now[0] += manager._TASK_CARD_EVENT_POLL_INTERVAL
+    manager._on_taskcard_changed(False)
+    manager._on_taskcard_changed(True)
+    edits = [call for call in acct.calls if call[0] == "edit_message"]
+    assert len(edits) == 2
+    assert "calls 2" in edits[-1][3]
+
+
+def test_active_seconds_tick_does_not_edit_after_interval(
+    tmp_path, monkeypatch,
+):
+    """An eligible blanket tick still dedupes a pure active-seconds change."""
+    acct = FakeAccount()
+    manager, _ = _manager(tmp_path, acct)
+    manager._TASK_CARD_EVENT_POLL_INTERVAL = 5.0
+    now = [300.0]
+    manager._task_card_edit_clock = lambda: now[0]
+    _pre_resident(acct, 555, manager)
+    live_metadata = {
+        "agent_lifecycle": "active",
+        "agent_active_seconds": 1.0,
+    }
+    monkeypatch.setattr(
+        manager,
+        "_task_card_event_metadata_snapshot",
+        lambda: dict(live_metadata),
+    )
+
+    manager._broadcast_task_card_event_window()
+    assert len([call for call in acct.calls if call[0] == "edit_message"]) == 1
+
+    now[0] += manager._TASK_CARD_EVENT_POLL_INTERVAL
+    live_metadata["agent_active_seconds"] = 6.0
+    manager._broadcast_task_card_event_window()
+    assert len([call for call in acct.calls if call[0] == "edit_message"]) == 1
+
+    live_metadata.clear()
+    live_metadata["agent_lifecycle"] = "idle"
+    manager._broadcast_task_card_event_window()
+    edits = [call for call in acct.calls if call[0] == "edit_message"]
+    assert len(edits) == 2
+    assert "agent · idle" in edits[-1][3]
+
+
+def test_fingerprint_ignores_only_wall_clock_ticks(tmp_path):
+    """Last Updated and active seconds are volatile; lifecycle/content are not."""
     manager, _ = _manager(tmp_path, FakeAccount())
-    a = "\u2699 WORKING\n\u2022 row\n\nfooter\nLast Updated: 10:00:00 U+8"
-    b = "\u2699 WORKING\n\u2022 row\n\nfooter\nLast Updated: 10:00:01 U+8"
-    c = "\u2699 WORKING\n\u2022 other\n\nfooter\nLast Updated: 10:00:00 U+8"
-    assert manager._task_card_automatic_fingerprint(a) == \
-        manager._task_card_automatic_fingerprint(b)
-    assert manager._task_card_automatic_fingerprint(a) != \
-        manager._task_card_automatic_fingerprint(c)
+    timestamp_a = "\u2699 WORKING\n\u2022 row\n\nfooter\nLast Updated: 10:00:00 U+8"
+    timestamp_b = "\u2699 WORKING\n\u2022 row\n\nfooter\nLast Updated: 10:00:01 U+8"
+    other_row = "\u2699 WORKING\n\u2022 other\n\nfooter\nLast Updated: 10:00:00 U+8"
+    assert manager._task_card_automatic_fingerprint(timestamp_a) == \
+        manager._task_card_automatic_fingerprint(timestamp_b)
+    assert manager._task_card_automatic_fingerprint(timestamp_a) != \
+        manager._task_card_automatic_fingerprint(other_row)
+
+    def render(metadata):
+        return TaskCardEventProjection.render_event_groups(
+            [], metadata=metadata, normal_rows=1,
+        )
+
+    active_12 = render({
+        "agent_lifecycle": "active", "agent_active_seconds": 12.0,
+    })
+    active_13 = render({
+        "agent_lifecycle": "active", "agent_active_seconds": 13.0,
+    })
+    idle = render({"agent_lifecycle": "idle"})
+    active_with_usage = render({
+        "agent_lifecycle": "active",
+        "agent_active_seconds": 13.0,
+        "api_calls": 1,
+    })
+    fingerprint = manager._task_card_automatic_fingerprint
+    assert fingerprint(active_12) == fingerprint(active_13)
+    assert fingerprint(active_12) != fingerprint(idle)
+    assert fingerprint(active_13) != fingerprint(active_with_usage)

--- a/tests/test_telegram_task_card_event_tail.py
+++ b/tests/test_telegram_task_card_event_tail.py
@@ -1364,6 +1364,53 @@ def test_blanket_force_bypasses_fingerprint_but_not_edit_gate(tmp_path):
     assert len([c for c in acct.calls if c[0] == "edit_message"]) == 1
 
 
+def test_replacement_force_throttled_retries_on_next_ordinary_blanket(tmp_path):
+    """A one-shot replacement force survives the gate until real delivery.
+
+    The replacement has byte-identical semantic content, so its normalized
+    fingerprint equals the previously delivered frame.  The subsequent call is
+    deliberately an ordinary blanket (no caller repeats ``force=True``).
+    """
+    acct = FakeAccount()
+    manager, _ = _manager(tmp_path, acct)
+    manager._TASK_CARD_EVENT_POLL_INTERVAL = 5.0
+    now = [100.0]
+    manager._task_card_edit_clock = lambda: now[0]
+    _pre_resident(acct, 555, manager)
+
+    events_path = _events_path(tmp_path)
+    line = _tool_call_line()
+    _write_lines(events_path, [line])
+    manager._poll_event_tail()
+    assert len([c for c in acct.calls if c[0] == "edit_message"]) == 1
+    delivered_fingerprint = manager._task_card_automatic_fingerprints[("mybot", 555)]
+    acct.calls.clear()
+
+    # Atomic same-content replacement changes file identity and takes the sole
+    # production force=True branch while the target gate remains closed.
+    replacement = events_path.with_suffix(".replacement")
+    _write_lines(replacement, [line])
+    replacement.replace(events_path)
+    manager._poll_event_tail()
+
+    assert acct.calls == []
+    assert manager._task_card_automatic_fingerprints[("mybot", 555)] == (
+        delivered_fingerprint
+    )
+    assert ("mybot", 555) in manager._task_card_pending_force
+
+    # Once eligible, a plain blanket drains the retained force before unchanged
+    # fingerprint dedupe and performs the required re-render exactly once.
+    now[0] += manager._TASK_CARD_EVENT_POLL_INTERVAL
+    manager._broadcast_task_card_event_window()
+
+    edits = [c for c in acct.calls if c[0] == "edit_message"]
+    assert len(edits) == 1
+    assert "bash" in edits[0][3]
+    assert ("mybot", 555) not in manager._task_card_pending_force
+    assert not manager._task_card_edit_is_pending("mybot", 555)
+
+
 def test_blanket_resends_when_resident_lost_on_same_frame(tmp_path, monkeypatch):
     """Fingerprint match plus a missing tracked resident must still re-send.
 

--- a/tests/test_telegram_task_card_in_place.py
+++ b/tests/test_telegram_task_card_in_place.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from pathlib import Path
+import threading
+import time
 
 from lingtai.mcp_servers.telegram.manager import TelegramManager
 from tests._notification_store_helpers import FakeNotificationStore
@@ -99,8 +101,21 @@ def _calls(account, kind):
     return [call for call in account.calls if call[0] == kind]
 
 
+def _controlled_gate(manager):
+    """Keep the production interval while advancing monotonic deterministically."""
+    now = [100.0]
+    manager._task_card_edit_clock = lambda: now[0]
+
+    def drain():
+        now[0] += manager._TASK_CARD_EVENT_POLL_INTERVAL
+        manager._flush_pending_task_card_edits()
+
+    return drain
+
+
 def test_repeated_automatic_and_programmable_updates_keep_one_message_id(tmp_path):
     manager, account = _manager(tmp_path)
+    drain = _controlled_gate(manager)
 
     created = _automatic(manager, "create", reasoning="first")
     resident_id = created["message_id"]
@@ -112,13 +127,51 @@ def test_repeated_automatic_and_programmable_updates_keep_one_message_id(tmp_pat
 
     assert len(_calls(account, "send")) == 1
     assert not _calls(account, "delete")
+    # The final programmable update coalesces every logical slot transition.
+    drain()
     final_text = account.messages[100]
     assert "second" in final_text
     assert "watch-v2" in final_text
 
 
+def test_pending_latest_worker_delivers_without_caller_retry(tmp_path):
+    manager, account = _manager(tmp_path)
+    manager._TASK_CARD_EVENT_POLL_INTERVAL = 0.02
+    delivered = threading.Event()
+    edit_times: list[float] = []
+    original_edit = account.edit_message
+
+    def edit_message(chat_id, message_id, text, **kwargs):
+        edit_times.append(time.monotonic())
+        result = original_edit(chat_id, message_id, text, **kwargs)
+        if "latest intent" in text:
+            delivered.set()
+        return result
+
+    account.edit_message = edit_message
+    resident_id = _automatic(manager, "create", reasoning="created")["message_id"]
+    _automatic(manager, "update", card_message_id=resident_id, reasoning="first edit")
+    queued = _automatic(
+        manager, "update", card_message_id=resident_id, reasoning="latest intent"
+    )
+    assert queued == {"status": "ok", "message_id": resident_id}
+    assert manager._task_card_edit_is_pending("mybot", 55)
+
+    manager._start_pending_task_card_edit_worker()
+    try:
+        assert delivered.wait(timeout=1.0)
+    finally:
+        manager._stop_pending_task_card_edit_worker()
+
+    assert "latest intent" in account.messages[100]
+    assert len(edit_times) == 2
+    assert edit_times[1] - edit_times[0] >= manager._TASK_CARD_EVENT_POLL_INTERVAL
+    assert not manager._task_card_edit_is_pending("mybot", 55)
+
+
 def test_unchanged_heartbeat_and_final_are_successful_noop_edits(tmp_path):
     manager, account = _manager(tmp_path)
+    drain = _controlled_gate(manager)
     created = _automatic(manager, "create", reasoning="steady")
     resident_id = created["message_id"]
 
@@ -138,6 +191,8 @@ def test_unchanged_heartbeat_and_final_are_successful_noop_edits(tmp_path):
 
     assert heartbeat == {"status": "ok", "message_id": resident_id}
     assert final == {"status": "ok", "message_id": resident_id}
+    drain()
+    assert not manager._task_card_edit_is_pending("mybot", 55)
     assert len(_calls(account, "send")) == 1
     assert not _calls(account, "delete")
     assert account.get_task_card(55) == resident_id
@@ -187,6 +242,7 @@ def test_exact_nondeletable_resident_self_heals_once_per_chat(tmp_path):
     )
     for index, description in enumerate(descriptions):
         manager, account = _manager(tmp_path / str(index))
+        drain = _controlled_gate(manager)
         stale_id = _automatic(manager, "create", reasoning="first")["message_id"]
         account.set_task_card(77, "mybot:77:88")
         account.edit_error = RuntimeError(
@@ -214,4 +270,8 @@ def test_exact_nondeletable_resident_self_heals_once_per_chat(tmp_path):
         )["message_id"] == replacement_id
         assert len(_calls(account, "send")) == 2
         assert len(_calls(account, "delete")) == 1
-        assert [call[2] for call in _calls(account, "edit")[-2:]] == [101, 101]
+        drain()
+        # Both post-rotation producers land in one edit of the newest resident.
+        assert [call[2] for call in _calls(account, "edit")] == [100, 101]
+        assert "later" in account.messages[101]
+        assert "watch" in account.messages[101]

--- a/tests/test_telegram_task_card_last_message.py
+++ b/tests/test_telegram_task_card_last_message.py
@@ -495,6 +495,8 @@ def test_persistence_failure_keeps_only_new_visible_card_and_fails_loud(tmp_path
 # ---------------------------------------------------------------------------
 def test_concurrent_channels_serialize_one_rotation(tmp_path):
     manager, account = _manager(tmp_path)
+    now = [100.0]
+    manager._task_card_edit_clock = lambda: now[0]
     _automatic(manager, "create", reasoning="first")  # mybot:55:100
     account.observe_incoming(55, 200)
 
@@ -548,6 +550,16 @@ def test_concurrent_channels_serialize_one_rotation(tmp_path):
     assert _calls(account, "delete") == [("delete", 55, 100)]
     assert account.resident[55] == "mybot:55:201"
     assert all(result["message_id"] == "mybot:55:201" for result in results)
+
+    # Whichever producer lost the rotation race remains pending.  Replace the
+    # barrier-only test lock, advance one real interval, and prove the eventual
+    # resident composition retains both producers' latest logical slots.
+    manager._task_card_delivery_locks["mybot:55"] = threading.RLock()
+    now[0] += manager._TASK_CARD_EVENT_POLL_INTERVAL
+    manager._flush_pending_task_card_edits()
+    assert "auto" in account.messages[201]
+    assert "steady" in account.messages[201]
+    assert not manager._task_card_edit_is_pending("mybot", 55)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_telegram_task_card_programmable.py
+++ b/tests/test_telegram_task_card_programmable.py
@@ -103,6 +103,17 @@ def _current(account: FakeAccount) -> str:
     return account.sent[max(account.sent)]
 
 
+def _controlled_gate(manager):
+    now = [100.0]
+    manager._task_card_edit_clock = lambda: now[0]
+
+    def drain():
+        now[0] += manager._TASK_CARD_EVENT_POLL_INTERVAL
+        manager._flush_pending_task_card_edits()
+
+    return drain
+
+
 def test_active_intrinsic_body_projects_onto_existing_resident(tmp_path):
     manager, acct, _service = _manager(tmp_path)
     _auto(manager, reasoning="compiling")
@@ -162,6 +173,7 @@ def test_missing_body_after_active_status_is_noop_and_keeps_last_good_projection
 
 def test_existing_automatic_channel_behavior_is_preserved_by_programmable_file_updates(tmp_path):
     manager, acct, _service = _manager(tmp_path)
+    drain = _controlled_gate(manager)
     _auto(manager, reasoning="stay put")
     automatic_only = _current(acct)
     _write_intrinsic_taskcard(tmp_path, status="active", body="watch body\n")
@@ -179,6 +191,7 @@ def test_existing_automatic_channel_behavior_is_preserved_by_programmable_file_u
             "reasoning": "next step",
         }
     )
+    drain()
     assert "next step" in _current(acct)
     assert "watch body" in _current(acct)
     assert automatic_only != _current(acct)
@@ -195,6 +208,7 @@ def test_inactive_clears_programmable_frame_but_preserves_resident_and_automatic
     body file either.
     """
     manager, acct, _service = _manager(tmp_path)
+    drain = _controlled_gate(manager)
     _auto(manager, reasoning="stay put")
     _write_intrinsic_taskcard(tmp_path, status="active", body="v1\n")
     manager._broadcast_programmable_task_card_file()
@@ -209,6 +223,7 @@ def test_inactive_clears_programmable_frame_but_preserves_resident_and_automatic
     calls_before_inactive = list(acct.calls)
     _write_intrinsic_taskcard(tmp_path, status="inactive", body="v2 (must not render)\n")
     manager._broadcast_programmable_task_card_file()
+    drain()
 
     new_calls = acct.calls[len(calls_before_inactive):]
     assert not any(call[0] in ("send", "delete") for call in new_calls)
@@ -239,6 +254,7 @@ def test_inactive_clears_programmable_frame_but_preserves_resident_and_automatic
             "reasoning": "still going",
         }
     )
+    drain()
     assert "still going" in _current(acct)
     assert acct.get_task_card(55) == resident_before
 
@@ -254,6 +270,7 @@ def test_inactive_clears_programmable_frame_but_preserves_resident_and_automatic
 def test_new_active_watch_after_inactive_renders_without_stale_state_corruption(tmp_path):
     """A fresh watch after `stop`/`remove` must render cleanly, not resurface old content."""
     manager, acct, _service = _manager(tmp_path)
+    drain = _controlled_gate(manager)
     _auto(manager)
     _write_intrinsic_taskcard(tmp_path, status="active", body="v1\n")
     manager._broadcast_programmable_task_card_file()
@@ -263,12 +280,14 @@ def test_new_active_watch_after_inactive_renders_without_stale_state_corruption(
     # Old watch retires and its body is removed, exactly as `task_card.remove` does.
     _write_intrinsic_taskcard(tmp_path, status="inactive", body=None)
     manager._broadcast_programmable_task_card_file()
+    drain()
     assert manager._task_card_channels["mybot:55"].get("programmable") is None
     assert "v1" not in _current(acct)
 
     # A brand-new watch starts: body written first, then status flips to active.
     _write_intrinsic_taskcard(tmp_path, status="active", body="v2 fresh\n")
     manager._broadcast_programmable_task_card_file()
+    drain()
 
     text = _current(acct)
     assert "v2 fresh" in text

--- a/tests/test_telegram_task_card_singleton.py
+++ b/tests/test_telegram_task_card_singleton.py
@@ -154,6 +154,8 @@ def test_many_repeated_creates_never_send_or_delete_again(tmp_path):
     ever edit — one send total, zero deletes, id stable throughout."""
     manager, service = _manager(tmp_path)
     acct = service.default_account
+    now = [100.0]
+    manager._task_card_edit_clock = lambda: now[0]
 
     r = _create(manager, reasoning="r0")
     resident = r["message_id"]
@@ -163,7 +165,12 @@ def test_many_repeated_creates_never_send_or_delete_again(tmp_path):
 
     assert len(_sends(acct)) == 1
     assert not _deletes(acct)
-    assert len(_edits(acct)) == 5  # one edit per repeated create
+    # r1 consumes this interval; r2..r5 coalesce to the newest accepted intent.
+    assert len(_edits(acct)) == 1
+    now[0] += manager._TASK_CARD_EVENT_POLL_INTERVAL
+    manager._flush_pending_task_card_edits()
+    assert len(_edits(acct)) == 2
+    assert "r5" in _edits(acct)[-1][3]
     assert acct.get_task_card(999) == resident
 
 

--- a/tests/test_telegram_task_card_toggle.py
+++ b/tests/test_telegram_task_card_toggle.py
@@ -49,6 +49,17 @@ def _manager(workdir: Path, service: TelegramService, inbound=None) -> TelegramM
     )
 
 
+def _controlled_gate(manager: TelegramManager):
+    now = [100.0]
+    manager._task_card_edit_clock = lambda: now[0]
+
+    def drain():
+        now[0] += manager._TASK_CARD_EVENT_POLL_INTERVAL
+        manager._flush_pending_task_card_edits()
+
+    return drain
+
+
 def _incoming_message(message_id: int = 53, *, text: str = "hello") -> dict[str, Any]:
     return {
         "id": f"main:123:{message_id}",
@@ -97,11 +108,21 @@ def test_taskcard_state_persists_false_and_true_across_service_instances(tmp_pat
     service = _service(tmp_path, "main")
     service.set_taskcard_enabled(False)
     state_path = tmp_path / "telegram" / "taskcard.json"
-    assert json.loads(state_path.read_text(encoding="utf-8")) == {"taskcard": False, "normal_rows": 1, "max_refreshes": 1000}
+    assert json.loads(state_path.read_text(encoding="utf-8")) == {
+        "taskcard": False,
+        "normal_rows": 1,
+        "max_refreshes": 1000,
+        "locale": "en",
+    }
     assert _service(tmp_path, "main").taskcard_enabled() is False
 
     service.set_taskcard_enabled(True)
-    assert json.loads(state_path.read_text(encoding="utf-8")) == {"taskcard": True, "normal_rows": 1, "max_refreshes": 1000}
+    assert json.loads(state_path.read_text(encoding="utf-8")) == {
+        "taskcard": True,
+        "normal_rows": 1,
+        "max_refreshes": 1000,
+        "locale": "en",
+    }
     assert _service(tmp_path, "main").taskcard_enabled() is True
 
 
@@ -246,7 +267,7 @@ def test_taskcard_invalid_help_and_unauthorized_forms_do_not_mutate(
             "update_id": update_id,
             "message": {"from": {"id": 7}, "chat": {"id": 10}, "text": text},
         })
-        assert replies[-1] == "❌ Usage: /taskcard on | /taskcard off | /taskcard N (1-10)"
+        assert replies[-1] == "❌ Usage: /taskcard on | /taskcard off | /taskcard N (1-10) | /taskcard lang zh|en"
         assert service.taskcard_enabled() is True
 
     account._process_update({
@@ -441,6 +462,7 @@ def test_programmable_watch_keeps_rendering_while_hidden_and_projects_after_reen
 ) -> None:
     service = _service(tmp_path, "main")
     manager = _manager(tmp_path, service)
+    drain = _controlled_gate(manager)
     account = service.get_account("main")
     sends: list[str] = []
     monkeypatch.setattr(
@@ -466,6 +488,7 @@ def test_programmable_watch_keeps_rendering_while_hidden_and_projects_after_reen
     service.set_taskcard_enabled(True)
     (taskcard_dir / "taskcard.md").write_text("visible latest", encoding="utf-8")
     manager._broadcast_programmable_task_card_file()
+    drain()
     assert any("visible latest" in text for text in sends)
 
 
@@ -477,6 +500,7 @@ def test_stopping_a_hidden_programmable_watch_does_not_resurface_after_reenable(
     /taskcard is turned back on. Ordinary hidden create/update stay untouched."""
     service = _service(tmp_path, "main")
     manager = _manager(tmp_path, service)
+    drain = _controlled_gate(manager)
     account = service.get_account("main")
     rendered: dict[int, str] = {}
 
@@ -503,8 +527,12 @@ def test_stopping_a_hidden_programmable_watch_does_not_resurface_after_reenable(
             args["card"] = card
         return manager._handle_task_card_update(args)
 
-    # A visible programmable resident is created and committed.
+    # A visible programmable resident is created and committed.  Leave a newer
+    # programmable body pending so hidden finalize must supersede it too.
     assert prog("create", {"lines": ["live watch"]})["status"] == "ok"
+    assert prog("update", {"lines": ["visible update"]})["status"] == "ok"
+    assert prog("update", {"lines": ["stale pending watch"]})["status"] == "ok"
+    assert manager._task_card_edit_is_pending("main", 123)
     assert manager._task_card_channels["main:123"].get("programmable")
 
     # Hide delivery, then STOP (finalize) the hidden watch: no transport occurs,
@@ -515,6 +543,7 @@ def test_stopping_a_hidden_programmable_watch_does_not_resurface_after_reenable(
     assert result.get("suppressed") is True
     assert len(rendered) == sends_before  # no transport while suppressed
     assert "programmable" not in manager._task_card_channels.get("main:123", {})
+    assert manager._task_card_pending_edits[("main", 123)][1] is None
 
     # Re-enable and drive an automatic update: the stale watch frame is gone.
     service.set_taskcard_enabled(True)
@@ -527,9 +556,11 @@ def test_stopping_a_hidden_programmable_watch_does_not_resurface_after_reenable(
             "reasoning": "after reenable",
         }
     )
+    drain()
     latest = rendered[max(rendered)]
     assert "after reenable" in latest
     assert "live watch" not in latest
+    assert "stale pending watch" not in latest
     assert "— TASK CARD —" not in latest
 
 
@@ -705,6 +736,7 @@ def test_taskcard_normal_rows_persist_and_are_shared_across_accounts(tmp_path: P
         "taskcard": True,
         "normal_rows": 7,
         "max_refreshes": 1000,
+        "locale": "en",
     }
     restored = _service(tmp_path, "one")
     assert restored.taskcard_enabled() is True
@@ -762,7 +794,7 @@ def test_taskcard_numeric_command_is_strict_and_does_not_toggle(
     assert service.taskcard_normal_rows() == 7
     assert "normal rows: 7" in replies[-1]
 
-    usage = "❌ Usage: /taskcard on | /taskcard off | /taskcard N (1-10)"
+    usage = "❌ Usage: /taskcard on | /taskcard off | /taskcard N (1-10) | /taskcard lang zh|en"
     for update_id, value in enumerate(
         ("0", "11", "-1", "1.5", "seven", "٧", "7 extra"), 2
     ):


### PR DESCRIPTION
## Problem

_TASK_CARD_EVENT_POLL_INTERVAL (default 5s) was only the wait after the Task Card poll loop body, not a hard per-message edit throttle. Three paths could issue Bot API edits faster than intended:

1. Same-tick double broadcast: _poll_event_tail() can broadcast on a changed tail, then the loop blanket _broadcast_task_card_event_window() runs again before the 5s wait.
2. Loop-external paths: inbound-message ensure/edit and _on_taskcard_changed() broadcast outside the poll loop.
3. Fingerprint time drift: agent_active_seconds advanced every second and entered the automatic fingerprint, so an active agent edited every tick with no real content change.

## Fix

- Add a resident-scoped monotonic edit gate keyed by (account, chat_id) at the _edit_resident_projection transport boundary. All edit paths share it, so concurrent producers issue at most one Bot API edit per target per _TASK_CARD_EVENT_POLL_INTERVAL. The timestamp is claimed before calling Telegram, so failed/unchanged requests still count.
- Normalize wall-clock-only fields out of the automatic fingerprint: exclude the Last Updated line (all locales) and the numeric active (Ns) seconds, while retaining lifecycle/usage/real content changes.

## Tests

- tests/test_telegram_task_card_event_tail.py: same-tick double broadcast, per-target independent throttle + 4.999s/5.000s boundary, inbound ensure + enable callback, force=True does not bypass the hard throttle, active-seconds-only change does not edit, lifecycle/usage/event content still changes the fingerprint, programmable current==body dedupe preserved.
- Focused + broad regression: 279 tests pass; ruff / py_compile / git diff --check clean.

---
Telegram: @lingtaidev4bot | Nickname: 守真
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai