### PR TITLE
docs(daemon): document MCP tool-name uniqueness across plugin mcp.json and task mcp

### DIFF
--- a/src/lingtai/tools/daemon/_tool_family.py
+++ b/src/lingtai/tools/daemon/_tool_family.py
@@ -154,7 +154,7 @@ def _emanate_task_schema() -> dict[str, Any]:
             "mcp": {
                 "type": "array",
                 "items": {"type": "object"},
-                "description": 'Optional one-run MCP registrations for this daemon task. Array of full MCP registration objects: {name, transport/type: stdio|http, command+args+env for stdio or url+headers for http}. The registrations are serialized into the daemon prompt as YAML; LingTai backend also starts them as task-scoped MCP clients and exposes their tools for this run. CLI backends receive the same serialized registrations as context and may load them if their runtime supports MCP. Secret env/header values are redacted in prompts.',
+                "description": 'Optional one-run MCP registrations for this daemon task. Array of full MCP registration objects: {name, transport/type: stdio|http, command+args+env for stdio or url+headers for http}. The registrations are serialized into the daemon prompt as YAML; LingTai backend also starts them as task-scoped MCP clients and exposes their tools for this run. CLI backends receive the same serialized registrations as context and may load them if their runtime supports MCP. Secret env/header values are redacted in prompts. Exposed tool names must be unique across this task: a plugin mcp.json server and a task-level `mcp` registration that expose the same tool name fail at dispatch with a duplicate-MCP-tool-name error (rename or dedupe one registration).',
             },
             "plugin": {
                 "type": "array",

--- a/src/lingtai/tools/daemon/manual/reference/cli-backends/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/cli-backends/SKILL.md
@@ -232,6 +232,13 @@ surface, closing them when the run finishes. Secret `env`/`headers` values are
 redacted in prompts. Beyond the daemon-eligible, opt-in `email` intrinsic, other
 intrinsics remain unavailable to keep daemon lightweight and non-recursive.
 
+> **MCP tool-name uniqueness.** Tool names exposed by MCP registrations must be
+> unique within a run. If a plugin `mcp.json` server and a task-level `mcp`
+> registration (or two registrations of either kind) expose the same tool name,
+> dispatch fails immediately with `ValueError: duplicate MCP tool name` before any
+> work starts — rename or dedupe one of the registrations. This is by design: both
+> injection paths are live at the same time, so same-server duplicates collide.
+
 Where each backend receives its native `daemon_common` MCP config:
 
 | Backend | Injection path |

--- a/src/lingtai/tools/plugin/manual/SKILL.md
+++ b/src/lingtai/tools/plugin/manual/SKILL.md
@@ -234,6 +234,12 @@ Three things to know when authoring one:
   addon-decompressed record already owns the name, the plugin's server is
   skipped and the existing record survives untouched. Same between two plugins:
   first declared wins.
+- **MCP tool names must stay unique within a daemon run.** A plugin's `mcp.json`
+  server is also injected into daemon tasks that select the plugin; if its
+  exposed tool name collides with a task-level `mcp` registration (or another
+  plugin/server), the daemon fails at dispatch with `duplicate MCP tool name` —
+  rename or dedupe one registration. This is expected: both injection paths are
+  live simultaneously.
 - **`${PLUGIN_ROOT}` and `./` paths are resolved to absolute** in the record. The
   record is a registration, not a launch spec: activating the server needs an
   `init.json` top-level `mcp` entry, and the kernel spawns from *that* entry's


### PR DESCRIPTION
## Summary

Live daemon injection experiment (2026-08-15) proved plugin `mcp.json` servers and task-level `mcp` registrations are both mounted for lingtai / claude-p / codex backends. One finding surfaced: if both paths expose the **same MCP tool name**, dispatch fails immediately with `ValueError: duplicate MCP tool name` before any work starts. This is fail-fast and low-risk, so we document it rather than change behavior (per product decision).

## Changes (docs-only, no behavior change)

1. **daemon tool schema** (`src/lingtai/tools/daemon/_tool_family.py`): `mcp` field description now notes tool names must be unique across the task and the duplicate-MCP-tool-name dispatch error + rename/dedupe remedy.
2. **daemon-manual cli-backends** (`src/lingtai/tools/daemon/manual/reference/cli-backends/SKILL.md`): added a callout explaining the uniqueness rule, the exact error, and that it is by design.
3. **plugin-manual** (`src/lingtai/tools/plugin/manual/SKILL.md`): added a bullet under `mcp.json` authoring notes about staying unique within a daemon run.

## Validation

- Live probes (lingtai `em-9184`, claude-p `em-b1ba`, codex `em-7021`) all mounted both `inject_echo` (plugin) and `task_echo` (task mcp) after renaming to distinct tool names.
- Docs-only diff: 3 files, +14/-1.
- No runtime/test code changed.

---

Telegram: @lingtaidev3bot | Nickname: 澄一

Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai