### PR TITLE
feat(tui): add "Ask agent for Task Card" hint after Last Updated line

### DIFF
--- a/src/lingtai/mcp_servers/task_card/event_projection.py
+++ b/src/lingtai/mcp_servers/task_card/event_projection.py
@@ -39,6 +39,7 @@ class TaskCardEventProjection:
         "en": {
             "header": "📋 ACTIVITIES",
             "time_prefix": "Last Updated: ",
+            "ask_agent": "Ask agent for \"Task Card\"",
             "footer_prefix": (
                 "Don't reply to this Task Card. Use /taskcard on|off to toggle; "
                 "/taskcard N sets normal rows (1-10"
@@ -61,6 +62,7 @@ class TaskCardEventProjection:
         "zh": {
             "header": "📋 活动",
             "time_prefix": "最后更新: ",
+            "ask_agent": "向 agent 询问 \"Task Card\"",
             "footer_prefix": (
                 "请勿回复此任务卡片。使用 /taskcard on|off 切换；"
                 "/taskcard N 设置显示组数 (1-10"
@@ -1047,6 +1049,7 @@ class TaskCardEventProjection:
             lines = [cls.header(locale), "", footer, cls.METADATA_DIVIDER]
             lines.extend(metadata_lines)
             lines.append(time_line)
+            lines.append(cls._locale_text("ask_agent", locale))
             return "\n".join(lines)
 
         api_scaffold = sum(len(line) + 1 for _, line in api_prepared)
@@ -1104,6 +1107,7 @@ class TaskCardEventProjection:
         lines.append(cls.METADATA_DIVIDER)
         lines.extend(metadata_lines)
         lines.append(time_line)
+        lines.append(cls._locale_text("ask_agent", locale))
         return "\n".join(lines)
 
     @classmethod

--- a/tests/test_task_card_event_projection_shared.py
+++ b/tests/test_task_card_event_projection_shared.py
@@ -133,7 +133,8 @@ def test_shared_render_is_byte_identical_to_telegram_golden_surface() -> None:
         "/taskcard N sets normal rows (1-10, current: 1).\n"
         "────────\n"
         "Session · active · calls 2\n"
-        "Last Updated: 02:30:00 U+8"
+        "Last Updated: 02:30:00 U+8\n"
+        "Ask agent for \"Task Card\""
     )
 
 


### PR DESCRIPTION
Adds a short locale-aware hint line, `Ask agent for "Task Card"`, immediately after the Task Cards `Last Updated:` line (both the empty and normal render paths) so users know they can ask the agent to interact with the card.

- en: `Ask agent for "Task Card"`; zh: `向 agent 询问 "Task Card"`.
- Updated shared projection test to cover the new trailing line.
- Validation: `pytest tests/test_task_card_event_projection_shared.py tests/test_telegram_task_card_rows.py` → 66 passed.

Telegram: @lingtaidev1bot | Nickname: 知微
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai