### PR TITLE
feat(telegram): show api-call count in Task Card daemon stats

### DIFF
--- a/src/lingtai/mcp_servers/task_card/event_projection.py
+++ b/src/lingtai/mcp_servers/task_card/event_projection.py
@@ -854,7 +854,7 @@ class TaskCardEventProjection:
                         f"cache {min(cached_tokens / input_tokens, 1.0):.1%}"
                     )
                 if cli_calls is not None and cli_calls > 0:
-                    stats_parts.append(f"CLI calls {cli_calls}")
+                    stats_parts.append(f"calls {cli_calls}")
 
             # All rows belong to one Async Work section. The priority value is
             # used only by the whole-line 500-character budget below.

--- a/tests/test_telegram_task_card_rows.py
+++ b/tests/test_telegram_task_card_rows.py
@@ -694,7 +694,7 @@ def test_metadata_renders_daemon_status_and_stats():
         "Async Work · running 3 · done 2 · failed 1",
         "Daemons · running 3 · done 2 · failed 1",
         "Backends · claude-p 1 · lingtai 2",
-        "Daemon stats · in 1.2M · out 340.0k · cache 85.0% · CLI calls 12",
+        "Daemon stats · in 1.2M · out 340.0k · cache 85.0% · calls 12",
     ]
 
 


### PR DESCRIPTION
## Summary

Add the api-call count to the Telegram Task Card's **Daemon stats** line so it matches the TUI mailview row format (`in <n> · out <n> · cache <pct> · calls <n>`).

The card already aggregates the api-call count (`cli_calls` = sum of `cli_tokens.calls` across active + terminal daemon runs in the 10-minute window) and rendered it as `CLI calls <n>`; this change renders it as `calls <n>` to match the TUI.

### Changes

- `src/lingtai/mcp_servers/task_card/event_projection.py` — daemon-stats line now renders `calls <n>` instead of `CLI calls <n>` (same data source: `daemon.cli_calls` from the resident card's async-work snapshot).
- `tests/test_telegram_task_card_rows.py` — updated expected daemon-stats line to `Daemon stats · in 1.2M · out 340.0k · cache 85.0% · calls 12`.

Telegram: @lingtaidev1bot | Nickname: 知微

Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
