### PR TITLE
feat(kernel): track last_api_call_at for taskcard active-since-API-call seconds

### DIFF
--- a/src/lingtai/kernel/base_agent/__init__.py
+++ b/src/lingtai/kernel/base_agent/__init__.py
@@ -772,6 +772,12 @@ class BaseAgent:
         now_wall = self._lifecycle_clock.wall_seconds()
         self._state_changed_at: float = now_wall
         self._last_progress_at: float = now_wall
+        #: Wall time of the most recent ``llm_call`` (API call start), used
+        #: to surface "how long has this agent been active since its last
+        #: API call" (Jason 2026-08-16). Seeded on state transitions like
+        #: ``_last_progress_at`` so a fresh ACTIVE turn starts at zero;
+        #: only ``llm_call`` bumps it afterwards.
+        self._last_api_call_at: float | None = now_wall
         self._active_turn_kind: str | None = None
         self._active_turn_started_at: float | None = None
         self._active_turn_id: str | None = None
@@ -993,6 +999,7 @@ class BaseAgent:
         now_wall = self._lifecycle_clock.wall_seconds()
         self._state_changed_at = now_wall
         self._last_progress_at = now_wall
+        self._last_api_call_at = now_wall
         if new_state == AgentState.ACTIVE:
             # The kernel doesn't know yet what kind of turn this will be —
             # the next progress event (``wake``, ``tc_wake_continue``,
@@ -1055,6 +1062,14 @@ class BaseAgent:
         # bookkeeping is in place even if the log service raises.
         if event_type in _PROGRESS_EVENTS:
             self._last_progress_at = self._lifecycle_clock.wall_seconds()
+            if event_type == "llm_call":
+                # "Active since last API call" — the wall time of the most
+                # recent LLM API call start, so external observers (taskcard
+                # footer, TUI Email To) can show how long the agent has been
+                # grinding since it last talked to the model (Jason
+                # 2026-08-16). Only ``llm_call`` bumps it, not responses,
+                # tools, or notifications.
+                self._last_api_call_at = self._lifecycle_clock.wall_seconds()
             kind = _PROGRESS_EVENTS[event_type]
             if kind is not None:
                 self._active_turn_kind = kind

--- a/src/lingtai/kernel/base_agent/identity.py
+++ b/src/lingtai/kernel/base_agent/identity.py
@@ -232,6 +232,7 @@ def _status(agent) -> dict:
     # reports/dual-agent-stuck-forensics-2026-05-26.md.
     state_changed_at = getattr(agent, "_state_changed_at", None)
     last_progress_at = getattr(agent, "_last_progress_at", None)
+    last_api_call_at = getattr(agent, "_last_api_call_at", None)
     no_progress_seconds = None
     if last_progress_at is not None:
         no_progress_seconds = round(max(0.0, agent._lifecycle_clock.wall_seconds() - last_progress_at), 1)
@@ -280,11 +281,13 @@ def _status(agent) -> dict:
             "state": agent._state.value,
             "state_changed_at": state_changed_at,
             "last_progress_at": last_progress_at,
+            "last_api_call_at": last_api_call_at,
             "no_progress_seconds": no_progress_seconds,
         },
         keys=(
             "current_time", "started_at", "uptime_seconds",
-            "state_changed_at", "last_progress_at", "no_progress_seconds",
+            "state_changed_at", "last_progress_at", "last_api_call_at",
+            "no_progress_seconds",
         ),
     )
 

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -2952,15 +2952,19 @@ class TelegramManager:
         return state if alive else "offline"
 
     def _task_card_active_seconds(self) -> float | None:
-        """Seconds since the agent's last progress while it is active.
+        """Seconds since the agent's last API call while it is active.
 
-        Reads ``.status.json``'s ``runtime.last_progress_at`` (the wall
-        timestamp ``BaseAgent._write_status_snapshot`` refreshes on every
-        turn) and returns its age only when the runtime reports ``active``.
-        This surfaces the live LLM/tool latency: while the model thinks or a
-        tool runs, ``last_progress_at`` stays put and the age grows; when
-        activity resumes it resets. Missing/malformed data, a non-active
-        state, or a future timestamp degrades to ``None``.
+        Reads ``.status.json``'s ``runtime.last_api_call_at`` (the wall
+        timestamp of the most recent ``llm_call`` event; ``BaseAgent``
+        refreshes it on every turn and every API call) and returns its age
+        only when the runtime reports ``active``. This is the "how long
+        has the agent been grinding since it last talked to the model"
+        signal Jason wants (2026-08-16): while the model thinks or a tool
+        runs, ``last_api_call_at`` stays put and the age grows; when a new
+        API call starts it resets. For older status files that predate the
+        field it falls back to ``runtime.last_progress_at``. Missing/
+        malformed data, a non-active state, or a future timestamp degrades
+        to ``None``.
         """
         try:
             raw = (self._working_dir / ".status.json").read_text(encoding="utf-8")
@@ -2977,12 +2981,14 @@ class TelegramManager:
             return None
         if runtime.get("state") != AgentState.ACTIVE.value:
             return None
-        last_progress = runtime.get("last_progress_at")
-        if not isinstance(last_progress, (int, float)) or isinstance(last_progress, bool):
+        anchor = runtime.get("last_api_call_at")
+        if not isinstance(anchor, (int, float)) or isinstance(anchor, bool):
+            anchor = runtime.get("last_progress_at")
+        if not isinstance(anchor, (int, float)) or isinstance(anchor, bool):
             return None
-        if not math.isfinite(last_progress):
+        if not math.isfinite(anchor):
             return None
-        age = time.time() - last_progress
+        age = time.time() - anchor
         return age if age >= 0 else None
 
     @staticmethod

--- a/tests/test_active_stuck_watchdog.py
+++ b/tests/test_active_stuck_watchdog.py
@@ -182,6 +182,45 @@ class TestStatusJsonExposesActiveTurn:
         assert isinstance(runtime["no_progress_seconds"], (int, float))
         assert runtime["no_progress_seconds"] >= 0
 
+    def test_status_exposes_last_api_call_at(self, tmp_path):
+        from lingtai.kernel import BaseAgent
+        agent = BaseAgent(
+            intrinsics=_TEST_INTRINSICS,
+            service=make_mock_service(),
+            agent_name="test",
+            working_dir=tmp_path / "test_agent",
+            workdir_lease=make_test_lease(),
+        agent_presence=make_test_presence_store(), snapshot_port=make_test_snapshot_port(), lifecycle_clock=make_test_lifecycle_clock(), source_revision_port=make_test_source_revision_port(), notification_store=notification_store_for(tmp_path / "test_agent"),
+        )
+        status = agent.status()
+        runtime = status["runtime"]
+        assert "last_api_call_at" in runtime
+        assert isinstance(runtime["last_api_call_at"], (int, float))
+
+    def test_llm_call_bumps_last_api_call_at_but_tool_call_does_not(self, tmp_path):
+        from lingtai.kernel import BaseAgent, AgentState
+        clock = make_test_lifecycle_clock()
+        agent = BaseAgent(
+            intrinsics=_TEST_INTRINSICS,
+            service=make_mock_service(),
+            agent_name="test",
+            working_dir=tmp_path / "test_agent",
+            workdir_lease=make_test_lease(),
+        agent_presence=make_test_presence_store(), snapshot_port=make_test_snapshot_port(), lifecycle_clock=clock, source_revision_port=make_test_source_revision_port(), notification_store=notification_store_for(tmp_path / "test_agent"),
+        )
+        agent._set_state(AgentState.ACTIVE, reason="test")
+        anchor = agent._last_api_call_at
+        clock.advance_wall(5.0)
+        # tool_call is progress but is NOT a new API call: anchor unchanged.
+        agent._log("tool_call", tool_call_id="t1")
+        assert agent._last_api_call_at == anchor
+        assert agent._last_progress_at > anchor
+        clock.advance_wall(5.0)
+        # llm_call is a new API call: anchor advances to now.
+        agent._log("llm_call", model="test", api_call_id="a1")
+        assert agent._last_api_call_at > anchor
+        assert agent._last_api_call_at == agent._last_progress_at
+
     def test_status_active_turn_block_present_only_in_active(self, tmp_path):
         from lingtai.kernel import BaseAgent, AgentState
         agent = BaseAgent(

--- a/tests/test_telegram_task_card_singleton.py
+++ b/tests/test_telegram_task_card_singleton.py
@@ -110,6 +110,60 @@ def _sends(account):
     return [c for c in account.calls if c[0] == "send_message"]
 
 
+# ---------------------------------------------------------------------------
+# ``_task_card_active_seconds`` — "active since last API call" (Jason
+# 2026-08-16): prefers ``runtime.last_api_call_at``, falls back to
+# ``runtime.last_progress_at`` for older status files.
+# ---------------------------------------------------------------------------
+
+def _write_status(tmp_path, runtime):
+    import json
+    (tmp_path / ".status.json").write_text(
+        json.dumps({"runtime": runtime}), encoding="utf-8"
+    )
+
+
+def test_task_card_active_seconds_prefers_last_api_call_at(tmp_path):
+    import time
+    from lingtai.kernel.state import AgentState
+
+    now = time.time()
+    _write_status(tmp_path, {
+        "state": AgentState.ACTIVE.value,
+        "last_progress_at": now - 2.0,
+        "last_api_call_at": now - 10.0,
+    })
+    manager, _ = _manager(tmp_path)
+    age = manager._task_card_active_seconds()
+    assert age is not None and 9.0 <= age <= 11.0
+
+
+def test_task_card_active_seconds_falls_back_to_last_progress_at(tmp_path):
+    import time
+    from lingtai.kernel.state import AgentState
+
+    now = time.time()
+    _write_status(tmp_path, {
+        "state": AgentState.ACTIVE.value,
+        "last_progress_at": now - 4.0,
+    })
+    manager, _ = _manager(tmp_path)
+    age = manager._task_card_active_seconds()
+    assert age is not None and 3.0 <= age <= 5.0
+
+
+def test_task_card_active_seconds_none_when_not_active(tmp_path):
+    from lingtai.kernel.state import AgentState
+
+    _write_status(tmp_path, {
+        "state": AgentState.IDLE.value,
+        "last_progress_at": 1_000.0,
+        "last_api_call_at": 1_000.0,
+    })
+    manager, _ = _manager(tmp_path)
+    assert manager._task_card_active_seconds() is None
+
+
 def _edits(account):
     return [c for c in account.calls if c[0] == "edit_message"]
 


### PR DESCRIPTION
## Summary

Jason 10373 chose option **B** for the TUI Email To "active" badge and
defined the semantic: **"how much time it has been active SINCE last api
call"** — the most useful info. The Telegram Task Card footer currently
measures `now - runtime.last_progress_at` (bumped on wake, llm_call,
llm_response, tool_call, tool_result, notifications), which is "time since
last progress", not "time since last API call".

This kernel PR:
1. Tracks `BaseAgent._last_api_call_at`, bumped **only** on `llm_call`
   (seeded like `_last_progress_at` on state transitions).
2. Exposes it as `runtime.last_api_call_at` in `.status.json`.
3. Makes the Telegram Task Card footer `_task_card_active_seconds` prefer
   `last_api_call_at`, falling back to `last_progress_at` for older status
   files.

TUI PR `#1401` (feat/tui-active-elapsed-seconds-20260816) consumes the new
field so both surfaces show the same number for the same agent.

## Changes

- `lingtai/kernel/base_agent/__init__.py`: `_last_api_call_at` field; seed on
  state transitions; bump on `llm_call` in `_log`.
- `lingtai/kernel/base_agent/identity.py`: emit `last_api_call_at` in the
  runtime block (+ time-veil scrub key).
- `lingtai/mcp_servers/telegram/manager.py`: `_task_card_active_seconds`
  prefers `last_api_call_at`, falls back to `last_progress_at`.
- Tests: status exposure, llm_call-vs-tool_call bump semantics, taskcard
  preference/fallback/non-active.

## Validation

- `tests/test_active_stuck_watchdog.py` PASS (incl. new status + bump tests)
- `tests/test_telegram_task_card_singleton.py` PASS (incl. new preference/
  fallback/non-active tests)
- Full touched suite: 181 passed

## Semantic (from Jason 10373)

> this i want it to mean how much time it has been active SINCE last api call
> this is most useful info

Telegram: @lingtaidev3bot | Nickname: 澄一
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
