### PR TITLE
perf(daemon): stop loading google-genai in every process to count tokens

### DIFF
--- a/src/lingtai/kernel/malloc_relief.py
+++ b/src/lingtai/kernel/malloc_relief.py
@@ -1,0 +1,75 @@
+"""Optional libc hint to return freed-but-retained heap pages to the OS.
+
+On macOS, libmalloc keeps the address space of a freed magazine region mapped
+and dirty, showing up in ``vmmap -summary`` as ``MALLOC_MEDIUM (empty)``. A
+long-lived daemon execution child that has processed a few large tool outputs
+can carry hundreds of MB of such pages: the memory is free to the allocator but
+still counted against the process RSS.
+
+``malloc_zone_pressure_relief(zone, goal)`` is Apple's documented request to
+release that space back. This module exposes it as an opt-in hook.
+
+**Measured result: it did not work.** On macOS 14 (Darwin 23.4, arm64,
+CPython 3.13) a synthetic 250MB transient produced 244.7MB of
+``MALLOC_MEDIUM (empty)``, and ``malloc_zone_pressure_relief(NULL, 0)``
+returned 0 bytes released and moved RSS by ~1MB. A realistic
+tool-output-shaped workload moved empty-region dirty pages 30.9MB -> 22.3MB
+but RSS only 57MB -> 56MB. So this is **disabled by default** and gated behind
+``LINGTAI_DAEMON_MEMORY_RELIEF=1`` purely so the hypothesis can be re-measured
+on a live daemon (different workload, macOS version, or allocation mix) without
+shipping a per-tool-batch cost to everyone.
+
+Do not enable it in production without measuring that specific daemon first.
+"""
+from __future__ import annotations
+
+import os
+
+_UNRESOLVED = object()
+_relief = _UNRESOLVED
+
+
+def enabled() -> bool:
+    """True when the operator opted in via ``LINGTAI_DAEMON_MEMORY_RELIEF=1``."""
+    return os.environ.get("LINGTAI_DAEMON_MEMORY_RELIEF", "").strip() == "1"
+
+
+def _resolve():
+    """Bind ``malloc_zone_pressure_relief`` once; None where unavailable."""
+    global _relief
+    if _relief is not _UNRESOLVED:
+        return _relief
+    _relief = None
+    try:
+        import ctypes
+        import ctypes.util
+        path = ctypes.util.find_library("c")
+        if path:
+            libc = ctypes.CDLL(path)
+            fn = getattr(libc, "malloc_zone_pressure_relief", None)
+            if fn is not None:
+                fn.restype = ctypes.c_size_t
+                fn.argtypes = [ctypes.c_void_p, ctypes.c_size_t]
+                _relief = fn
+    except Exception:
+        # Non-Darwin, no libc handle, or a hardened runtime that refuses the
+        # dlopen — the hint is strictly best-effort, so stay silent.
+        _relief = None
+    return _relief
+
+
+def relieve() -> int:
+    """Ask libc to return empty heap regions. Returns bytes released (0 if noop).
+
+    Never raises: this is a hint, and a failure to give it is not an error.
+    """
+    if not enabled():
+        return 0
+    fn = _resolve()
+    if fn is None:
+        return 0
+    try:
+        # NULL zone == every zone; goal 0 == release as much as possible.
+        return int(fn(None, 0))
+    except Exception:
+        return 0

--- a/src/lingtai/kernel/token_counter.py
+++ b/src/lingtai/kernel/token_counter.py
@@ -10,22 +10,55 @@ from .logging import get_logger
 _tokenizer = None
 _backend: str = "none"
 
+
+def _find_spec_safe(name: str):
+    """``importlib.util.find_spec`` that never raises.
+
+    find_spec imports parent packages and propagates any error they raise, so
+    treat every failure as "not importable".
+    """
+    import importlib.util
+    try:
+        return importlib.util.find_spec(name)
+    except Exception:
+        return None
+
+
 def _init_tokenizer() -> None:
     global _tokenizer, _backend
     logger = get_logger()
 
-    # Try google-genai first
-    try:
-        from google.genai._common import ExperimentalWarning
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=ExperimentalWarning)
-            from google.genai.local_tokenizer import LocalTokenizer
-        _tokenizer = LocalTokenizer()
-        _backend = "gemini"
-        logger.debug("token_counter: using google-genai LocalTokenizer")
-        return
-    except (ImportError, Exception):
-        pass
+    # Try google-genai first.
+    #
+    # ``google.genai.local_tokenizer`` hard-imports ``sentencepiece`` at module
+    # scope, and sentencepiece is not a declared dependency — so on a stock
+    # install this branch always raises ModuleNotFoundError and we fall through.
+    # But by then the ``google.genai`` package import has already run, resident
+    # for the life of the process at a measured ~66MB RSS (it drags in
+    # pydantic_core, cryptography, websockets, brotli, charset_normalizer).
+    # Every process that counts a single token paid that — including daemon
+    # execution children running an entirely different provider.
+    #
+    # Probe for sentencepiece with find_spec (no import, no cost) first. When it
+    # is absent the google branch cannot succeed, so skipping it is exactly
+    # equivalent to running it, minus the memory.
+    if _find_spec_safe("sentencepiece") is None:
+        logger.debug(
+            "token_counter: sentencepiece absent, skipping google-genai "
+            "LocalTokenizer (its import cannot succeed)"
+        )
+    else:
+        try:
+            from google.genai._common import ExperimentalWarning
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=ExperimentalWarning)
+                from google.genai.local_tokenizer import LocalTokenizer
+            _tokenizer = LocalTokenizer()
+            _backend = "gemini"
+            logger.debug("token_counter: using google-genai LocalTokenizer")
+            return
+        except (ImportError, Exception):
+            pass
 
     # Try tiktoken
     try:

--- a/src/lingtai/kernel/tool_executor.py
+++ b/src/lingtai/kernel/tool_executor.py
@@ -7,6 +7,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Any, Callable
 
+from . import malloc_relief
 from .llm.base import ToolCall
 from .loop_guard import LoopGuard
 from .meta_block import (
@@ -1022,6 +1023,11 @@ class ToolExecutor:
             )
         finally:
             self._current_api_call_id = previous_api_call_id
+            # A tool batch is this process's largest transient allocation, so
+            # it is the only point where returning empty heap regions could pay
+            # off. Off unless LINGTAI_DAEMON_MEMORY_RELIEF=1 — see the measured
+            # (negative) result in malloc_relief's docstring.
+            malloc_relief.relieve()
 
     def _execute_with_current_api_call_id(
         self,


### PR DESCRIPTION
## Summary

Every LingTai-backend daemon execution child loads the full `google.genai` package (~66MB RSS resident) on every session build, even when the daemon runs a completely different provider. The code path: `kernel/token_counter.py` tries `google.genai` LocalTokenizer first, but `google.genai.local_tokenizer` hard-imports `sentencepiece`, which is **not a declared dependency** and absent on stock installs — so the branch always fails, after the google-genai import has already run and become permanently resident. We pay the memory cost of a real tokenizer and then fall back to `len(text)//4`.

Fix: probe `sentencepiece` with `find_spec` (no import, no cost) before trying the google branch. When sentencepiece is absent the branch cannot succeed, so skipping it is exactly equivalent minus the memory.

## Measured (real detached LingTai-backend children, 3 reps each)

| | RSS |
|---|---:|
| before | 113.1 MB |
| after | 76.6 MB |

**−36.5 MB per child (−32%)** for openai/anthropic providers. Gemini daemons: identical backend and counts, ~17MB saved. CLI-backend children (no session build) carry no google-genai fingerprint at 40MB, confirming the leak is session-build-specific.

## Also in this PR

`malloc_relief.py` — opt-in (`LINGTAI_DAEMON_MEMORY_RELIEF=1`) libc `malloc_zone_pressure_relief` hook after tool batches. **Measured negative**: reproduced 244.7MB `MALLOC_MEDIUM (empty)`, but the API returned 0 bytes released and RSS moved ~1MB. Disabled by default; included so the hypothesis can be re-measured live. Do not enable in production without measuring that daemon.

## Tests

- Daemon suites: 212 passed, 1 failed — `test_emanate_without_preset_inherits_parent`, confirmed pre-existing on a clean `origin/main` worktree (fails identically there; base 03b11723).
- Tool/token suites: 525 passed.
- Broad ~2065-test sweep on both trees: base 34 failed, patched 33 — patched failure set is a strict subset of base, so **zero new failures**.

## Note

Follow-up (not in this PR): daemons currently estimate tokens with `len(text)//4` while carrying the memory cost of a real tokenizer. Adding `tiktoken` (~10MB) or declaring the estimate intentional is a product call.

Telegram: @lingtaidev4bot | Nickname: dev4bot
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai