### PR TITLE
feat(nudge): advise on large event journals

### DIFF
--- a/src/lingtai/kernel/nudge/ANATOMY.md
+++ b/src/lingtai/kernel/nudge/ANATOMY.md
@@ -3,6 +3,7 @@ related_files:
   - src/lingtai/kernel/ANATOMY.md
   - src/lingtai/kernel/nudge/__init__.py
   - src/lingtai/kernel/nudge/folder_size.py
+  - src/lingtai/kernel/nudge/event_journal_count.py
   - src/lingtai/kernel/nudge/init_config.py
   - src/lingtai/kernel/nudge/goal.py
   - src/lingtai/kernel/nudge/kernel_version.py
@@ -41,7 +42,7 @@ the ordinary Notification Store channel; it does not create a second transport.
   New built-in producer entries carry fixed `nudge_channel` metadata:
   `release_version` for `kernel_version`, `source_integrity` for
   `source_drift`, `configuration_staleness` for `init_config_shape`, and
-  `storage_size` for `folder_size`;
+  `storage_size` for `folder_size` and `event_journal_line_count`;
   unrelated legacy/unknown entries remain channel-less, and legacy entries
   persisted before this field existed remain visible as-is until their producer
   rewrites or removes them.
@@ -68,6 +69,14 @@ the ordinary Notification Store channel; it does not create a second transport.
   shared `upsert`/`remove` so global repeat/enable/retry semantics stay live.
   Emits/clears a `storage_size` finding when the directory crosses
   `LINGTAI_NUDGE_FOLDER_SIZE_GB` (default `5` decimal GB) (`src/lingtai/kernel/nudge/folder_size.py:1-182`).
+  `event_journal_count.py` has no user setting: its once-per-UTC-day direct
+  physical-line count is a fixed advisory human-discussion boundary.
+- `event_journal_count.py` — fixed 1,000,000-record advisory for active root
+  `events.jsonl`. It directly counts physical newlines once per UTC day for an
+  unchanged regular non-link file, with immediate re-count after identity
+  change/shrink; ordinary heartbeats only open/fstat the exact path. It never
+  parses, indexes, scans elsewhere, or changes journal data
+  (`src/lingtai/kernel/nudge/event_journal_count.py:1-151`).
 - `kernel_version.py` — read-only installed/running observation plus bounded
   GitHub/Gitee release-manifest comparison; it does not own a product repeat
   cadence (`src/lingtai/kernel/nudge/kernel_version.py:91-229`). Its remote

--- a/src/lingtai/kernel/nudge/__init__.py
+++ b/src/lingtai/kernel/nudge/__init__.py
@@ -45,7 +45,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping
 
-from . import folder_size, init_config, kernel_version, goal, source_drift
+from . import event_journal_count, folder_size, init_config, kernel_version, goal, source_drift
 
 
 DEFAULT_ENABLED = True
@@ -62,6 +62,7 @@ _ENTRY_CHANNEL_BY_KIND = {
     "source_drift": ENTRY_CHANNEL_SOURCE_INTEGRITY,
     "init_config_shape": ENTRY_CHANNEL_CONFIG_STALENESS,
     "folder_size": ENTRY_CHANNEL_STORAGE_SIZE,
+    "event_journal_line_count": ENTRY_CHANNEL_STORAGE_SIZE,
 }
 
 # Hard maximum for one nudge entry's inline, model-visible JSON serialization.
@@ -224,6 +225,7 @@ def run_checks(agent) -> None:
     _run_one(agent, "source_drift", source_drift.check)
     _run_one(agent, "init_config_shape", init_config.check)
     _run_one(agent, "folder_size", folder_size.check)
+    _run_one(agent, "event_journal_line_count", event_journal_count.check)
 
 
 def run_system_notifications(agent) -> None:

--- a/src/lingtai/kernel/nudge/event_journal_count.py
+++ b/src/lingtai/kernel/nudge/event_journal_count.py
@@ -1,0 +1,164 @@
+"""Low-frequency, advisory-only direct count of the active event journal.
+
+The expensive observation is deliberately bounded to once per UTC day for an
+unchanged file. It counts physical newline-delimited records directly from the
+active root JSONL file and never parses, rebuilds, checkpoints, or otherwise
+changes journal data.
+"""
+from __future__ import annotations
+
+import json
+import os
+import stat as stat_module
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+_KIND = "event_journal_line_count"
+_THRESHOLD_RECORDS = 1_000_000
+_STATE_FILE = Path(".notification") / ".nudge_state.json"
+_CHUNK_BYTES = 1024 * 1024
+
+
+def check(agent) -> None:
+    """Evaluate a direct count at most once per UTC day for an unchanged file.
+
+    Every heartbeat opens the exact active path with a non-following,
+    non-blocking descriptor and only fstats it. A whole-file read is due on a
+    new UTC date, a file identity change, or a shrink. Missing, linked,
+    non-regular, or unreadable paths are quiet no-findings.
+    """
+    from . import remove, upsert
+
+    events_path = Path(agent._working_dir) / "logs" / "events.jsonl"
+    opened = _open_regular_event_file(events_path)
+    if opened is None:
+        remove(agent, _KIND)
+        return
+
+    fd, source_stat = opened
+    try:
+        state_root = _load_persistent_state(agent)
+        state = state_root.setdefault(_KIND, {})
+        identity = [source_stat.st_dev, source_stat.st_ino]
+        today = _today_utc()
+        previous_size = state.get("size_bytes")
+        needs_count = (
+            state.get("last_check_date") != today
+            or state.get("file_identity") != identity
+            or not isinstance(previous_size, int)
+            or source_stat.st_size < previous_size
+        )
+
+        if needs_count:
+            try:
+                record_count = _count_newline_records(fd)
+            except OSError:
+                state.update(
+                    {
+                        "last_check_date": today,
+                        "file_identity": identity,
+                        "size_bytes": source_stat.st_size,
+                        "record_count": None,
+                    }
+                )
+                _save_persistent_state(agent, state_root)
+                remove(agent, _KIND)
+                return
+            state.update(
+                {
+                    "last_check_date": today,
+                    "file_identity": identity,
+                    "size_bytes": source_stat.st_size,
+                    "record_count": record_count,
+                }
+            )
+            _save_persistent_state(agent, state_root)
+
+        record_count = state.get("record_count")
+    finally:
+        os.close(fd)
+
+    if not isinstance(record_count, int) or record_count < _THRESHOLD_RECORDS:
+        remove(agent, _KIND)
+        return
+
+    upsert(
+        agent,
+        _KIND,
+        {
+            "title": "Active event journal reached 1,000,000 records",
+            "detail": (
+                "A low-frequency agent-folder organization check directly counted "
+                "at least 1,000,000 newline-delimited records in the active root "
+                "events.jsonl. Discuss handling with your human before taking any "
+                "action. This advisory does not automatically rename, create a new "
+                "file, archive, delete, compress, parse, rebuild, or otherwise "
+                "change journal data."
+            ),
+            "source": "direct-event-journal-count",
+            "active_events_path": str(events_path),
+            "threshold_records": _THRESHOLD_RECORDS,
+            "cadence": "once per UTC day for an unchanged file; immediate re-count after identity change or shrink",
+        },
+    )
+
+
+def _open_regular_event_file(path: Path) -> tuple[int, os.stat_result] | None:
+    """Open exactly ``path`` without link-following, or return quiet unknown."""
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    if not nofollow:
+        return None
+    flags = os.O_RDONLY | nofollow | getattr(os, "O_NONBLOCK", 0)
+    try:
+        fd = os.open(path, flags)
+    except OSError:
+        return None
+    try:
+        source_stat = os.fstat(fd)
+        if not stat_module.S_ISREG(source_stat.st_mode):
+            os.close(fd)
+            return None
+        return fd, source_stat
+    except OSError:
+        os.close(fd)
+        return None
+
+
+def _count_newline_records(fd: int) -> int:
+    """Count physical newline records without retaining or interpreting content."""
+    count = 0
+    while chunk := os.read(fd, _CHUNK_BYTES):
+        count += chunk.count(b"\n")
+    return count
+
+
+def _today_utc() -> str:
+    return datetime.now(timezone.utc).date().isoformat()
+
+
+def _persistent_path(agent) -> Path:
+    return Path(agent._working_dir) / _STATE_FILE
+
+
+def _load_persistent_state(agent) -> dict[str, Any]:
+    path = _persistent_path(agent)
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _save_persistent_state(agent, state: dict[str, Any]) -> None:
+    path = _persistent_path(agent)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(path.name + ".tmp")
+    tmp.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    tmp.replace(path)
+
+
+__all__ = ["check"]

--- a/tests/ANATOMY.md
+++ b/tests/ANATOMY.md
@@ -169,6 +169,7 @@ related_files:
   - tests/test_file_io_sidecar.py
   - tests/test_file_tool_family.py
   - tests/test_filesystem_mail.py
+  - tests/test_event_journal_count_nudge.py
   - tests/test_folder_size_nudge.py
   - tests/test_fsutil.py
   - tests/test_gated_session_proxy.py

--- a/tests/test_event_journal_count_nudge.py
+++ b/tests/test_event_journal_count_nudge.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from lingtai.kernel import nudge as nudge_mod
+from lingtai.kernel.nudge import ENTRY_CHANNEL_STORAGE_SIZE
+from lingtai.kernel.nudge import event_journal_count
+from tests._notification_store_helpers import notification_store_for, snapshot_notifications
+
+
+class _Agent:
+    def __init__(self, workdir: Path) -> None:
+        self._working_dir = workdir
+        self._notification_store = notification_store_for(workdir)
+        self._notification_fp = ()
+        self.logs: list[tuple[str, dict]] = []
+
+    def _log(self, event: str, **fields) -> None:
+        self.logs.append((event, fields))
+
+
+def _entries(workdir: Path) -> list[dict]:
+    return snapshot_notifications(workdir).get("nudge", {}).get("data", {}).get("nudges", [])
+
+
+def _events_path(workdir: Path, data: bytes = b"seed\n") -> Path:
+    path = workdir / "logs" / "events.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(data)
+    return path
+
+
+@pytest.fixture(autouse=True)
+def _fixed_day(monkeypatch) -> None:
+    monkeypatch.setattr(event_journal_count, "_today_utc", lambda: "2026-08-16")
+
+
+def test_exact_threshold_emits_human_discussion_advisory(monkeypatch, tmp_path: Path) -> None:
+    agent = _Agent(tmp_path)
+    path = _events_path(tmp_path)
+    monkeypatch.setattr(
+        event_journal_count,
+        "_count_newline_records",
+        lambda _: event_journal_count._THRESHOLD_RECORDS,
+    )
+
+    event_journal_count.check(agent)
+
+    entry = _entries(tmp_path)[0]
+    assert entry["kind"] == "event_journal_line_count"
+    assert entry["nudge_channel"] == ENTRY_CHANNEL_STORAGE_SIZE
+    assert entry["active_events_path"] == str(path)
+    assert entry["threshold_records"] == event_journal_count._THRESHOLD_RECORDS
+    assert entry["cadence"] == "once per UTC day for an unchanged file; immediate re-count after identity change or shrink"
+    assert "Discuss handling with your human" in entry["detail"]
+    for boundary in ("rename", "create a new file", "archive", "delete", "compress"):
+        assert boundary in entry["detail"]
+
+
+def test_under_threshold_clears_stale_finding(monkeypatch, tmp_path: Path) -> None:
+    agent = _Agent(tmp_path)
+    _events_path(tmp_path)
+    nudge_mod.upsert(agent, "event_journal_line_count", {"title": "stale", "detail": "old"})
+    monkeypatch.setattr(event_journal_count, "_count_newline_records", lambda _: 999_999)
+
+    event_journal_count.check(agent)
+
+    assert _entries(tmp_path) == []
+
+
+def test_missing_file_is_quiet_no_finding(tmp_path: Path) -> None:
+    agent = _Agent(tmp_path)
+    nudge_mod.upsert(agent, "event_journal_line_count", {"title": "stale", "detail": "old"})
+
+    event_journal_count.check(agent)
+
+    assert _entries(tmp_path) == []
+
+
+def test_unchanged_file_does_not_repeat_direct_count(monkeypatch, tmp_path: Path) -> None:
+    agent = _Agent(tmp_path)
+    path = _events_path(tmp_path)
+    calls: list[int] = []
+
+    def count(fd: int) -> int:
+        calls.append(fd)
+        return 0
+
+    monkeypatch.setattr(event_journal_count, "_count_newline_records", count)
+    event_journal_count.check(agent)
+    event_journal_count.check(agent)
+
+    assert len(calls) == 1
+    assert path.exists()
+
+
+def test_utc_date_rollover_recounts_unchanged_file(monkeypatch, tmp_path: Path) -> None:
+    agent = _Agent(tmp_path)
+    _events_path(tmp_path)
+    day = ["2026-08-16"]
+    calls: list[int] = []
+    monkeypatch.setattr(event_journal_count, "_today_utc", lambda: day[0])
+    monkeypatch.setattr(event_journal_count, "_count_newline_records", lambda fd: calls.append(fd) or 0)
+
+    event_journal_count.check(agent)
+    day[0] = "2026-08-17"
+    event_journal_count.check(agent)
+
+    assert len(calls) == 2
+
+
+def test_same_size_replacement_recounts_immediately(monkeypatch, tmp_path: Path) -> None:
+    agent = _Agent(tmp_path)
+    path = _events_path(tmp_path, b"first\n")
+    counts = iter([event_journal_count._THRESHOLD_RECORDS, 0])
+    monkeypatch.setattr(event_journal_count, "_count_newline_records", lambda _: next(counts))
+
+    event_journal_count.check(agent)
+    assert len(_entries(tmp_path)) == 1
+    replacement = path.with_name("replacement.jsonl")
+    replacement.write_bytes(b"other\n")
+    replacement.replace(path)
+    event_journal_count.check(agent)
+
+    assert _entries(tmp_path) == []
+
+
+def test_shrink_recounts_same_day_and_clears_stale_observation(monkeypatch, tmp_path: Path) -> None:
+    agent = _Agent(tmp_path)
+    path = _events_path(tmp_path, b"a\n" * 20)
+    counts = iter([event_journal_count._THRESHOLD_RECORDS, 0])
+    monkeypatch.setattr(event_journal_count, "_count_newline_records", lambda _: next(counts))
+
+    event_journal_count.check(agent)
+    assert len(_entries(tmp_path)) == 1
+    path.write_bytes(b"small\n")
+    event_journal_count.check(agent)
+
+    assert _entries(tmp_path) == []
+
+
+def test_symlink_is_quiet_and_never_counts(monkeypatch, tmp_path: Path) -> None:
+    agent = _Agent(tmp_path)
+    path = _events_path(tmp_path)
+    target = tmp_path / "outside.jsonl"
+    target.write_bytes(b"outside\n")
+    path.unlink()
+    path.symlink_to(target)
+    monkeypatch.setattr(event_journal_count, "_count_newline_records", lambda _: pytest.fail("must not count a link"))
+
+    event_journal_count.check(agent)
+
+    assert _entries(tmp_path) == []
+
+
+def test_fifo_is_quiet_and_never_blocks_or_counts(monkeypatch, tmp_path: Path) -> None:
+    agent = _Agent(tmp_path)
+    path = _events_path(tmp_path)
+    path.unlink()
+    os.mkfifo(path)
+    monkeypatch.setattr(event_journal_count, "_count_newline_records", lambda _: pytest.fail("must not count a FIFO"))
+
+    event_journal_count.check(agent)
+
+    assert _entries(tmp_path) == []
+
+
+def test_unavailable_open_is_quiet_no_finding(monkeypatch, tmp_path: Path) -> None:
+    agent = _Agent(tmp_path)
+    _events_path(tmp_path)
+    nudge_mod.upsert(agent, "event_journal_line_count", {"title": "stale", "detail": "old"})
+    monkeypatch.setattr(event_journal_count, "_open_regular_event_file", lambda _: None)
+
+    event_journal_count.check(agent)
+
+    assert _entries(tmp_path) == []
+
+
+def test_counter_uses_physical_newlines_without_json_interpretation(tmp_path: Path) -> None:
+    path = _events_path(tmp_path, b"not-json\n{also-not-json}\nunterminated")
+    opened = event_journal_count._open_regular_event_file(path)
+    assert opened is not None
+    fd, _ = opened
+    try:
+        assert event_journal_count._count_newline_records(fd) == 2
+    finally:
+        os.close(fd)


### PR DESCRIPTION
## Summary

- Add a `storage_size` Nudge that directly counts newline-delimited records in the active root `logs/events.jsonl` and advises human discussion at **1,000,000** records.
- Bound the expensive read to once per UTC day for an unchanged file; ordinary Nudge calls use a cheap file observation and recount after identity change or shrink.
- Keep the feature advisory-only: it does not automatically rename, create, archive, delete, compress, parse, rebuild, index, or otherwise handle journal data.

## Validation

- `python -m compileall -q src/lingtai/kernel/nudge/event_journal_count.py`
- `python -m pytest -q tests/test_event_journal_count_nudge.py tests/test_folder_size_nudge.py tests/test_nudge_policy.py tests/test_nudge_inline_cap.py tests/test_kernel_version_nudge.py` — **90 passed**
- `git diff --check` — clean before commit.
- The broad architecture-graph test has a known unrelated `origin/main` failure: duplicate `src/lingtai/kernel/llm/reasoning_effort.py` in `src/lingtai/kernel/llm/ANATOMY.md`; this PR does not touch that file.

## Review visibility / draft status

This is intentionally a **Draft** for review. The first independent snapshot review drove leaf-link/non-regular-file, cadence/replacement coverage, and Anatomy-state fixes. The r2 report still identifies broader security/state/platform concerns (trusted `logs/` traversal, concurrent shared Nudge-state merging, and Windows secure-open semantics):

- `workspace/events-journal-direct-count-nudge-20260816/independent-review.md`
- `workspace/events-journal-direct-count-nudge-20260816/independent-review-r2.md`

Jason explicitly directed opening this PR for gradual review (Telegram messages 10405 and 10411). This body does **not** represent those r2 findings as resolved, and no merge is requested.

## Measurement context

One Jason-authorized read-only benchmark on a 1,367,406,589-byte journal counted 1,011,654 newline records in 1.41s wall time (1.30s user / 0.10s sys), supporting low-frequency use only, not a heartbeat scan.

Telegram: @lingtaidev3bot | Nickname: 澄一
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
