### PR TITLE
feat(taskcard): show LingTai daemon model stats

### DIFF
--- a/src/lingtai/mcp_servers/task_card/event_projection.py
+++ b/src/lingtai/mcp_servers/task_card/event_projection.py
@@ -834,6 +834,22 @@ class TaskCardEventProjection:
                 for backend, value in sorted(safe_backends):
                     backend_parts.append(f"{backend} {value}")
 
+            if isinstance(daemon, dict) and isinstance(daemon.get("model_counts"), dict):
+                safe_models: list[tuple[str, int]] = []
+                for raw_model, raw_count in daemon["model_counts"].items():
+                    model = cls.machine_identifier(raw_model, limit=128)
+                    value = count(raw_count)
+                    if model is not None and value is not None and value > 0:
+                        safe_models.append((model, value))
+                safe_models.sort()
+                model_total = sum(value for _, value in safe_models)
+                if model_total == 1:
+                    daemon_parts.append(safe_models[0][0])
+                elif model_total > 1:
+                    daemon_parts.extend(
+                        f"{model} × {value}" for model, value in safe_models
+                    )
+
             stats_parts: list[str] = []
             if isinstance(daemon, dict):
                 input_tokens = count(daemon.get("input_tokens"))

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -2722,6 +2722,7 @@ class TelegramManager:
         totals = {"input": 0, "output": 0, "cached": 0}
         cli_calls = 0
         backend_counts: dict[str, int] = {}
+        model_counts: dict[str, int] = {}
         included = False
         try:
             children = list(daemons_dir.iterdir())
@@ -2760,6 +2761,12 @@ class TelegramManager:
                 )
                 backend = TaskCardEventProjection.machine_identifier(backend, limit=48) or "unknown"
                 backend_counts[backend] = backend_counts.get(backend, 0) + 1
+                if state.get("backend") == "lingtai":
+                    model = TaskCardEventProjection.machine_identifier(
+                        state.get("model"), limit=128
+                    )
+                    if model is not None and model != "unknown":
+                        model_counts[model] = model_counts.get(model, 0) + 1
 
                 tokens = state.get("tokens")
                 cli_tokens = state.get("cli_tokens")
@@ -2793,7 +2800,7 @@ class TelegramManager:
                 continue
         if not included:
             return None
-        return {
+        snapshot = {
             **counts,
             "backend_counts": backend_counts,
             "input_tokens": totals["input"],
@@ -2801,6 +2808,9 @@ class TelegramManager:
             "cached_tokens": totals["cached"],
             "cli_calls": cli_calls,
         }
+        if model_counts:
+            snapshot["model_counts"] = model_counts
+        return snapshot
 
     def _task_card_async_shell_snapshot(self) -> dict | None:
         """Read-only async-shell lane using only durable ``state.json`` files."""

--- a/src/lingtai/tools/daemon/__init__.py
+++ b/src/lingtai/tools/daemon/__init__.py
@@ -4959,6 +4959,10 @@ class DaemonManager:
             em_id = self._new_emanation_id(reserved_ids=set(ids))
             ids.append(em_id)
             resolved = resolved_presets[i]
+            effective_llm = (
+                resolved["llm"] if resolved else self._implicit_parent_preset_llm()
+            )
+            effective_model = effective_llm["model"]
 
             # Build tool surface and system prompt up front so the run_dir
             # records the prompt verbatim before any LLM call. Validation
@@ -4989,9 +4993,6 @@ class DaemonManager:
             )
             task_context = self._append_daemon_common_context(task_context)
 
-            # Effective model for this emanation (preset overrides if present)
-            effective_model = (resolved["llm"]["model"]
-                               if resolved else self._default_model)
             system_prompt = "[daemon prompt pending MCP startup]"
 
             # Construct run_dir — creates folder on disk, writes daemon.json,
@@ -5069,7 +5070,6 @@ class DaemonManager:
                 return {"status": "error", "message": str(e)}
 
             self._close_task_mcp_clients(task_mcp_clients)  # none connected in this branch
-            effective_llm = resolved["llm"] if resolved else self._implicit_parent_preset_llm()
             try:
                 self._spawn_detached_lingtai_run(
                     run_dir,

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -3579,6 +3579,34 @@ def test_emanate_with_preset_passes_through(tmp_path, monkeypatch):
     assert data.get("preset_model") == "deepseek-v3"
 
 
+def test_emanate_without_preset_persists_the_detached_effective_model(tmp_path, monkeypatch):
+    """daemon.json model follows the LLM sent to detached execution, not stale cache."""
+    agent = _make_agent(tmp_path, ["file", "daemon"])
+    mgr = agent.get_capability("daemon")
+    stale_model = agent.service.model
+    effective_model = "gpt-5.6-daemon"
+    assert stale_model != effective_model
+    agent.service.model = effective_model
+    captured = {}
+
+    def fake_spawn(run_dir, **kwargs):
+        captured["run_dir"] = run_dir
+        captured["effective_llm"] = kwargs["effective_llm"]
+
+    monkeypatch.setattr(mgr, "_spawn_detached_lingtai_run", fake_spawn)
+
+    result = mgr.handle({"action": "emanate", "tasks": [
+        {"task": "task A", "tools": ["file"]},
+    ]})
+
+    assert result["status"] == "dispatched"
+    state = json.loads(
+        captured["run_dir"].daemon_json_path.read_text(encoding="utf-8")
+    )
+    assert captured["effective_llm"]["model"] == effective_model
+    assert state["model"] == effective_model
+
+
 def test_emanate_without_preset_inherits_parent(tmp_path, monkeypatch):
     """Omitted preset inherits parent effective identity without allowlist reads."""
     agent = _make_agent(tmp_path, ["file", "daemon"])

--- a/tests/test_telegram_task_card_rows.py
+++ b/tests/test_telegram_task_card_rows.py
@@ -773,6 +773,30 @@ def test_metadata_daemon_stats_require_positive_counts():
     assert lines == ["Async Work · running 1", "Daemons · running 1"]
 
 
+def test_metadata_displays_lingtai_daemon_models_compactly_and_deterministically():
+    single = TelegramManager._format_task_card_metadata({
+        "async_work": {"daemon": {
+            "running": 1,
+            "model_counts": {"gpt-5.6": 1},
+        }},
+    })
+    assert single == [
+        "Async Work · running 1",
+        "Daemons · running 1 · gpt-5.6",
+    ]
+
+    multiple = TelegramManager._format_task_card_metadata({
+        "async_work": {"daemon": {
+            "running": 3,
+            "model_counts": {"zeta-2": 1, "alpha-1": 2, "unsafe model": 99},
+        }},
+    })
+    assert multiple == [
+        "Async Work · running 3",
+        "Daemons · running 3 · alpha-1 × 2 · zeta-2 × 1",
+    ]
+
+
 def test_daemon_snapshot_scans_daemons_dir_and_windows(tmp_path):
     import json as _json
     from datetime import datetime, timedelta, timezone
@@ -786,9 +810,9 @@ def test_daemon_snapshot_scans_daemons_dir_and_windows(tmp_path):
     recent = (now - timedelta(minutes=2)).strftime("%Y-%m-%dT%H:%M:%SZ")
     old = (now - timedelta(minutes=30)).strftime("%Y-%m-%dT%H:%M:%SZ")
     for name, state in [
-        ("em-1", {"state": "running", "backend": "lingtai", "tokens": {"input": 1000, "output": 500, "cached": 800, "calls": 3}}),
-        ("em-2", {"state": "done", "backend": "claude-p", "finished_at": recent, "tokens": {"input": 2000, "output": 700, "cached": 1500, "calls": 4}}),
-        ("em-3", {"state": "failed", "finished_at": recent, "cli_tokens": {"input": 3000, "output": 100, "cached": 0, "calls": 1}}),
+        ("em-1", {"state": "running", "backend": "lingtai", "model": "gpt-5.6", "tokens": {"input": 1000, "output": 500, "cached": 800, "calls": 3}}),
+        ("em-2", {"state": "done", "backend": "claude-p", "model": "claude-external", "finished_at": recent, "tokens": {"input": 2000, "output": 700, "cached": 1500, "calls": 4}}),
+        ("em-3", {"state": "failed", "finished_at": recent, "model": "external-unknown", "cli_tokens": {"input": 3000, "output": 100, "cached": 0, "calls": 1}}),
         ("em-4", {"state": "done", "backend": "codex", "finished_at": old, "tokens": {"input": 9999, "output": 9999, "cached": 9999, "calls": 99}}),
     ]:
         (daemons / name / "daemon.json").write_text(_json.dumps(state), encoding="utf-8")
@@ -803,6 +827,10 @@ def test_daemon_snapshot_scans_daemons_dir_and_windows(tmp_path):
     assert snap["output_tokens"] == 500 + 700 + 100
     assert snap["cached_tokens"] == 800 + 1500 + 0
     assert snap["cli_calls"] == 1
+    # Only actual LingTai backend model values are eligible; external and
+    # backend-less records remain visible in their existing lanes but are not
+    # misrepresented as LingTai model statistics.
+    assert snap["model_counts"] == {"gpt-5.6": 1}
     # Backend distribution counts only in-window runs; em-3 without a backend
     # falls back to "unknown".
     assert snap["backend_counts"] == {"lingtai": 1, "claude-p": 1, "unknown": 1}


### PR DESCRIPTION
## Summary
- Make a LingTai daemon run's persisted `daemon.json.model` come from the same effective LLM mapping sent to detached execution.
- Add a bounded, safe, LingTai-only `model × count` lane to Telegram's automatic Task Card metadata, preserving its existing active/recent-terminal window and metadata budget.
- Exclude external CLI, backend-less, unsafe, missing, and `unknown` model values; do not change the intrinsic Task Card artifact or async-job protocol.

## Validation
- `/Users/huangzesen/work/GitHub/lingtai-kernel/.venv/bin/python -m pytest -q tests/test_telegram_task_card_rows.py tests/test_daemon.py::test_emanate_without_preset_persists_the_detached_effective_model` — 60 passed.
- `/Users/huangzesen/work/GitHub/lingtai-kernel/.venv/bin/python -m pytest -q tests/test_task_card_event_projection_shared.py tests/test_telegram_task_card_event_tail.py` — 59 passed.
- `/Users/huangzesen/work/GitHub/lingtai-kernel/.venv/bin/python -m pytest -q -x tests/test_daemon.py -k 'not test_emanate_without_preset_inherits_parent'` — 134 passed, 1 deselected.
- `git diff --check` — pass.
- Independent frozen-snapshot review — PASS (P0/P1/P2 = 0), patch SHA `030c3a437db53ab54e03951435e71bdf969e9d3e203419696eab2ceee0a5640e`.
- The deselected full-module test has a confirmed pre-existing central-daemon-manager versus direct-supervisor mock mismatch; the new default-manager truthfulness regression passes.

## Scope
- No schema/data-version, migration, runtime configuration, intrinsic Task Card artifact, or independent async-job protocol change.
- Created under Jason's explicit authorization; **do not merge without a separate authorization**.

Telegram: @lingtaidev3bot | Nickname: 澄一
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
