### PR TITLE
feat(daemon): add immutable task file inputs

### DIFF
--- a/src/lingtai/tools/daemon/CONTRACT.md
+++ b/src/lingtai/tools/daemon/CONTRACT.md
@@ -241,6 +241,30 @@ task; a non-list value fails preflight before run-dir creation. External CLI
 backends receive the plugin's skills and MCP registrations through the normal
 skill/mcp oneshot context and mount no plugin-native surface.
 
+Optional `tasks[].task_files` is an array of `{path, label?, role?}` objects
+naming UTF-8 text input files under the parent agent working directory.
+Preflight (before any run-dir creation, preset work, or scheduling) resolves
+each path relative to that working directory, enforces containment inside it
+(fully-resolved, symlinks followed), validates UTF-8 text and the practical
+limits (`TASK_FILES_MAX_PER_TASK` files per task, `TASK_FILE_MAX_BYTES` per
+file), and snapshots the bytes content-addressed into the immutable read-only
+input store `daemons/_task_files/` (one blob per SHA-256 across the whole
+dispatch/group, published atomically via `os.replace`). Any malformed,
+out-of-root, missing, oversize, or non-UTF-8 entry refuses the whole batch
+with a `tasks[i].task_files[j]`-context error — task input never silently
+falls back to the mutable original path. Each run's durable
+`daemon.json.call_parameters.task_files` records `{manifest, files}` pointing
+at the compact per-dispatch manifest (`daemons/_task_files/manifest-<group>.json`)
+and that run's snapshot rows (`path`, `label`, `role`, `sha256`, `size`,
+`snapshot`), so `check`, retry, and relaunch never need the original file.
+Every backend receives only a compact `## Parent-provided task files`
+oneshot-context section with the snapshot paths — never file contents —
+keeping the daemon system prompt within its 20,000-character budget
+regardless of input size. The `_task_files` store is internal-only: its
+leading underscore excludes it from every run-dir scan
+(`_looks_like_daemon_run_dir`), so `list`/recovery/`check` never surface it
+as a run.
+
 LingTai-backend daemon LLM construction uses one effective context window:
 an explicit daemon preset's canonical `manifest.llm.context_limit` wins,
 otherwise an implicit/no-preset daemon inherits the parent service's valid
@@ -272,7 +296,7 @@ continues on full history and never falls back to a different wire).
 
 | Action | Required inputs | Optional inputs | Success output | Error shapes |
 |---|---|---|---|---|
-| `emanate` | `tasks[]` (each `task`+`tools`) | `backend`, `max_turns`, `timeout`, per-task `prompt` (LingTai only), `skills`/`mcp`/`preset`/`backend_options`/`context_token_limit`/`plugin` | `{status: "dispatched", count, ids: [...], group_id, handoff}`; `handoff` tells the model it may go idle or call `system(action='sleep')` while waiting for the terminal notification, and conditionally says that if Telegram is connected and a Task Card is available for the current turn, the model should use it to report progress via `telegram(action='manual')` and that manual's `Programmable Task Card` section; read `daemon-manual` and `notification-manual` for details | `{status: "error", message}` — obsolete `system_prompt` migration, CLI `prompt`, bad limits, or tool-surface/preset failure |
+| `emanate` | `tasks[]` (each `task`+`tools`) | `backend`, `max_turns`, `timeout`, per-task `prompt` (LingTai only), `skills`/`mcp`/`preset`/`backend_options`/`context_token_limit`/`plugin`/`task_files` | `{status: "dispatched", count, ids: [...], group_id, handoff}`; `handoff` tells the model it may go idle or call `system(action='sleep')` while waiting for the terminal notification, and conditionally says that if Telegram is connected and a Task Card is available for the current turn, the model should use it to report progress via `telegram(action='manual')` and that manual's `Programmable Task Card` section; read `daemon-manual` and `notification-manual` for details | `{status: "error", message}` — obsolete `system_prompt` migration, CLI `prompt`, bad limits, or tool-surface/preset failure |
 | `list` | — | `contains`, `status`, `include_done` (default true), `last` | `{...}` list blob of matching emanations (running + persisted history) | `{status: "error", message}` |
 | `ask` | `id`, `message` | — | `{status: "sent", id, output}` (resume-capable CLI ask returns immediately as `{status: "sent", id, async: true, ...}`); an active common-MCP CLI returns `{status: "queued", id, delivery: "checkpoint", message_id}` | `{status: "error", id, message}` — unknown/absent id or terminal backend resume unsupported; an active backend without common MCP remains `{status: "busy", ...}` |
 | `check` | `id` | `last` (default 20), `truncate` (default 500) | `{id, run_id, state, backend, path, turn, current_tool, elapsed_s, finished_at, tokens, result_preview, result_path, last_output, error, latest_checkpoint, pending_checkpoint_messages, events: [...]}`; pending is a count, never message content | `{status: "error", message}` — unknown id, no run_dir, invalid `last`/`truncate`, or read failure |
@@ -639,6 +663,18 @@ stale `running`/`active` `daemon.json` records whose `parent_pid` is dead are
 reaped to `failed`.
 
 ## Process and Terminal Boundaries
+
+### 10. Task input files are snapshot-only, never live-path reads
+
+Optional `tasks[].task_files` input is copied once, content-addressed, into the
+immutable `daemons/_task_files/` store before any run starts; the daemon prompt
+and every backend receive only the compact manifest rows (`label`, `role`,
+`sha256`, `size`, `snapshot` path). A worker must read the snapshot paths, and
+no backend may embed file contents into the prompt/JSONL or point the worker at
+the mutable original path — the original may change or disappear after dispatch
+without affecting the run, its `check` inspection, or a relaunch. Preflight
+fails the whole batch loudly for any malformed, out-of-root, missing, oversize,
+or non-UTF-8 entry; there is no silent fallback to the original path.
 
 ### External CLI process boundary
 

--- a/src/lingtai/tools/daemon/__init__.py
+++ b/src/lingtai/tools/daemon/__init__.py
@@ -13,6 +13,7 @@ Usage:
 """
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
@@ -508,6 +509,25 @@ _DAEMON_COMPLETION_FILE = "daemon_completion.json"
 _DAEMON_CLAUDE_MCP_CONFIG_FILE = "claude-mcp-config.json"
 _DAEMON_COMPLETION_STATUSES = {"done", "failed", "incomplete"}
 _SOURCE_ROOT = Path(__file__).resolve().parents[3]
+
+#: Optional per-task input files (``tasks[].task_files``): the parent resolves
+#: every path under the agent working directory, validates UTF-8 text and the
+#: practical limits below, and snapshots the bytes content-addressed into an
+#: immutable read-only input store BEFORE any run-dir creation or scheduling.
+#: Workers receive only a compact manifest pointing at the snapshot paths —
+#: never the file contents and never the mutable original paths — so retry and
+#: relaunch never need the original file. The store lives under the daemons
+#: root as ``daemons/_task_files/``; the leading underscore is the run-dir
+#: scan's marker that the store is internal and never a run (see
+#: ``_looks_like_daemon_run_dir``).
+_TASK_FILES_STORE_DIR_NAME = "_task_files"
+_TASK_FILES_MANIFEST_VERSION = 1
+#: Per-task cap on task_files entries; bounds the compact manifest/prompt rows.
+TASK_FILES_MAX_PER_TASK = 50
+#: Per-file byte cap for one task input file; bounds the immutable blob store.
+TASK_FILE_MAX_BYTES = 1_000_000
+#: Cap on a task_files label/role string; keeps the prompt manifest compact.
+_TASK_FILES_ANNOTATION_MAX_CHARS = 200
 # Tools emanations can never use (no recursion, no spawning, no identity mutation)
 EMANATION_BLACKLIST = {
     "daemon",
@@ -2617,11 +2637,213 @@ class DaemonManager:
         return self._render_task_skill_catalog(rows)
 
     @staticmethod
+    def _resolve_task_file_path(raw_path: str, working_dir: Path) -> Path:
+        """Resolve one daemon task file path to a contained absolute file.
+
+        Relative paths resolve against the agent working directory; ``~`` is
+        expanded. The fully-resolved path (symlinks followed) must stay inside
+        the working directory, so a symlink escaping the root is out-of-root.
+        """
+        p = Path(raw_path).expanduser()
+        if not p.is_absolute():
+            p = working_dir / p
+        p = p.resolve(strict=False)
+        if not p.is_file():
+            raise ValueError(f"task file path does not resolve to a file: {raw_path}")
+        root = working_dir.resolve(strict=False)
+        try:
+            p.relative_to(root)
+        except ValueError:
+            raise ValueError(
+                f"task file path is outside the agent working directory: {raw_path}"
+            ) from None
+        return p
+
+    @staticmethod
+    def _store_task_file_blob(store_dir: Path, sha256: str, data: bytes) -> Path:
+        """Write one immutable content-addressed blob; return its path.
+
+        The blob is named by its SHA-256 so identical bytes across tasks and
+        dispatches share one file. ``os.replace`` makes the publish atomic: a
+        torn write never leaves a trusted corrupt blob behind.
+        """
+        blob = store_dir / sha256
+        if blob.exists():
+            return blob
+        store_dir.mkdir(parents=True, exist_ok=True)
+        tmp = store_dir / f".{sha256}.tmp"
+        tmp.write_bytes(data)
+        try:
+            os.replace(tmp, blob)
+        except OSError:
+            tmp.unlink(missing_ok=True)
+            raise
+        return blob
+
+    def _task_files_store_dir(self) -> Path:
+        """The internal content-addressed task input store for this agent."""
+        return self._agent._working_dir / "daemons" / _TASK_FILES_STORE_DIR_NAME
+
+    def _snapshot_task_files(self, spec: dict) -> list[dict] | None:
+        """Validate ``spec['task_files']`` and plan its snapshot rows.
+
+        Returns one manifest row per file (``path``, ``label``, ``role``,
+        ``sha256``, ``size``, ``resolved``, ``snapshot``) or ``None`` when the
+        task omits ``task_files``. Any malformed entry, out-of-root/missing
+        path, oversize file, or non-UTF-8 file raises ``ValueError`` so the
+        caller can refuse the whole batch before any run-dir creation or
+        scheduling — task input never silently falls back to the mutable
+        original path. This phase writes nothing; the caller materializes the
+        validated batch (``_materialize_task_files``) only after every task in
+        the dispatch has passed, so a refused batch leaves no store side
+        effects.
+        """
+        raw = spec.get("task_files")
+        if raw is None:
+            return None
+        if not isinstance(raw, list):
+            raise ValueError(
+                "task_files must be an array of {path, label?, role?} objects"
+            )
+        if len(raw) > TASK_FILES_MAX_PER_TASK:
+            raise ValueError(
+                f"task_files exceeds the {TASK_FILES_MAX_PER_TASK}-file limit"
+            )
+        rows: list[dict] = []
+        store_dir = self._task_files_store_dir()
+        for idx, item in enumerate(raw):
+            if not isinstance(item, dict):
+                raise ValueError(f"task_files[{idx}] must be an object with path")
+            path = item.get("path")
+            if not isinstance(path, str) or not path.strip():
+                raise ValueError(f"task_files[{idx}].path must be a non-empty string")
+            label = item.get("label")
+            if label is not None and (
+                not isinstance(label, str)
+                or len(label) > _TASK_FILES_ANNOTATION_MAX_CHARS
+            ):
+                raise ValueError(
+                    f"task_files[{idx}].label must be a string of at most "
+                    f"{_TASK_FILES_ANNOTATION_MAX_CHARS} characters"
+                )
+            role = item.get("role")
+            if role is not None and (
+                not isinstance(role, str)
+                or len(role) > _TASK_FILES_ANNOTATION_MAX_CHARS
+            ):
+                raise ValueError(
+                    f"task_files[{idx}].role must be a string of at most "
+                    f"{_TASK_FILES_ANNOTATION_MAX_CHARS} characters"
+                )
+            resolved = self._resolve_task_file_path(
+                path.strip(), self._agent._working_dir
+            )
+            try:
+                data = resolved.read_bytes()
+            except OSError as e:
+                raise ValueError(
+                    f"cannot read task file {path!r}: {e}"
+                ) from e
+            if len(data) > TASK_FILE_MAX_BYTES:
+                raise ValueError(
+                    f"task file {path!r} exceeds the {TASK_FILE_MAX_BYTES}-byte "
+                    "limit"
+                )
+            try:
+                data.decode("utf-8")
+            except UnicodeDecodeError as e:
+                raise ValueError(
+                    f"task file {path!r} is not valid UTF-8 text: {e}"
+                ) from e
+            # A NUL makes the payload a binary blob for this text-only contract
+            # even though Python's UTF-8 decoder accepts it.
+            if b"\x00" in data:
+                raise ValueError(f"task file {path!r} is not valid UTF-8 text: contains NUL byte")
+            sha256 = hashlib.sha256(data).hexdigest()
+            rows.append({
+                "path": path.strip(),
+                "label": label,
+                "role": role,
+                "sha256": sha256,
+                "size": len(data),
+                "resolved": str(resolved),
+                "snapshot": str(store_dir / sha256),
+            })
+        return rows or None
+
+    def _materialize_task_files(
+        self, group_id: str, rows_per_task: list[list[dict] | None]
+    ) -> str:
+        """Write the validated batch's blobs and one compact per-dispatch manifest.
+
+        Runs only after every task in the dispatch passed validation. The
+        manifest is indexed by task order (``None`` for a task without
+        ``task_files``). Each run's durable ``call_parameters.task_files``
+        points at this manifest plus its own rows, so retry/relaunch reads the
+        immutable snapshot instead of any mutable original path.
+        """
+        store_dir = self._task_files_store_dir()
+        # Verify every original first. Only after the whole batch still matches
+        # preflight do we publish any content-addressed blob, so an intervening
+        # source mutation cannot leave a partial task-files store behind.
+        blobs: dict[str, bytes] = {}
+        for rows in rows_per_task:
+            if not rows:
+                continue
+            for r in rows:
+                resolved = Path(r["resolved"])
+                data = resolved.read_bytes()
+                # TOCTOU guard: the mutable original must still be byte-for-byte
+                # what preflight validated; anything else fails loudly rather
+                # than silently snapshotting different content than dispatched.
+                if hashlib.sha256(data).hexdigest() != r["sha256"]:
+                    raise ValueError(
+                        f"task file changed during dispatch: {r['path']!r}"
+                    )
+                blobs.setdefault(r["sha256"], data)
+        for sha256, data in blobs.items():
+            self._store_task_file_blob(store_dir, sha256, data)
+        manifest = {
+            "version": _TASK_FILES_MANIFEST_VERSION,
+            "group_id": group_id,
+            "files": rows_per_task,
+        }
+        path = store_dir / f"manifest-{group_id}.json"
+        atomic_write_json(path, manifest)
+        return str(path)
+
+    @staticmethod
+    def _render_task_files_catalog(rows: list[dict] | None) -> str | None:
+        """Render the compact read-only manifest rows for the daemon prompt.
+
+        Only metadata and the immutable snapshot paths are rendered — never
+        file contents, and never the mutable original paths the worker could
+        re-read behind the snapshot's back.
+        """
+        if not rows:
+            return None
+        lines = [
+            "The parent snapshotted these task input files into a read-only "
+            "store; read them from the given snapshot paths when your task "
+            "requires them (the original paths may change or disappear):",
+            "task_files:",
+        ]
+        for r in rows:
+            lines.append(f"  - label: {r['label'] or r['path']}")
+            if r.get("role"):
+                lines.append(f"    role: {r['role']}")
+            lines.append(f"    sha256: {r['sha256']}")
+            lines.append(f"    size: {r['size']}")
+            lines.append(f"    snapshot: {r['snapshot']}")
+        return "\n".join(lines)
+
+    @staticmethod
     def _combine_oneshot_context(
         system_prompt: str | None,
         skill_catalog: str | None,
         mcp_catalog: str | None = None,
         plugin_catalog: str | None = None,
+        task_files_catalog: str | None = None,
     ) -> str | None:
         parts = []
         if system_prompt:
@@ -2632,6 +2854,8 @@ class DaemonManager:
             parts.append("## Parent-provided MCP registrations\n" + mcp_catalog)
         if plugin_catalog:
             parts.append("## Parent-selected plugins\n" + plugin_catalog)
+        if task_files_catalog:
+            parts.append("## Parent-provided task files\n" + task_files_catalog)
         return "\n\n".join(parts) or None
 
     @staticmethod
@@ -4762,6 +4986,20 @@ class DaemonManager:
                 except ValueError as exc:
                     return {"status": "error", "message": f"tasks[{i}].prompt: {exc}"}
 
+        # Pre-flight: optional per-task input files. Resolve every path under
+        # the parent working directory, validate UTF-8 text and the practical
+        # limits, and snapshot the bytes content-addressed BEFORE any run-dir
+        # creation, preset work, or scheduling — a single bad entry refuses the
+        # whole batch loudly and nothing is left half-started. Workers receive
+        # only the compact manifest/snapshot paths, never file contents.
+        task_files_rows: list[list[dict] | None] = []
+        for i, spec in enumerate(tasks):
+            try:
+                rows = self._snapshot_task_files(spec)
+            except ValueError as exc:
+                return {"status": "error", "message": f"tasks[{i}].task_files: {exc}"}
+            task_files_rows.append(rows)
+
         # Per-batch limit overrides. max_turns is capped at the manager's
         # ceiling (self._max_turns, also the schema maximum); timeout has no
         # schema maximum, so self._timeout is only the default when omitted.
@@ -4829,6 +5067,7 @@ class DaemonManager:
                 effective_max_turns=effective_max_turns,
                 effective_timeout=effective_timeout,
                 requested_timeout=requested_timeout,
+                task_files_rows=task_files_rows,
             )
 
         # Pre-flight: validate per-task ``context_token_limit`` (LingTai backend
@@ -4955,6 +5194,17 @@ class DaemonManager:
         parent_pid = os.getpid()
         use_central_manager = self._should_use_central_daemon_manager(len(tasks))
 
+        # One compact manifest per dispatch/group next to the immutable blobs;
+        # each run's durable metadata points at it (see call_parameters below).
+        task_files_manifest = None
+        if any(rows for rows in task_files_rows):
+            try:
+                task_files_manifest = self._materialize_task_files(
+                    group_id, task_files_rows
+                )
+            except (OSError, ValueError) as exc:
+                return {"status": "error", "message": f"task_files: {exc}"}
+
         for i, spec in enumerate(tasks):
             em_id = self._new_emanation_id(reserved_ids=set(ids))
             ids.append(em_id)
@@ -4978,6 +5228,7 @@ class DaemonManager:
                 task_mcp_regs, task_mcp_catalog = self._task_mcp_registrations(spec)
                 task_skill_catalog = self._task_skill_catalog(spec)
                 task_plugin_catalog, plugin_skill_rows, plugin_mcp_regs = self._task_plugin_context(spec)
+                task_files_catalog = self._render_task_files_catalog(task_files_rows[i])
             except Exception as e:
                 self._close_task_mcp_clients(task_mcp_clients)
                 return {"status": "error", "message": str(e)}
@@ -4989,7 +5240,8 @@ class DaemonManager:
                 )
             task_mcp_regs = list(task_mcp_regs) + list(plugin_mcp_regs)
             task_context = self._combine_oneshot_context(
-                None, task_skill_catalog, task_mcp_catalog, task_plugin_catalog
+                None, task_skill_catalog, task_mcp_catalog, task_plugin_catalog,
+                task_files_catalog=task_files_catalog,
             )
             task_context = self._append_daemon_common_context(task_context)
 
@@ -5019,6 +5271,10 @@ class DaemonManager:
                         "mcp": [],
                         "prompt": self._task_first_prompt(spec),
                         "context_token_limit": spec.get("context_token_limit"),
+                        "task_files": {
+                            "manifest": task_files_manifest,
+                            "files": task_files_rows[i],
+                        },
                     },
                     log_callback=self._log,
                     preset_name=resolved["name"] if resolved else None,
@@ -5041,7 +5297,8 @@ class DaemonManager:
                     )
                 task_mcp_catalog = self._render_task_mcp_catalog(task_mcp_regs)
                 task_context = self._combine_oneshot_context(
-                    None, task_skill_catalog, task_mcp_catalog, task_plugin_catalog
+                    None, task_skill_catalog, task_mcp_catalog, task_plugin_catalog,
+                    task_files_catalog=task_files_catalog,
                 )
                 task_context = self._append_daemon_common_context(task_context)
                 # Detached ownership starts task MCP only in the supervisor.
@@ -5148,6 +5405,7 @@ class DaemonManager:
         effective_max_turns: int,
         effective_timeout: float,
         requested_timeout: float | None = None,
+        task_files_rows: list[list[dict] | None] | None = None,
     ) -> dict:
         """Dispatch emanations via an external CLI backend.
 
@@ -5224,9 +5482,22 @@ class DaemonManager:
         parent_pid = os.getpid()
         use_central_manager = self._should_use_central_daemon_manager(len(tasks))
 
-        for spec, context in zip(tasks, contexts):
+        # The preflight validated every task input file; materialize the blobs
+        # and one compact per-dispatch manifest for the group's runs.
+        task_files_rows = task_files_rows or [None] * len(tasks)
+        task_files_manifest = None
+        if any(rows for rows in task_files_rows):
+            try:
+                task_files_manifest = self._materialize_task_files(
+                    group_id, task_files_rows
+                )
+            except (OSError, ValueError) as exc:
+                return {"status": "error", "message": f"task_files: {exc}"}
+
+        for i, (spec, context) in enumerate(zip(tasks, contexts)):
             em_id = self._new_emanation_id(reserved_ids=set(ids))
             ids.append(em_id)
+            task_files_catalog = self._render_task_files_catalog(task_files_rows[i])
             user_backend_argv = list(context.backend_argv)
             backend_argv = list(user_backend_argv)
             backend_harness_argv: list[str] = []
@@ -5240,7 +5511,8 @@ class DaemonManager:
             system_prompt = f"[{backend} backend — task delegated to external CLI]"
 
             task_context = self._combine_oneshot_context(
-                context.system_prompt, context.skill_catalog, context.mcp_catalog
+                context.system_prompt, context.skill_catalog, context.mcp_catalog,
+                task_files_catalog=task_files_catalog,
             )
             if _cli_backend_loads_common_mcp(backend):
                 task_context = self._append_daemon_common_context(task_context)
@@ -5271,6 +5543,10 @@ class DaemonManager:
                         "skills": spec.get("skills", []),
                         "mcp": [],
                         "backend_options": public_backend_options,
+                        "task_files": {
+                            "manifest": task_files_manifest,
+                            "files": task_files_rows[i],
+                        },
                     },
                     log_callback=self._log,
                     backend=backend,
@@ -5291,7 +5567,8 @@ class DaemonManager:
                     )
                 mcp_catalog = self._render_task_mcp_catalog(mcp_regs)
                 task_context = self._combine_oneshot_context(
-                    None, context.skill_catalog, mcp_catalog
+                    None, context.skill_catalog, mcp_catalog,
+                    task_files_catalog=task_files_catalog,
                 )
                 if _cli_backend_loads_common_mcp(backend):
                     task_context = self._append_daemon_common_context(task_context)
@@ -5538,8 +5815,12 @@ class DaemonManager:
 
     @staticmethod
     def _looks_like_daemon_run_dir(run_path: Path) -> bool:
+        # Leading-underscore entries under the daemons root are internal-only
+        # (e.g. the ``_task_files`` task input store) and never runs; this keeps
+        # list/recovery/check scans from surfacing the store as an emanation.
         return (
             run_path.is_dir()
+            and not run_path.name.startswith("_")
             and (
                 run_path.name.startswith("em-")
                 or (run_path / ".prompt").exists()

--- a/src/lingtai/tools/daemon/_tool_family.py
+++ b/src/lingtai/tools/daemon/_tool_family.py
@@ -182,6 +182,20 @@ def _emanate_task_schema() -> dict[str, Any]:
                 "additionalProperties": _backend_option_value_schema(),
                 "description": 'Optional free-form CLI options for \'claude-code\' / \'codex\' / \'opencode\' / \'mimocode\' / \'qwen-code\' / \'oh-my-pi\' / \'kimicode\' / \'deepseek\' / \'cursor\' backends ONLY (ignored by lingtai). JSON object mapping flag names to values: true → flag only (e.g. {"search": true} → --search); string/int/float → \'--flag <value>\'; list of scalars → \'--flag <v1> --flag <v2>\'; false/null omits the flag. Underscores in keys become dashes; unsafe keys are rejected. One reserved key is not a flag: `env` (a JSON object of string->string) injects environment variables into the spawned CLI subprocess (e.g. {"env": {"CLAUDE_CONFIG_DIR": "..."}} for claude-p/claude-code profile selection); its names must match [A-Za-z_][A-Za-z0-9_]* and its values must be strings. All other nested objects are rejected. Applies only when starting the emanation (not to `ask`). Discover supported flags by running \'claude --help\', \'codex exec --help\', \'opencode run --help\', \'mimo run --help\', \'qwen --help\', \'omp --help\', \'kimi --help\', \'dsh --help\', or \'agent --help\' in bash — the CLI\'s flag list changes between versions; this field is intentionally a passthrough rather than a fixed list. See daemon-manual.',
             },
+            "task_files": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "path": {"type": "string"},
+                        "label": {"type": "string"},
+                        "role": {"type": "string"},
+                    },
+                    "required": ["path"],
+                    "additionalProperties": False,
+                },
+                "description": 'Optional per-task input files for this daemon run. Array of {path, label?, role?}: path is a UTF-8 text file under the parent agent working directory (absolute or relative; relative paths resolve against the parent working directory). At dispatch the parent resolves every path, validates UTF-8 text and size limits, snapshots the bytes content-addressed into an immutable read-only input store, and the daemon receives only a compact manifest pointing at the snapshot paths \u2014 never the file contents and never the mutable original paths. Malformed, out-of-root, missing, non-UTF-8, or oversize entries refuse the whole batch before any run starts.',
+            },
             "prompt": {
                 "type": "string",
                 "description": 'Optional first ordinary user message for a LingTai daemon. Blank or omitted uses exactly "Begin the assigned daemon task.". Unsupported by external CLI backends.',

--- a/src/lingtai/tools/daemon/manual/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/SKILL.md
@@ -141,7 +141,7 @@ Behavior worth knowing before wiring it into a job:
   replaying pending terminal notifications) *and* never lazily repair a
   `daemon.json` that is missing, unreadable, or written by an older
   `data_version`. Such runs are still listed — reconstructed in memory — with a
-  stderr note naming them; run `daemon(action="list")` as the owning agent to
+  stderr note naming them; run `daemon(action="list", input={"contains": null, "status": null, "include_done": null, "last": null})` as the owning agent to
   actually repair them.
 - **Terminal notifications stay with the owning agent.** Runs dispatched from
   the CLI are detached and still notify the agent that owns the working
@@ -285,6 +285,20 @@ Behavior notes:
     cannot mount plugins yet receive the plugin's skills and mcp.json servers
     separately as normal skill/mcp oneshot context until the whole-plugin
     injection matures.
+  - `task_files` answers **which local text files this daemon should read**. It
+    is optional and is an array of `{path, label?, role?}` objects; `path` is a
+    UTF-8 text file under the parent agent working directory (absolute or
+    relative; relative paths resolve against the parent working directory). At
+    dispatch the parent resolves every path, validates UTF-8 and size limits,
+    and snapshots the bytes content-addressed into an immutable read-only input
+    store (`daemons/_task_files/` under the parent working directory); the
+    daemon receives only a compact `## Parent-provided task files` manifest
+    listing label/role/sha256/size and the snapshot path for each file — never
+    the file contents and never the mutable original paths, so the run keeps
+    working (and can be re-checked or relaunched) even if the original file
+    changes or is deleted. Malformed, out-of-root, missing, non-UTF-8, or
+    oversize entries refuse the whole batch before any run starts. Up to
+    `TASK_FILES_MAX_PER_TASK` files per task, `TASK_FILE_MAX_BYTES` per file.
   - `preset`: optional body/model/tool-shape override for this daemon — an
     explicit `.json`/`.jsonc` path. On the LingTai backend it must already be
     a member of the parent agent's resolved `manifest.preset.allowed` set

--- a/tests/test_daemon_task_files.py
+++ b/tests/test_daemon_task_files.py
@@ -1,0 +1,457 @@
+# tests/test_daemon_task_files.py
+"""Tests for optional per-task ``task_files`` input to ``daemon`` emanate.
+
+Covers the additive contract: ``task`` stays required and omitting
+``task_files`` keeps old behavior; parent preflight resolves every path under
+the agent working directory, validates UTF-8 text and practical limits, and
+snapshots bytes content-addressed into the immutable ``daemons/_task_files/``
+store; per-run durable metadata points at a compact manifest + snapshot rows;
+the daemon prompt receives only the compact manifest (snapshot paths, never
+contents); malformed/out-of-root/missing/oversize/non-UTF-8 input refuses the
+whole batch before any dispatch; and ``list``/recovery never surface the
+internal store as a run.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from lingtai.tools import daemon as daemon_pkg
+from tests._daemon_helpers import (
+    daemon_emanate_task_schema,
+    install_fake_detached_owner,
+    make_daemon_agent as _make_agent,
+)
+
+
+def _write_input(agent, rel: str, data: str | bytes) -> Path:
+    p = agent._working_dir / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    if isinstance(data, bytes):
+        p.write_bytes(data)
+    else:
+        p.write_text(data, encoding="utf-8")
+    return p
+
+
+def _dispatch(mgr, tasks):
+    return mgr.handle({"action": "emanate", "tasks": tasks})
+
+
+def _capture_lingtai_spawn(monkeypatch, mgr):
+    captured = []
+
+    def fake_spawn(run_dir, **kwargs):
+        captured.append((run_dir, kwargs))
+        run_dir.mark_done("ok")
+
+    monkeypatch.setattr(mgr, "_spawn_detached_lingtai_run", fake_spawn)
+    return captured
+
+
+def _durable_task_files(run_dir) -> dict:
+    state = json.loads(run_dir.daemon_json_path.read_text(encoding="utf-8"))
+    return state["call_parameters"]["task_files"]
+
+
+# ---------------------------------------------------------------------------
+# Schema: task_files is optional; task/tools requirements unchanged
+# ---------------------------------------------------------------------------
+
+def test_emanate_task_schema_declares_optional_task_files():
+    task = daemon_emanate_task_schema()
+
+    task_files = task["properties"]["task_files"]
+    assert task_files["type"] == "array"
+    item = task_files["items"]
+    assert item["required"] == ["path"]
+    assert set(item["properties"]) == {"path", "label", "role"}
+    assert item["additionalProperties"] is False
+    # task remains required and tools remains required; task_files is add-only.
+    assert task["required"] == ["task", "tools"]
+
+
+def test_omitting_task_files_keeps_old_behavior(tmp_path, monkeypatch):
+    agent = _make_agent(tmp_path, ["file", "daemon"])
+    mgr = agent.get_capability("daemon")
+    captured = _capture_lingtai_spawn(monkeypatch, mgr)
+
+    result = _dispatch(mgr, [{"task": "clean the repo", "tools": ["file"]}])
+
+    assert result["status"] == "dispatched"
+    assert not (agent._working_dir / "daemons" / "_task_files").exists()
+    prompt = captured[0][0].prompt_path.read_text(encoding="utf-8")
+    assert "Parent-provided task files" not in prompt
+    assert captured[0][1]["task"] == "clean the repo"
+
+
+# ---------------------------------------------------------------------------
+# Preflight refuses malformed / out-of-root / missing / oversize / non-UTF-8
+# input loudly, before any run-dir creation or dispatch
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "task_files,message_part",
+    [
+        ("not-a-list", "must be an array"),
+        (["a string"], "must be an object with path"),
+        ([{"label": "x"}], "path must be a non-empty string"),
+        ([{"path": ""}], "path must be a non-empty string"),
+        ([{"path": 7}], "path must be a non-empty string"),
+    ],
+)
+def test_task_files_malformed_entries_refuse_whole_batch(
+    tmp_path, monkeypatch, task_files, message_part
+):
+    agent = _make_agent(tmp_path, ["file", "daemon"])
+    mgr = agent.get_capability("daemon")
+    _capture_lingtai_spawn(monkeypatch, mgr)
+
+    result = _dispatch(mgr, [
+        {"task": "t", "tools": ["file"], "task_files": task_files},
+    ])
+
+    assert result["status"] == "error"
+    assert "tasks[0].task_files" in result["message"]
+    assert message_part in result["message"]
+    assert not (agent._working_dir / "daemons").exists()
+    assert not mgr._emanations
+
+
+def test_task_files_out_of_root_path_refuses(tmp_path, monkeypatch):
+    agent = _make_agent(tmp_path, ["file", "daemon"])
+    mgr = agent.get_capability("daemon")
+    outside = tmp_path / "outside.txt"
+    outside.write_text("secret", encoding="utf-8")
+    _capture_lingtai_spawn(monkeypatch, mgr)
+
+    result = _dispatch(mgr, [{
+        "task": "t", "tools": ["file"],
+        "task_files": [{"path": str(outside)}],
+    }])
+
+    assert result["status"] == "error"
+    assert "outside the agent working directory" in result["message"]
+    assert not (agent._working_dir / "daemons").exists()
+
+
+def test_task_files_relative_escape_refuses(tmp_path, monkeypatch):
+    agent = _make_agent(tmp_path, ["file", "daemon"])
+    mgr = agent.get_capability("daemon")
+    outside = tmp_path / "outside.txt"
+    outside.write_text("secret", encoding="utf-8")
+    _capture_lingtai_spawn(monkeypatch, mgr)
+
+    result = _dispatch(mgr, [{
+        "task": "t", "tools": ["file"],
+        "task_files": [{"path": "../outside.txt"}],
+    }])
+
+    assert result["status"] == "error"
+    assert "outside the agent working directory" in result["message"]
+    assert not (agent._working_dir / "daemons").exists()
+
+
+def test_task_files_missing_path_refuses(tmp_path, monkeypatch):
+    agent = _make_agent(tmp_path, ["file", "daemon"])
+    mgr = agent.get_capability("daemon")
+    _capture_lingtai_spawn(monkeypatch, mgr)
+
+    result = _dispatch(mgr, [{
+        "task": "t", "tools": ["file"],
+        "task_files": [{"path": "inputs/absent.txt"}],
+    }])
+
+    assert result["status"] == "error"
+    assert "does not resolve to a file" in result["message"]
+    assert not (agent._working_dir / "daemons").exists()
+
+
+def test_task_files_oversize_refuses(tmp_path, monkeypatch):
+    agent = _make_agent(tmp_path, ["file", "daemon"])
+    mgr = agent.get_capability("daemon")
+    monkeypatch.setattr(daemon_pkg, "TASK_FILE_MAX_BYTES", 8)
+    _write_input(agent, "inputs/big.txt", "x" * 9)
+    _capture_lingtai_spawn(monkeypatch, mgr)
+
+    result = _dispatch(mgr, [{
+        "task": "t", "tools": ["file"],
+        "task_files": [{"path": "inputs/big.txt"}],
+    }])
+
+    assert result["status"] == "error"
+    assert "exceeds the 8-byte limit" in result["message"]
+    assert not (agent._working_dir / "daemons").exists()
+
+
+def test_task_files_non_utf8_refuses(tmp_path, monkeypatch):
+    agent = _make_agent(tmp_path, ["file", "daemon"])
+    mgr = agent.get_capability("daemon")
+    _write_input(agent, "inputs/binary.bin", b"\xff\xfe\x00\x01")
+    _capture_lingtai_spawn(monkeypatch, mgr)
+
+    result = _dispatch(mgr, [{
+        "task": "t", "tools": ["file"],
+        "task_files": [{"path": "inputs/binary.bin"}],
+    }])
+
+    assert result["status"] == "error"
+    assert "not valid UTF-8 text" in result["message"]
+    assert not (agent._working_dir / "daemons").exists()
+
+
+def test_task_files_too_many_files_refuses(tmp_path, monkeypatch):
+    agent = _make_agent(tmp_path, ["file", "daemon"])
+    mgr = agent.get_capability("daemon")
+    monkeypatch.setattr(daemon_pkg, "TASK_FILES_MAX_PER_TASK", 2)
+    for i in range(3):
+        _write_input(agent, f"inputs/f{i}.txt", f"body {i}")
+    _capture_lingtai_spawn(monkeypatch, mgr)
+
+    result = _dispatch(mgr, [{
+        "task": "t", "tools": ["file"],
+        "task_files": [{"path": f"inputs/f{i}.txt"} for i in range(3)],
+    }])
+
+    assert result["status"] == "error"
+    assert "2-file limit" in result["message"]
+    assert not (agent._working_dir / "daemons").exists()
+
+
+def test_task_files_oversized_label_refuses(tmp_path, monkeypatch):
+    agent = _make_agent(tmp_path, ["file", "daemon"])
+    mgr = agent.get_capability("daemon")
+    monkeypatch.setattr(daemon_pkg, "_TASK_FILES_ANNOTATION_MAX_CHARS", 5)
+    _write_input(agent, "inputs/a.txt", "body")
+    _capture_lingtai_spawn(monkeypatch, mgr)
+
+    result = _dispatch(mgr, [{
+        "task": "t", "tools": ["file"],
+        "task_files": [{"path": "inputs/a.txt", "label": "way too long"}],
+    }])
+
+    assert result["status"] == "error"
+    assert "label must be a string of at most 5 characters" in result["message"]
+    assert not (agent._working_dir / "daemons").exists()
+
+
+def test_task_files_later_task_failure_refuses_whole_batch_without_store(tmp_path, monkeypatch):
+    """A bad entry in a later task refuses the batch with zero store side effects."""
+    agent = _make_agent(tmp_path, ["file", "daemon"])
+    mgr = agent.get_capability("daemon")
+    _write_input(agent, "inputs/ok.txt", "fine body")
+    _write_input(agent, "inputs/bad.txt", b"\x00\x01\x02")
+    _capture_lingtai_spawn(monkeypatch, mgr)
+
+    result = _dispatch(mgr, [
+        {"task": "t1", "tools": ["file"], "task_files": [{"path": "inputs/ok.txt"}]},
+        {"task": "t2", "tools": ["file"], "task_files": [{"path": "inputs/bad.txt"}]},
+    ])
+
+    assert result["status"] == "error"
+    assert "tasks[1].task_files" in result["message"]
+    assert not (agent._working_dir / "daemons").exists()
+    assert not mgr._emanations
+
+
+# ---------------------------------------------------------------------------
+# Snapshot: content-addressed once per dispatch/group; durable rows; prompt
+# carries only the compact manifest (snapshot paths), never file contents
+# ---------------------------------------------------------------------------
+
+def test_task_files_snapshot_once_per_group_and_durable_rows(tmp_path, monkeypatch):
+    agent = _make_agent(tmp_path, ["file", "daemon"])
+    mgr = agent.get_capability("daemon")
+    content = "alpha input body\n"
+    src = _write_input(agent, "inputs/alpha.txt", content)
+    captured = _capture_lingtai_spawn(monkeypatch, mgr)
+
+    result = _dispatch(mgr, [
+        {
+            "task": "t1", "tools": ["file"],
+            "task_files": [{"path": "inputs/alpha.txt", "label": "spec", "role": "input"}],
+        },
+        {
+            "task": "t2", "tools": ["file"],
+            "task_files": [{"path": str(src), "label": "spec2"}],
+        },
+    ])
+
+    assert result["status"] == "dispatched"
+    store = agent._working_dir / "daemons" / "_task_files"
+    sha = hashlib.sha256(content.encode("utf-8")).hexdigest()
+    manifest_name = f"manifest-{result['group_id']}.json"
+    assert sorted(p.name for p in store.iterdir()) == sorted([sha, manifest_name])
+    blob = store / sha
+    assert blob.read_bytes() == content.encode("utf-8")
+    manifest = json.loads((store / manifest_name).read_text(encoding="utf-8"))
+    assert manifest["version"] == 1
+    assert manifest["group_id"] == result["group_id"]
+    assert len(manifest["files"]) == 2
+
+    # Durable per-run metadata points at the manifest and this run's rows.
+    assert len(captured) == 2
+    first_row = _durable_task_files(captured[0][0])["files"][0]
+    assert first_row["path"] == "inputs/alpha.txt"
+    assert first_row["label"] == "spec"
+    assert first_row["role"] == "input"
+    assert first_row["sha256"] == sha
+    assert first_row["size"] == len(content)
+    assert first_row["snapshot"] == str(blob)
+    assert _durable_task_files(captured[0][0])["manifest"] == str(store / manifest_name)
+    second_row = _durable_task_files(captured[1][0])["files"][0]
+    assert second_row["label"] == "spec2"
+    assert second_row.get("role") is None
+    assert second_row["snapshot"] == str(blob)
+
+    # The prompt receives the compact manifest only: metadata + snapshot paths,
+    # never the file contents.
+    prompt = captured[0][0].prompt_path.read_text(encoding="utf-8")
+    assert "## Parent-provided task files" in prompt
+    assert "task_files:" in prompt
+    assert "spec" in prompt
+    assert "input" in prompt
+    assert sha in prompt
+    assert str(blob) in prompt
+    assert content.strip() not in prompt
+
+
+def test_task_files_preserves_distinct_attachment_rows_for_one_path(tmp_path, monkeypatch):
+    agent = _make_agent(tmp_path, ["file", "daemon"])
+    mgr = agent.get_capability("daemon")
+    _write_input(agent, "inputs/spec.txt", "same bytes")
+    captured = _capture_lingtai_spawn(monkeypatch, mgr)
+
+    result = _dispatch(mgr, [{
+        "task": "compare inputs", "tools": ["file"],
+        "task_files": [
+            {"path": "inputs/spec.txt", "label": "before", "role": "baseline"},
+            {"path": "inputs/spec.txt", "label": "after", "role": "target"},
+        ],
+    }])
+
+    assert result["status"] == "dispatched"
+    rows = _durable_task_files(captured[0][0])["files"]
+    assert [(r["label"], r["role"]) for r in rows] == [
+        ("before", "baseline"), ("after", "target"),
+    ]
+    # Attachment rows stay distinct while immutable blob storage is deduplicated.
+    assert rows[0]["snapshot"] == rows[1]["snapshot"]
+
+
+def test_task_files_relaunch_reads_snapshot_not_original(tmp_path, monkeypatch):
+    agent = _make_agent(tmp_path, ["file", "daemon"])
+    mgr = agent.get_capability("daemon")
+    src = _write_input(agent, "inputs/alpha.txt", "original bytes v1")
+    _capture_lingtai_spawn(monkeypatch, mgr)
+
+    result = _dispatch(mgr, [{
+        "task": "t", "tools": ["file"],
+        "task_files": [{"path": "inputs/alpha.txt"}],
+    }])
+    assert result["status"] == "dispatched"
+
+    store = agent._working_dir / "daemons" / "_task_files"
+    sha = hashlib.sha256(b"original bytes v1").hexdigest()
+    blob = store / sha
+    assert blob.read_bytes() == b"original bytes v1"
+
+    # The mutable original changes; the immutable snapshot still serves the run.
+    src.write_text("mutated after dispatch", encoding="utf-8")
+    assert blob.read_bytes() == b"original bytes v1"
+
+    # Durable metadata points at the manifest and the snapshot, never the source.
+    run_dir = mgr._emanations[result["ids"][0]]["run_dir"]
+    tf = _durable_task_files(run_dir)
+    assert tf["manifest"].startswith(str(store))
+    assert tf["files"][0]["snapshot"] == str(blob)
+    assert tf["files"][0]["resolved"] == str(src.resolve())
+
+
+def test_task_files_shared_blob_across_dispatches_deduplicates(tmp_path, monkeypatch):
+    agent = _make_agent(tmp_path, ["file", "daemon"])
+    mgr = agent.get_capability("daemon")
+    _write_input(agent, "inputs/alpha.txt", "same bytes")
+    _capture_lingtai_spawn(monkeypatch, mgr)
+
+    first = _dispatch(mgr, [{
+        "task": "t1", "tools": ["file"],
+        "task_files": [{"path": "inputs/alpha.txt"}],
+    }])
+    second = _dispatch(mgr, [{
+        "task": "t2", "tools": ["file"],
+        "task_files": [{"path": "inputs/alpha.txt"}],
+    }])
+    assert first["status"] == second["status"] == "dispatched"
+
+    store = agent._working_dir / "daemons" / "_task_files"
+    sha = hashlib.sha256(b"same bytes").hexdigest()
+    assert len([p for p in store.iterdir() if p.name == sha]) == 1
+    manifests = [p for p in store.iterdir() if p.name.startswith("manifest-")]
+    assert len(manifests) == 2  # one compact manifest per dispatch
+
+
+# ---------------------------------------------------------------------------
+# The internal input store is never surfaced as a run by list/recovery scans
+# ---------------------------------------------------------------------------
+
+def test_task_files_store_is_never_listed_as_a_run(tmp_path, monkeypatch):
+    agent = _make_agent(tmp_path, ["file", "daemon"])
+    mgr = agent.get_capability("daemon")
+    _write_input(agent, "inputs/alpha.txt", "x")
+    _capture_lingtai_spawn(monkeypatch, mgr)
+
+    result = _dispatch(mgr, [{
+        "task": "t", "tools": ["file"],
+        "task_files": [{"path": "inputs/alpha.txt"}],
+    }])
+    assert result["status"] == "dispatched"
+
+    store = agent._working_dir / "daemons" / "_task_files"
+    assert store.is_dir()
+    assert not mgr._looks_like_daemon_run_dir(store)
+    history = mgr._iter_daemon_history_states()
+    assert all(run_path.name != "_task_files" for run_path, _state in history)
+    listing = mgr._handle_list()["emanations"]
+    assert all(item["id"] != "_task_files" for item in listing)
+
+
+# ---------------------------------------------------------------------------
+# CLI backends receive the same compact manifest and durable rows
+# ---------------------------------------------------------------------------
+
+def test_task_files_reach_cli_backend_prompt_and_durable_rows(tmp_path, monkeypatch):
+    agent = _make_agent(tmp_path, ["file", "daemon"])
+    mgr = agent.get_capability("daemon")
+    # This test observes the classic detached CLI payload. Disable the manager
+    # path explicitly rather than coupling its assertion to manager routing.
+    monkeypatch.setattr(mgr, "_manager_pool_size", 0)
+    content = "cli input body"
+    _write_input(agent, "inputs/cli.txt", content)
+    records = install_fake_detached_owner(monkeypatch)
+
+    result = mgr.handle({
+        "action": "emanate",
+        "backend": "opencode",
+        "tasks": [{
+            "task": "run with input", "tools": ["file"],
+            "task_files": [{"path": "inputs/cli.txt", "label": "spec", "role": "input"}],
+        }],
+    })
+
+    assert result["status"] == "dispatched"
+    assert len(records) == 1
+    composed_task = records[0]["manifest"]["task"]
+    assert "## Parent-provided task files" in composed_task
+    assert "spec" in composed_task
+    sha = hashlib.sha256(content.encode("utf-8")).hexdigest()
+    store = agent._working_dir / "daemons" / "_task_files"
+    assert str(store / sha) in composed_task
+    assert content not in composed_task
+    run_dir = records[0]["run_dir"]
+    tf = _durable_task_files(run_dir)
+    assert tf["files"][0]["sha256"] == sha
+    assert tf["files"][0]["snapshot"] == str(store / sha)

--- a/tests/test_tool_family_daemon_migration.py
+++ b/tests/test_tool_family_daemon_migration.py
@@ -299,8 +299,8 @@ def test_emanate_nested_task_schema_preserves_every_field():
     task = daemon_emanate_task_schema()
 
     assert set(task["properties"]) == {
-        "task", "tools", "skills", "mcp", "preset", "backend_options",
-        "prompt", "context_token_limit",
+        "task", "tools", "skills", "mcp", "plugin", "preset", "backend_options",
+        "prompt", "context_token_limit", "task_files",
     }
     assert task["required"] == ["task", "tools"]
     # The nested task object stays OPEN: the engine's own strict per-task
@@ -779,8 +779,8 @@ def test_responses_wire_preserves_the_root_action_input_correlation():
         # The complex nested emanate task object survives both wires intact.
         task_items = emanate_condition["properties"]["tasks"]["items"]
         assert set(task_items["properties"]) == {
-            "task", "tools", "skills", "mcp", "preset", "backend_options",
-            "prompt", "context_token_limit",
+            "task", "tools", "skills", "mcp", "plugin", "preset", "backend_options",
+            "prompt", "context_token_limit", "task_files",
         }
 
 


### PR DESCRIPTION
## Summary
- Adds optional, strictly-additive `tasks[].task_files[{path,label,role}]` to daemon emanation.
- Freezes contained UTF-8 text inputs into a content-addressed immutable snapshot store before scheduling; workers receive compact manifest/snapshot paths rather than copied file bodies.
- Preserves required `task` and legacy no-`task_files` behavior; rejects malformed, out-of-root, missing, binary/NUL, oversize, or changed inputs before dispatch.
- Adds durable per-run manifest provenance, CLI/LingTai prompt parity, store-history exclusion, and schema/manual coverage.

## Validation
- `git diff --check`
- `PYTHONPATH=src python3 -m pytest tests/test_daemon_task_files.py tests/test_tool_family_daemon_migration.py -p no:cacheprovider -q` — 88 passed

## Review
- DeepSeek V4 Flash created the initial candidate; parent repaired its focused failures.
- Independent Claude Opus review found duplicate attachment-row fidelity and pre-materialization atomicity issues; both were fixed and regression-covered. The reviewer’s identical-byte snapshot-path concern is intentional content-addressing behavior, not a defect.

## Scope
No scheduler/manager redesign, automatic cleanup/GC, merge, release, config/auth mutation, or delete behavior.

Telegram: @lingtaidev2bot | Nickname: 观一
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
