### PR TITLE
fix(openai): support Moonshot schema quirks

### DIFF
--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -1309,10 +1309,12 @@ def _build_responses_tools(schemas: list[FunctionSchema] | None) -> list[dict] |
 # only the transformations explicitly registered for the exact base_url host;
 # unmatched providers keep the canonical schema byte-for-byte.
 #
-# See <https://github.com/Lingtai-AI/lingtai/issues/694> for the Kimi API error
-# that motivated this boundary.
+# See <https://github.com/Lingtai-AI/lingtai/issues/694> and
+# <https://github.com/Lingtai-AI/lingtai/issues/913> for the two official Kimi
+# API hosts that require this boundary.
 _SITE_SCHEMA_QUIRKS: dict[str, frozenset[str]] = {
     "api.kimi.com": frozenset({"move_type_into_union_branches"}),
+    "api.moonshot.cn": frozenset({"move_type_into_union_branches"}),
 }
 
 

--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -1381,6 +1381,26 @@ def _apply_site_quirks(
 def _apply_quirk_dict(params: dict, active: frozenset[str]) -> dict:
     """Apply the registered quirks to one parameters dict."""
     if "move_type_into_union_branches" in active:
+        # Moonshot's validator enforces two conflicting rules at the
+        # parameters ROOT: type:"object" is required, AND anyOf/oneOf at
+        # root may not coexist with a parent type. So a root-level union
+        # (conditional constraints, e.g. the daemon ``compact`` tool)
+        # cannot be expressed on the wire at all — drop it before the
+        # branch move runs so the required root type stays at the root.
+        # ``compact`` independently enforces its dropped run/_reason
+        # condition; other affected tools must enforce relaxed union
+        # constraints at their dispatch/server boundary. Nested nodes are
+        # unaffected.
+        if (
+            isinstance(params, dict)
+            and params.get("type") == "object"
+            and ("anyOf" in params or "oneOf" in params)
+        ):
+            params = {
+                key: value
+                for key, value in params.items()
+                if key not in ("anyOf", "oneOf")
+            }
         return _move_type_into_union_branches(params)
     return params
 

--- a/tests/test_site_schema_quirks.py
+++ b/tests/test_site_schema_quirks.py
@@ -119,16 +119,14 @@ def test_exact_kimi_host_applies_chat_quirk() -> None:
     original = copy.deepcopy(_CHAT_TOOL)
     result = _apply_site_quirks("https://api.kimi.com/coding/v1", [_CHAT_TOOL])
     parameters = result[0]["function"]["parameters"]
-    assert "type" not in parameters
-    assert all(branch["type"] == "object" for branch in parameters["anyOf"])
+    assert parameters == {"type": "object"}
     assert _CHAT_TOOL == original
 
 
 def test_exact_kimi_host_applies_responses_quirk() -> None:
     result = _apply_site_quirks("https://api.kimi.com/coding/v1", [_RESPONSES_TOOL])
     parameters = result[0]["parameters"]
-    assert "type" not in parameters
-    assert all(branch["type"] == "object" for branch in parameters["oneOf"])
+    assert parameters == {"type": "object"}
 
 
 def test_exact_moonshot_host_applies_real_daemon_compact_quirk() -> None:
@@ -139,8 +137,12 @@ def test_exact_moonshot_host_applies_real_daemon_compact_quirk() -> None:
         [compact_tool],
     )
     parameters = result[0]["function"]["parameters"]
-    assert "type" not in parameters
-    assert all(branch["type"] == "object" for branch in parameters["anyOf"])
+    assert parameters["type"] == "object"
+    assert "anyOf" not in parameters
+    assert "oneOf" not in parameters
+    assert parameters["properties"] == original["function"]["parameters"]["properties"]
+    assert parameters["required"] == original["function"]["parameters"]["required"]
+    assert parameters["additionalProperties"] is False
     assert compact_tool == original
 
 
@@ -175,3 +177,72 @@ def test_site_registry_is_exact_and_named() -> None:
         "api.kimi.com": frozenset({"move_type_into_union_branches"}),
         "api.moonshot.cn": frozenset({"move_type_into_union_branches"}),
     }
+
+
+def _chat(parameters: dict) -> dict:
+    return {
+        "type": "function",
+        "function": {
+            "name": "x",
+            "description": "x",
+            "parameters": parameters,
+        },
+    }
+
+
+def test_root_anyof_and_oneof_are_stripped_before_recursive_move() -> None:
+    tool = _chat(
+        {
+            "type": "object",
+            "properties": {"x": {"type": "string"}},
+            "required": ["x"],
+            "additionalProperties": False,
+            "anyOf": [{"required": ["x"]}],
+            "oneOf": [{"required": ["x"]}],
+        }
+    )
+    original = copy.deepcopy(tool)
+    result = _apply_site_quirks("https://api.moonshot.cn/v1", [tool])[0][
+        "function"
+    ]["parameters"]
+    assert result == {
+        "type": "object",
+        "properties": {"x": {"type": "string"}},
+        "required": ["x"],
+        "additionalProperties": False,
+    }
+    assert tool == original
+
+
+def test_nested_union_still_uses_pr_1408_branch_move() -> None:
+    tool = _chat(
+        {
+            "type": "object",
+            "properties": {
+                "payload": {
+                    "type": "object",
+                    "anyOf": [{"required": ["x"]}, {"required": ["y"]}],
+                }
+            },
+        }
+    )
+    result = _apply_site_quirks("https://api.moonshot.cn/v1", [tool])[0][
+        "function"
+    ]["parameters"]
+    assert result["type"] == "object"
+    nested = result["properties"]["payload"]
+    assert "type" not in nested
+    assert [branch["type"] for branch in nested["anyOf"]] == ["object", "object"]
+
+
+def test_allof_root_is_untouched() -> None:
+    parameters = {
+        "type": "object",
+        "properties": {"x": {"type": "string"}},
+        "allOf": [{"required": ["x"]}],
+    }
+    result = _apply_site_quirks(
+        "https://api.moonshot.cn/v1",
+        [_chat(parameters)],
+    )[0]["function"]["parameters"]
+    assert result == parameters

--- a/tests/test_site_schema_quirks.py
+++ b/tests/test_site_schema_quirks.py
@@ -1,4 +1,4 @@
-"""Site-specific schema quirk regressions for issue #694."""
+"""Site-specific schema quirk regressions for issues #694 and #913."""
 
 from __future__ import annotations
 
@@ -7,6 +7,7 @@ import copy
 from lingtai.llm.openai.adapter import (
     _SITE_SCHEMA_QUIRKS,
     _apply_site_quirks,
+    _build_tools,
     _move_type_into_union_branches,
 )
 
@@ -106,6 +107,13 @@ _RESPONSES_TOOL = {
     },
 }
 
+def _daemon_compact_tool() -> dict:
+    from lingtai.tools.daemon import DaemonManager
+
+    manager = DaemonManager.__new__(DaemonManager)
+    schemas, _handlers = manager._daemon_intrinsic_surface()
+    return _build_tools([schemas["compact"]])[0]
+
 
 def test_exact_kimi_host_applies_chat_quirk() -> None:
     original = copy.deepcopy(_CHAT_TOOL)
@@ -121,6 +129,27 @@ def test_exact_kimi_host_applies_responses_quirk() -> None:
     parameters = result[0]["parameters"]
     assert "type" not in parameters
     assert all(branch["type"] == "object" for branch in parameters["oneOf"])
+
+
+def test_exact_moonshot_host_applies_real_daemon_compact_quirk() -> None:
+    compact_tool = _daemon_compact_tool()
+    original = copy.deepcopy(compact_tool)
+    result = _apply_site_quirks(
+        "https://api.moonshot.cn/v1",
+        [compact_tool],
+    )
+    parameters = result[0]["function"]["parameters"]
+    assert "type" not in parameters
+    assert all(branch["type"] == "object" for branch in parameters["anyOf"])
+    assert compact_tool == original
+
+
+def test_moonshot_lookalike_host_does_not_apply_quirk() -> None:
+    compact_tool = _daemon_compact_tool()
+    assert _apply_site_quirks(
+        "https://api.moonshot.cn.example.test/v1",
+        [compact_tool],
+    ) == [compact_tool]
 
 
 def test_openrouter_does_not_apply_kimi_quirk() -> None:
@@ -144,4 +173,5 @@ def test_none_and_empty_inputs_are_passthrough() -> None:
 def test_site_registry_is_exact_and_named() -> None:
     assert _SITE_SCHEMA_QUIRKS == {
         "api.kimi.com": frozenset({"move_type_into_union_branches"}),
+        "api.moonshot.cn": frozenset({"move_type_into_union_branches"}),
     }


### PR DESCRIPTION
## Summary

- register the official `api.moonshot.cn` host for the existing Kimi/Moonshot OpenAI-compatible schema quirk
- preserve an object-typed tool-parameters root by stripping root-level `anyOf`/`oneOf` before applying the existing recursive branch transform below it
- cover the real daemon `compact` schema plus nested unions, root `allOf`, exact/lookalike hosts, and canonical-schema immutability

The daemon always exposes its intrinsic `compact` tool. Its parameters root contains `type: object`, properties/required fields, and a conditional root `anyOf`. Moonshot's validator imposes two incompatible root rules: `parameters.type` must remain `object`, while a root union may not sit beside that parent type. The compatible wire form therefore keeps the plain object root and removes only its root `anyOf`/`oneOf`; nested unions still use the existing `move_type_into_union_branches` transform.

This transformation remains exact-host and outgoing-copy only. It does not mutate the canonical tool schema, change daemon lifecycle behavior, or affect unmatched providers. The `compact` handler independently enforces its dropped `run`/`_reason` condition; other tools whose root unions are relaxed on these hosts remain responsible for equivalent conditional enforcement at their dispatch/server boundary.

## Real-use correction

After the initial PR was opened, 望舒 (`kimi-agent`) reproduced the remaining daemon failure against `https://api.moonshot.cn/v1`, identified the root-union contradiction, and reported successful shell/file daemon smoke runs after the follow-up. This update integrates that real-use finding and corrects the original `compact` test oracle, which had incorrectly treated a root without `type` as the expected Moonshot shape.

## Validation

- [x] `git diff --check`
- [x] Corrected test-oracle fail-first against original PR head `3ee27fa6`: `4 failed, 15 passed`
- [x] `PYTHONPATH="$PWD/src" .venv/bin/python -m pytest -q tests/test_site_schema_quirks.py` — `19 passed`
- [x] `PYTHONPATH="$PWD/src" .venv/bin/python -m pytest -q -x tests/test_tool_family_daemon_migration.py` — `67 passed`
- [x] Focused compact runtime safety tests (blank reason, missing action, mixed batch) — `3 passed`
- [x] Broader daemon/OpenAI regression files, excluding one deterministic pre-existing baseline failure described below — `245 passed, 1 deselected`
- [x] `.venv/bin/python -m py_compile src/lingtai/llm/openai/adapter.py tests/test_site_schema_quirks.py`

The deselected `tests/test_daemon.py::test_emanate_without_preset_inherits_parent` currently fails because its mocked detached-spawn record remains empty. The same isolated test fails identically against an untouched archive of the original PR head `3ee27fa6`; neither touched file participates in that path.

## Notes

- Fixes Lingtai-AI/lingtai#913.
- Scope remains limited to the existing exact-host quirk registry, one adapter-local wire transformation, and focused regression tests; there is no wildcard, suffix match, global provider rewrite, or daemon lifecycle change.
- Root Anatomy/Contract design principles, OpenAI adapter Anatomy, daemon Contract, root Behaviors, and test methodology were checked. This change moves no files or symbols, changes no composition/state ownership, and adds no new interface or normative daemon behavior, so no architecture/contract document update is needed.
- The maintainer-side validation used no Moonshot credential or live provider call. Wangshu's two live daemon smoke runs are collaborator-supplied real-use evidence. Logs, examples, and test fixtures contain no secrets.
