### PR TITLE
fix(nudge): keep folder-size probes off heartbeat

### DIFF
--- a/src/lingtai/kernel/nudge/ANATOMY.md
+++ b/src/lingtai/kernel/nudge/ANATOMY.md
@@ -18,6 +18,7 @@ related_files:
   - src/lingtai/CONTRACT.md
   - tests/test_nudge_prompts.py
   - tests/test_kernel_version_nudge.py
+  - tests/test_folder_size_nudge.py
   - ENVIRONMENT_VARIABLES.md
 maintenance: |
   Keep related_files as repo-relative paths to real files. Include neighboring
@@ -65,8 +66,11 @@ the ordinary Notification Store channel; it does not create a second transport.
   `init.json` independently (`src/lingtai/kernel/nudge/init_config.py:1-74`).
 - `folder_size.py` — read-only recursive size walk of the agent working
   directory, throttled to one walk per UTC day via a per-kind persistent date
-  gate; every heartbeat re-evaluates the persisted observation through the
-  shared `upsert`/`remove` so global repeat/enable/retry semantics stay live.
+  gate. The walk runs in a daemon worker with one in-process flight per
+  canonical working directory; a later heartbeat alone consumes and persists
+  the result, so the heartbeat never waits for a large filesystem traversal.
+  Every heartbeat re-evaluates the persisted observation through the shared
+  `upsert`/`remove` so global repeat/enable/retry semantics stay live.
   Emits/clears a `storage_size` finding when the directory crosses
   `LINGTAI_NUDGE_FOLDER_SIZE_GB` (default `5` decimal GB) (`src/lingtai/kernel/nudge/folder_size.py:1-182`).
   `event_journal_count.py` has no user setting: its once-per-UTC-day direct
@@ -97,8 +101,8 @@ the ordinary Notification Store channel; it does not create a second transport.
 ## Connections
 
 `../base_agent/lifecycle.py` calls `run_checks` once per heartbeat
-(checks must never block on the network — long work goes to a background
-thread, see `kernel_version.py`);
+(checks must never block on network or recursive filesystem probes — long work
+goes to a background thread, see `kernel_version.py` and `folder_size.py`);
 protected goal reminders are dispatched separately by
 `run_system_notifications`. Producer checks call `upsert`/`remove`; the shared
 `NotificationStorePort` persists `nudge.json`. `notification(action="dismiss_channel", input={"channel": "nudge", ...},
@@ -126,6 +130,12 @@ cost), never the upsert/remove decision, which is re-evaluated on every
 heartbeat so shared global enabled/repeat values stay product semantics. Goal
 source state remains protected `.notification/goal.json` and its reminder
 remains in `system.json`.
+
+While a folder-size walk is running, process-local ephemeral state holds one
+pending probe per canonical working directory. The worker publishes only an
+in-memory result or bounded error; the heartbeat thread owns all persistent
+state and Notification Store mutations. A result that finishes after its UTC
+start date is discarded and measured again for the current day.
 
 Findings that exceed `INLINE_MAX_CHARS` also persist their complete original
 body to `<working_dir>/tmp/nudge-findings/<kind>-<sha256>.json`

--- a/src/lingtai/kernel/nudge/folder_size.py
+++ b/src/lingtai/kernel/nudge/folder_size.py
@@ -13,6 +13,7 @@ import math
 import os
 from datetime import datetime, timezone
 from pathlib import Path
+from threading import Lock, Thread
 from typing import Any, Mapping
 
 _KIND = "folder_size"
@@ -20,10 +21,23 @@ _STATE_FILE = Path(".notification") / ".nudge_state.json"
 DEFAULT_LIMIT_GB = 5.0
 LIMIT_ENV = "LINGTAI_NUDGE_FOLDER_SIZE_GB"
 _BYTES_PER_GB = 1_000_000_000
+_PROBE_LOCK = Lock()
+_PROBES_BY_WORKDIR: dict[str, "_Probe"] = {}
+
+
+class _Probe:
+    """One in-process directory measurement owned by a heartbeat workdir."""
+
+    def __init__(self, path: Path, start_date: str) -> None:
+        self.path = path
+        self.start_date = start_date
+        self.total_bytes: int | None = None
+        self.error: str | None = None
+        self.done = False
 
 
 def check(agent) -> None:
-    """Evaluate the folder-size nudge on every heartbeat (walk max once/day)."""
+    """Evaluate the nudge without performing a recursive walk on heartbeat."""
     persistent = _load_persistent_state(agent)
     folder_state = persistent.setdefault(_KIND, {})
 
@@ -31,14 +45,23 @@ def check(agent) -> None:
     if invalid:
         _safe_log(agent, "folder_size_limit_invalid", value=invalid)
 
-    if folder_state.get("last_check_date") != _today_utc():
-        try:
-            total_bytes = _dir_size(Path(agent._working_dir))
-        except Exception as e:  # pragma: no cover - defensive
-            _safe_log(agent, "folder_size_probe_error", error=str(e)[:200])
+    today = _today_utc()
+    completed = _take_completed_probe(Path(agent._working_dir))
+    if completed is not None:
+        if completed.start_date != today:
+            pass
+        elif completed.error is not None:
+            _safe_log(agent, "folder_size_probe_error", error=completed.error[:200])
             return
-        folder_state.update({"last_check_date": _today_utc(), "size_bytes": total_bytes, "limit_gb": limit_gb})
-        _save_persistent_state(agent, persistent)
+        else:
+            folder_state.update(
+                {"last_check_date": completed.start_date, "size_bytes": completed.total_bytes, "limit_gb": limit_gb}
+            )
+            _save_persistent_state(agent, persistent)
+
+    if folder_state.get("last_check_date") != today:
+        _start_probe(Path(agent._working_dir), today)
+        return
 
     if "size_bytes" not in folder_state:
         return
@@ -72,6 +95,40 @@ def check(agent) -> None:
             "checked_at_date": folder_state.get("last_check_date"),
         },
     )
+
+
+def _start_probe(workdir: Path, start_date: str) -> None:
+    path = workdir.resolve()
+    key = str(path)
+    with _PROBE_LOCK:
+        if key in _PROBES_BY_WORKDIR:
+            return
+        probe = _Probe(path, start_date)
+        _PROBES_BY_WORKDIR[key] = probe
+    Thread(target=_measure_probe, args=(probe,), daemon=True).start()
+
+
+def _measure_probe(probe: _Probe) -> None:
+    try:
+        total_bytes = _dir_size(probe.path)
+    except Exception as e:
+        with _PROBE_LOCK:
+            probe.error = str(e)[:200]
+            probe.done = True
+        return
+    with _PROBE_LOCK:
+        probe.total_bytes = total_bytes
+        probe.done = True
+
+
+def _take_completed_probe(workdir: Path) -> _Probe | None:
+    key = str(workdir.resolve())
+    with _PROBE_LOCK:
+        probe = _PROBES_BY_WORKDIR.get(key)
+        if probe is None or not probe.done:
+            return None
+        del _PROBES_BY_WORKDIR[key]
+        return probe
 
 
 def _read_limit_gb(environ: Mapping[str, str] | None = None) -> tuple[float, str | None]:

--- a/src/lingtai/kernel/nudge/folder_size.py
+++ b/src/lingtai/kernel/nudge/folder_size.py
@@ -61,7 +61,6 @@ def check(agent) -> None:
 
     if folder_state.get("last_check_date") != today:
         _start_probe(Path(agent._working_dir), today)
-        return
 
     if "size_bytes" not in folder_state:
         return

--- a/tests/test_folder_size_nudge.py
+++ b/tests/test_folder_size_nudge.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 import math
+import threading
+import time
 from pathlib import Path
 
 import pytest
@@ -20,6 +22,7 @@ from tests._notification_store_helpers import notification_store_for, snapshot_n
 
 CHUNK = 2 * 1024 * 1024  # 2 MiB
 TINY_LIMIT = "0.0001"  # 100_000 decimal bytes
+_POLL = threading.Event()
 
 
 class _Agent:
@@ -63,6 +66,48 @@ def _force_next_walk(workdir):
     _state_file(workdir).write_text(json.dumps(data), encoding="utf-8")
 
 
+def _call_until(call, ready, *, timeout=1.0):
+    """Drive heartbeats until their observable result arrives."""
+    deadline = time.monotonic() + timeout
+    while True:
+        call()
+        if ready():
+            return
+        remaining = deadline - time.monotonic()
+        assert remaining > 0, "heartbeat did not publish the expected result"
+        _POLL.wait(min(0.01, remaining))
+
+
+def _check_until(agent, ready, *, timeout=1.0):
+    _call_until(lambda: folder_size.check(agent), ready, timeout=timeout)
+
+
+def _run_checks_until(agent, ready, *, timeout=1.0):
+    _call_until(lambda: run_checks(agent), ready, timeout=timeout)
+
+
+def _check_until_raises(agent, error, *, timeout=1.0):
+    deadline = time.monotonic() + timeout
+    while True:
+        try:
+            folder_size.check(agent)
+        except error:
+            return
+        remaining = deadline - time.monotonic()
+        assert remaining > 0, "heartbeat did not raise the expected error"
+        _POLL.wait(min(0.01, remaining))
+
+
+def _current_folder_state(workdir):
+    return _state(workdir).get("folder_size", {}).get("last_check_date") == _today_utc()
+
+
+def _assert_fast_check(agent):
+    started = time.monotonic()
+    folder_size.check(agent)
+    assert time.monotonic() - started <= 0.5
+
+
 def test_limit_env_default_invalid_and_non_finite(monkeypatch):
     monkeypatch.delenv(LIMIT_ENV, raising=False)
     assert _read_limit_gb() == (DEFAULT_LIMIT_GB, None)
@@ -90,15 +135,15 @@ def test_under_limit_noop_and_clears(monkeypatch, tmp_path):
     agent = _Agent(tmp_path)
     (tmp_path / "small.bin").write_bytes(b"y" * 1024)
     monkeypatch.setenv(LIMIT_ENV, "5")
-    folder_size.check(agent)
+    _check_until(agent, lambda: _current_folder_state(tmp_path))
     assert _entries(tmp_path) == []
     nudge_mod.upsert(agent, "folder_size", {"title": "stale", "detail": "old"})
-    folder_size.check(agent)
+    _check_until(agent, lambda: _entries(tmp_path) == [])
     assert _entries(tmp_path) == []
 
 
 def test_over_limit_emits_facts(over_agent, tmp_path):
-    folder_size.check(over_agent)
+    _check_until(over_agent, lambda: bool(_entries(tmp_path)))
     entry = _entries(tmp_path)[0]
     assert entry["kind"] == "folder_size"
     assert entry["nudge_channel"] == ENTRY_CHANNEL_STORAGE_SIZE
@@ -113,7 +158,7 @@ def test_no_non_finite_reaches_state_or_notification(monkeypatch, tmp_path):
     agent = _Agent(tmp_path)
     (tmp_path / "chunk.bin").write_bytes(b"z" * CHUNK)
     monkeypatch.setenv(LIMIT_ENV, "nan")
-    folder_size.check(agent)
+    _check_until(agent, lambda: _current_folder_state(tmp_path))
     state = _state(tmp_path)["folder_size"]
     assert state["limit_gb"] == DEFAULT_LIMIT_GB
     for entry in _entries(tmp_path):
@@ -124,16 +169,16 @@ def test_decimal_gb_boundary(monkeypatch, tmp_path):
     agent = _Agent(tmp_path)
     monkeypatch.setenv(LIMIT_ENV, TINY_LIMIT)
     (tmp_path / "at-limit.bin").write_bytes(b"a" * 100_000)
-    folder_size.check(agent)
+    _check_until(agent, lambda: _current_folder_state(tmp_path))
     assert _entries(tmp_path) == []
     (tmp_path / "over.bin").write_bytes(b"b" * 1)
     _force_next_walk(tmp_path)
-    folder_size.check(agent)
+    _check_until(agent, lambda: bool(_entries(tmp_path)))
     assert len(_entries(tmp_path)) == 1
 
 
 def test_walk_gate_skips_second_walk_same_day(over_agent, tmp_path):
-    folder_size.check(over_agent)
+    _check_until(over_agent, lambda: _current_folder_state(tmp_path))
     first = _state(tmp_path)["folder_size"]["size_bytes"]
     (tmp_path / "more.bin").write_bytes(b"q" * (3 * 1024 * 1024))
     folder_size.check(over_agent)
@@ -142,7 +187,7 @@ def test_walk_gate_skips_second_walk_same_day(over_agent, tmp_path):
 
 
 def test_global_repeat_expiry_reappears_same_day(over_agent, tmp_path, monkeypatch):
-    folder_size.check(over_agent)
+    _check_until(over_agent, lambda: bool(_entries(tmp_path)))
     first = _state(tmp_path)["folder_size"]["size_bytes"]
     monkeypatch.setenv("LINGTAI_NUDGE_REPEAT_INTERVAL", "2s")
     nudge_mod.record_dismissal(over_agent)
@@ -166,12 +211,12 @@ def test_global_repeat_expiry_reappears_same_day(over_agent, tmp_path, monkeypat
 
 
 def test_enable_off_on_restores_same_day(over_agent, tmp_path, monkeypatch):
-    folder_size.check(over_agent)
+    _check_until(over_agent, lambda: bool(_entries(tmp_path)))
     monkeypatch.setenv("LINGTAI_NUDGE_ENABLED", "off")
-    run_checks(over_agent)
+    _run_checks_until(over_agent, lambda: _entries(tmp_path) == [])
     assert _entries(tmp_path) == []
     monkeypatch.setenv("LINGTAI_NUDGE_ENABLED", "on")
-    run_checks(over_agent)
+    _run_checks_until(over_agent, lambda: bool(_entries(tmp_path)))
     assert len(_entries(tmp_path)) == 1
 
 
@@ -182,30 +227,150 @@ def test_transient_upsert_failure_retried_same_day(over_agent, tmp_path, monkeyp
         raise RuntimeError("transient store failure")
 
     monkeypatch.setattr(nudge_mod, "upsert", fail)
-    with pytest.raises(RuntimeError, match="transient"):
-        folder_size.check(over_agent)
+    _check_until_raises(over_agent, RuntimeError)
     first = _state(tmp_path)["folder_size"]["size_bytes"]
     monkeypatch.setattr(nudge_mod, "upsert", real)
-    folder_size.check(over_agent)
+    _check_until(over_agent, lambda: bool(_entries(tmp_path)))
     assert _state(tmp_path)["folder_size"]["size_bytes"] == first
     assert len(_entries(tmp_path)) == 1
 
 
 def test_run_checks_dispatches(over_agent, tmp_path, monkeypatch):
     monkeypatch.setenv("LINGTAI_NUDGE_ENABLED", "on")
-    run_checks(over_agent)
+    _run_checks_until(over_agent, lambda: bool(_entries(tmp_path)))
     assert any(e["kind"] == "folder_size" for e in _entries(tmp_path))
 
 
 def test_reprobe_next_day_clears(over_agent, tmp_path):
-    folder_size.check(over_agent)
+    _check_until(over_agent, lambda: bool(_entries(tmp_path)))
     assert len(_entries(tmp_path)) == 1
     (tmp_path / "chunk.bin").unlink()
     _force_next_walk(tmp_path)
-    folder_size.check(over_agent)
+    _check_until(over_agent, lambda: _current_folder_state(tmp_path) and _entries(tmp_path) == [])
     assert _entries(tmp_path) == []
 
 
 def test_today_utc_format():
     v = _today_utc()
     assert len(v) == 10 and v[4] == "-" and v[7] == "-"
+
+
+def test_blocking_probe_returns_and_is_single_flight_until_a_heartbeat_consumes_it(monkeypatch, tmp_path):
+    agent = _Agent(tmp_path)
+    monkeypatch.setenv(LIMIT_ENV, TINY_LIMIT)
+    started = threading.Event()
+    release = threading.Event()
+    calls = 0
+
+    def blocked_probe(path):
+        nonlocal calls
+        calls += 1
+        started.set()
+        assert release.wait(3.0)
+        return CHUNK
+
+    monkeypatch.setattr(folder_size, "_dir_size", blocked_probe)
+    try:
+        _assert_fast_check(agent)
+        assert started.wait(1.0)
+        _assert_fast_check(agent)
+        assert calls == 1
+        release.set()
+        _check_until(agent, lambda: bool(_entries(tmp_path)) and _current_folder_state(tmp_path))
+    finally:
+        release.set()
+
+
+def test_blocked_workdir_probe_does_not_delay_another_workdir(monkeypatch, tmp_path):
+    first_path = tmp_path / "first"
+    second_path = tmp_path / "second"
+    first_path.mkdir()
+    second_path.mkdir()
+    first = _Agent(first_path)
+    second = _Agent(second_path)
+    monkeypatch.setenv(LIMIT_ENV, TINY_LIMIT)
+    first_started = threading.Event()
+    second_started = threading.Event()
+    release = threading.Event()
+
+    def probe(path):
+        if path == first_path:
+            first_started.set()
+            assert release.wait(3.0)
+        else:
+            second_started.set()
+        return CHUNK
+
+    monkeypatch.setattr(folder_size, "_dir_size", probe)
+    try:
+        _assert_fast_check(first)
+        assert first_started.wait(1.0)
+        _assert_fast_check(second)
+        assert second_started.wait(1.0)
+        _check_until(second, lambda: bool(_entries(second_path)))
+        assert "folder_size" not in _state(first_path)
+        release.set()
+        _check_until(first, lambda: bool(_entries(first_path)))
+    finally:
+        release.set()
+
+
+def test_probe_error_is_bounded_and_the_next_heartbeat_retries(monkeypatch, tmp_path):
+    agent = _Agent(tmp_path)
+    monkeypatch.setenv(LIMIT_ENV, TINY_LIMIT)
+    first_attempt = threading.Event()
+    calls = 0
+
+    def flaky_probe(path):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            first_attempt.set()
+            raise RuntimeError("x" * 500)
+        return CHUNK
+
+    monkeypatch.setattr(folder_size, "_dir_size", flaky_probe)
+    _assert_fast_check(agent)
+    assert first_attempt.wait(1.0)
+    _check_until(agent, lambda: any(event == "folder_size_probe_error" for event, _ in agent.logs))
+    errors = [fields["error"] for event, fields in agent.logs if event == "folder_size_probe_error"]
+    assert errors == ["x" * 200]
+    _check_until(agent, lambda: bool(_entries(tmp_path)))
+    assert calls == 2
+
+
+def test_probe_completed_after_utc_rollover_is_discarded_and_remeasured(monkeypatch, tmp_path):
+    agent = _Agent(tmp_path)
+    monkeypatch.setenv(LIMIT_ENV, TINY_LIMIT)
+    today = {"value": "2026-08-17"}
+    monkeypatch.setattr(folder_size, "_today_utc", lambda: today["value"])
+    started = threading.Event()
+    release = threading.Event()
+    calls = 0
+
+    def rollover_probe(path):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            started.set()
+            assert release.wait(3.0)
+            return CHUNK
+        return CHUNK + 1
+
+    monkeypatch.setattr(folder_size, "_dir_size", rollover_probe)
+    try:
+        _assert_fast_check(agent)
+        assert started.wait(1.0)
+        today["value"] = "2026-08-18"
+        release.set()
+        _check_until(
+            agent,
+            lambda: _state(tmp_path).get("folder_size", {}).get("last_check_date") == today["value"]
+            and bool(_entries(tmp_path)),
+        )
+        entry = _entries(tmp_path)[0]
+        assert calls == 2
+        assert entry["size_bytes"] == CHUNK + 1
+        assert entry["checked_at_date"] == "2026-08-18"
+    finally:
+        release.set()

--- a/tests/test_folder_size_nudge.py
+++ b/tests/test_folder_size_nudge.py
@@ -281,6 +281,41 @@ def test_blocking_probe_returns_and_is_single_flight_until_a_heartbeat_consumes_
         release.set()
 
 
+def test_prior_observation_remains_effective_while_new_day_probe_is_pending(monkeypatch, tmp_path):
+    agent = _Agent(tmp_path)
+    monkeypatch.setenv(LIMIT_ENV, TINY_LIMIT)
+    _state_file(tmp_path).parent.mkdir(parents=True, exist_ok=True)
+    _state_file(tmp_path).write_text(
+        json.dumps(
+            {
+                "folder_size": {
+                    "last_check_date": "2026-08-17",
+                    "size_bytes": CHUNK,
+                    "limit_gb": 5,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(folder_size, "_today_utc", lambda: "2026-08-18")
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocked_probe(path):
+        started.set()
+        assert release.wait(3.0)
+        return CHUNK
+
+    monkeypatch.setattr(folder_size, "_dir_size", blocked_probe)
+    try:
+        _assert_fast_check(agent)
+        assert started.wait(1.0)
+        assert bool(_entries(tmp_path))
+        assert _state(tmp_path)["folder_size"]["last_check_date"] == "2026-08-17"
+    finally:
+        release.set()
+
+
 def test_blocked_workdir_probe_does_not_delay_another_workdir(monkeypatch, tmp_path):
     first_path = tmp_path / "first"
     second_path = tmp_path / "second"


### PR DESCRIPTION
## Summary

- move the recursive working-directory size walk off the 1-second heartbeat
- keep one daemon probe in flight per canonical working directory
- let heartbeat code alone consume results and mutate persistent nudge state
- preserve the previous observation while a new UTC-day measurement is pending
- discard results that complete after their UTC start date and retry for the current day

## Why

A roughly 45 GB working directory made the synchronous recursive walk exceed the
120-second watchdog window. The agent was killed, restarted, and immediately
entered the same scan again. This change makes heartbeat latency independent of
directory traversal time while retaining the existing daily gate and nudge policy.

## Behavioral boundaries

- no new dependency, scheduler, environment variable, or synchronous fallback
- dynamic threshold, dismissal/repeat/enable, notification retry, and symlink semantics remain unchanged
- a probe worker publishes only an in-memory result/error; persistent writes stay on heartbeat
- strict singleflight is retained if a filesystem call wedges; fresh observation then waits for process restart rather than leaking concurrent scans, while the prior persisted observation remains active

## Tests

- TDD regression first reproduced a heartbeat blocked for about 3 seconds
- `17 passed, 1 deselected` for `tests/test_folder_size_nudge.py` on Windows; the deselected existing symlink test requires a Windows privilege unavailable in this environment
- async concurrency/cross-day/error cases repeated 5 rounds successfully after final review
- direct Nudge Anatomy governance check passed
- real large-workdir smoke: `check()` returned in `0.000480s` while the background traversal started
- independent reviewer found no blocking issues after the cross-day pending-observation fix

## Full-suite limitation

The complete Windows suite cannot collect in this environment because existing
POSIX-only tests import `fcntl`. The repository-wide docs gates also have existing
unrelated baseline failures on current `main`; the changed Nudge Anatomy document
passes its focused governance validation.

## Architecture documentation

`src/lingtai/kernel/nudge/ANATOMY.md` now records the background singleflight
probe, heartbeat-only persistence boundary, and stale cross-day result behavior.
No public Contract or BEHAVIORS change is required because this corrects the
existing non-blocking heartbeat implementation invariant without adding a new
agent-facing capability.
