### PR TITLE
feat(daemon): align CLI and tool reclaim lifecycle

### DIFF
--- a/src/lingtai/adapters/posix/daemon_manager.py
+++ b/src/lingtai/adapters/posix/daemon_manager.py
@@ -336,6 +336,7 @@ class _DaemonManagerProcess:
         idle_since: float | None = None
         while True:
             self._reap_finished_threads()
+            self._consume_queue_cancel_requests()
             self._start_queued_jobs()
             if self.active or list(self.queue_dir.glob("*.json")):
                 idle_since = None
@@ -355,6 +356,82 @@ class _DaemonManagerProcess:
             finished = [run_id for run_id, thread in self.active.items() if not thread.is_alive()]
             for run_id in finished:
                 self.active.pop(run_id, None)
+
+    def _consume_queue_cancel_requests(self) -> None:
+        """Honor durable reclaim requests for still-queued jobs before start.
+
+        A queued job has no execution worker and therefore no control watcher
+        yet; this pass is the queue-phase consumer of the same run-local
+        ``control/`` spool. The queue job file's ``unlink()`` is the single
+        arbitration token, shared with ``_start_queued_jobs``: whoever unlinks
+        the job owns the run's fate, so a pending reclaim is honored on
+        exactly one branch — here (terminal ``cancelled`` before start) or by
+        the started worker's own active watcher. Queued ``ask`` requests are
+        deliberately left untouched for that future watcher.
+        """
+        from lingtai.kernel.daemon_supervisor import control
+
+        for job_path in sorted(self.queue_dir.glob("*.json")):
+            job = read_json(job_path, default={}, expect=dict)
+            if not isinstance(job, dict) or "request" not in job:
+                # Malformed jobs stay owned by _start_queued_jobs' quarantine.
+                continue
+            try:
+                request = decode_request(str(job["request"]))
+            except Exception:
+                continue
+            # Canonical layout puts the manifest inside the run directory, so
+            # the spool can be probed cheaply before any manifest read.
+            run_path = Path(request.manifest_path).parent
+            pending = control.pending_requests(run_path)
+            if not pending:
+                continue
+            try:
+                manifest = _read_manifest_for_request(request)
+                run_dir = _attach_run_dir(manifest)
+            except Exception:
+                continue
+            reclaim_requests: list[Path] = []
+            for req_path in pending:
+                try:
+                    req = control.read_request(req_path)
+                except Exception:
+                    control.mark_request_done(
+                        req_path, {"status": "error", "error": "unreadable request"}
+                    )
+                    continue
+                if req.get("run_id") != request.run_id:
+                    control.mark_request_done(
+                        req_path, {"status": "rejected", "error": "run_id mismatch"}
+                    )
+                    continue
+                if req.get("kind") != "reclaim":
+                    continue
+                reclaim_requests.append(req_path)
+            if not reclaim_requests:
+                continue
+            state = run_dir.read_state_from_disk(run_dir.path)
+            if state.get("state") not in {"running", "active"}:
+                for req_path in reclaim_requests:
+                    control.mark_request_done(req_path, {
+                        "status": "rejected",
+                        "error": f"run is already {state.get('state')!r}",
+                    })
+                continue
+            try:
+                job_path.unlink()
+            except OSError:
+                continue  # the worker won the handoff; its watcher consumes this
+            with self.lock:
+                self.capsules.pop(request.run_id, None)
+            run_dir.update_state(owner="manager", manager_pid=os.getpid())
+            run_dir.mark_cancelled()
+            _publish_terminal(run_dir, manifest)
+            self._journal(request.run_id, "cancelled_queued", request, {})
+            for req_path in reclaim_requests:
+                control.mark_request_done(
+                    req_path, {"status": "accepted", "phase": "queued"}
+                )
 
     def _start_queued_jobs(self) -> None:
         with self.lock:

--- a/src/lingtai/cli_daemon.py
+++ b/src/lingtai/cli_daemon.py
@@ -9,7 +9,7 @@ skin over the *existing* engine: it builds a minimal agent-shaped facade
 model uses.  No emanation, preset, run-directory, supervisor, or notification
 logic is reimplemented here.
 
-Three actions are exposed, deliberately fewer than the tool's six:
+Four actions are exposed, deliberately fewer than the tool's six:
 
 ``emanate``
     Dispatch a batch from a tasks JSON file.  Preview-by-default; ``--yes`` is
@@ -31,8 +31,13 @@ Three actions are exposed, deliberately fewer than the tool's six:
     unmodified ``_handle_list`` / ``_handle_check`` units, the same forwarding
     shape ``daemon/execution_host.py`` uses inside a supervisor process.
 
-``ask`` and ``reclaim`` are intentionally absent: this surface performs no
-side effect beyond spawning daemons exactly as the tool would.
+``reclaim``
+    Cancel every active or queued detached run of this agent directory,
+    through the same family dispatch and durable control spool the tool's
+    ``daemon(action="reclaim")`` uses — a CLI-created daemon stays exactly as
+    controllable as an agent-created one.
+
+``ask`` is intentionally absent.
 """
 from __future__ import annotations
 
@@ -981,10 +986,22 @@ def _handle_check(args) -> int:
     return 0 if result.get("status") != "error" else 1
 
 
+def _handle_reclaim(args) -> int:
+    from lingtai.adapters.posix.event_journal import PosixJsonlEventJournalAdapter
+
+    agent_dir = _resolve_agent_dir(args.agent_dir)
+    journal = PosixJsonlEventJournalAdapter(agent_dir)
+    agent = _CliDaemonAgent.for_dispatch(agent_dir, journal=journal)
+    result = _dispatch_through_tool_family(agent, "reclaim", {})
+    _emit_json(result)
+    return 0 if result.get("status") == "reclaimed" else 1
+
+
 _HANDLERS = {
     "emanate": _handle_emanate,
     "list": _handle_list,
     "check": _handle_check,
+    "reclaim": _handle_reclaim,
 }
 
 
@@ -1034,6 +1051,17 @@ def add_daemon_parser(sub: "argparse._SubParsersAction") -> None:
         type=Path,
         default=None,
         help="Agent working directory containing init.json (default: cwd)",
+    )
+
+    reclaim = daemon_sub.add_parser(
+        "reclaim",
+        help="Cancel every active or queued detached daemon run of this agent",
+    )
+    reclaim.add_argument(
+        "--agent-dir",
+        type=Path,
+        required=True,
+        help="Agent working directory containing init.json",
     )
 
     check = daemon_sub.add_parser("check", help="Inspect one daemon run (read-only)")

--- a/src/lingtai/tools/daemon/__init__.py
+++ b/src/lingtai/tools/daemon/__init__.py
@@ -9173,8 +9173,11 @@ class DaemonManager:
             if entry.get("detached") and entry.get("run_dir") is not None
         }
         # A fresh manager has no in-memory registry. Discover only exact
-        # supervisor-owned active records; this is a control facade, not an
-        # execution-owner adoption path.
+        # control-capable active detached records — supervisor-owned or
+        # central-manager-owned, same durable owner set as the ask/entry
+        # facades (`_durable_detached_entry`/`_handle_ask_detached`); this is
+        # a control facade, not an execution-owner adoption path.
+        skipped_dead_manager = 0
         daemons_dir = self._agent._working_dir / "daemons"
         if daemons_dir.is_dir():
             for run_path in daemons_dir.iterdir():
@@ -9186,17 +9189,35 @@ class DaemonManager:
                     continue
                 if state.get("state") not in {"running", "active"}:
                     continue
-                if state.get("owner") != "supervisor":
+                owner = state.get("owner")
+                if owner not in {"supervisor", "manager"}:
                     continue
                 pid = state.get("supervisor_pid")
-                if not isinstance(pid, int) or not self._pid_identity_matches(
-                    pid, state.get("supervisor_start_identity")
-                ):
+                if isinstance(pid, int) and not isinstance(pid, bool):
+                    # Active detached record: both owners stamp the exact
+                    # supervisor_pid/start identity at execution start, so one
+                    # unchanged guard covers supervisor- and manager-owned runs.
+                    if not self._pid_identity_matches(
+                        pid, state.get("supervisor_start_identity")
+                    ):
+                        continue
+                elif owner == "manager":
+                    # Queued central-manager record (no execution worker yet):
+                    # eligible only behind a live, identity-matched manager
+                    # whose queue loop consumes the reclaim before start. A
+                    # dead or mismatched manager gets no request and no
+                    # signal; the startup reaper owns terminalizing its
+                    # records.
+                    if not self._manager_owner_alive(state):
+                        skipped_dead_manager += 1
+                        continue
+                else:
                     continue
                 try:
                     run_dirs.setdefault(run_path, DaemonRunDir.attach(run_path))
                 except (OSError, ValueError, json.JSONDecodeError):
                     continue
+        self._last_reclaim_skipped_dead_manager = skipped_dead_manager
         if not run_dirs:
             return 0, 0
 
@@ -9240,6 +9261,8 @@ class DaemonManager:
         self._log(
             "daemon_reclaim", cancelled_count=cancelled,
             detached_confirmed=detached_confirmed, detached_pending=detached_pending,
+            skipped_dead_manager=getattr(
+                self, "_last_reclaim_skipped_dead_manager", 0),
         )
         result = {
             "status": "reclaimed",

--- a/tests/test_cli_daemon.py
+++ b/tests/test_cli_daemon.py
@@ -816,6 +816,24 @@ def test_inspection_does_not_require_a_usable_init(tmp_path, monkeypatch, capsys
     assert "em-1" in capsys.readouterr().out
 
 
+def test_reclaim_dispatches_through_the_daemon_family(tmp_path, monkeypatch, capsys):
+    """CLI reclaim is the tool-family reclaim surface, not a second control path."""
+    agent_dir = _write_agent_dir(tmp_path)
+    calls: list[tuple[Path, str, dict]] = []
+
+    def fake_dispatch(agent, action, action_input):
+        calls.append((agent._working_dir, action, action_input))
+        return {"status": "reclaimed", "cancelled": 2}
+
+    monkeypatch.setattr("lingtai.cli_daemon._dispatch_through_tool_family", fake_dispatch)
+
+    assert _run_cli(monkeypatch, [
+        "daemon", "reclaim", "--agent-dir", str(agent_dir),
+    ]) == 0
+    assert calls == [(agent_dir, "reclaim", {})]
+    assert json.loads(capsys.readouterr().out) == {"status": "reclaimed", "cancelled": 2}
+
+
 # ---------------------------------------------------------------------------
 # Read-only list / check
 # ---------------------------------------------------------------------------

--- a/tests/test_daemon_central_manager.py
+++ b/tests/test_daemon_central_manager.py
@@ -563,3 +563,44 @@ def test_central_manager_malformed_top_level_queue_job_is_terminal(tmp_path):
     record = json.loads((journal_dir / "em-bad.json").read_text(encoding="utf-8"))
     assert record["state"] == "failed_malformed_queue_job"
     assert record["error"]["type"] == "ValueError"
+
+
+def test_reclaim_cancels_active_and_queued_central_manager_runs(tmp_path, monkeypatch):
+    """One daemon-family reclaim cancels central-manager active and queued runs."""
+    from lingtai.cli_daemon import (
+        _CliDaemonAgent,
+        _ReadOnlyDaemonView,
+        _dispatch_through_tool_family,
+    )
+
+    agent = make_daemon_agent(tmp_path, ["file", "daemon"])
+    _enable_detached_fake_llm(monkeypatch, agent, sleep_s=8.0)
+    manager = DaemonManager(agent, manager_pool_size=1)
+    try:
+        result = manager._handle_emanate([
+            {"task": "slow task A", "tools": ["file"]},
+            {"task": "slow task B", "tools": ["file"]},
+        ])
+        active_dir = manager._emanations[result["ids"][0]]["run_dir"]
+        queued_dir = manager._emanations[result["ids"][1]]["run_dir"]
+        queued_job = agent._working_dir / MANAGER_DIR / "queue" / f"{result['ids'][1]}.json"
+        _wait_for(
+            lambda: DaemonRunDir.read_state_from_disk(active_dir.path).get("supervisor_pid"),
+            timeout=10.0,
+            message="first managed run to start",
+        )
+        assert queued_job.exists()
+
+        outcome = _dispatch_through_tool_family(agent, "reclaim", {})
+        assert outcome == {"status": "reclaimed", "cancelled": 2, "natural_terminal": 0}
+        _wait_state(active_dir, "cancelled")
+        _wait_state(queued_dir, "cancelled")
+        assert not queued_job.exists()
+
+        view = _ReadOnlyDaemonView(_CliDaemonAgent.for_inspection(agent._working_dir))
+        listed = view._handle_list(
+            contains="", status_filter="cancelled", include_done=True, limit=None,
+        )
+        assert set(result["ids"]) <= {entry["id"] for entry in listed["emanations"]}
+    finally:
+        _terminate_resident_manager(agent)


### PR DESCRIPTION
## Summary

- Add `lingtai-agent daemon reclaim --agent-dir …`, routed through the same `DaemonFamilyDispatcher` action as `daemon(action="reclaim")`.
- Let a fresh daemon manager reclaim central-manager-owned runs: active runs use the existing control watcher; queued runs are terminalized by the existing manager queue through its durable control spool before they start.
- Keep the agent/TUI view unified: CLI and tool runs share durable `daemon.json` records, so existing list and TUI count readers see the same terminal state.

## Validation

```text
PYTHONPATH=src:. python3 -m pytest -q \
  tests/test_cli_daemon.py::test_reclaim_dispatches_through_the_daemon_family \
  tests/test_daemon_central_manager.py::test_reclaim_cancels_active_and_queued_central_manager_runs
# 2 passed in 0.79s

git diff --check
# pass
```

## Scope

Compressed to 5 files (`+196/-9`): the manager queue consumer, fresh-manager reclaim discovery, CLI reclaim command, and two direct regressions. No new registry, TUI side path, or master abstraction. Draft only; no merge, release, config activation, or cleanup.

Telegram: @lingtaidev3bot | Nickname: 澄一
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
