### PR TITLE
fix(system): refuse refresh after cache budget exhaustion

### DIFF
--- a/src/lingtai/intrinsic_skills/context-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/context-manual/SKILL.md
@@ -2,13 +2,15 @@
 name: context-manual
 description: |
   Router and operational guide for the context tool: molt, summarize/rebuild, session journaling, and post-wipe recovery. Read it when molting, compacting or rebuilding provider context, tending the four durable stores, or waking from a system-performed wipe. Routes consequential handoffs to assets/molt-template.md and the summarize/rebuild procedure to reference/summarize-manual.
-version: 2.1.0
-last_changed_at: "2026-08-07T00:00:00Z"
+version: 2.2.0
+last_changed_at: "2026-08-18T00:00:00Z"
 related_files:
 - src/lingtai/tools/context/__init__.py
 - src/lingtai/tools/context/_molt.py
 - src/lingtai/tools/context/_session_journal.py
 - src/lingtai/tools/system/summarize.py
+- src/lingtai/tools/system/preset.py
+- src/lingtai/tools/system/CONTRACT.md
 maintenance: |
   Tracks the tool/capability behavior it teaches; update when that tool's behavior changes.
 ---
@@ -196,10 +198,11 @@ When this reminder appears, follow the urgent cadence in `reference/summarize-ma
 
 ### Cache-miss budget
 
-The soft **cache-miss token budget** (default 1,000,000 via `manifest.cache_miss_budget`, cumulative since your last molt, surfaced as `cache miss budget {N} reached, molt now`) is owned by the resident `meta_guidance` token-efficiency guidance. Two details only documented here:
+The soft **cache-miss token budget** (default 1,000,000 via `manifest.cache_miss_budget`, cumulative since your last molt, surfaced as `cache miss budget {N} reached, molt now`) is owned by the resident `meta_guidance` token-efficiency guidance. Three details only documented here:
 
-- It is **overridable at runtime** by `LINGTAI_CACHE_MISS_BUDGET` (positive int, read live at every budget resolution, so `env_file` + refresh applies it without an init.json edit; an invalid or non-positive value silently falls back to the configured budget). `_meta.agent_meta.agent_state.context` reports the effective `cache_miss_budget` and the current `cache_miss_tokens`.
+- It is **overridable at runtime** by `LINGTAI_CACHE_MISS_BUDGET` (positive int, read live at every budget resolution; while under budget, `env_file` + refresh applies it without an init.json edit; an invalid or non-positive value silently falls back to the configured budget). `_meta.agent_meta.agent_state.context` reports the effective `cache_miss_budget` and the current `cache_miss_tokens`.
 - The total **survives a refresh/restart** — it is not the since-refresh runtime delta, so refreshing does not reset the remaining budget. If the sustained context-pressure reminder is also active, both warnings are preserved in `context.molt`.
+- At or above the budget, `system(action='refresh')` refuses rather than replaying preserved context for a recovery it cannot deliver. Tend durable stores, then call `context(action='molt')`; that starts the new budget cycle. An operator may still use an out-of-band refresh signal when an exhausted agent must apply a raised env-file value.
 
 ## 8. Post-Wipe Recovery
 

--- a/src/lingtai/intrinsic_skills/system-manual/reference/refresh-precheck/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/refresh-precheck/SKILL.md
@@ -8,8 +8,8 @@ description: |
   consistency, newly introduced env vars, context-vs-target-context_limit,
   durable-store and working-tree state, source_drift, and what to check when
   a refresh fails or comes back with a broken surface.
-version: 1.0.0
-last_changed_at: "2026-08-07T00:00:00Z"
+version: 1.1.0
+last_changed_at: "2026-08-18T00:00:00Z"
 tags: [lingtai, system, refresh, preset, precheck, checklist, mcp, env, pth, editable-install, verification, lifecycle]
 related_files:
 - src/lingtai/intrinsic_skills/system-manual/SKILL.md
@@ -20,6 +20,8 @@ related_files:
 - src/lingtai/prompts/substrate/substrate.md
 - src/lingtai/prompts/procedures/procedures.md
 - src/lingtai/tools/system/schema.py
+- src/lingtai/tools/system/preset.py
+- src/lingtai/tools/system/CONTRACT.md
 - src/lingtai/kernel/presets.py
 maintenance: |
   Sequencing-only node: every check here cites the owner that holds the fact
@@ -170,8 +172,14 @@ If current context exceeds the target's limit, **the swap is refused before acti
 have already told a human "switching now" is a self-inflicted incident. Order is:
 tend durable stores → `context(action="molt", …)` → re-check → swap.
 
-Note also that the cache-miss budget (`manifest.cache_miss_budget`, default 1,000,000)
-accumulates **since last molt and survives a refresh** — refreshing does not reset it.
+### Step 5b — Cache-miss budget (unconditional; runtime checks it first)
+
+The cache-miss budget (`manifest.cache_miss_budget`, default 1,000,000) accumulates
+**since last molt and survives a refresh**. At or above it, `system(action='refresh')`
+refuses before preset/MCP work and directs you to tend durable stores then
+`context(action='molt')`; retrying refresh cannot clear the total. If the goal is to
+apply a raised env-file budget value while already exhausted, use the operator-owned
+out-of-band refresh path instead.
 
 ### Step 6 — Newly introduced environment variables (trigger: the change adds an env read)
 
@@ -253,10 +261,11 @@ system(action="refresh", input={"revert_preset": true},
        reasoning="return to default preset after experimenting")
 ```
 
-The refresh path checks `allowed` membership → checks target context limit → activates
-atomically (writing raw `init.json`) → persists the new default for a named swap →
-best-effort retries failed MCPs → rebuilds LLM/config/capabilities/MCP/prompts,
-preserving conversation history where a live session exists.
+The refresh path checks the cache-miss budget → checks `allowed` membership → checks
+target context limit → activates atomically (writing raw `init.json`) → persists the new
+default for a named swap → best-effort retries failed MCPs → rebuilds
+LLM/config/capabilities/MCP/prompts, preserving conversation history where a live session
+exists.
 
 Note: refresh requests a **deferred relaunch** and only when the runtime can build a
 valid launch command and has a configured refresh watcher. Without a launch command it
@@ -294,7 +303,7 @@ is success** — diagnose before believing the refresh happened.
 | Refresh returned but nothing changed | Re-run the interpreter/import probe in the new process | A refresh only loads code already on disk. It cannot pull a commit or repair an incomplete checkout. Check for a still-held old process or a different environment. |
 | `lingtai` imports from the wrong source, or an edit to the checkout has no effect | Step 2 — list `*lingtai*.pth` + `lingtai-*.dist-info` in the runtime venv's site-packages and compare each `.pth` entry against `lingtai.__file__` | Two markers (editable + non-editable) → `sys.path` order decides, not intent. A `.pth` naming a path that no longer exists → the entry is skipped and the next candidate wins. Orphaned `dist-info` with no `.pth` → stale metadata reporting a version nothing imports. Repair the install via pip/installer with step-0 authority; do **not** refresh against a mismatched marker. |
 | Refresh returned without relaunching | Can the runtime build a valid launch command? Is a refresh watcher configured? | Missing launch command → returns silently; missing watcher → raises. Diagnose the launcher, do not retry blindly. |
-| Refresh raised | The raised error text first | Then `init.json` parse, then `allowed` membership, then target `context_limit` — these are the three gates that reject *before* any runtime change (so the old surface is intact). |
+| Refresh raised or returns an error | The error text first | Then cache-miss budget, `init.json` parse, `allowed` membership, and target `context_limit` — these four gates reject before runtime change, so the old surface is intact. Exhausted budget → tend durable stores and molt; do not retry refresh. |
 | Preset swap refused | Was the path in `system(action="presets")` output? Does current context fit the target `context_limit`? | Unauthorized path → ask the config owner to add it to `manifest.preset.allowed`, then refresh, then re-verify with `presets`. Context too large → molt first. |
 | Broken/missing MCP surface after refresh | `mcp(action="info")` `problems` list; `init.json` `mcp` block vs. `mcp_registry.jsonl` records | Fix the registry/config, then refresh **once** more. Do not loop refreshes against an unfixed config. |
 | Active preset file missing or malformed | Which one? | Missing → materialization may fall back to a different loadable default (so the running preset may not be the one you think). Malformed **existing active** preset → materialization fails rather than silently substituting. Read `system/manifest.resolved.json` to see what actually loaded. |

--- a/src/lingtai/kernel/config.py
+++ b/src/lingtai/kernel/config.py
@@ -188,8 +188,9 @@ class AgentConfig:
     # cache-miss (uncached input) total reaches or exceeds this value, a "molt
     # now" reminder is restamped into _meta.agent_meta.agent_state.context.molt (see
     # meta_block.build_cache_miss_budget_context) and the budget value is surfaced
-    # under _meta.agent_meta.agent_state.context. It is a soft cap — nothing is blocked; the
-    # agent is expected to molt. The cache-miss total is read from the cumulative
+    # under _meta.agent_meta.agent_state.context. It is advisory in metadata; the
+    # agent-facing system(refresh) tool refuses an exhausted budget because refresh
+    # cannot clear it. The cache-miss total is read from the cumulative
     # get_token_usage() totals (which SURVIVE restore_token_state), so a refresh
     # does NOT reset the remaining budget; a successful molt starts a new
     # since-last-molt session/budget cycle. It is deliberately NOT the

--- a/src/lingtai/kernel/meta_block.py
+++ b/src/lingtai/kernel/meta_block.py
@@ -1387,8 +1387,10 @@ def build_cache_miss_budget_context(agent) -> dict | None:
     Returns ``None`` (no guard) when: the ``context`` intrinsic is absent (matching
     :func:`build_molt_context`, since ``molt`` presupposes the molt action), the
     budget is not a positive int, the cumulative-usage getter is missing/raising,
-    or the cache-miss total is below the budget.  It is a soft signal only —
-    nothing is blocked — and NOT a new event route (no emission-event payload).
+    or the cache-miss total is below the budget. It is advisory in this metadata
+    path; the agent-facing `system(action='refresh')` tool separately refuses an
+    exhausted budget because refresh cannot clear it. This remains NOT a new event
+    route (no emission-event payload).
     """
     if "context" not in getattr(agent, "_intrinsics", set()):
         return None

--- a/src/lingtai/tools/system/ANATOMY.md
+++ b/src/lingtai/tools/system/ANATOMY.md
@@ -6,6 +6,7 @@ related_files:
   - src/lingtai/tools/system/__init__.py
   - src/lingtai/tools/system/karma.py
   - src/lingtai/tools/system/preset.py
+  - src/lingtai/kernel/meta_block.py
   - src/lingtai/tools/system/schema.py
   - src/lingtai/tools/system/summarize.py
   - src/lingtai/tools/system/name.py
@@ -19,6 +20,7 @@ related_files:
   - src/lingtai/kernel/tool_result_summary.py
   - src/lingtai/intrinsic_skills/system-manual/SKILL.md
   - tests/test_tool_family_system_migration.py
+  - tests/test_refresh_cache_miss_budget_guard.py
 maintenance: |
   Keep related_files as repo-relative paths to real files. Include neighboring
   ANATOMY.md files so the anatomy graph stays connected rather than isolated;
@@ -54,9 +56,10 @@ System intrinsic — runtime, lifecycle, and identity. Provides the agent with r
 
 - `preset.py` — Preset management and refresh.
   - `_preset_ref_in()` (`preset.py:9-36`) — normalized membership test for preset path strings (~/foo vs absolute).
-  - `_check_context_fits()` (`preset.py:39-76`) — verify agent's current context fits within target preset's context_limit.
-  - `_refresh()` (`preset.py:79-199`) — stop, reload config + MCP servers, restart. Handles preset swap (named or revert) with authorization gate and context-limit guard. **Empty-string normalization:** `args.get('preset')` returning `''` or whitespace-only is treated as absent (`preset_name = None`) before any conflict/swap logic; this protects against tool-call providers that serialize optional string fields as `""` instead of omitting them — without normalization, an empty string would fall into the allowed-list gate and surface as `"preset '' is not in this agent's allowed list"`. The `preset='' + revert_preset=True` combination is consequently treated as a plain revert (no conflict). **MCP retry hook (issue #34):** before calling `agent._perform_refresh()`, invokes `agent._retry_failed_mcps()` if the Agent subclass defines it. Failures are logged and swallowed so a flaky MCP cannot block refresh itself. Lets the documented "fix config → refresh" recovery path work in-process.
-  - `_presets()` (`preset.py:202-282`) — list available presets with LLM connectivity probing.
+  - `_check_context_fits()` (`preset.py:37-74`) — verify agent's current context fits within target preset's context_limit.
+  - `_check_cache_miss_budget()` (`preset.py:77-98`) — consume `build_cache_miss_budget_context()` as the single cache-budget decision shared with the model-visible `molt now` reminder; returns the `_check_context_fits` triple shape and therefore fails open for the same unavailable/no-budget cases.
+  - `_refresh()` (`preset.py:101-239`) — stop, reload config + MCP servers, restart. Handles preset swap (named or revert) with authorization gate and context-limit guard. **Cache-miss budget guard:** immediately after the preset/revert conflict check — and therefore before the revert-default read, the allowed-list gate, `_check_context_fits`, activation, and `_perform_refresh` — it calls `_check_cache_miss_budget()` and, when the budget is exhausted, logs `refresh_refused_cache_miss_budget` (`cache_miss_tokens`, `cache_miss_budget`) and returns `{status: 'error', message}` redirecting to durable stores then `context(action='molt')`. Refresh preserves the conversation and the cache-miss total survives it, so refresh is structurally unable to clear the budget; refusing keeps it from replaying the preserved context at full cost for a recovery it cannot deliver. Only this agent-facing tool path is guarded; direct operator and internal recovery callers of `agent._perform_refresh()` are deliberately unaffected. **Empty-string normalization:** `args.get('preset')` returning `''` or whitespace-only is treated as absent (`preset_name = None`) before any conflict/swap logic; this protects against tool-call providers that serialize optional string fields as `""` instead of omitting them — without normalization, an empty string would fall into the allowed-list gate and surface as `"preset '' is not in this agent's allowed list"`. The `preset='' + revert_preset=True` combination is consequently treated as a plain revert (no conflict). **MCP retry hook (issue #34):** before calling `agent._perform_refresh()`, invokes `agent._retry_failed_mcps()` if the Agent subclass defines it. Failures are logged and swallowed so a flaky MCP cannot block refresh itself. Lets the documented "fix config → refresh" recovery path work in-process.
+  - `_presets()` (`preset.py:242-322`) — list available presets with LLM connectivity probing.
 
 - `karma.py` — Karma-gated lifecycle actions.
   - `_KARMA_ACTIONS` / `_NIRVANA_ACTIONS` (`karma.py:13-14`) — gate mapping sets.

--- a/src/lingtai/tools/system/CONTRACT.md
+++ b/src/lingtai/tools/system/CONTRACT.md
@@ -1,12 +1,14 @@
 ---
 name: system-contract
 tool: system
-contract_version: 3
+contract_version: 4
 related_files:
   - src/lingtai/tools/system/__init__.py
   - src/lingtai/tools/system/schema.py
   - src/lingtai/tools/system/name.py
   - src/lingtai/tools/system/summarize.py
+  - src/lingtai/tools/system/preset.py
+  - src/lingtai/kernel/meta_block.py
   - src/lingtai/tools/system/ANATOMY.md
   - src/lingtai/tools/system/BEHAVIORS.md
   - src/lingtai/tools/CONTRACT.md
@@ -14,7 +16,9 @@ related_files:
   - src/lingtai/tools/context/CONTRACT.md
   - src/lingtai/kernel/tool_result_summary.py
   - src/lingtai/intrinsic_skills/system-manual/SKILL.md
+  - src/lingtai/intrinsic_skills/context-manual/SKILL.md
   - tests/test_tool_family_system_migration.py
+  - tests/test_refresh_cache_miss_budget_guard.py
 maintenance: |
   Keep related_files as repo-relative paths to real files, including the
   paired ANATOMY.md, the LTP/ToolFamily contracts this family is governed by,
@@ -27,6 +31,10 @@ maintenance: |
   and the two name actions arrived here from the dissolved psyche family.
   summarize.py stays here as a private engine only — keep the context Contract
   link current, since that family owns the public actions driving it.
+  contract_version 4 narrows `refresh`: it is refused outright once the
+  since-last-molt cache-miss budget is exhausted (§Refresh preconditions).
+  Keep that clause, `preset.py:_check_cache_miss_budget`, and the kernel
+  budget resolver it shares (`meta_block._resolve_cache_miss_budget`) in step.
 ---
 
 # System capability contract
@@ -110,7 +118,7 @@ siblings.
 
 | Action | Required inputs | Optional inputs | Success output | Error shapes |
 |---|---|---|---|---|
-| `refresh` | — | `reason`, `preset`, `revert_preset` | `{status: "ok", message}` | `{status: "error", message}` on preset/revert conflict, unauthorized preset, oversize context, or activation failure |
+| `refresh` | — | `reason`, `preset`, `revert_preset` | `{status: "ok", message}` | `{status: "error", message}` on preset/revert conflict, exhausted cache-miss budget (§Refresh preconditions), unauthorized preset, oversize context, or activation failure |
 | `sleep` | — | `reason`, `force` | `{status: "ok", message}` (self-sleep; refuses with an ok+message when notifications pending and not `force`) | — |
 | `lull` | `address` | `reason` | `{status: "asleep", address}` | `{error: True, message}` (no karma, no/invalid address, self-target, target not running) |
 | `suspend` | `address` | `reason` | `{status: "suspended", address}` | `{error: True, message}` (as above) |
@@ -173,6 +181,33 @@ refusal paths ([B004](BEHAVIORS.md#behavior-b004),
 ([B006](BEHAVIORS.md#behavior-b006)). Change any of these behaviors, update the
 matching behavior entry and this clause together.
 
+### Refresh preconditions
+
+`refresh` rebuilds the runtime from `init.json` with the **same identity and a
+preserved conversation**. Two capacity preconditions can refuse before preset
+activation, MCP retry, or relaunch, each with `{status: "error", message}`:
+
+1. **Cache-miss budget (unconditional).** The since-last-molt cache-miss total
+   is `max(input_tokens - cached_tokens, 0)` over the cumulative token counters,
+   which survive `restore_token_state` and are reset only by a molt. A refresh
+   therefore cannot lower it — it replays the preserved context at full
+   cold-cache cost and returns with the same budget exhausted. When that total
+   reaches or exceeds the effective budget (the `LINGTAI_CACHE_MISS_BUDGET`
+   env override, then `manifest.cache_miss_budget`; resolved by the kernel's
+   `meta_block._resolve_cache_miss_budget`, the same value behind the
+   `cache miss budget {N} reached, molt now` reminder), `refresh` is refused
+   before any preset or MCP work, logs `refresh_refused_cache_miss_budget`, and
+   redirects to durable stores then `context(action='molt')`. It never molts on
+   the agent's behalf. Below budget, refresh behavior is unchanged.
+   The refusal fails **open** — no refusal at all — when the `context`
+   intrinsic is absent (that agent has no molt action and must not be trapped),
+   when no positive-int budget resolves, or when usage cannot be read.
+   This gate is on the **tool** path only; direct operator and internal recovery
+   callers of `_perform_refresh` are deliberately not gated.
+2. **Target `context_limit` (preset swap/revert only).** If current context
+   exceeds the target preset's `context_limit`, the swap is refused
+   (`preset_swap_refused_oversize`) — molt first, then retry.
+
 ## State & storage
 
 Karma verbs write **signal files** into the *target* agent's working directory;
@@ -216,6 +251,8 @@ drive it are `context`'s.
 | `sleep` transitions the agent to ASLEEP (self, no karma) | `src/lingtai/tools/system/karma.py:_sleep` | `tests/test_system.py::test_system_self_sleep` |
 | Unknown/legacy actions return the unknown-action error | `src/lingtai/tools/system/__init__.py:handle` | `tests/test_system.py::test_system_rejects_unknown_and_retired_actions` |
 | `refresh` with an unauthorized preset is refused | `src/lingtai/tools/system/preset.py:_refresh` | `tests/test_system.py::test_refresh_with_unauthorized_preset_returns_error` |
+| `refresh` is refused, with a molt redirect and no preset/MCP side effect, once the since-last-molt cache-miss budget is exhausted | `src/lingtai/tools/system/preset.py:_check_cache_miss_budget` | `tests/test_refresh_cache_miss_budget_guard.py::test_refresh_refused_when_cache_miss_budget_exhausted`, `::test_refusal_precedes_any_preset_side_effect` |
+| That refusal reads the same budget as the kernel `molt now` reminder, and never fires below budget or for an agent that cannot molt | `src/lingtai/kernel/meta_block.py:_resolve_cache_miss_budget` | `tests/test_refresh_cache_miss_budget_guard.py::test_env_override_moves_the_refusal_threshold_both_ways`, `::test_refresh_proceeds_when_cache_miss_is_below_budget`, `::test_refresh_not_refused_when_context_intrinsic_is_absent` |
 | `refresh` cannot combine `preset` and `revert_preset` | `src/lingtai/tools/system/preset.py:_refresh` | `tests/test_system.py::test_refresh_revert_preset_with_preset_arg_errors` |
 | `presets` lists the allowed library and strips credentials | `src/lingtai/tools/system/preset.py:_presets` | `tests/test_system.py::test_presets_action_lists_full_library`, `tests/test_system.py::test_presets_action_strips_credentials` |
 | `cpr` propagates launch failure instead of reporting success | `src/lingtai/tools/system/karma.py:_cpr` | `tests/test_system.py::test_cpr_propagates_launch_failure_instead_of_resuscitated` |
@@ -238,6 +275,7 @@ drive it are `context`'s.
 
 | Invariant | Automated test | Manual check | Risk if broken |
 |---|---|---|---|
+| `refresh` never pretends to recover a cache-budget-exhausted agent | `tests/test_refresh_cache_miss_budget_guard.py` | Exhaust the budget, call `system(action='refresh')` | An unbounded refresh loop that replays preserved context at full cost and never clears the budget |
 | Karma gate blocks unauthorized control | `tests/test_system.py::test_refresh_with_unauthorized_preset_returns_error` + karma gate paths | Call `lull` without `admin.karma` | Any agent could sleep/destroy peers |
 | `nirvana` requires karma AND nirvana | karma gate in `src/lingtai/tools/system/karma.py:_check_karma_gate` | Call `nirvana` with only karma | Irreversible deletion by under-privileged agent |
 | The private engine preserves the original in events.jsonl | `tests/test_system_summarize.py::test_summarize_replaces_block_content` | `context(action='summarize')` a result, grep events.jsonl by tool_call_id | Loss of original tool output |
@@ -251,7 +289,7 @@ drive it are `context`'s.
 Run before merging system changes:
 
 ```bash
-python -m pytest tests/test_system.py tests/test_system_summarize.py tests/test_system_dismiss.py tests/test_notification_tool.py tests/test_karma.py tests/test_tool_family_system_migration.py tests/test_tool_family_context_migration.py tests/test_intrinsic_manual_actions.py -q
+python -m pytest tests/test_system.py tests/test_refresh_cache_miss_budget_guard.py tests/test_preset_context_guard.py tests/test_system_summarize.py tests/test_system_dismiss.py tests/test_notification_tool.py tests/test_karma.py tests/test_tool_family_system_migration.py tests/test_tool_family_context_migration.py tests/test_intrinsic_manual_actions.py -q
 ```
 
 ## Schema and glossary ownership

--- a/src/lingtai/tools/system/preset.py
+++ b/src/lingtai/tools/system/preset.py
@@ -74,6 +74,30 @@ def _check_context_fits(agent, preset_name: str) -> tuple:
     return True, None, None
 
 
+def _check_cache_miss_budget(agent) -> tuple:
+    """Return the meta guard's exact cache-budget decision for ``refresh``.
+
+    The shared builder uses the same intrinsic gate, budget resolution, and
+    cumulative cache-miss arithmetic as the model-visible ``molt now`` reminder.
+    A refresh cannot lower that total because it preserves the conversation, so
+    this tool path refuses only when that exact guard is active.
+    """
+    from lingtai.kernel.meta_block import build_cache_miss_budget_context
+
+    guard = build_cache_miss_budget_context(agent)
+    if guard is None:
+        return True, None, None
+
+    cache_miss = guard["cache_miss_tokens"]
+    budget = guard["cache_miss_budget"]
+    return False, (
+        f"cache-miss budget exhausted ({cache_miss} of {budget} tokens since "
+        f"your last molt) — refresh preserves this conversation and cannot clear "
+        f"the budget. Tend durable stores, then call context(action='molt'); "
+        f"refresh again after the molt if still needed."
+    ), {"cache_miss_tokens": cache_miss, "cache_miss_budget": budget}
+
+
 def _refresh(agent, args: dict) -> dict:
     from lingtai.kernel.i18n import t
     reason = args.get("reason", "")
@@ -99,6 +123,18 @@ def _refresh(agent, args: dict) -> dict:
             "status": "error",
             "message": "cannot specify both 'preset' and 'revert_preset' — choose one",
         }
+
+    # Guard: refuse the WHOLE refresh — plain, named swap, or revert alike —
+    # once the since-last-molt cache-miss budget is exhausted. Refresh is
+    # deliberately non-resetting, so it cannot recover a budget-exhausted
+    # agent; performing it would replay the preserved context at full cost and
+    # return with the same guard tripped. Runs before the revert/allowed/
+    # oversize preset gates so no preset is activated and no default is
+    # persisted on a refresh that is going to be refused anyway.
+    under_budget, budget_refuse_msg, budget_extra = _check_cache_miss_budget(agent)
+    if not under_budget:
+        agent._log("refresh_refused_cache_miss_budget", **budget_extra)
+        return {"status": "error", "message": budget_refuse_msg}
 
     # Revert path: read default name from disk, then route through the same
     # context-limit guard and activation as a named swap.

--- a/src/lingtai/tools/system/schema.py
+++ b/src/lingtai/tools/system/schema.py
@@ -212,7 +212,9 @@ INPUT_SCHEMAS: dict[str, dict[str, Any]] = {
 # argument references restated in the ``input`` shape they now take.
 ACTION_ENUM_DESCRIPTION = (
     "refresh: rebuild from init.json — same identity, preserved conversation. "
-    "Reloads MCP, capabilities, addons, LLM, prompt sections. See "
+    "Reloads MCP, capabilities, addons, LLM, prompt sections. Because the "
+    "conversation is preserved, your since-last-molt cache-miss total survives "
+    "it: once that budget is exhausted refresh is refused — molt first. See "
     "system-manual.\n\n"
     "presets: list available presets with tags, connectivity, capabilities. "
     "See system-manual.\n\n"

--- a/tests/test_refresh_cache_miss_budget_guard.py
+++ b/tests/test_refresh_cache_miss_budget_guard.py
@@ -1,0 +1,221 @@
+"""Tests for the cache-miss budget guard on ``system(action='refresh')``.
+
+The since-last-molt cache-miss total is read from the CUMULATIVE token
+counters, which deliberately survive ``restore_token_state`` — so a refresh
+(same identity, preserved conversation) can never lower it. It replays the
+preserved context at full cold-cache cost and returns with the budget still
+exhausted. The tool must therefore refuse and redirect to
+``context(action='molt')`` instead of performing a recovery it cannot deliver.
+
+Below budget, refresh behavior is unchanged. An agent with no ``context``
+intrinsic cannot molt and is never refused.
+"""
+import json
+from pathlib import Path
+
+from lingtai.tools.registry import INTRINSICS as _TEST_INTRINSICS
+from tests._workdir_lease_helpers import make_test_lease
+from tests._snapshot_helpers import make_test_snapshot_port, make_test_source_revision_port
+from tests._lifecycle_clock_helpers import make_test_lifecycle_clock
+from tests._notification_store_helpers import notification_store_for
+from tests._agent_presence_helpers import make_test_presence_store
+
+DEFAULT_BUDGET = 1_000_000
+
+
+def _build_workdir(wd: Path) -> None:
+    wd.mkdir(parents=True, exist_ok=True)
+    env = wd / ".env"
+    env.write_text("PLACEHOLDERKEY=sk-test\n")
+    init = {
+        "manifest": {
+            "agent_name": "test", "language": "en",
+            "llm": {"provider": "PLACEHOLDER", "model": "PLACEHOLDER",
+                    "api_key": None, "api_key_env": "PLACEHOLDERKEY"},
+            "capabilities": {},
+            "context_limit": 200000,
+            "soul": {"delay": 120}, "stamina": 3600,
+            "molt_pressure": 0.8, "molt_prompt": "", "max_turns": 50,
+            "admin": {"karma": True}, "streaming": False,
+        },
+        "principle": "p", "covenant": "c", "pad": "", "lingtai": "",
+        "soul": "",
+        "env_file": str(env),
+    }
+    (wd / "init.json").write_text(json.dumps(init))
+
+
+def _make_test_agent(tmp_path, *, intrinsics=None):
+    """BaseAgent stand-in with stubbed ``_perform_refresh``/``get_token_usage``."""
+    from lingtai.kernel.base_agent import BaseAgent
+    from unittest.mock import MagicMock
+
+    svc = MagicMock()
+    svc.get_adapter.return_value = MagicMock()
+    svc.provider = "gemini"
+    svc.model = "gemini-test"
+    wd = tmp_path / "test"
+    _build_workdir(wd)
+    return BaseAgent(
+        intrinsics=_TEST_INTRINSICS if intrinsics is None else intrinsics,
+        service=svc, agent_name="test", working_dir=wd,
+        workdir_lease=make_test_lease(), snapshot_port=make_test_snapshot_port(),
+        agent_presence=make_test_presence_store(),
+        lifecycle_clock=make_test_lifecycle_clock(),
+        source_revision_port=make_test_source_revision_port(),
+        notification_store=notification_store_for(wd),
+    )
+
+
+def _stub_usage(agent, monkeypatch, *, input_tokens: int, cached_tokens: int) -> None:
+    """Stub the cumulative counters the guard reads (cache miss = input - cached)."""
+    monkeypatch.setattr(agent, "get_token_usage", lambda: {
+        "input_tokens": input_tokens, "cached_tokens": cached_tokens,
+        "output_tokens": 0, "thinking_tokens": 0, "total_tokens": 0,
+        "api_calls": 0, "ctx_total_tokens": 1000,
+        "ctx_system_tokens": 0, "ctx_tools_tokens": 0, "ctx_history_tokens": 1000,
+    })
+
+
+def _record_refresh(agent, monkeypatch) -> list:
+    calls: list = []
+    monkeypatch.setattr(agent, "_perform_refresh", lambda: calls.append(True))
+    return calls
+
+
+def _record_log(agent, monkeypatch) -> list:
+    events: list = []
+    real_log = agent._log
+    monkeypatch.setattr(
+        agent, "_log",
+        lambda evt, **kw: (events.append((evt, kw)), real_log(evt, **kw))[1],
+    )
+    return events
+
+
+def test_refresh_refused_when_cache_miss_budget_exhausted(tmp_path, monkeypatch):
+    """The reported loop: refresh at/above budget is refused, not performed."""
+    agent = _make_test_agent(tmp_path)
+    # 1_100_000 cache miss against the default 1_000_000 budget.
+    _stub_usage(agent, monkeypatch, input_tokens=1_200_000, cached_tokens=100_000)
+    perform_calls = _record_refresh(agent, monkeypatch)
+    log_events = _record_log(agent, monkeypatch)
+
+    result = agent._intrinsics["system"]({"action": "refresh", "input": {"reason": "recover"}})
+
+    assert result["status"] == "error"
+    msg = result["message"]
+    assert "1100000" in msg and "1000000" in msg
+    # The redirect must name the only action that actually clears the budget.
+    assert "molt" in msg.lower()
+    assert perform_calls == []  # refresh NOT performed
+    assert "refresh_refused_cache_miss_budget" in [e for e, _ in log_events]
+    refusal = next(kw for e, kw in log_events if e == "refresh_refused_cache_miss_budget")
+    assert refusal == {"cache_miss_tokens": 1_100_000, "cache_miss_budget": DEFAULT_BUDGET}
+
+
+def test_refresh_refused_at_cache_miss_budget_boundary(tmp_path, monkeypatch):
+    """The inclusive budget boundary is refused, matching the molt reminder."""
+    agent = _make_test_agent(tmp_path)
+    _stub_usage(agent, monkeypatch, input_tokens=DEFAULT_BUDGET, cached_tokens=0)
+    perform_calls = _record_refresh(agent, monkeypatch)
+
+    result = agent._intrinsics["system"]({"action": "refresh", "input": {}})
+
+    assert result["status"] == "error"
+    assert perform_calls == []
+
+
+def test_refresh_proceeds_when_cache_miss_is_below_budget(tmp_path, monkeypatch):
+    """Existing refresh behavior below budget is unchanged."""
+    agent = _make_test_agent(tmp_path)
+    _stub_usage(agent, monkeypatch, input_tokens=DEFAULT_BUDGET - 1, cached_tokens=0)
+    perform_calls = _record_refresh(agent, monkeypatch)
+
+    result = agent._intrinsics["system"]({"action": "refresh", "input": {"reason": "config change"}})
+
+    assert result["status"] == "ok"
+    assert perform_calls == [True]
+
+
+def test_refusal_precedes_any_preset_side_effect(tmp_path, monkeypatch):
+    """An exhausted budget refuses before the preset gates touch anything.
+
+    The guard runs ahead of the allowed-list check, the context-limit check,
+    and activation, so a refused refresh activates no preset and rewrites no
+    ``manifest.preset.default``.
+    """
+    agent = _make_test_agent(tmp_path)
+    _stub_usage(agent, monkeypatch, input_tokens=2_000_000, cached_tokens=0)
+    perform_calls = _record_refresh(agent, monkeypatch)
+
+    def _boom(*_args, **_kwargs):
+        raise AssertionError("preset activation must not run on a refused refresh")
+
+    monkeypatch.setattr(agent, "_activate_preset", _boom)
+    monkeypatch.setattr(agent, "_activate_default_preset", _boom)
+    init_before = (agent._working_dir / "init.json").read_text()
+
+    result = agent._intrinsics["system"]({
+        "action": "refresh",
+        "input": {"preset": str(tmp_path / "ghost.json")},
+    })
+
+    assert result["status"] == "error"
+    # The budget refusal, not the allowed-list refusal.
+    assert "cache-miss budget" in result["message"]
+    assert "allowed" not in result["message"]
+    assert perform_calls == []
+    assert (agent._working_dir / "init.json").read_text() == init_before
+
+
+def test_env_override_moves_the_refusal_threshold_both_ways(tmp_path, monkeypatch):
+    """The refusal reads the same budget the ``molt now`` reminder reads.
+
+    ``LINGTAI_CACHE_MISS_BUDGET`` is live-read at every resolution
+    (``meta_block._resolve_cache_miss_budget``), so a lowered override refuses
+    a total the default would allow, and a raised override allows one the
+    default would refuse.
+    """
+    agent = _make_test_agent(tmp_path)
+    _stub_usage(agent, monkeypatch, input_tokens=20_000, cached_tokens=0)
+    perform_calls = _record_refresh(agent, monkeypatch)
+
+    monkeypatch.setenv("LINGTAI_CACHE_MISS_BUDGET", "10000")
+    refused = agent._intrinsics["system"]({"action": "refresh", "input": {}})
+    assert refused["status"] == "error"
+    assert "10000" in refused["message"]
+    assert perform_calls == []
+
+    monkeypatch.setenv("LINGTAI_CACHE_MISS_BUDGET", "10000000")
+    allowed = agent._intrinsics["system"]({"action": "refresh", "input": {}})
+    assert allowed["status"] == "ok"
+    assert perform_calls == [True]
+
+
+def test_refresh_not_refused_when_context_intrinsic_is_absent(tmp_path, monkeypatch):
+    """No molt action → no refusal; the guard must never trap such an agent."""
+    agent = _make_test_agent(
+        tmp_path,
+        intrinsics={k: v for k, v in _TEST_INTRINSICS.items() if k != "context"},
+    )
+    assert "context" not in agent._intrinsics
+    _stub_usage(agent, monkeypatch, input_tokens=5_000_000, cached_tokens=0)
+    perform_calls = _record_refresh(agent, monkeypatch)
+
+    result = agent._intrinsics["system"]({"action": "refresh", "input": {}})
+
+    assert result["status"] == "ok"
+    assert perform_calls == [True]
+
+
+def test_refresh_proceeds_when_cache_usage_is_unreadable(tmp_path, monkeypatch):
+    """A broken usage read must not trap an otherwise valid refresh."""
+    agent = _make_test_agent(tmp_path)
+    monkeypatch.setattr(agent, "get_token_usage", lambda: (_ for _ in ()).throw(RuntimeError()))
+    perform_calls = _record_refresh(agent, monkeypatch)
+
+    result = agent._intrinsics["system"]({"action": "refresh", "input": {}})
+
+    assert result["status"] == "ok"
+    assert perform_calls == [True]


### PR DESCRIPTION
## Summary

- Refuse agent-facing `system(action='refresh')` once the since-last-molt cache-miss budget is exhausted, with a durable-stores → `context(action='molt')` recovery message.
- Reuse `build_cache_miss_budget_context()` so the refusal has exactly the same intrinsic gate, env/config threshold, and cumulative arithmetic as the existing `molt now` reminder.
- Document the new refusal in the system contract/anatomy/schema and the two refresh/context manuals; add focused boundary, below-budget, side-effect, env-override, no-context, and unreadable-usage regressions.

## Root cause

The budget deliberately survives refresh/restart, while refresh preserves and replays conversation. Refresh therefore cannot clear an exhausted cache-miss total and can add cold-cache cost, but previously returned an `ok` receipt without checking the condition. This is distinct from benchmark-tester's old suspension and is not a context-window-size failure.

## Validation

- `/opt/homebrew/bin/python3 -m pytest -q tests/test_refresh_cache_miss_budget_guard.py tests/test_preset_context_guard.py` → **15 passed**
- `python src/lingtai/intrinsic_skills/lingtai-kernel-anatomy/scripts/check_anatomy_drift.py --check` checked the touched anchors; it still reports 5 pre-existing unrelated drifts under i18n/notification_store/nudge.
- `git diff --check` → passed.
- Repository docs/architecture checks retain pre-existing unrelated failures: duplicate LLM anatomy link, legacy no-frontmatter documents, and the local Feishu MCP dependency mismatch. The broader system command also retains one unrelated sleep-envelope test failure caused by its stale Store stub.

## Review

Claude implementation plus two independent frozen-snapshot Opus reviews. Review artifacts are local-only; their findings were incorporated: shared meta decision, accurate refresh/env guidance, direct-path attribution, exact anatomy anchors, and the inclusive threshold test.

## Scope

No auto-molt, new configuration flag, live refresh, merge, release, deployment, or cleanup. Direct operator/internal `_perform_refresh` callers remain outside this agent-facing tool guard.

Telegram: @lingtaidev3bot | Nickname: 澄一

Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
