### PR TITLE
feat(tools): compiler-style agent diagnostics for failed tool input fields

### DIFF
--- a/src/lingtai/tools/context/__init__.py
+++ b/src/lingtai/tools/context/__init__.py
@@ -61,7 +61,12 @@ from ._snapshots import SNAPSHOT_SCHEMA_VERSION, _write_molt_snapshot, _write_mo
 # Molt (the public surface)
 from ._molt import _context_molt, context_forget  # noqa: F401
 from .._manual import load_installed_manual  # noqa: F401
-from ..tool_family import ChildTool, ToolFamily
+from ..tool_family import (
+    TRIGGER_UNSUPPORTED_INPUT_FIELD,
+    ChildTool,
+    DiagnosticDescriptor,
+    ToolFamily,
+)
 from ..tool_family.manual import build_manual_child
 
 # The summarize/rebuild engine. It stays in ``system/summarize.py`` — moving
@@ -104,6 +109,32 @@ _MOLT_INPUT_SCHEMA: dict[str, Any] = {
     },
     "required": ["summary", "session_journal_path", "keep_tool_calls", "keep_last"],
     "additionalProperties": False,
+}
+
+# ``molt``'s own static, mechanical diagnostic for a foreign ``input`` field
+# (cross-action, e.g. a ``summarize``/``rebuild`` key, or wholly unknown, e.g.
+# a smuggled ``files``): declared once, adjacent to ``_MOLT_INPUT_SCHEMA``,
+# per ``tool_family/CONTRACT.md`` "Diagnostics sidecar". The generic
+# dispatcher only ever supplies the structural ``location`` around this
+# verbatim text — it does not (and must not) claim `session_journal_path`
+# has to be relative; the existing in-workdir-absolute-normalizes-to-relative
+# policy is unchanged and unrelated to this diagnostic.
+_MOLT_UNSUPPORTED_INPUT_DIAGNOSTIC = DiagnosticDescriptor(
+    code="CTX_MOLT_UNSUPPORTED_INPUT_FIELD",
+    expected_form=(
+        "an input object containing only summary, session_journal_path, "
+        "keep_tool_calls, and keep_last"
+    ),
+    reason="molt rejects foreign action input before it can shed context",
+    fix="remove the foreign field or choose the action that owns it",
+)
+
+#: Per-child diagnostic sidecars, keyed by child name then structural
+#: trigger. Only ``molt`` opts in today; a child absent here (``summarize``,
+#: ``rebuild``, ``manual``) gets exactly the generic dispatcher's legacy
+#: three-key failure for a foreign ``input`` field, unchanged.
+_CHILD_DIAGNOSTICS: dict[str, Mapping[str, DiagnosticDescriptor]] = {
+    "molt": {TRIGGER_UNSUPPORTED_INPUT_FIELD: _MOLT_UNSUPPORTED_INPUT_DIAGNOSTIC},
 }
 
 #: One item of the summarize/rebuild ``items`` array. Declared once and reused
@@ -318,7 +349,13 @@ def _build_children(agent, envelope: Mapping[str, Any] | None = None) -> list[Ch
         return _dispatch
 
     return [
-        ChildTool(name, schema, _bind(handler, name), title=f"{name} input")
+        ChildTool(
+            name,
+            schema,
+            _bind(handler, name),
+            title=f"{name} input",
+            diagnostics=_CHILD_DIAGNOSTICS.get(name),
+        )
         for name, schema, handler in _CHILD_SPECS
     ] + [build_manual_child(agent, _MANUAL_SKILL_NAME)]
 

--- a/src/lingtai/tools/tool_family/ANATOMY.md
+++ b/src/lingtai/tools/tool_family/ANATOMY.md
@@ -53,8 +53,14 @@ this package too — using it is optional, not mandatory).
 ## Components
 
 - `ChildTool` — a frozen descriptor pairing one child's canonical name,
-  `input_schema`, and `handler`; name doubles as the model `action` constant
-  and dispatch key (`__init__.py:76-95`).
+  `input_schema`, `handler`, and an optional `diagnostics` sidecar; name
+  doubles as the model `action` constant and dispatch key
+  (`__init__.py:138-166`, preceded by the `DiagnosticDescriptor` dataclass at
+  `__init__.py:120-135`). `diagnostics` maps a structural trigger name
+  (today: only
+  `TRIGGER_UNSUPPORTED_INPUT_FIELD`) to the static `DiagnosticDescriptor`
+  (`code`/`expected_form`/`reason`/`fix`) that action owns for it — see
+  "Diagnostics sidecar" below.
 - `ToolFamily` — validates a fixed child registry (duplicate names and a
   `manual` reserved-name collision fail loudly at construction), composes a
   model-facing schema from each child's own `input_schema` plus a REQUIRED
@@ -64,7 +70,7 @@ this package too — using it is optional, not mandatory).
   and strips root `summarize`, rejects unknown root fields, and rejects
   `input` keys outside the selected child's own declared schema properties
   before calling that child's handler with only its `input`
-  (`__init__.py:98-281`). Two enforcement layers correlate `action` with
+  (`__init__.py:169-438`). Two enforcement layers correlate `action` with
   `input`, generated purely from the child registry with no name/schema
   mapping table: (1) schema-level — a root `allOf` with one `if`/`then`
   condition per child, each `if` testing `action` via `const` against that
@@ -76,6 +82,24 @@ this package too — using it is optional, not mandatory).
   correlation was adopted after a live non-strict Codex Responses probe on
   2026-07-27 accepted a raw root `allOf`/`if`/`then` schema without error on
   the current route (see `CONTRACT.md` "Contract rules").
+
+### Diagnostics sidecar
+
+`DiagnosticDescriptor` (`__init__.py`, next to `ChildTool`) is a frozen,
+fully static value an action author writes once, adjacent to that action's
+own `input_schema` — never computed, parsed, or guessed. When `handle()`
+rejects a selected action's `input` for a key outside its declared
+properties, `_build_diagnostics` checks whether that child declared a
+`TRIGGER_UNSUPPORTED_INPUT_FIELD` entry; if so, it additively attaches a
+`diagnostics` array to the otherwise-unchanged legacy failure result, one
+entry per foreign field, each pairing a mechanically computed
+`<family>/<action>/input.<field>` location with the descriptor's own text
+verbatim. A field label that is not conventional-identifier-shaped, or
+contains a secret-shaped substring, is dropped by the generic
+`_is_safe_field_label` check rather than surfaced. This sidecar is read only
+by `handle()` — `build_schema()` never touches it, so it cannot reach any
+provider wire. See `CONTRACT.md` "Diagnostics sidecar" for the full rules and
+`../context/ANATOMY.md`/below for `molt`'s concrete declaration.
 - `manual.py` — owns `MANUAL_INPUT_SCHEMA`, the single strict-empty `manual`
   input schema every family reuses, and `build_manual_child()`, which wraps
   `../_manual.py`'s
@@ -238,7 +262,12 @@ root and threads it to that child out-of-band, via the same Host-owned seam
 `avatar` uses for its spawn mission brief. The generic package is not widened:
 `_ROOT_FIELDS` is unchanged and no envelope field reaches any child. The sibling
 `pad` and `lingtai` families are independent consumers with their own final
-action inventories.
+action inventories. `context` is also the first concrete "Diagnostics
+sidecar" declaration: a `_CHILD_DIAGNOSTICS` mapping next to `_MOLT_INPUT_SCHEMA`
+gives `molt`'s `ChildTool` a `TRIGGER_UNSUPPORTED_INPUT_FIELD`
+`DiagnosticDescriptor` stating its own allowed-field set and refusal reason;
+the sibling `summarize`/`rebuild`/`manual` children declare none, so a
+foreign `input` key on those still renders the plain legacy failure.
 
 ## Composition
 

--- a/src/lingtai/tools/tool_family/BEHAVIORS.md
+++ b/src/lingtai/tools/tool_family/BEHAVIORS.md
@@ -558,3 +558,62 @@ Pass when every evidence item holds. Fail if an abs send omits
 `_return_route`, a reply self-delivers to the responder's own inbox, or the
 ambiguity guard silently sends instead of refusing. Forbidden side effect: an
 ambiguous reply must create no sent record and dispatch no mail.
+
+## Behavior T010 — molt's unsupported-input-field diagnostic is additive and local
+
+- **id**: T010
+- **title**: `context.molt`'s own declared diagnostic sidecar names the
+  foreign `input` field and location on a failed molt call, the legacy
+  three-key failure is unchanged underneath it, a sibling action with no
+  sidecar still gets the plain legacy failure, and the diagnostic never
+  claims `session_journal_path` must be relative
+- **guards**: `tool-family` § Diagnostics sidecar
+  ([CONTRACT.md](CONTRACT.md#diagnostics-sidecar))
+- **runner**: any LingTai agent with the `context` tool
+- **prerequisites**: a working dir (`<wd>`) with a valid session-journal entry
+  path available for `session_journal_path` (see `../context/CONTRACT.md`);
+  no other setup
+- **estimate**: 1 min
+
+### Steps
+1. Call `context(action="molt", input={"summary": "s", "session_journal_path":
+   "<valid path>", "keep_tool_calls": null, "keep_last": null, "files":
+   ["a.txt"]}, reasoning="...")` — `files` is a wholly foreign key smuggled
+   into `molt`'s own `input`.
+2. Call `context(action="summarize", input={"items": [], "session_journal_path":
+   "<valid path>"}, reasoning="...")` — `session_journal_path` here is a
+   cross-action key that belongs to `molt`, not `summarize`.
+3. Call `context(action="molt", input={"summary": "s", "session_journal_path":
+   "<valid path>", "keep_tool_calls": null, "keep_last": null}, reasoning="...")`
+   with every field correctly nested — a normal, well-formed call — to confirm
+   the diagnostic path is not taken when nothing is foreign.
+
+### Expected evidence
+- [ ] Step 1 returns `{"status": "failed", "error_code": "INVALID_ARGUMENT",
+      "message": "unsupported context input field", "diagnostics":
+      [{"location": "context/molt/input.files", "code":
+      "CTX_MOLT_UNSUPPORTED_INPUT_FIELD", "expected_form": "an input object
+      containing only summary, session_journal_path, keep_tool_calls, and
+      keep_last", "reason": "molt rejects foreign action input before it can
+      shed context", "fix": "remove the foreign field or choose the action
+      that owns it"}]}` and molt performed no shed/no I/O (no new
+      `system/summaries/` file, no session state change).
+- [ ] Step 2 returns the plain legacy `{"status": "failed", "error_code":
+      "INVALID_ARGUMENT", "message": "unsupported context input field"}` with
+      **no** `diagnostics` key — `summarize` declares no sidecar entry, so the
+      cross-action key gets exactly the pre-existing failure shape.
+- [ ] Neither step's message or diagnostic claims or implies that
+      `session_journal_path` must be relative — an in-workdir absolute
+      journal path remains a separate, valid, unrelated policy untouched by
+      this feature.
+- [ ] Step 3 succeeds (or fails only for reasons unrelated to field shape,
+      e.g. an invalid journal) with no `diagnostics` key present — the
+      sidecar never fires when `input` matches the declared schema.
+
+### Pass / Fail
+Pass when every evidence item holds. Fail if the `diagnostics` array is
+missing, wraps a second envelope, appears for an opted-out action, contains a
+raw value/path/exception string, or if any wording implies
+`session_journal_path` must be relative. Forbidden side effect: any rejected
+molt call (with or without a diagnostic) must shed no context and write no
+new snapshot/summary/session state.

--- a/src/lingtai/tools/tool_family/CONTRACT.md
+++ b/src/lingtai/tools/tool_family/CONTRACT.md
@@ -156,6 +156,67 @@ method is a required interface a family must implement against — a
 conforming family may satisfy the same wire shape without ever importing this
 package, per `../CONTRACT.md` "Implementation independence".
 
+`ChildTool.diagnostics` is a third, optional Port surface: a passive,
+non-wire sidecar mapping a structural trigger name to the static
+`DiagnosticDescriptor` (`code`, `expected_form`, `reason`, `fix`) that action
+owns for it. It never participates in `build_schema()` and is read only by
+`handle()`.
+
+## Diagnostics sidecar
+
+Guarded by: [T010](BEHAVIORS.md#behavior-t010).
+
+Compiler-style, agent-visible hints for a failed tool call are declared
+**adjacent to the relevant action's own definition**, not centralized in this
+generic package, and rendered generically. Today's one structural trigger is
+`TRIGGER_UNSUPPORTED_INPUT_FIELD`: a selected action's own `input` carrying a
+key outside its declared schema `properties` (cross-action or wholly
+foreign) — the case `handle()` was already rejecting fail-closed as
+`INVALID_ARGUMENT: unsupported <family> input field` before any handler I/O,
+per "Contract rules" below.
+
+- A `ChildTool` opts in by declaring `diagnostics={TRIGGER_UNSUPPORTED_INPUT_FIELD:
+  <DiagnosticDescriptor>}`. Declining (the default, `diagnostics=None` or no
+  entry for a trigger) yields the exact pre-existing legacy `status`/
+  `error_code`/`message` failure result for that trigger — unchanged,
+  byte-for-byte.
+- `DiagnosticDescriptor` is a frozen, fully static value: `code`,
+  `expected_form`, `reason`, and `fix` are fixed strings the owning action's
+  author writes once, next to that action's own `input_schema`. This package
+  never inspects/parses prose, never guesses a tool-specific reason, and
+  keeps no central tool-name/message table mapping actions to text — the
+  owning action supplies the text; the generic dispatcher supplies only
+  structure.
+- On a recognized trigger for an opted-in child, `handle()` computes a
+  **structural fact and location only** — `<family>/<child>/input.<field>` —
+  and pairs it with the child's own descriptor text verbatim, added as an
+  **additive** `diagnostics: [...]` array alongside the unchanged legacy
+  three-key failure result. One entry is emitted per foreign field.
+- A field *label* is only ever surfaced when it is conventional-identifier-
+  shaped and carries no secret-shaped substring (`_is_safe_field_label`); an
+  unsafe-shaped or non-identifier label is silently dropped from the
+  `diagnostics` array rather than surfaced, and if every candidate field is
+  dropped this way, no `diagnostics` key is added at all — the legacy result
+  is untouched. This package never emits a raw rejected value, a raw path, an
+  argument, an exception string, or a JSON blob in a diagnostic; only the
+  vetted field label, structural location, and the descriptor's own static
+  text.
+- The sidecar is passive and non-wire by construction: `diagnostics` is never
+  read by `build_schema()`, so it can never reach a provider's Chat
+  Completions or Responses tool schema. It performs no I/O and changes no
+  control flow — the fail-closed rejection order, the "no handler I/O for a
+  cross-action/unknown `input` key" guarantee, and every other envelope rule
+  below are unaffected; this is presentation enrichment of an
+  already-computed rejection, not a new enforcement path.
+- `context.molt` (`../context/CONTRACT.md`) is the first concrete
+  declaration: it owns a `DiagnosticDescriptor` for
+  `TRIGGER_UNSUPPORTED_INPUT_FIELD` stating the allowed `input` field set
+  (`summary`, `session_journal_path`, `keep_tool_calls`, `keep_last`) and
+  that molt rejects foreign action input before it can shed context. It does
+  not, and must not, claim `session_journal_path` must be relative — the
+  existing in-workdir-absolute-normalizes-to-relative policy for that field
+  is unrelated and unchanged by this sidecar.
+
 ## Adapters
 
 `web_search/__init__.py` is the first production Adapter/consumer:
@@ -331,7 +392,13 @@ deliberately collapses.
 module-level composition shape: a schema-only `ToolFamily` at import time
 (which is also the registry collision check) and an agent-bound one per
 `handle(agent, args)` call, both from one `_CHILD_SPECS` source. It registers
-`build_manual_child(agent, "context-manual")` directly and unwrapped.
+`build_manual_child(agent, "context-manual")` directly and unwrapped. It is
+also the first concrete declaration of the "Diagnostics sidecar" above:
+`molt`'s `ChildTool` carries a `diagnostics={TRIGGER_UNSUPPORTED_INPUT_FIELD:
+...}` entry stating molt's own allowed `input` field set and refusal reason,
+declared adjacent to `_MOLT_INPUT_SCHEMA` in `context/__init__.py`; the
+sibling `summarize`, `rebuild`, and `manual` children declare none, so a
+foreign `input` key on those still renders the exact legacy failure.
 
 It also exercises a boundary the earlier intrinsics could only half-prove.
 `soul`, `notification`, `system`, and `email` merely *drop* the kernel-injected
@@ -441,6 +508,16 @@ Guarded by: [T006](BEHAVIORS.md#behavior-t006)
   family's own Host/presentation layer, per the no-double-wrap rule above.
 - This package owns no external MCP mounting, registry, adapter, schema, or
   test; it MUST NOT be extended to add one.
+- `handle()`'s foreign-`input`-field rejection MAY be additively enriched
+  with a `diagnostics` array, per "Diagnostics sidecar" above, but the
+  legacy `status`/`error_code`/`message` failure result MUST remain
+  byte-for-byte unchanged for a child that declares no descriptor for the
+  trigger. `ChildTool.diagnostics` MUST NOT be read by `build_schema()` or
+  reach any provider-facing schema; this package MUST NOT keep a central
+  tool-name/message table or infer descriptor text — only the owning
+  `ChildTool` supplies it. A diagnostic field label MUST pass the generic
+  safety check before being surfaced; a rejected value, path, argument,
+  exception string, or JSON blob MUST NEVER appear in a diagnostic.
 
 ## Contract tests
 
@@ -460,11 +537,20 @@ dependency added) shows the schema itself rejects a mismatched
 `action`/`input` pairing, `handle()` remains authoritative and fail-closed
 regardless, and both the `allOf` conditions and the `oneOf` branches are
 mutation-isolated from each other and from a child's own canonical schema.
+It also proves the "Diagnostics sidecar" contract using an opted-in fake
+`widget` child: the exact owner-declared `DiagnosticDescriptor` and
+mechanically derived `<family>/<action>/input.<field>` location are returned
+for a recognized foreign-`input`-field trigger; an opted-out child yields the
+byte-for-byte legacy three-key failure with no `diagnostics` key; an
+unknown/cross-action key is still rejected before any handler I/O regardless
+of opt-in; and an unsafe- or non-identifier-shaped field label (and any raw
+rejected value) never appears in a `diagnostics` entry.
 `tests/test_tool_family_wire_parity.py`
 proves the composed schema (including required `reasoning`) survives both
 Chat Completions and Responses wires (including a real Agent
 startup for `web`) at the existing OpenAI adapter seam with zero adapter code
-changes. `tests/test_tool_family_manual_contract.py` invokes the actual
+changes, and that `ChildTool.diagnostics` text never appears anywhere in
+either wire's tool schema. `tests/test_tool_family_manual_contract.py` invokes the actual
 generic manual child handler (not an unused presentational helper) and
 proves the ManualTool reserved name, strict empty input, the canonical
 `content[0].text`/`structuredContent.manual_path` return shape,
@@ -504,8 +590,14 @@ schema (including the nested task object) surviving both wires.
 `tests/test_context_ownership_redesign.py` are the family-specific evidence for
 `context` (`../context/CONTRACT.md`): the final action inventory, strict branch
 isolation, `_tc_id` isolation on the consume-rather-than-drop molt path,
-refusal-before-shed journal gates, the manual child, and full reconstruction
-ordering. `tests/test_pad_lingtai_split.py` independently pins the two sibling
+refusal-before-shed journal gates, the manual child, full reconstruction
+ordering, and `molt`'s own `TRIGGER_UNSUPPORTED_INPUT_FIELD` declaration —
+proving a foreign `input` field on `molt` (e.g. `files`) yields the
+`CTX_MOLT_UNSUPPORTED_INPUT_FIELD` diagnostic at `context/molt/input.files`
+with molt's own allowed-field-set text, while the sibling `summarize` action
+still gets the plain legacy failure for a cross-action `session_journal_path`
+key, and no diagnostic ever claims `session_journal_path` must be relative.
+`tests/test_pad_lingtai_split.py` independently pins the two sibling
 families' narrower public inventories.
 
 `tests/test_tool_family_soul_migration.py` is the equivalent family-specific

--- a/src/lingtai/tools/tool_family/__init__.py
+++ b/src/lingtai/tools/tool_family/__init__.py
@@ -32,17 +32,29 @@ optional helper, not a mandatory base class: a family may use
 :class:`ToolFamily` directly, or hand-write an equivalent ``handle()`` the way
 ``web`` did before adopting it. Two children in a family are not required to
 share anything beyond their registration in one :class:`ToolFamily`.
+
+A ``ChildTool`` may also declare a passive, non-wire ``diagnostics`` sidecar —
+static, mechanical :class:`DiagnosticDescriptor` text the *action* owns for a
+structural dispatch-time trigger it opts into (today: a foreign key in its
+own ``input``). ``handle()`` additively enriches its already fail-closed
+rejection with this text plus a generically computed ``location``; it never
+inspects/parses prose, guesses a reason, or keeps a central tool-name/message
+table, and the sidecar never reaches ``build_schema()`` or any provider wire.
+See ``CONTRACT.md`` "Diagnostics sidecar" for the full contract.
 """
 from __future__ import annotations
 
 import copy
+import re
 from dataclasses import dataclass
 from typing import Any, Callable, Mapping, Sequence
 
 __all__ = [
     "ChildTool",
+    "DiagnosticDescriptor",
     "ToolFamily",
     "ToolFamilyError",
+    "TRIGGER_UNSUPPORTED_INPUT_FIELD",
 ]
 
 # The one reserved child name every family may offer at most once. Colliding
@@ -53,6 +65,38 @@ RESERVED_MANUAL_NAME = "manual"
 
 # Envelope root fields admitted alongside ``action``/``input``.
 _ROOT_FIELDS = {"action", "input", "reasoning", "_reasoning", "summarize"}
+
+# The one structural trigger a ChildTool may currently declare a diagnostic
+# descriptor for: the selected action's own ``input`` carrying a key outside
+# its declared schema properties (cross-action or wholly foreign). Additional
+# triggers would be added here, never invented ad hoc by a consumer.
+TRIGGER_UNSUPPORTED_INPUT_FIELD = "unsupported_input_field"
+
+# A diagnostic field *label* (never the rejected value) is only ever surfaced
+# when it looks like a conventional identifier and carries no secret-shaped
+# substring — this is a generic safety boundary, not a tool-specific
+# allow/deny table, so it applies uniformly to every opted-in child.
+_SAFE_FIELD_LABEL_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,63}$")
+_UNSAFE_FIELD_LABEL_SUBSTRINGS = (
+    "password",
+    "passwd",
+    "secret",
+    "token",
+    "credential",
+    "apikey",
+    "api_key",
+    "private",
+    "auth",
+    "access_key",
+    "session_key",
+)
+
+
+def _is_safe_field_label(label: str) -> bool:
+    if not isinstance(label, str) or not _SAFE_FIELD_LABEL_PATTERN.match(label):
+        return False
+    lowered = label.lower()
+    return not any(bad in lowered for bad in _UNSAFE_FIELD_LABEL_SUBSTRINGS)
 
 # Same canonical English reasoning-property description the kernel injects
 # for every tool (``kernel/base_agent/tools.py:_REASONING_DESCRIPTION``).
@@ -74,6 +118,24 @@ class ToolFamilyError(ValueError):
 
 
 @dataclass(frozen=True, slots=True)
+class DiagnosticDescriptor:
+    """One action-owned, static, mechanical diagnostic for a structural trigger.
+
+    Declared adjacent to the action it describes — see
+    :attr:`ChildTool.diagnostics` — never computed or guessed by the generic
+    dispatcher. ``code``, ``expected_form``, ``reason``, and ``fix`` are all
+    fixed strings the owning action's author writes once; :class:`ToolFamily`
+    only ever supplies the structural ``location`` (family/action/input.field)
+    around this verbatim text, and never inspects/parses it.
+    """
+
+    code: str
+    expected_form: str
+    reason: str
+    fix: str
+
+
+@dataclass(frozen=True, slots=True)
 class ChildTool:
     """One family-owned child: canonical name, schema, and handler.
 
@@ -84,12 +146,21 @@ class ChildTool:
     is the child's own responsibility). ``handler`` receives only the
     validated ``input`` mapping (never ``action``, ``reasoning``, or
     ``summarize``) and returns the child's own raw, canonical result dict.
+
+    ``diagnostics`` is an optional, passive, non-wire sidecar: a mapping from
+    structural trigger name (e.g. :data:`TRIGGER_UNSUPPORTED_INPUT_FIELD`) to
+    the static :class:`DiagnosticDescriptor` this action owns for that
+    trigger. It never reaches ``build_schema()`` or any provider wire — only
+    ``handle()`` reads it, to enrich its own already-fail-closed rejection
+    with additive, mechanical hint text. A child that declares no entry for a
+    trigger gets exactly the legacy failure result for it, unchanged.
     """
 
     name: str
     input_schema: Mapping[str, Any]
     handler: Callable[[Mapping[str, Any]], dict[str, Any]]
     title: str | None = None
+    diagnostics: Mapping[str, DiagnosticDescriptor] | None = None
 
     def branch_title(self) -> str:
         return self.title or f"{self.name} input"
@@ -251,7 +322,11 @@ class ToolFamily:
         alone is not the dispatch-time authorization boundary: ``input`` keys
         are validated against the selected child's own declared
         ``input_schema`` properties, rejecting any key belonging to another
-        action's branch, before the child handler ever runs.
+        action's branch, before the child handler ever runs. That specific
+        rejection is additively enriched via ``_build_diagnostics`` when the
+        selected child opted in for :data:`TRIGGER_UNSUPPORTED_INPUT_FIELD`
+        (see ``ChildTool.diagnostics``); an opted-out child gets the exact
+        legacy three-key failure, unchanged.
 
         Invalid JSON can make ``action`` an unhashable value (e.g. ``[]`` or
         ``{}``) — the issue #513 blocker class. Such an ``action`` simply
@@ -312,11 +387,52 @@ class ToolFamily:
         action_input = raw.get("input")
         if not isinstance(action_input, Mapping):
             return self._envelope_error("INVALID_ARGUMENT", "input must be an object")
-        if set(action_input) - allowed:
+        foreign_input_fields = set(action_input) - allowed
+        if foreign_input_fields:
             return self._envelope_error(
-                "INVALID_ARGUMENT", f"unsupported {self.name} input field"
+                "INVALID_ARGUMENT",
+                f"unsupported {self.name} input field",
+                self._build_diagnostics(
+                    child, TRIGGER_UNSUPPORTED_INPUT_FIELD, foreign_input_fields
+                ),
             )
         return child.handler(action_input)
 
-    def _envelope_error(self, code: str, message: str) -> dict[str, Any]:
-        return {"status": "failed", "error_code": code, "message": message}
+    def _build_diagnostics(
+        self, child: ChildTool, trigger: str, fields: set[str]
+    ) -> list[dict[str, str]] | None:
+        """Render an additive diagnostic entry per safe field label, if opted in.
+
+        Purely structural: this method computes only the ``location``
+        (family/action/input.field) and reads the child's own static
+        :class:`DiagnosticDescriptor` for ``trigger`` verbatim — it never
+        inspects/parses prose, guesses a reason, or consults a central
+        tool-name/message table. A field whose label fails the generic safety
+        check (:func:`_is_safe_field_label`) is silently dropped rather than
+        surfaced; if every candidate field is dropped, or the child declared
+        no descriptor for this trigger, this returns ``None`` and the caller's
+        legacy three-key failure result is unaffected.
+        """
+        descriptor = (child.diagnostics or {}).get(trigger)
+        if descriptor is None:
+            return None
+        entries = [
+            {
+                "location": f"{self.name}/{child.name}/input.{field}",
+                "code": descriptor.code,
+                "expected_form": descriptor.expected_form,
+                "reason": descriptor.reason,
+                "fix": descriptor.fix,
+            }
+            for field in sorted(fields)
+            if _is_safe_field_label(field)
+        ]
+        return entries or None
+
+    def _envelope_error(
+        self, code: str, message: str, diagnostics: list[dict[str, str]] | None = None
+    ) -> dict[str, Any]:
+        result: dict[str, Any] = {"status": "failed", "error_code": code, "message": message}
+        if diagnostics:
+            result["diagnostics"] = diagnostics
+        return result

--- a/tests/test_tool_family_context_migration.py
+++ b/tests/test_tool_family_context_migration.py
@@ -963,6 +963,155 @@ def test_pending_summaries_survive_to_a_later_bare_rebuild(tmp_path):
     assert iface._entries[1].content[0].content["status"] == SUMMARY_STATUS_DONE
 
 
+# ---------------------------------------------------------------------------
+# Diagnostic sidecar — the first concrete local declaration
+# (SONNET_DIAGNOSTIC_CONTRACT.md "Required design" #6): ``context.molt``
+# opts a static descriptor in for its own foreign-input-field structural
+# failure (example field ``files``, already exercised without the
+# diagnostic in ``test_wrong_branch_input_is_rejected_before_any_handler_io``
+# above). These tests pin the additive ``diagnostics`` payload verbatim
+# against the shared contract's own candidate shape, that molt state is
+# untouched (no I/O), and that an action which does NOT opt in (summarize,
+# receiving molt's own ``session_journal_path``) keeps the exact
+# pre-existing legacy failure with no additive key at all.
+# ---------------------------------------------------------------------------
+
+
+def test_molt_foreign_files_field_yields_the_documented_local_diagnostic(tmp_path):
+    """A foreign ``files`` field on molt's own input must produce the
+    documented additive ``diagnostics`` entry, on top of the exact legacy
+    three-key failure, while never touching molt state (no snapshot/archive/
+    shed) — the sidecar only adds explanation, never relaxes fail-closed I/O
+    ordering. It must also never echo the raw rejected value anywhere."""
+    agent = _agent(tmp_path)
+    try:
+        before_count = agent._molt_count
+        result = _call(agent, {
+            "action": "molt",
+            "input": _molt_input(_JOURNAL_REL, files=["x.txt"]),
+        })
+
+        # Exact legacy compatibility: status/error_code/message unchanged.
+        assert result["status"] == "failed"
+        assert result["error_code"] == "INVALID_ARGUMENT"
+        assert "unsupported context input field" in result["message"]
+
+        # The documented additive diagnostic, verbatim per the shared
+        # contract's candidate shape — molt safely states its own allowed
+        # input field set and explains itself, without claiming anything
+        # about `session_journal_path` needing to be relative/absolute.
+        assert result["diagnostics"] == [{
+            "location": "context/molt/input.files",
+            "code": "CTX_MOLT_UNSUPPORTED_INPUT_FIELD",
+            "expected_form": (
+                "an input object containing only summary, "
+                "session_journal_path, keep_tool_calls, and keep_last"
+            ),
+            "reason": "molt rejects foreign action input before it can shed context",
+            "fix": "remove the foreign field or choose the action that owns it",
+        }]
+
+        # No molt state changed — this is explanation, not relaxed I/O.
+        assert agent._molt_count == before_count
+        assert not (agent._working_dir / "history" / "snapshots").exists()
+        assert not (agent._working_dir / "history" / "chat_history_archive.jsonl").exists()
+
+        # No raw rejected value, path, or exception string leaked anywhere.
+        dumped = json.dumps(result)
+        assert "x.txt" not in dumped
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_cross_action_session_journal_path_on_summarize_keeps_the_undiagnosed_legacy_failure(tmp_path):
+    """A foreign field cross-smuggled onto a DIFFERENT action than the one
+    that owns a descriptor gets that selected action's own behavior. Only
+    ``context.molt`` opts into a local descriptor this slice ("Required
+    design" #1: "A selected action must own static safe descriptor(s) for
+    the structural trigger it opts into"), so ``context.summarize``
+    receiving molt's own ``session_journal_path`` field stays the exact
+    pre-existing legacy three-key failure, with no additive ``diagnostics``
+    key at all."""
+    agent = _agent(tmp_path)
+    try:
+        result = _call(agent, {
+            "action": "summarize",
+            "input": {"items": [], "session_journal_path": _JOURNAL_REL},
+        })
+        assert result == {
+            "status": "failed",
+            "error_code": "INVALID_ARGUMENT",
+            "message": "unsupported context input field",
+        }
+        assert "diagnostics" not in result
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_molt_secret_shaped_unsafe_field_label_is_dropped_from_diagnostics(tmp_path):
+    """``molt`` is opted in for ``TRIGGER_UNSUPPORTED_INPUT_FIELD``, but a
+    foreign field whose *label itself* looks secret-shaped (contains an
+    unsafe substring like ``token``) must never be surfaced in a diagnostic
+    — the generic ``tool_family`` safety check, not molt-specific logic.
+    Legacy failure stays exact, no ``diagnostics`` key at all, the label and
+    its raw value never leak into the serialized result, and molt state is
+    untouched (fail-closed, no I/O)."""
+    agent = _agent(tmp_path)
+    try:
+        before_count = agent._molt_count
+        result = _call(agent, {
+            "action": "molt",
+            "input": _molt_input(_JOURNAL_REL, api_token="sk-should-never-leak"),
+        })
+
+        assert result == {
+            "status": "failed",
+            "error_code": "INVALID_ARGUMENT",
+            "message": "unsupported context input field",
+        }
+        assert "diagnostics" not in result
+        dumped = json.dumps(result)
+        assert "api_token" not in dumped
+        assert "sk-should-never-leak" not in dumped
+
+        assert agent._molt_count == before_count
+        assert not (agent._working_dir / "history" / "snapshots").exists()
+        assert not (agent._working_dir / "history" / "chat_history_archive.jsonl").exists()
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_molt_non_identifier_shaped_field_label_is_dropped_from_diagnostics(tmp_path):
+    """A foreign field whose label is not conventional-identifier-shaped
+    (contains punctuation/whitespace) is dropped the same way as an unsafe
+    one — the exact legacy failure, no ``diagnostics`` key, no leak of
+    either the label or its raw value, and molt state untouched
+    (fail-closed, no I/O)."""
+    agent = _agent(tmp_path)
+    try:
+        before_count = agent._molt_count
+        sentinel_value = "molt-non-identifier-label-sentinel-2c9f7e1b"
+        payload = _molt_input(_JOURNAL_REL)
+        payload["not an identifier!"] = sentinel_value
+        result = _call(agent, {"action": "molt", "input": payload})
+
+        assert result == {
+            "status": "failed",
+            "error_code": "INVALID_ARGUMENT",
+            "message": "unsupported context input field",
+        }
+        assert "diagnostics" not in result
+        dumped = json.dumps(result)
+        assert "not an identifier!" not in dumped
+        assert sentinel_value not in dumped
+
+        assert agent._molt_count == before_count
+        assert not (agent._working_dir / "history" / "snapshots").exists()
+        assert not (agent._working_dir / "history" / "chat_history_archive.jsonl").exists()
+    finally:
+        agent.stop(timeout=1.0)
+
+
 def test_root_summarize_bool_is_never_domain_input_of_the_summarize_action(tmp_path):
     """The ACTION named ``summarize`` and the ROOT bool named ``summarize``.
 

--- a/tests/test_tool_family_generic.py
+++ b/tests/test_tool_family_generic.py
@@ -6,11 +6,15 @@ boilerplate in ``lingtai.tools.tool_family`` is generic, not Web-specific.
 """
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from lingtai.tools.tool_family import (
     RESERVED_MANUAL_NAME,
+    TRIGGER_UNSUPPORTED_INPUT_FIELD,
     ChildTool,
+    DiagnosticDescriptor,
     ToolFamily,
     ToolFamilyError,
 )
@@ -442,3 +446,258 @@ def test_build_schema_all_of_conditions_are_mutation_isolated():
     # allOf.then.input and the oneOf branch do not share a container either.
     first_spin_branch = next(b for b in first["properties"]["input"]["oneOf"] if b["title"] == "spin input")
     assert first_spin_branch["properties"]["speed"]["type"] == "integer"
+
+
+# ---------------------------------------------------------------------------
+# Diagnostic sidecar — compiler-style hints for a recognized structural
+# failure (``tool_family/CONTRACT.md`` "Diagnostics sidecar").
+#
+# ``ChildTool.diagnostics: Mapping[str, DiagnosticDescriptor] | None`` is
+# keyed by *structural trigger* (today only ``TRIGGER_UNSUPPORTED_INPUT_FIELD``),
+# not by field name — an opted-in child owns exactly one static
+# ``DiagnosticDescriptor`` (``code``/``expected_form``/``reason``/``fix``) per
+# trigger and that same text is reused for EVERY safe foreign field name
+# ``handle()`` encounters for that trigger; there is no per-field
+# registration. This is a passive sidecar declared adjacent to a child's
+# existing name/input_schema/handler — never part of ``input_schema`` itself,
+# so it can never reach ``build_schema()``'s wire output (see
+# ``test_tool_family_wire_parity.py``). For the *selected* action's own
+# ``set(action_input) - allowed`` rejection (the "unsupported <family> input
+# field" structural failure), ``ToolFamily.handle()`` emits one additive
+# ``diagnostics`` list entry per offending field whose *label* passes the
+# generic safety check (conventional-identifier-shaped, no secret-shaped
+# substring) — never guessing, never parsing prose, never consulting a
+# central tool-name table. Each entry is
+# ``{"location": "<family>/<action>/input.<field>", **descriptor-fields}``,
+# where ``location`` is the only value ``ToolFamily`` computes itself. Legacy
+# ``status``/``error_code``/``message`` are unchanged either way. No
+# ``diagnostics`` key is added at all when the child never opted in for the
+# trigger, or when every offending field's label fails the safety check.
+# ---------------------------------------------------------------------------
+
+_SPIN_DIAGNOSTIC = DiagnosticDescriptor(
+    code="WIDGET_SPIN_UNSUPPORTED_INPUT_FIELD",
+    expected_form="an input object containing only speed",
+    reason="spin rejects foreign action input before it can spin",
+    fix="remove the foreign field or choose the action that owns it",
+)
+
+
+def _spin_child_with_diagnostics(
+    calls: list[dict], descriptor: DiagnosticDescriptor = _SPIN_DIAGNOSTIC
+) -> ChildTool:
+    def handler(input_):
+        calls.append(dict(input_))
+        return {"status": "ok", "action": "spin", "speed": input_.get("speed")}
+
+    return ChildTool(
+        name="spin",
+        input_schema={
+            "type": "object",
+            "properties": {"speed": {"type": "integer"}},
+            "required": ["speed"],
+            "additionalProperties": False,
+        },
+        handler=handler,
+        title="spin input",
+        diagnostics={TRIGGER_UNSUPPORTED_INPUT_FIELD: descriptor},
+    )
+
+
+def _expected_entry(family: str, action: str, field: str, descriptor: DiagnosticDescriptor) -> dict:
+    return {
+        "location": f"{family}/{action}/input.{field}",
+        "code": descriptor.code,
+        "expected_form": descriptor.expected_form,
+        "reason": descriptor.reason,
+        "fix": descriptor.fix,
+    }
+
+
+def test_opted_in_child_yields_owner_defined_descriptor_and_mechanical_location():
+    """An opted-in child's own static descriptor is emitted verbatim,
+    additive to the exact legacy failure, at a mechanically derived
+    ``family/action/input.field`` location."""
+    calls: list[dict] = []
+    child = _spin_child_with_diagnostics(calls)
+    fam = ToolFamily("widget", [child, _manual_child()])
+
+    result = fam.handle({"action": "spin", "input": {"speed": 1, "turbo": True}, "reasoning": "r"})
+
+    assert result["status"] == "failed"
+    assert result["error_code"] == "INVALID_ARGUMENT"
+    assert result["message"] == "unsupported widget input field"
+    assert result["diagnostics"] == [_expected_entry("widget", "spin", "turbo", _SPIN_DIAGNOSTIC)]
+    assert calls == []  # no handler I/O on a rejected call
+
+
+def test_opted_in_child_emits_its_descriptor_for_every_safe_foreign_field_sorted():
+    """There is no per-field registration: an opted-in child's ONE static
+    descriptor is reused for every safe foreign field name present, one
+    diagnostics entry per field, in sorted field-name order (matching
+    ``handle()``'s own ``sorted(fields)`` iteration)."""
+    calls: list[dict] = []
+    child = _spin_child_with_diagnostics(calls)
+    fam = ToolFamily("widget", [child, _manual_child()])
+
+    result = fam.handle({"action": "spin", "input": {"speed": 1, "zeta": True, "alpha": True}})
+
+    assert result["diagnostics"] == [
+        _expected_entry("widget", "spin", "alpha", _SPIN_DIAGNOSTIC),
+        _expected_entry("widget", "spin", "zeta", _SPIN_DIAGNOSTIC),
+    ]
+    assert calls == []
+
+
+def test_opted_out_child_yields_exact_legacy_three_key_failure():
+    """A child that never opts in (default ``diagnostics=None``) renders the
+    exact pre-existing three-key failure — no additive key, no behavior
+    change from before this feature existed."""
+    calls: list[dict] = []
+    fam = _widget_family(calls)  # plain ``_spin_child`` — no diagnostics sidecar
+
+    result = fam.handle({"action": "spin", "input": {"speed": 1, "turbo": True}})
+
+    assert result == {
+        "status": "failed",
+        "error_code": "INVALID_ARGUMENT",
+        "message": "unsupported widget input field",
+    }
+    assert "diagnostics" not in result
+    assert calls == []
+
+
+def test_secret_shaped_field_label_is_dropped_from_diagnostics_and_never_leaked():
+    """A foreign field whose *label itself* looks secret-shaped (contains an
+    unsafe substring like ``token``) must never be surfaced in a diagnostic,
+    even on an opted-in child — the generic safety check, not molt-specific
+    logic. Legacy failure stays exact, no ``diagnostics`` key, and neither
+    the label nor its raw value ever leaks into the serialized result."""
+    calls: list[dict] = []
+    child = _spin_child_with_diagnostics(calls)
+    fam = ToolFamily("widget", [child, _manual_child()])
+
+    result = fam.handle({"action": "spin", "input": {"speed": 1, "api_token": "sk-should-never-leak"}})
+
+    assert result == {
+        "status": "failed",
+        "error_code": "INVALID_ARGUMENT",
+        "message": "unsupported widget input field",
+    }
+    assert "diagnostics" not in result
+    dumped = json.dumps(result)
+    assert "api_token" not in dumped
+    assert "sk-should-never-leak" not in dumped
+    assert calls == []
+
+
+def test_non_identifier_shaped_field_label_is_dropped_from_diagnostics():
+    """A foreign field whose label is not conventional-identifier-shaped
+    (punctuation/whitespace) is dropped the same way as an unsafe one — the
+    exact legacy failure, no ``diagnostics`` key, no leak."""
+    calls: list[dict] = []
+    child = _spin_child_with_diagnostics(calls)
+    fam = ToolFamily("widget", [child, _manual_child()])
+
+    result = fam.handle({"action": "spin", "input": {"speed": 1, "not an identifier!": "x"}})
+
+    assert result == {
+        "status": "failed",
+        "error_code": "INVALID_ARGUMENT",
+        "message": "unsupported widget input field",
+    }
+    assert "diagnostics" not in result
+    assert "not an identifier!" not in json.dumps(result)
+    assert calls == []
+
+
+def test_mixed_offending_fields_only_the_safe_identifier_label_is_surfaced():
+    """A safe identifier-shaped field, a secret-shaped-label field, and a
+    non-identifier-shaped field arrive together: only the safe one gets a
+    diagnostics entry, and the other two never appear anywhere — not their
+    label, not any value — in the serialized result. Proves the drop is
+    per-field, not all-or-nothing."""
+    calls: list[dict] = []
+    child = _spin_child_with_diagnostics(calls)
+    fam = ToolFamily("widget", [child, _manual_child()])
+
+    result = fam.handle({
+        "action": "spin",
+        "input": {
+            "speed": 1,
+            "turbo": True,              # safe, identifier-shaped
+            "api_token": "sk-secret",   # unsafe: secret-shaped label
+            "not valid!": "x",          # unsafe: non-identifier-shaped
+        },
+    })
+
+    assert result["diagnostics"] == [_expected_entry("widget", "spin", "turbo", _SPIN_DIAGNOSTIC)]
+    dumped = json.dumps(result)
+    assert "api_token" not in dumped
+    assert "sk-secret" not in dumped
+    assert "not valid!" not in dumped
+    assert calls == []
+
+
+def test_diagnostics_never_echoes_a_raw_rejected_value():
+    """A secret-shaped raw value submitted for a safe-labeled field must
+    never appear anywhere in the diagnostic payload — only the static
+    descriptor text and the mechanically computed location are ever
+    emitted."""
+    calls: list[dict] = []
+    child = _spin_child_with_diagnostics(calls)
+    fam = ToolFamily("widget", [child, _manual_child()])
+    secret = "sk-super-secret-token-should-never-leak"
+
+    result = fam.handle({"action": "spin", "input": {"speed": 1, "turbo": secret}})
+
+    assert secret not in json.dumps(result)
+
+
+def test_diagnostics_sidecar_is_owner_defined_not_a_generic_central_table():
+    """Two unrelated families, each opting in their OWN distinct descriptor
+    text for the same-named offending field, each get back their own text
+    verbatim — proving ``ToolFamily`` holds no central tool-name/message
+    table and does not guess a tool-specific reason itself."""
+    calls_a: list[dict] = []
+    calls_b: list[dict] = []
+    descriptor_a = DiagnosticDescriptor(
+        code="WIDGET_A_UNSUPPORTED_INPUT_FIELD",
+        expected_form="an input object containing only speed",
+        reason="family A's own reason",
+        fix="family A's own fix",
+    )
+    descriptor_b = DiagnosticDescriptor(
+        code="WIDGET_B_UNSUPPORTED_INPUT_FIELD",
+        expected_form="an input object containing only speed",
+        reason="family B's own reason",
+        fix="family B's own fix",
+    )
+    fam_a = ToolFamily(
+        "widget_a",
+        [_spin_child_with_diagnostics(calls_a, descriptor_a), _manual_child()],
+    )
+    fam_b = ToolFamily(
+        "widget_b",
+        [_spin_child_with_diagnostics(calls_b, descriptor_b), _manual_child()],
+    )
+
+    result_a = fam_a.handle({"action": "spin", "input": {"speed": 1, "turbo": True}})
+    result_b = fam_b.handle({"action": "spin", "input": {"speed": 1, "turbo": True}})
+
+    assert result_a["diagnostics"] == [_expected_entry("widget_a", "spin", "turbo", descriptor_a)]
+    assert result_b["diagnostics"] == [_expected_entry("widget_b", "spin", "turbo", descriptor_b)]
+
+
+def test_diagnostics_do_not_relocate_extra_fields_or_weaken_the_allowed_set():
+    """The sidecar only adds explanatory payload to an existing rejection —
+    it must never coerce/relocate the offending field into the handler's
+    input, and must never widen what the handler ends up receiving."""
+    calls: list[dict] = []
+    child = _spin_child_with_diagnostics(calls)
+    fam = ToolFamily("widget", [child, _manual_child()])
+
+    result = fam.handle({"action": "spin", "input": {"speed": 1, "turbo": True}})
+
+    assert result["status"] == "failed"
+    assert calls == []  # the handler never ran — no relocation, no I/O

--- a/tests/test_tool_family_wire_parity.py
+++ b/tests/test_tool_family_wire_parity.py
@@ -8,8 +8,15 @@ provider wire shapes at the smallest existing adapter seam
 """
 from __future__ import annotations
 
+import json
+
 from lingtai.kernel.llm.base import FunctionSchema
-from lingtai.tools.tool_family import ChildTool, ToolFamily
+from lingtai.tools.tool_family import (
+    TRIGGER_UNSUPPORTED_INPUT_FIELD,
+    ChildTool,
+    DiagnosticDescriptor,
+    ToolFamily,
+)
 
 
 def _widget_family() -> ToolFamily:
@@ -103,5 +110,96 @@ def test_real_agent_startup_builds_web_family_schema_on_both_wires(tmp_path):
         assert responses["properties"]["input"]["type"] == "object"
         assert len(chat["properties"]["input"]["oneOf"]) == 3
         assert len(responses["properties"]["input"]["anyOf"]) == 3
+    finally:
+        agent.stop(timeout=1.0)
+
+
+# ---------------------------------------------------------------------------
+# Provider-wire blindness regression (SONNET_DIAGNOSTIC_CONTRACT.md "Required
+# design" #1/#3): the diagnostic sidecar (assumed ``ChildTool.diagnostics``,
+# see ``test_tool_family_generic.py``) is passive and dispatch-time-only. It
+# must never be reachable through ``build_schema()`` or either provider wire
+# builder — those only ever read a child's ``input_schema``/``title``.
+# ---------------------------------------------------------------------------
+
+
+def test_diagnostics_sidecar_never_reaches_either_provider_wire():
+    """A fake family's child opts into a diagnostic sidecar (keyed by
+    structural trigger, per ``ChildTool.diagnostics: Mapping[str,
+    DiagnosticDescriptor]``) with distinctive descriptor text; neither the
+    composed schema nor either provider wire representation may contain that
+    text, or even the word "diagnostics"."""
+    secret_marker = "WIDGET_SPIN_UNSUPPORTED_INPUT_FIELD_should_never_reach_a_wire"
+    descriptor = DiagnosticDescriptor(
+        code=secret_marker,
+        expected_form="an input object containing only speed",
+        reason="spin rejects foreign action input before it can spin",
+        fix="remove the foreign field or choose the action that owns it",
+    )
+
+    def spin_handler(input_):
+        return {"status": "ok"}
+
+    child = ChildTool(
+        "spin",
+        {
+            "type": "object",
+            "properties": {"speed": {"type": "integer"}},
+            "required": ["speed"],
+            "additionalProperties": False,
+        },
+        spin_handler,
+        title="spin input",
+        diagnostics={TRIGGER_UNSUPPORTED_INPUT_FIELD: descriptor},
+    )
+    fam = ToolFamily("widget", [child])
+    schema = fam.build_schema()
+
+    dumped_schema = json.dumps(schema)
+    assert "diagnostics" not in dumped_schema
+    assert secret_marker not in dumped_schema
+    assert descriptor.reason not in dumped_schema
+    assert descriptor.fix not in dumped_schema
+    assert descriptor.expected_form not in dumped_schema
+
+    from lingtai.llm.openai.adapter import _build_responses_tools, _build_tools
+
+    function_schema = FunctionSchema(name="widget", description="widget", parameters=schema)
+    chat = _build_tools([function_schema])[0]
+    responses = _build_responses_tools([function_schema])[0]
+    for wire in (chat, responses):
+        dumped_wire = json.dumps(wire)
+        assert "diagnostics" not in dumped_wire
+        assert secret_marker not in dumped_wire
+        assert descriptor.reason not in dumped_wire
+        assert descriptor.fix not in dumped_wire
+
+
+def test_context_molt_diagnostic_descriptor_never_reaches_either_provider_wire(tmp_path):
+    """Real-family regression: once ``context.molt`` opts into its own local
+    diagnostic descriptor for a foreign ``files`` input field
+    (`tools/context/__init__.py`, per the shared contract's "Required
+    design" #6), that descriptor's own code/text must still never appear on
+    either provider wire for the real, live-agent-composed ``context``
+    schema — the sidecar is dispatch-time-only and never schema-composed."""
+    from lingtai.agent import Agent
+    from lingtai.kernel.base_agent.tools import _build_tool_schemas
+    from tests._service_helpers import make_gemini_mock_service as make_mock_service
+
+    agent = Agent(
+        service=make_mock_service(), agent_name="wire-blindness-test",
+        working_dir=tmp_path,
+    )
+    try:
+        from lingtai.llm.openai.adapter import _build_responses_tools, _build_tools
+
+        schemas = [s for s in _build_tool_schemas(agent) if s.name == "context"]
+        chat = _build_tools(schemas)[0]
+        responses = _build_responses_tools(schemas)[0]
+        for wire in (chat, responses):
+            dumped = json.dumps(wire)
+            assert "diagnostics" not in dumped
+            assert "CTX_MOLT_UNSUPPORTED_INPUT_FIELD" not in dumped
+            assert "molt rejects foreign action input" not in dumped
     finally:
         agent.stop(timeout=1.0)


### PR DESCRIPTION
## What

Agent-facing failed tool calls should read like compiler diagnostics, not opaque `unsupported <family> input field`. This makes that obligation **normative and local** - every tool/action definition mechanically declares its own compiler-style diagnostic right beside its `ChildTool`; a generic renderer only computes the structural `family/action/input.field` location and reproduces that declaration verbatim.

## Why

A real agent hit `context(action='molt')` and was told only `INVALID_ARGUMENT: unsupported context input field`; retrying different `summary` values wasted several turns because the error named neither the offending field nor the accepted shape. This PR lets `context.molt` (and, mechanically, any opted-in action) explain which field is wrong, what shape is expected, why, and how to fix it - without guessing or leaking values.

## How

- `ChildTool` gains an optional, **non-wire** `diagnostics` sidecar mapping a structural trigger (`TRIGGER_UNSUPPORTED_INPUT_FIELD`) to an action-owned frozen `DiagnosticDescriptor(code, expected_form, reason, fix)`.
- Generic `ToolFamily.handle` already rejects extra selected-action input keys fail-closed before handler I/O. When the child opted in, it now additively emits a diagnostics array for each **safe** foreign field label; unsafe/secret-shaped/non-identifier labels are silently dropped and never leak, neither label nor raw value.
- An opted-out child (by default) retains the **exact** legacy three-key failure, unchanged.
- The sidecar is never exposed through `build_schema` / JSON Schema / provider wires.
- `context.molt` opts in with a declaration whose `expected_form` names only `summary, session_journal_path, keep_tool_calls, keep_last` and explains the pre-shed rejection.
- Contracts updated: ToolFamily Contract (structural diagnostics only, redaction, wire blindness, compatibility), Behavior T010, and Anatomy citations.
- Focused regressions: generic ownership, opted-out compatibility, safe foreign fields, secret + non-identifier unsafe-label redaction (no diagnostics / no raw label / no raw value / no handler I/O), provider-wire blindness, and context.molt foreign-field coverage (no I/O).

## Notes

- The path-domain validator already accepts and normalizes in-workdir absolute `session_journal_path`; this diagnostic intentionally does **not** claim that field must be relative - it only reports foreign/unsupported fields.
- A central heuristic/tool-name/message table is intentionally avoided; all hint text is declared at each child's definition.
