### PR TITLE
fix(refresh-watcher): bounded heartbeat poll + duplicate-exit wait for slow MCP boot

### DIFF
--- a/src/lingtai/kernel/refresh_watcher/ANATOMY.md
+++ b/src/lingtai/kernel/refresh_watcher/ANATOMY.md
@@ -51,10 +51,14 @@ walkthrough.
 - `RefreshWatcherProcessHandle`, `RefreshWatcherProcessObservation`, and
   `RefreshWatcherProcessPort` define the local observe/liveness/start/graceful
   stop/force-stop boundary (`src/lingtai/kernel/refresh_watcher/__init__.py:79-145`).
-- `render_watcher_script(request)` renders the existing ACK/lock, heartbeat,
-  retry, matcher, redaction, and alert policy and calls only an injected
+- `render_watcher_script(request)` renders the ACK/lock, heartbeat, retry,
+  matcher, redaction, and alert policy and calls only an injected
   `PROCESS_MECHANISM` global for process operations
-  (`src/lingtai/kernel/refresh_watcher/watcher_program.py:53-431`).
+  (`src/lingtai/kernel/refresh_watcher/watcher_program.py:69-571`). Its
+  wall-clock policy lives in module-top constants — `MAX_ATTEMPTS`,
+  `HEALTH_CHECK_WAIT`, `HEALTH_CHECK_BUDGET`, `WATCHER_POLL_INTERVAL`,
+  `DUPLICATE_EXIT_WAIT` — that the renderer embeds as plain assignments
+  (`src/lingtai/kernel/refresh_watcher/watcher_program.py:24-40`).
 - `select_refresh_watcher` is the fail-loud outer selector
   (`src/lingtai/adapters/refresh_watcher.py:14-35`).
 

--- a/src/lingtai/kernel/refresh_watcher/BEHAVIORS.md
+++ b/src/lingtai/kernel/refresh_watcher/BEHAVIORS.md
@@ -1,6 +1,6 @@
 ---
 name: refresh-watcher-behavior-tests
-behavior_version: 1
+behavior_version: 2
 labt_version: 2
 contract: CONTRACT.md
 anatomy: ANATOMY.md
@@ -9,6 +9,8 @@ related_files:
   - src/lingtai/kernel/refresh_watcher/ANATOMY.md
   - src/lingtai/kernel/refresh_watcher/__init__.py
   - src/lingtai/kernel/refresh_watcher/watcher_program.py
+  - tests/test_perform_refresh_handshake.py
+  - tests/test_refresh_watcher_process.py
 maintenance: |
   Created during the every-contract-needs-behaviors sweep. Keep this file
   reciprocal with CONTRACT.md and ANATOMY.md (tridirectional loop): when a
@@ -19,8 +21,9 @@ maintenance: |
 
 Self-contained agent behavior tasks guarding the observable behavior clauses of
 `src/lingtai/kernel/refresh_watcher/CONTRACT.md` (one detached watcher spawn per
-refresh, frozen request, handshake normalization, env-overwrite policy). Pinned
-pytest commands must run from the repo root with the project's Python.
+refresh, frozen request, handshake normalization, env-overwrite policy, and the
+bounded relaunch health-check/duplicate-exit waits). Pinned pytest commands must
+run from the repo root with the project's Python.
 
 ## Behavior RW001 — a successful refresh spawns the detached watcher exactly once, and failed ACK setup does not spawn
 
@@ -43,3 +46,30 @@ pytest commands must run from the repo root with the project's Python.
 
 ### Pass / Fail
 Pass when the suites pass and the one-spawn/zero-spawn observations hold. Fail on a second spawn, on a spawn after failed ACK setup, or on a request that carries generated source or caller environment; record the evidence trail in the task report.
+
+## Behavior RW002 — a slow-booting relaunch is not declared dead, and a terminated duplicate is gone before the next attempt
+
+- **id**: RW002
+- **title**: a slow-booting relaunch is not declared dead, and a terminated duplicate is gone before the next attempt
+- **guards**: `refresh-watcher` § Contract rules, rule 2
+- **runner**: any LingTai agent with `shell` and `file` access to this repository
+- **prerequisites**: a clean checkout of `<repo>`; a scratch agent working directory `<scratch>`
+- **estimate**: ≈ 25 minutes
+- **motivation**: production incident 2026-08-19 (`spiritual-bliss-attractor/.lingtai/codex`) exhausted all 12 relaunch attempts. The health check slept `HEALTH_CHECK_WAIT` once and sampled `.agent.heartbeat` a single time — too early for an agent still spawning MCP stdio servers — and the loop retried immediately after SIGKILLing a duplicate that had not yet released the working directory, so every attempt collided again with `another lingtai agent is already running`.
+
+### Steps
+1. From `<repo>`, run `python -m pytest tests/test_refresh_watcher_process.py tests/test_perform_refresh_handshake.py -q` and capture the outcome.
+2. Read the rendered policy (`render_watcher_script`) and confirm the post-relaunch health check is a bounded poll (`_await_fresh_heartbeat`, `HEALTH_CHECK_BUDGET`, `WATCHER_POLL_INTERVAL`) rather than one `time.sleep(HEALTH_CHECK_WAIT)` followed by a single heartbeat read.
+3. In `<scratch>`, run the rendered policy against a fake `PROCESS_MECHANISM` whose relaunch writes its first `.agent.heartbeat` later than `HEALTH_CHECK_WAIT` but inside `HEALTH_CHECK_BUDGET`; record the launch count and the `refresh_watcher_success` event.
+4. In `<scratch>`, run the rendered policy against a fake whose duplicate only leaves the process table some time after `force_stop`; record the timestamp of each `start_agent` call and of the duplicate's disappearance.
+5. In `<scratch>`, run the rendered policy against a fake whose duplicate never dies; record `logs/refresh_failed_permanent.json` and the emitted event types.
+
+### Expected evidence
+- [ ] Step 1: both suites pass.
+- [ ] Step 2: the rendered policy contains `_await_fresh_heartbeat` bounded by `HEALTH_CHECK_BUDGET`, `_await_duplicate_exit` bounded by `DUPLICATE_EXIT_WAIT`, and no single-sample `time.time() - hb_ts < HEALTH_CHECK_WAIT + 10` health check.
+- [ ] Step 3: exactly one `start_agent` call, exit code 0, and one `refresh_watcher_success` event whose `heartbeat_wait` exceeds `HEALTH_CHECK_WAIT`.
+- [ ] Step 4: the second `start_agent` call happens no earlier than the duplicate's disappearance, and no `refresh_watcher_stale_duplicate_still_alive` event is emitted.
+- [ ] Step 5: the loop terminates after `MAX_ATTEMPTS`; the artifact records `last_cleanup_action = 'terminate_stale_duplicate'` and `last_cleanup_result = 'still_alive'`; one `refresh_watcher_stale_duplicate_still_alive` event per attempt; the final event is `refresh_failed_permanent`.
+
+### Pass / Fail
+Pass when a heartbeat that arrives after `HEALTH_CHECK_WAIT` but inside `HEALTH_CHECK_BUDGET` is accepted on the first attempt, the retry waits for a terminated duplicate, and an undying duplicate is reported honestly instead of hanging. Fail on a slow boot costing a second attempt, on a retry that starts while the duplicate still matches the same-agent guard, on an unbounded wait, or on a terminal artifact that hides the `still_alive` outcome; record the evidence trail in the task report.

--- a/src/lingtai/kernel/refresh_watcher/CONTRACT.md
+++ b/src/lingtai/kernel/refresh_watcher/CONTRACT.md
@@ -4,6 +4,7 @@ contract_version: 3
 root_contract: CONTRACT.md
 related_files:
   - src/lingtai/kernel/refresh_watcher/ANATOMY.md
+  - src/lingtai/kernel/refresh_watcher/BEHAVIORS.md
   - src/lingtai/kernel/base_agent/CONTRACT.md
   - src/lingtai/kernel/refresh_watcher/__init__.py
   - src/lingtai/kernel/refresh_watcher/watcher_program.py
@@ -187,7 +188,13 @@ operations, and may import the canonical
 a process-table command, perform process termination, or launch a replacement.
 Instead, stale-duplicate cleanup calls the injected process Port in the order
 chosen by policy (`observe` → `is_alive` → `graceful_stop` → grace polling →
-`force_stop` when needed), and relaunch calls `start_agent` once per retry.
+`force_stop` when needed → bounded `observe`/`is_alive` re-checks of the
+canonical same-agent guard until the duplicate is gone or `DUPLICATE_EXIT_WAIT`
+expires), and relaunch calls `start_agent` once per retry. The post-termination
+re-check deliberately reuses the same-agent guard rather than raw liveness: the
+duplicate is often a process this watcher itself launched on an earlier attempt
+and never reaps, so its PID survives as a zombie that `is_alive` alone would
+report alive indefinitely.
 
 The generated policy must continue to redact bounded stderr/cleanup/relaunch
 errors before all three terminal-failure sinks. It must continue to use the
@@ -197,9 +204,21 @@ same matcher import and not embed a second matcher implementation.
 
 1. Outer `spawn_detached` and request wire behavior remain lossless,
    deterministic, immutable, and exactly-once at the successful handshake.
-2. The generated watcher keeps the prior ACK/lock deadlines, heartbeat
-   threshold, retry count/timing, signal-file cleanup, duplicate decision,
-   redaction, artifact, system notification, and event semantics.
+2. The generated watcher keeps the prior ACK/lock deadlines, heartbeat freshness
+   threshold, `MAX_ATTEMPTS` retry budget, signal-file cleanup, duplicate
+   decision, redaction, artifact, system notification, and prior event
+   semantics. Its post-relaunch health check polls `.agent.heartbeat` every
+   `WATCHER_POLL_INTERVAL` until a fresh heartbeat appears or
+   `HEALTH_CHECK_BUDGET` expires, instead of sampling once after a single
+   `HEALTH_CHECK_WAIT` sleep; it returns early when this attempt's own stderr
+   segment already carries the duplicate guard, so a refused launch does not
+   spend the whole budget. After a cleanup that terminated a duplicate, the
+   watcher waits up to `DUPLICATE_EXIT_WAIT` for that PID to stop matching the
+   canonical same-agent guard before starting the next attempt; when the
+   duplicate outlives that wait it records `last_cleanup_result = 'still_alive'`
+   and retries anyway. Both waits are bounded, so the loop still terminates
+   within `MAX_ATTEMPTS` attempts.
+   Guarded by: [RW002](BEHAVIORS.md#behavior-rw002)
 3. Core policy never imports or constructs an adapter and never directly owns
    process observation, liveness, launch, or termination. The generated policy
    uses only the injected `RefreshWatcherProcessPort` global.

--- a/src/lingtai/kernel/refresh_watcher/MANUAL.md
+++ b/src/lingtai/kernel/refresh_watcher/MANUAL.md
@@ -51,9 +51,15 @@ data afterward.
    — raising `ValueError` before generating any source if the snapshot is
    invalid JSON or not a JSON object — then renders complete Python program
    source independent of the parent process's live objects: the ACK/lock handshake poll, the
-   12-attempt relaunch loop with a 10s health-check wait, stale same-agent
-   duplicate-process cleanup (SIGTERM → 5s grace → SIGKILL), redacted event
-   logging, and the terminal failure artifact/notification. This module
+   12-attempt relaunch loop whose health check polls `.agent.heartbeat` every
+   0.5s for up to 60s (long enough for an agent still spawning its MCP stdio
+   servers to write a first heartbeat, and short-circuited as soon as that
+   attempt's own stderr shows the duplicate guard), stale same-agent
+   duplicate-process cleanup (SIGTERM → 5s grace → SIGKILL → up to 15s waiting
+   for the duplicate to stop matching the same-agent guard before the next
+   attempt), redacted event logging, and the terminal failure
+   artifact/notification. Every wait is bounded, so the loop still ends in at
+   most 12 attempts. This module
    performs no OS calls itself. Executing the rendered source requires an
    importable LingTai package for the kernel's redaction helper and canonical
    Core process-command matcher. The duplicate-process guard imports

--- a/src/lingtai/kernel/refresh_watcher/watcher_program.py
+++ b/src/lingtai/kernel/refresh_watcher/watcher_program.py
@@ -8,10 +8,12 @@ only assembles policy source and never constructs a concrete process adapter.
 The entrypoint injects that adapter as the ``PROCESS_MECHANISM`` global.
 
 The stale same-agent guard imports the canonical Core matcher at runtime rather
-than embedding another matcher. Request identity fields are serialized JSON
-snapshots and are validated before source generation. The renderer itself
-performs no operating-system process operation; file, time, heartbeat, retry,
-redaction, and alert policy remain in the generated Core policy.
+than embedding another matcher, and is reused to decide when a terminated
+duplicate has actually released the working directory. Request identity fields
+are serialized JSON snapshots and are validated before source generation. The
+renderer itself performs no operating-system process operation; file, time,
+heartbeat, retry, redaction, and alert policy remain in the generated Core
+policy.
 """
 from __future__ import annotations
 
@@ -21,7 +23,21 @@ from . import RefreshWatcherRequest
 
 MAX_ATTEMPTS = 12
 HEALTH_CHECK_WAIT = 10
+# A relaunched agent boots its MCP stdio servers before the first heartbeat
+# write. Production incident 2026-08-19 (spiritual-bliss-attractor/codex) showed
+# that boot exceeding a single ``HEALTH_CHECK_WAIT`` sleep on every one of the
+# 12 attempts, so the watcher declared a healthy-but-slow agent dead. The health
+# check therefore polls for a fresh heartbeat every ``WATCHER_POLL_INTERVAL``
+# until ``HEALTH_CHECK_BUDGET`` expires rather than sampling once.
+HEALTH_CHECK_BUDGET = 60
+WATCHER_POLL_INTERVAL = 0.5
+# The same incident showed the other half of the starvation: cleanup sent
+# SIGKILL to a stale duplicate and the next attempt started immediately, hitting
+# 'another lingtai agent is already running' again because the duplicate had not
+# left the process table yet. Bound how long the watcher waits for that exit.
+DUPLICATE_EXIT_WAIT = 15
 STDERR_TAIL_CHARS = 1200
+DUPLICATE_GUARD_MESSAGE = "another lingtai agent is already running"
 
 
 def _decode_identity_fields(identity_fields_json: str) -> dict:
@@ -100,6 +116,10 @@ def render_watcher_script(request: RefreshWatcherRequest) -> str:
         f"identity_fields = {identity_fields!r}\n"
         f"MAX_ATTEMPTS = {MAX_ATTEMPTS}\n"
         f"HEALTH_CHECK_WAIT = {HEALTH_CHECK_WAIT}\n"
+        f"HEALTH_CHECK_BUDGET = {HEALTH_CHECK_BUDGET}\n"
+        f"WATCHER_POLL_INTERVAL = {WATCHER_POLL_INTERVAL}\n"
+        f"DUPLICATE_EXIT_WAIT = {DUPLICATE_EXIT_WAIT}\n"
+        f"DUPLICATE_GUARD_MESSAGE = {DUPLICATE_GUARD_MESSAGE!r}\n"
         # The watcher writes events.jsonl through its own log() below, bypassing
         # the in-process CompositeLoggingService.redact_for_trajectory. Secret-
         # shaped values reach these events via stderr_tail (relaunched-process
@@ -346,6 +366,60 @@ def render_watcher_script(request: RefreshWatcherRequest) -> str:
         "def is_alive():\n"
         "    age = heartbeat_age()\n"
         "    return age is not None and age < 30\n"
+        # The attempt marker written before every start_agent lets the health
+        # check attribute a duplicate-guard line to *this* attempt. Read only the
+        # tail so a multi-hundred-megabyte relaunch log stays cheap to poll, and
+        # report False whenever this attempt's marker is not inside that window,
+        # so a stale guard line from an earlier attempt can never end the poll.
+        "def _attempt_marker(attempt):\n"
+        "    return f'--- relaunch attempt {attempt} ---'\n"
+        "def _duplicate_guard_seen(attempt):\n"
+        "    try:\n"
+        "        with open(stderr_log, 'rb') as f:\n"
+        "            try:\n"
+        "                f.seek(0, os.SEEK_END)\n"
+        "                f.seek(max(0, f.tell() - 8192))\n"
+        "            except OSError:\n"
+        "                pass\n"
+        "            window = f.read().decode('utf-8', 'replace')\n"
+        "    except OSError:\n"
+        "        return False\n"
+        "    marker = _attempt_marker(attempt)\n"
+        "    if marker not in window:\n"
+        "        return False\n"
+        "    return DUPLICATE_GUARD_MESSAGE in window.rsplit(marker, 1)[1]\n"
+        # Poll for a fresh heartbeat instead of sampling once after a fixed
+        # sleep: a slow MCP boot writes its first heartbeat well after
+        # HEALTH_CHECK_WAIT (incident 2026-08-19) and was being declared dead.
+        # The poll is bounded by HEALTH_CHECK_BUDGET so the watcher still
+        # terminates, and returns early once this attempt's own stderr proves
+        # the launch was refused by the duplicate guard and no heartbeat is
+        # coming, after one settle interval so that launch finishes flushing.
+        # Freshness is safe to test immediately: the attempt only
+        # reaches here after the is_alive() gate proved the heartbeat was
+        # missing or at least 30s old, so anything younger than
+        # HEALTH_CHECK_WAIT + 10 was written by the process just started.
+        "def _await_fresh_heartbeat(attempt):\n"
+        "    started = time.time()\n"
+        "    deadline = started + HEALTH_CHECK_BUDGET\n"
+        "    guard_seen = False\n"
+        "    while True:\n"
+        "        age = heartbeat_age()\n"
+        "        if age is not None and age < HEALTH_CHECK_WAIT + 10:\n"
+        "            return round(time.time() - started, 3)\n"
+        "        if guard_seen:\n"
+        "            return None\n"
+        "        if _duplicate_guard_seen(attempt):\n"
+        # Settle for one poll interval before giving up: the refused launch
+        # writes its 'PID <n>' line immediately after the guard line, and the
+        # caller reads that tail to identify the duplicate.
+        "            guard_seen = True\n"
+        "            time.sleep(WATCHER_POLL_INTERVAL)\n"
+        "            continue\n"
+        "        remaining = deadline - time.time()\n"
+        "        if remaining <= 0:\n"
+        "            return None\n"
+        "        time.sleep(min(WATCHER_POLL_INTERVAL, remaining))\n"
         "def _extract_duplicate_pid(stderr_tail):\n"
         "    for line in stderr_tail.splitlines():\n"
         "        line = line.strip()\n"
@@ -413,6 +487,35 @@ def render_watcher_script(request: RefreshWatcherRequest) -> str:
         "        failure_state['last_cleanup_result'] = 'sigkill_error'\n"
         "        failure_state['last_cleanup_error'] = str(e)\n"
         "        return False\n"
+        # graceful_stop/force_stop only *request* the duplicate's exit. Starting
+        # the next relaunch while the duplicate still holds the working directory
+        # reproduces the same guard and burns another attempt (incident
+        # 2026-08-19), so wait a bounded DUPLICATE_EXIT_WAIT before retrying.
+        #
+        # The blocking condition is re-checked with the same canonical
+        # same-agent-run guard cleanup used, not with a bare liveness probe: the
+        # duplicate is frequently a process this very watcher launched on an
+        # earlier attempt, and the watcher never reaps its children, so after a
+        # SIGKILL its PID survives as a zombie that a liveness probe would report
+        # alive forever. A zombie's process-table command line no longer matches
+        # an agent run for this working directory, so it correctly reads as gone.
+        #
+        # If a live duplicate outlives the wait, record that in failure_state and
+        # let the loop retry anyway rather than hanging.
+        "def _await_duplicate_exit(attempt, pid):\n"
+        "    if not pid:\n"
+        "        return True\n"
+        "    deadline = time.time() + DUPLICATE_EXIT_WAIT\n"
+        "    while True:\n"
+        "        if not _is_same_agent_run(pid):\n"
+        "            return True\n"
+        "        remaining = deadline - time.time()\n"
+        "        if remaining <= 0:\n"
+        "            log('refresh_watcher_stale_duplicate_still_alive', attempt=attempt,\n"
+        "                pid=pid, waited=DUPLICATE_EXIT_WAIT)\n"
+        "            failure_state['last_cleanup_result'] = 'still_alive'\n"
+        "            return False\n"
+        "        time.sleep(min(WATCHER_POLL_INTERVAL, remaining))\n"
         "for attempt in range(1, MAX_ATTEMPTS + 1):\n"
         "    # Check if already alive before relaunching\n"
         "    if is_alive():\n"
@@ -427,7 +530,7 @@ def render_watcher_script(request: RefreshWatcherRequest) -> str:
         "    log('refresh_watcher_relaunch', attempt=attempt)\n"
         "    try:\n"
         "        with open(stderr_log, 'a') as serr:\n"
-        "            serr.write(f'--- relaunch attempt {attempt} ---\\n')\n"
+        "            serr.write(_attempt_marker(attempt) + '\\n')\n"
         "            serr.flush()\n"
         "        proc = _process_mechanism().start_agent(cmd, stderr_log)\n"
         "    except Exception as e:\n"
@@ -447,16 +550,11 @@ def render_watcher_script(request: RefreshWatcherRequest) -> str:
         "    failure_state['last_relaunch_pid'] = proc.pid\n"
         "    failure_state['last_relaunch_error'] = None\n"
         "    # Wait for the new process to start writing heartbeat\n"
-        "    time.sleep(HEALTH_CHECK_WAIT)\n"
-        "    hb = os.path.join(wd, '.agent.heartbeat')\n"
-        "    if os.path.exists(hb):\n"
-        "        try:\n"
-        "            hb_ts = float(open(hb).read().strip())\n"
-        "            if time.time() - hb_ts < HEALTH_CHECK_WAIT + 10:\n"
-        "                log('refresh_watcher_success', attempt=attempt, pid=proc.pid)\n"
-        "                sys.exit(0)\n"
-        "        except (ValueError, OSError):\n"
-        "            pass\n"
+        "    heartbeat_wait = _await_fresh_heartbeat(attempt)\n"
+        "    if heartbeat_wait is not None:\n"
+        "        log('refresh_watcher_success', attempt=attempt, pid=proc.pid,\n"
+        "            heartbeat_wait=heartbeat_wait)\n"
+        "        sys.exit(0)\n"
         "    # Process not alive — log failure and retry\n"
         "    stderr_tail = ''\n"
         "    try:\n"
@@ -474,11 +572,21 @@ def render_watcher_script(request: RefreshWatcherRequest) -> str:
         "    failure_state['last_cleanup_error'] = None\n"
         "    log('refresh_watcher_relaunch_dead', attempt=attempt, pid=proc.pid,\n"
         "        stderr_tail=stderr_tail[-500:])\n"
-        "    if 'another lingtai agent is already running' in stderr_tail:\n"
-        "        _cleanup_stale_duplicate(stderr_tail, attempt)\n"
+        "    if DUPLICATE_GUARD_MESSAGE in stderr_tail:\n"
+        "        if _cleanup_stale_duplicate(stderr_tail, attempt):\n"
+        "            _await_duplicate_exit(attempt, failure_state['last_duplicate_pid'])\n"
         "alert_id, meta = _publish_refresh_failed_permanent()\n"
         "log('refresh_failed_permanent', alert_id=alert_id, **meta)\n"
     )
 
 
-__all__ = ["render_watcher_script", "MAX_ATTEMPTS", "HEALTH_CHECK_WAIT", "STDERR_TAIL_CHARS"]
+__all__ = [
+    "render_watcher_script",
+    "MAX_ATTEMPTS",
+    "HEALTH_CHECK_WAIT",
+    "HEALTH_CHECK_BUDGET",
+    "WATCHER_POLL_INTERVAL",
+    "DUPLICATE_EXIT_WAIT",
+    "STDERR_TAIL_CHARS",
+    "DUPLICATE_GUARD_MESSAGE",
+]

--- a/tests/test_perform_refresh_handshake.py
+++ b/tests/test_perform_refresh_handshake.py
@@ -93,6 +93,14 @@ def _fast_watcher_script(script: str) -> str:
         script
         .replace("MAX_ATTEMPTS = 12", "MAX_ATTEMPTS = 2")
         .replace("HEALTH_CHECK_WAIT = 10", "HEALTH_CHECK_WAIT = 0.1")
+        # The health check polls for a fresh heartbeat instead of sampling once
+        # (slow-MCP-boot incident 2026-08-19), and waits for a terminated
+        # duplicate to release the working directory before retrying. Both
+        # windows are bounded by module-top constants; shrink them so these
+        # subprocess tests still finish inside their timeout.
+        .replace("HEALTH_CHECK_BUDGET = 60", "HEALTH_CHECK_BUDGET = 5")
+        .replace("WATCHER_POLL_INTERVAL = 0.5", "WATCHER_POLL_INTERVAL = 0.02")
+        .replace("DUPLICATE_EXIT_WAIT = 15", "DUPLICATE_EXIT_WAIT = 1")
         .replace("deadline = time.time() + 60", "deadline = time.time() + 1")
         .replace("deadline = time.time() + 5", "deadline = time.time() + 0.05")
     )
@@ -784,6 +792,53 @@ def test_refresh_watcher_script_cleans_stale_duplicate_process(tmp_path):
     assert ".graceful_stop(observation)" in script
     assert ".force_stop(observation)" in script
     assert "refresh_watcher_stale_duplicate" in script
+
+
+def test_refresh_watcher_script_bounds_health_check_and_duplicate_exit_waits(tmp_path):
+    """Production incident 2026-08-19 (spiritual-bliss-attractor codex): all 12
+    relaunch attempts were starved because the health check slept
+    `HEALTH_CHECK_WAIT` once and read `.agent.heartbeat` a single time — too
+    early for an agent still spawning MCP stdio servers — and because the loop
+    retried immediately after SIGKILLing a duplicate that had not yet released
+    the working directory. The rendered policy must therefore carry a bounded
+    heartbeat poll and a bounded post-cleanup exit wait, both as module-top
+    constants rather than inline literals, and must still terminate.
+    """
+    from lingtai.kernel.refresh_watcher.watcher_program import (
+        DUPLICATE_EXIT_WAIT,
+        HEALTH_CHECK_BUDGET,
+        HEALTH_CHECK_WAIT,
+        MAX_ATTEMPTS,
+        WATCHER_POLL_INTERVAL,
+    )
+
+    agent = _make_agent_with_launch_cmd(tmp_path)
+    script = _capture_watcher_script(agent)
+
+    # The contract's default attempt budget is unchanged by this fix.
+    assert MAX_ATTEMPTS == 12
+    # The poll budget must actually cover a slow MCP boot, i.e. be meaningfully
+    # longer than the single sleep it replaces, and be bounded.
+    assert HEALTH_CHECK_BUDGET > HEALTH_CHECK_WAIT
+    assert 0 < WATCHER_POLL_INTERVAL < HEALTH_CHECK_BUDGET
+    assert 0 < DUPLICATE_EXIT_WAIT
+
+    assert f"HEALTH_CHECK_BUDGET = {HEALTH_CHECK_BUDGET}" in script
+    assert f"WATCHER_POLL_INTERVAL = {WATCHER_POLL_INTERVAL}" in script
+    assert f"DUPLICATE_EXIT_WAIT = {DUPLICATE_EXIT_WAIT}" in script
+
+    # The single blind sleep-then-sample health check is gone.
+    assert "if time.time() - hb_ts < HEALTH_CHECK_WAIT + 10:" not in script
+    assert "def _await_fresh_heartbeat(attempt):" in script
+    assert "deadline = started + HEALTH_CHECK_BUDGET" in script
+
+    # Cleanup's exit wait reuses the canonical same-agent guard rather than a
+    # bare liveness probe: a duplicate this watcher itself launched is never
+    # reaped, so its PID survives as a zombie a liveness probe calls alive.
+    assert "def _await_duplicate_exit(attempt, pid):" in script
+    assert "if not _is_same_agent_run(pid):" in script
+    assert "failure_state['last_cleanup_result'] = 'still_alive'" in script
+    assert "_await_duplicate_exit(attempt, failure_state['last_duplicate_pid'])" in script
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_refresh_watcher_process.py
+++ b/tests/test_refresh_watcher_process.py
@@ -1,7 +1,10 @@
 """Behavioral evidence for the watcher-local process-mechanism Port."""
 from __future__ import annotations
 
+import json
 import sys
+import threading
+import time
 from pathlib import Path
 
 import pytest
@@ -78,15 +81,28 @@ class FakeWatcherProcess(RefreshWatcherProcessPort):
         self.duplicate_alive = False
 
 
-def _run_policy(
-    tmp_path: Path,
-    *,
-    force: bool,
-    include_duplicate_pid: bool = True,
-) -> FakeWatcherProcess:
-    working_dir = tmp_path / ("force" if force else "graceful")
+def _prepare_working_dir(tmp_path: Path, slug: str) -> Path:
+    working_dir = tmp_path / slug
     (working_dir / "logs").mkdir(parents=True)
     (working_dir / ".refresh.taken").touch()
+    return working_dir
+
+
+def _fast_policy_script(
+    working_dir: Path,
+    *,
+    max_attempts: str = "2",
+    health_check_wait: str = "0.01",
+    health_check_budget: str = "1",
+    poll_interval: str = "0.005",
+    duplicate_exit_wait: str = "0.05",
+) -> str:
+    """Render the policy with every wall-clock constant shrunk for tests.
+
+    The renderer keeps its timing policy in module-top constants that are
+    embedded as plain assignments, so tests substitute the assignment text
+    rather than reaching into the generated program's runtime state.
+    """
     request = RefreshWatcherRequest(
         taken_path=str(working_dir / ".refresh.taken"),
         lock_path=str(working_dir / ".agent.lock"),
@@ -97,14 +113,38 @@ def _run_policy(
         agent_name="alice",
         address=str(working_dir),
     )
-    script = render_watcher_script(request)
-    script = (
-        script.replace("MAX_ATTEMPTS = 12", "MAX_ATTEMPTS = 2")
-        .replace("HEALTH_CHECK_WAIT = 10", "HEALTH_CHECK_WAIT = 0.01")
+    return (
+        render_watcher_script(request)
+        .replace("MAX_ATTEMPTS = 12", f"MAX_ATTEMPTS = {max_attempts}")
+        .replace("HEALTH_CHECK_WAIT = 10", f"HEALTH_CHECK_WAIT = {health_check_wait}")
+        .replace(
+            "HEALTH_CHECK_BUDGET = 60", f"HEALTH_CHECK_BUDGET = {health_check_budget}"
+        )
+        .replace(
+            "WATCHER_POLL_INTERVAL = 0.5", f"WATCHER_POLL_INTERVAL = {poll_interval}"
+        )
+        .replace(
+            "DUPLICATE_EXIT_WAIT = 15", f"DUPLICATE_EXIT_WAIT = {duplicate_exit_wait}"
+        )
         .replace("deadline = time.time() + 60", "deadline = time.time() + 1")
         .replace("deadline = time.time() + 5", "deadline = time.time() + 0.02")
         .replace("time.sleep(0.2)", "time.sleep(0.005)")
     )
+
+
+def _read_events(working_dir: Path) -> list[dict]:
+    raw = (working_dir / "logs" / "events.jsonl").read_text(encoding="utf-8")
+    return [json.loads(line) for line in raw.splitlines() if line.strip()]
+
+
+def _run_policy(
+    tmp_path: Path,
+    *,
+    force: bool,
+    include_duplicate_pid: bool = True,
+) -> FakeWatcherProcess:
+    working_dir = _prepare_working_dir(tmp_path, "force" if force else "graceful")
+    script = _fast_policy_script(working_dir)
     mechanism = FakeWatcherProcess(
         working_dir,
         force=force,
@@ -137,7 +177,11 @@ def test_refresh_watcher_selector_returns_windows_adapter_on_win32(monkeypatch):
 def test_core_policy_chooses_process_port_operations_without_keywords(tmp_path):
     graceful = _run_policy(tmp_path, force=False)
     assert graceful.launches == 2
-    assert [name for name, _ in graceful.calls].count("observe") == 1
+    # One observation to decide the duplicate is this same agent, plus one to
+    # re-check the same-agent guard after termination — the policy will not
+    # start the next attempt into a duplicate that is still holding the
+    # working directory.
+    assert [name for name, _ in graceful.calls].count("observe") == 2
     assert ("graceful_stop", 4242) in graceful.calls
     assert not any(name == "force_stop" for name, _ in graceful.calls)
     assert ("start_agent", 1) in graceful.calls
@@ -162,3 +206,226 @@ def test_core_policy_does_not_observe_missing_duplicate_pid(tmp_path):
     assert not any(name == "observe" for name, _ in mechanism.calls)
     assert not any(name == "graceful_stop" for name, _ in mechanism.calls)
     assert not any(name == "force_stop" for name, _ in mechanism.calls)
+
+
+# ---------------------------------------------------------------------------
+# Slow boot vs. duplicate starvation (production incident 2026-08-19)
+#
+# `logs/refresh_failed_permanent.json` for the spiritual-bliss-attractor codex
+# agent recorded 12 exhausted relaunch attempts with the heartbeat missing. The
+# relaunch log showed each attempt either booting MCP stdio servers (imap and
+# telegram slow to connect, so the first heartbeat landed well after the 10s
+# health-check sleep) or colliding with the previous not-yet-dead process,
+# whose SIGKILL the loop never waited on before retrying. The three fakes below
+# reproduce each half of that starvation against the generated Core policy.
+# ---------------------------------------------------------------------------
+
+
+class SlowBootProcess(RefreshWatcherProcessPort):
+    """A relaunch whose first heartbeat lands well after HEALTH_CHECK_WAIT."""
+
+    def __init__(self, working_dir: Path, *, boot_delay: float) -> None:
+        self.working_dir = working_dir
+        self.boot_delay = boot_delay
+        self.launches = 0
+        self.timers: list[threading.Timer] = []
+
+    def _write_heartbeat(self) -> None:
+        (self.working_dir / ".agent.heartbeat").write_text(
+            str(time.time()), encoding="utf-8"
+        )
+
+    def observe(self, pid):  # pragma: no cover - never reached in this scenario
+        raise AssertionError("a healthy slow boot must not inspect a duplicate")
+
+    def is_alive(self, process) -> bool:  # pragma: no cover - not reached
+        raise AssertionError("a healthy slow boot must not probe liveness")
+
+    def start_agent(self, cmd, stderr_log: str) -> RefreshWatcherProcessHandle:
+        self.launches += 1
+        timer = threading.Timer(self.boot_delay, self._write_heartbeat)
+        timer.daemon = True
+        self.timers.append(timer)
+        timer.start()
+        return RefreshWatcherProcessHandle(pid=9100 + self.launches)
+
+    def graceful_stop(self, process) -> None:  # pragma: no cover - not reached
+        raise AssertionError("a healthy slow boot must not be terminated")
+
+    def force_stop(self, process) -> None:  # pragma: no cover - not reached
+        raise AssertionError("a healthy slow boot must not be killed")
+
+
+def test_slow_booting_relaunch_is_accepted_within_the_bounded_poll_window(tmp_path):
+    """A first heartbeat arriving after HEALTH_CHECK_WAIT is still a success.
+
+    The previous policy slept exactly HEALTH_CHECK_WAIT once and read the
+    heartbeat a single time, so an agent still spawning MCP stdio servers was
+    declared dead and retried until the attempts ran out. The health check now
+    polls until HEALTH_CHECK_BUDGET expires, so one launch is enough.
+    """
+    working_dir = _prepare_working_dir(tmp_path, "slow-boot")
+    script = _fast_policy_script(
+        working_dir,
+        health_check_wait="0.05",
+        health_check_budget="5",
+        poll_interval="0.01",
+    )
+    mechanism = SlowBootProcess(working_dir, boot_delay=0.4)
+
+    with pytest.raises(SystemExit) as exit_info:
+        exec(compile(script, "<refresh-policy>", "exec"), {"PROCESS_MECHANISM": mechanism})
+
+    assert exit_info.value.code == 0
+    assert mechanism.launches == 1, "a slow boot must not cost a second attempt"
+
+    success = [e for e in _read_events(working_dir) if e["type"] == "refresh_watcher_success"]
+    assert len(success) == 1
+    # The heartbeat genuinely arrived later than the old single sleep would
+    # have waited, so this is evidence of the poll and not of a lucky sample.
+    assert success[0]["heartbeat_wait"] > 0.05
+    assert not (working_dir / "logs" / "refresh_failed_permanent.json").exists()
+
+
+class UnkillableDuplicateProcess(RefreshWatcherProcessPort):
+    """Every relaunch collides with a same-agent duplicate that never dies."""
+
+    DUPLICATE_PID = 4242
+
+    def __init__(self, working_dir: Path) -> None:
+        self.working_dir = working_dir
+        self.launches = 0
+        self.calls: list[tuple[str, int | None]] = []
+        self.observation = RefreshWatcherProcessObservation(
+            pid=self.DUPLICATE_PID,
+            command_line=f"{sys.executable} -m lingtai run {working_dir}",
+        )
+
+    def observe(self, pid: int):
+        self.calls.append(("observe", pid))
+        return self.observation if pid == self.DUPLICATE_PID else None
+
+    def is_alive(self, process) -> bool:
+        self.calls.append(("is_alive", process.pid))
+        return process.pid == self.DUPLICATE_PID
+
+    def start_agent(self, cmd, stderr_log: str) -> RefreshWatcherProcessHandle:
+        self.launches += 1
+        self.calls.append(("start_agent", self.launches))
+        with open(stderr_log, "a", encoding="utf-8") as stream:
+            stream.write("another lingtai agent is already running\n")
+            stream.write(f"PID {self.DUPLICATE_PID}: stale duplicate\n")
+        return RefreshWatcherProcessHandle(pid=9200 + self.launches)
+
+    def graceful_stop(self, process) -> None:
+        self.calls.append(("graceful_stop", process.pid))
+
+    def force_stop(self, process) -> None:
+        self.calls.append(("force_stop", process.pid))
+
+
+def test_undying_duplicate_records_still_alive_and_fails_permanently(tmp_path):
+    """An unkillable duplicate must be reported honestly, not retried forever.
+
+    Every attempt terminates the duplicate, waits DUPLICATE_EXIT_WAIT for it to
+    release the working directory, and gives up on that wait rather than
+    hanging. After MAX_ATTEMPTS the terminal artifact says exactly that.
+    """
+    working_dir = _prepare_working_dir(tmp_path, "undying-duplicate")
+    script = _fast_policy_script(working_dir, max_attempts="3")
+    mechanism = UnkillableDuplicateProcess(working_dir)
+
+    # The loop runs to exhaustion and publishes the terminal alert; it does not
+    # exit early, so no SystemExit is raised here.
+    exec(compile(script, "<refresh-policy>", "exec"), {"PROCESS_MECHANISM": mechanism})
+
+    assert mechanism.launches == 3
+    assert ("force_stop", 4242) in mechanism.calls
+
+    artifact = json.loads(
+        (working_dir / "logs" / "refresh_failed_permanent.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    metadata = artifact["metadata"]
+    assert artifact["type"] == "refresh_failed_permanent"
+    assert metadata["attempts"] == 3
+    assert metadata["last_duplicate_pid"] == 4242
+    assert metadata["last_cleanup_action"] == "terminate_stale_duplicate"
+    assert metadata["last_cleanup_result"] == "still_alive"
+
+    types = [event["type"] for event in _read_events(working_dir)]
+    assert types.count("refresh_watcher_stale_duplicate_still_alive") == 3
+    assert types.count("refresh_watcher_success") == 0
+    assert types[-1] == "refresh_failed_permanent"
+
+
+class DelayedDeathDuplicateProcess(RefreshWatcherProcessPort):
+    """The duplicate only leaves the process table some time after force_stop."""
+
+    DUPLICATE_PID = 4242
+
+    def __init__(self, working_dir: Path, *, death_delay: float) -> None:
+        self.working_dir = working_dir
+        self.death_delay = death_delay
+        self.launches = 0
+        self.death_time: float | None = None
+        self.start_times: list[float] = []
+        self.observation = RefreshWatcherProcessObservation(
+            pid=self.DUPLICATE_PID,
+            command_line=f"{sys.executable} -m lingtai run {working_dir}",
+        )
+
+    def _dead(self) -> bool:
+        return self.death_time is not None and time.time() >= self.death_time
+
+    def observe(self, pid: int):
+        return self.observation if pid == self.DUPLICATE_PID else None
+
+    def is_alive(self, process) -> bool:
+        return process.pid == self.DUPLICATE_PID and not self._dead()
+
+    def start_agent(self, cmd, stderr_log: str) -> RefreshWatcherProcessHandle:
+        self.launches += 1
+        self.start_times.append(time.time())
+        if self.launches == 1:
+            with open(stderr_log, "a", encoding="utf-8") as stream:
+                stream.write("another lingtai agent is already running\n")
+                stream.write(f"PID {self.DUPLICATE_PID}: stale duplicate\n")
+        else:
+            (self.working_dir / ".agent.heartbeat").write_text(
+                str(time.time()), encoding="utf-8"
+            )
+        return RefreshWatcherProcessHandle(pid=9300 + self.launches)
+
+    def graceful_stop(self, process) -> None:
+        """Requested, but this duplicate ignores the graceful stop."""
+
+    def force_stop(self, process) -> None:
+        self.death_time = time.time() + self.death_delay
+
+
+def test_next_attempt_waits_for_the_killed_duplicate_to_actually_exit(tmp_path):
+    """The retry must not start into a duplicate that is still holding the dir.
+
+    `force_stop` only *requests* the exit. Starting the next relaunch before it
+    completes is what reproduced 'another lingtai agent is already running' on
+    attempt after attempt in the incident.
+    """
+    working_dir = _prepare_working_dir(tmp_path, "delayed-death")
+    script = _fast_policy_script(working_dir, duplicate_exit_wait="5")
+    mechanism = DelayedDeathDuplicateProcess(working_dir, death_delay=0.3)
+
+    with pytest.raises(SystemExit) as exit_info:
+        exec(compile(script, "<refresh-policy>", "exec"), {"PROCESS_MECHANISM": mechanism})
+
+    assert exit_info.value.code == 0
+    assert mechanism.launches == 2
+    assert mechanism.death_time is not None
+    # The second launch happened only after the duplicate was actually gone.
+    assert mechanism.start_times[1] >= mechanism.death_time
+
+    types = [event["type"] for event in _read_events(working_dir)]
+    assert "refresh_watcher_stale_duplicate_killed" in types
+    assert "refresh_watcher_stale_duplicate_still_alive" not in types
+    assert "refresh_watcher_success" in types


### PR DESCRIPTION
## Problem

SciAccelBench root agent (spiritual-bliss-attractor/.lingtai/codex) failed to reboot on 2026-08-19: refresh_failed_permanent.json recorded 12 relaunch attempts with last heartbeat missing, cleanup terminate_stale_duplicate -> sigkill_sent.

The refresh watcher only declared success when a fresh `.agent.heartbeat` appeared within a single fixed `HEALTH_CHECK_WAIT` (10s) sleep, but the relaunched agent boots slower than that (reads init.json, then starts 4 MCP stdio servers — feishu/imap/telegram/wechat). Each retry then collided with the previous not-fully-dead process ("another lingtai agent is already running PID …"), triggering a sigkill that severed MCP children pipes (BrokenPipeError noise — a symptom of the kill race, not the primary blocker). After 12 attempts the watcher wrote refresh_failed_permanent with heartbeat still missing.

## Fix

1. **Bounded heartbeat polling** replaces the single 10s sample: poll `.agent.heartbeat` every `WATCHER_POLL_INTERVAL` (0.5s) until a fresh heartbeat (age < HEALTH_CHECK_WAIT+10) appears or `HEALTH_CHECK_BUDGET` (60s) expires, so a slow MCP boot is accepted rather than declared dead. Success event now carries `heartbeat_wait=<seconds>` for diagnosability. Early exit when this attempt's own stderr proves the duplicate guard refused the launch.
2. **Wait for the stale duplicate to actually go** before the next attempt: after `_cleanup_stale_duplicate` returns true, `_await_duplicate_exit` polls up to `DUPLICATE_EXIT_WAIT` (15s) using the canonical same-agent-run guard (`not _is_same_agent_run(pid)` — deliberately not bare liveness, because the watcher never reaps its children so a SIGKILLed duplicate survives as a zombie that a liveness probe reports alive forever). On timeout it logs `refresh_watcher_stale_duplicate_still_alive` and records `last_cleanup_result = "still_alive"`, then retries.

Contract intact: same refresh_failed_permanent.json fields, MAX_ATTEMPTS=12, duplicate-identity verification, redaction, notification lock, heartbeat freshness threshold. No new flags; additions are three timing constants + one new event type + one new last_cleanup_result value.

## Validation

- `git diff --check` clean.
- `python -m pytest tests/test_refresh_watcher_process.py tests/test_perform_refresh_handshake.py tests/test_deep_refresh.py tests/test_architecture_documents.py -q` → **92 passed, 1 failed**; the single failure is a pre-existing baseline in `test_architecture_documents.py` (duplicate `related_files` entry in `src/lingtai/llm/ANATOMY.md` at base HEAD, untouched by this patch).
- Three new focused tests: slow-boot relaunch accepted within the bounded poll window; undying duplicate records `still_alive` and fails permanently after MAX_ATTEMPTS; next attempt waits for the killed duplicate to actually exit.
- Worst-case time to a refresh_failed_permanent alert grows from ~3 min to ~16 min (bounded); incident-shaped collisions cost ~20s/attempt (~4 min). `HEALTH_CHECK_BUDGET` is the single knob if that trade is wrong.

## Note

- Missing `.secrets/feishu.json` / wechat config on the incident agent are secondary config errors (non-fatal), not addressed here.
- The MCP BrokenPipeError in the incident is treated as the documented symptom of the SIGKILL severing stdio pipes; if it proves an independent fault it needs its own fix.

Telegram: @lingtaidev3bot | Nickname: 澄一
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
