### PR TITLE
daemon: add lingtai-agent daemon run-sync headless subcommand

### DIFF
--- a/src/lingtai/cli_daemon.py
+++ b/src/lingtai/cli_daemon.py
@@ -9,7 +9,8 @@ skin over the *existing* engine: it builds a minimal agent-shaped facade
 model uses.  No emanation, preset, run-directory, supervisor, or notification
 logic is reimplemented here.
 
-Four actions are exposed, deliberately fewer than the tool's six:
+Five actions are exposed: four deliberately fewer than the tool's six, plus
+one the tool has no need for:
 
 ``emanate``
     Dispatch a batch from a tasks JSON file.  Preview-by-default; ``--yes`` is
@@ -37,13 +38,25 @@ Four actions are exposed, deliberately fewer than the tool's six:
     ``daemon(action="reclaim")`` uses — a CLI-created daemon stays exactly as
     controllable as an agent-created one.
 
+``run-sync``
+    One prompt in, one result out, blocking — the ``claude -p`` / ``codex
+    exec`` shape, for a caller that is a script rather than an agent.  It is
+    composition, not a fifth engine path: a single-task ``emanate`` request is
+    built in memory and put through the *same* schema validation, preset gate,
+    capability gate, and family dispatch ``emanate --yes`` uses, then the
+    read-only ``check`` binding above is polled until the run is terminal.
+    The model never needs this action — an agent that blocks on its own daemon
+    has simply made a synchronous call — so it exists only here.
+
 ``ask`` is intentionally absent.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
+import time
 from pathlib import Path
 from typing import Any
 
@@ -58,6 +71,18 @@ _MAX_TASKS_FILE_BYTES = 4 * 1024 * 1024
 
 #: Task text shown per row in the ``emanate`` preview.
 _PREVIEW_TASK_CHARS = 120
+
+#: Default ``run-sync`` poll cadence, seconds. Short enough that a quick
+#: emanation is not padded by the wait, long enough that a long one does not
+#: re-read ``events.jsonl`` and ``daemon.json`` in a tight loop.
+_RUN_SYNC_POLL_INTERVAL_S = 2.0
+
+#: Consulted for ``run-sync``'s preset when ``--preset`` is absent, so a shell
+#: or CI job can pin one preset for a whole session of calls. The flag wins.
+_RUN_SYNC_PRESET_ENV = "LINGTAI_P_PRESET"
+
+#: Per-field width of a ``--stream`` tail line.
+_STREAM_FIELD_CHARS = 100
 
 
 class CliDaemonError(Exception):
@@ -613,7 +638,8 @@ def _collect(value: Any, schema: dict, path: str) -> list[str]:
     return errors
 
 
-def _validate_emanate_input(payload: dict) -> list[dict]:
+def _validate_emanate_input(payload: dict, *,
+                            source: str = "--tasks file") -> list[dict]:
     """Validate the tasks file against the daemon tool's own ``emanate`` schema.
 
     This runs at **preview** time, before ``--yes`` is even considered, so a
@@ -635,6 +661,11 @@ def _validate_emanate_input(payload: dict) -> list[dict]:
     ``_tool_family`` so the engine can return domain-specific errors, but a
     typo'd key in a CI tasks file should not be silently ignored; the property
     list is read from the schema, so it tracks the schema automatically.
+
+    ``source`` names the caller in the two whole-request refusals, so
+    ``run-sync`` — which builds its request in memory — does not report a
+    ``--tasks file`` it was never given. Only the wording moves; every rule
+    below is the one both callers are held to.
     """
     from lingtai.tools.daemon import _BACKEND_SCHEMA_ENUM
     from lingtai.tools.daemon._tool_family import (
@@ -654,13 +685,13 @@ def _validate_emanate_input(payload: dict) -> list[dict]:
     _check_schema(candidate, input_schema, "", errors)
     if errors:
         raise CliDaemonError(
-            "--tasks file does not match the daemon emanate schema:\n  - "
+            f"{source} does not match the daemon emanate schema:\n  - "
             + "\n  - ".join(errors)
         )
 
     tasks = candidate["tasks"]
     if not tasks:
-        raise CliDaemonError("--tasks file defines no tasks")
+        raise CliDaemonError(f"{source} defines no tasks")
 
     for i, spec in enumerate(tasks):
         unknown = sorted(set(spec) - task_props)
@@ -997,11 +1028,339 @@ def _handle_reclaim(args) -> int:
     return 0 if result.get("status") == "reclaimed" else 1
 
 
+# --------------------------------------------------------------------------
+# run-sync — one prompt in, one result out
+# --------------------------------------------------------------------------
+
+
+def _parse_tools_flag(raw: str | None) -> list[str] | None:
+    """Split ``--tools a,b,c`` into a list; ``None`` means the flag was absent.
+
+    An explicitly empty value (``--tools ""``) is an empty list — a deliberate
+    result-only daemon — and is kept distinct from an absent flag, which
+    inherits the surface :func:`_default_run_sync_tools` derives.
+    """
+    if raw is None:
+        return None
+    return [name.strip() for name in raw.split(",") if name.strip()]
+
+
+def _default_run_sync_tools(agent: _CliDaemonAgent) -> list[str]:
+    """The tool surface a bare ``run-sync`` (no ``--tools``) inherits.
+
+    ``emanate`` never needs this: its tasks file always states ``tools``,
+    because the daemon schema requires the field.  A ``-p``-shaped call has no
+    file, so the default has to come from somewhere — and it is read off the
+    engine rather than chosen: ``_parent_host_tool_floor()``, intersected with
+    what this agent actually grants.
+
+    That floor is the right default for three independent reasons, all of them
+    the engine's own facts:
+
+    * It is the one parent surface reachable in **both** branches of
+      ``_build_tool_surface``.  A preset emanation may borrow only the floor,
+      so a wider default would ask a preset's sandbox for tools it does not
+      have and the engine would refuse the run outright — the default must not
+      be able to do that, and this one cannot, preset or no preset.
+    * It is the host primitive set — read/write/edit/glob/grep plus shell —
+      which is what a one-shot external call actually needs.  Optional and
+      provider capabilities (``vision``, ``web_search``, …) are opt-in through
+      ``--tools``, fail-closed, exactly as they are for a preset emanation.
+    * It is instantiable on this facade.  ``_CliDaemonAgent`` is deliberately
+      not a live :class:`~lingtai.agent.Agent`; capabilities that reconcile a
+      system-prompt section (``mcp``, ``knowledge``) raise ``AttributeError``
+      against it, which ``install_tool_surface`` does not catch — it catches
+      what ``Agent.__init__`` catches, and widening that here would make the
+      CLI more tolerant than the agent it stands in for.
+
+    The intersection with :meth:`effective_capabilities` means an agent that
+    put ``shell`` in ``manifest.disable`` does not get it back through an
+    implicit default; the return value is taken *after*
+    :meth:`install_tool_surface` so a capability whose ``setup()`` was skipped
+    is never requested either.
+    """
+    from lingtai.tools.daemon import _parent_host_tool_floor
+
+    agent.install_tool_surface(
+        set(agent.effective_capabilities()) & _parent_host_tool_floor()
+    )
+    return sorted(schema.name for schema in agent._tool_schemas)
+
+
+def _resolve_run_sync_preset(args) -> str | None:
+    """``--preset`` wins over ``LINGTAI_P_PRESET``; neither means "inherit".
+
+    Returning ``None`` leaves the task's ``preset`` key *omitted*, which is the
+    engine's existing no-preset path (inherit the parent's regular tool surface
+    and the implicit parent preset LLM) — no separate CLI fallback exists or
+    should.
+    """
+    for candidate in (args.preset, os.environ.get(_RUN_SYNC_PRESET_ENV)):
+        if isinstance(candidate, str) and candidate.strip():
+            return candidate.strip()
+    return None
+
+
+class _EventTail:
+    """Byte-offset tail over one run's append-only ``logs/events.jsonl``.
+
+    Read in binary and resumed from :meth:`tell` so a multi-byte character
+    split across two polls is never decoded twice or mangled, and a line still
+    mid-write is held back as ``_partial`` until its newline lands.  The file
+    is the daemon's own event log, written for ``check``; nothing here asks the
+    run to produce anything extra.
+    """
+
+    def __init__(self, events_path: Path) -> None:
+        self._path = events_path
+        self._offset = 0
+        self._partial = ""
+
+    def drain(self) -> list[dict]:
+        """Return every complete event appended since the last call."""
+        try:
+            size = self._path.stat().st_size
+        except OSError:
+            return []
+        if size < self._offset:  # replaced under us — restart rather than skew
+            self._offset = 0
+            self._partial = ""
+        if size == self._offset:
+            return []
+        try:
+            with open(self._path, "rb") as handle:
+                handle.seek(self._offset)
+                chunk = handle.read()
+                self._offset = handle.tell()
+        except OSError:
+            return []
+
+        lines = (self._partial + chunk.decode("utf-8", "replace")).split("\n")
+        self._partial = lines.pop()
+        events: list[dict] = []
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                parsed = json.loads(line)
+            except ValueError:
+                continue
+            if isinstance(parsed, dict):
+                events.append(parsed)
+        return events
+
+
+def _compact(value: str) -> str:
+    """Collapse a value to one short single-line fragment."""
+    text = " ".join(str(value).split())
+    if len(text) > _STREAM_FIELD_CHARS:
+        text = text[:_STREAM_FIELD_CHARS] + "…"
+    return text
+
+
+def _format_stream_event(event: dict) -> str:
+    """One compact line for one daemon event.
+
+    Redacted first with the same policy ``_emit_json`` applies, so a tool
+    argument preview carrying a credential-shaped key is not printed in the
+    clear just because it arrived through the live tail instead of the final
+    snapshot.
+    """
+    event = _redact_preserving_nulls(event)
+    parts = [str(event.get("event") or "event")]
+    for key in ("name", "status", "stream", "turn"):
+        value = event.get(key)
+        if value not in (None, ""):
+            parts.append(f"{key}={value}")
+    for key in ("args_preview", "text", "message", "detail", "result_path"):
+        value = event.get(key)
+        if isinstance(value, str) and value.strip():
+            parts.append(_compact(value))
+            break
+    return "· " + " ".join(parts)
+
+
+def _read_result_text(snapshot: dict) -> str:
+    """The run's full terminal result, falling back to the stored preview.
+
+    ``result.txt`` is the complete text; ``result_preview`` in ``daemon.json``
+    is capped by the writer.  Preferring the file means ``run-sync`` prints the
+    whole answer, and falling back means a run that recorded a preview but no
+    file (or whose file is unreadable) still prints what it has.
+    """
+    path = snapshot.get("result_path")
+    if isinstance(path, str) and path:
+        try:
+            return Path(path).read_text(encoding="utf-8")
+        except OSError:
+            pass
+    preview = snapshot.get("result_preview")
+    return preview if isinstance(preview, str) else ""
+
+
+def _poll_until_terminal(agent_dir: Path, em_id: str, *, poll_interval: float,
+                         deadline: float | None, stream: bool) -> tuple[dict, bool]:
+    """Block until the run is terminal, returning ``(snapshot, timed_out)``.
+
+    The status source is the *same* read-only ``check`` binding
+    ``lingtai-agent daemon check`` uses — one ``_ReadOnlyDaemonView`` built
+    once and reused, so a poll loop of any length still creates, repairs, and
+    reaps nothing.  Terminal states come from ``DaemonRunDir._TERMINAL_STATES``
+    rather than a restated tuple.
+
+    ``timed_out`` is the CLI's own wall-clock ceiling expiring, which is not
+    the same event as the run reaching state ``timeout`` — the daemon keeps
+    running under its own watchdog; only this command stops waiting.
+    """
+    from lingtai.tools.daemon.run_dir import DaemonRunDir
+
+    view = _ReadOnlyDaemonView(_CliDaemonAgent.for_inspection(agent_dir))
+    tail: _EventTail | None = None
+
+    while True:
+        snapshot = view._handle_check(em_id)
+        if snapshot.get("status") == "error":
+            raise CliDaemonError(str(snapshot.get("message", "check failed")))
+        if stream:
+            if tail is None and isinstance(snapshot.get("path"), str):
+                tail = _EventTail(Path(snapshot["path"]) / "logs" / "events.jsonl")
+            if tail is not None:
+                for event in tail.drain():
+                    print(_format_stream_event(event), file=sys.stderr, flush=True)
+        if snapshot.get("state") in DaemonRunDir._TERMINAL_STATES:
+            return snapshot, False
+        remaining = None if deadline is None else deadline - time.monotonic()
+        if remaining is not None and remaining <= 0:
+            return snapshot, True
+        time.sleep(poll_interval if remaining is None else min(poll_interval, remaining))
+
+
+def _handle_run_sync(args) -> int:
+    from lingtai.adapters.posix.event_journal import PosixJsonlEventJournalAdapter
+
+    if args.poll_interval <= 0:
+        raise CliDaemonError(
+            f"--poll-interval must be > 0 (got {args.poll_interval})"
+        )
+    started = time.monotonic()
+    agent_dir = _resolve_agent_dir(args.agent_dir)
+    preset = _resolve_run_sync_preset(args)
+
+    agent = _CliDaemonAgent.for_dispatch(
+        agent_dir, journal=PosixJsonlEventJournalAdapter(agent_dir),
+    )
+    # Before any capability is instantiated: a preset this agent does not allow
+    # must not get as far as deciding the default tool surface.
+    _enforce_preset_allowlist(agent, [{"preset": preset}] if preset else [])
+
+    tools = _parse_tools_flag(args.tools)
+    explicit_tools = tools is not None
+    if tools is None:
+        tools = _default_run_sync_tools(agent)
+
+    payload = {
+        "tasks": [{
+            "task": args.prompt,
+            "tools": tools,
+            # Omitted, not null, when absent — omission is the engine's
+            # documented inherit-the-parent path.
+            **({"preset": preset} if preset else {}),
+        }],
+        "max_turns": args.max_turns,
+        "timeout": args.timeout,
+    }
+    # The same validator, preset gate, and capability gate ``emanate`` runs,
+    # against the same schema objects — a request built in memory is held to
+    # exactly what a tasks file is held to.
+    tasks = _validate_emanate_input(payload, source="run-sync")
+    _enforce_preset_allowlist(agent, tasks)
+    _enforce_capability_policy(agent, tasks)
+    if explicit_tools:
+        agent.install_tool_surface(set(tools))
+
+    dispatched = _dispatch_through_tool_family(agent, "emanate", {
+        "tasks": tasks,
+        "backend": None,
+        "max_turns": args.max_turns,
+        "timeout": args.timeout,
+    })
+    if dispatched.get("status") != "dispatched":
+        raise CliDaemonError(str(dispatched.get("message", "emanate failed")))
+    ids = dispatched.get("ids") or []
+    if not ids:
+        raise CliDaemonError("emanate reported no daemon id to wait on")
+    em_id = ids[0]
+
+    deadline = None if args.timeout is None else started + float(args.timeout)
+    snapshot, waited_out = _poll_until_terminal(
+        agent_dir, em_id,
+        poll_interval=args.poll_interval,
+        deadline=deadline,
+        stream=args.stream,
+    )
+    return _report_run_sync(args, snapshot, em_id, agent_dir, tools, preset, waited_out)
+
+
+def _report_run_sync(args, snapshot: dict, em_id: str, agent_dir: Path,
+                     tools: list[str], preset: str | None, waited_out: bool) -> int:
+    """Print the terminal result per ``--output-format`` and pick the exit code.
+
+    ``text`` is deliberately bare — the result and nothing else on stdout, so
+    ``run-sync ... > answer.txt`` and shell substitution both work.  Every
+    diagnostic (the failure reason, the wall-clock give-up notice, the
+    ``--stream`` tail) goes to stderr for the same reason.
+    """
+    state = "timeout" if waited_out else str(snapshot.get("state") or "unknown")
+    result_text = _read_result_text(snapshot)
+
+    if args.output_format == "json":
+        _emit_json({
+            "status": state,
+            "id": em_id,
+            "run_id": snapshot.get("run_id"),
+            "agent_dir": str(agent_dir),
+            "backend": snapshot.get("backend"),
+            "preset": preset,
+            "tools": tools,
+            "result": result_text,
+            "result_path": snapshot.get("result_path"),
+            "error": snapshot.get("error"),
+            "turn": snapshot.get("turn"),
+            "elapsed_s": snapshot.get("elapsed_s"),
+            "finished_at": snapshot.get("finished_at"),
+            "tokens": snapshot.get("tokens", {}),
+            "events_total": snapshot.get("events_total"),
+            "path": snapshot.get("path"),
+            "gave_up_waiting": waited_out,
+        })
+    elif result_text:
+        print(result_text)
+
+    if waited_out:
+        print(
+            f"error: gave up waiting after --timeout {args.timeout}s; daemon "
+            f"{em_id} is still running under its own watchdog — inspect it with "
+            f"'lingtai-agent daemon check {em_id} --agent-dir {agent_dir}' or stop "
+            f"it with 'lingtai-agent daemon reclaim --agent-dir {agent_dir}'",
+            file=sys.stderr,
+        )
+    elif state != "done":
+        detail = snapshot.get("error") or snapshot.get("result_preview") or ""
+        print(
+            f"error: daemon {em_id} finished {state}"
+            + (f": {_compact(str(detail))}" if detail else ""),
+            file=sys.stderr,
+        )
+    return 0 if state == "done" and not waited_out else 1
+
+
 _HANDLERS = {
     "emanate": _handle_emanate,
     "list": _handle_list,
     "check": _handle_check,
     "reclaim": _handle_reclaim,
+    "run-sync": _handle_run_sync,
 }
 
 
@@ -1062,6 +1421,72 @@ def add_daemon_parser(sub: "argparse._SubParsersAction") -> None:
         type=Path,
         required=True,
         help="Agent working directory containing init.json",
+    )
+
+    run_sync = daemon_sub.add_parser(
+        "run-sync",
+        help="Run one prompt as a daemon, block until it finishes, print the result",
+    )
+    run_sync.add_argument(
+        "prompt",
+        help="The task for the daemon, as a single string",
+    )
+    run_sync.add_argument(
+        "--agent-dir",
+        type=Path,
+        required=True,
+        help="Agent working directory containing init.json",
+    )
+    run_sync.add_argument(
+        "--tools",
+        default=None,
+        help=(
+            "Comma-separated capability names, e.g. 'file,shell'. Omit for "
+            "this agent's granted share of the host tool floor; pass an empty "
+            "value for a result-only daemon with no tools"
+        ),
+    )
+    run_sync.add_argument(
+        "--preset",
+        default=None,
+        help=(
+            f"Preset file path, as listed by system(action='presets'). "
+            f"Defaults to ${_RUN_SYNC_PRESET_ENV}; with neither, the daemon "
+            f"inherits this agent's own model and tool surface"
+        ),
+    )
+    run_sync.add_argument(
+        "--max-turns",
+        type=int,
+        default=None,
+        help="Max LLM tool-loop turns for this daemon (default: the parent ceiling)",
+    )
+    run_sync.add_argument(
+        "--timeout",
+        type=float,
+        default=None,
+        help=(
+            "Wall-clock ceiling in seconds for the whole command, and the "
+            "daemon's own watchdog timeout (default: no CLI ceiling, engine "
+            "default watchdog)"
+        ),
+    )
+    run_sync.add_argument(
+        "--poll-interval",
+        type=float,
+        default=_RUN_SYNC_POLL_INTERVAL_S,
+        help=f"Seconds between status polls (default: {_RUN_SYNC_POLL_INTERVAL_S})",
+    )
+    run_sync.add_argument(
+        "--output-format",
+        choices=("text", "json"),
+        default="text",
+        help="'text' prints the result alone; 'json' prints the full envelope",
+    )
+    run_sync.add_argument(
+        "--stream",
+        action="store_true",
+        help="Tail the run's events to stderr while waiting",
     )
 
     check = daemon_sub.add_parser("check", help="Inspect one daemon run (read-only)")

--- a/src/lingtai/tools/daemon/manual/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/SKILL.md
@@ -99,6 +99,7 @@ identical.
 lingtai-agent daemon emanate --tasks batch.json --agent-dir ~/agents/foo [--backend lingtai] [--yes]
 lingtai-agent daemon list  [--status running] [--agent-dir ~/agents/foo]
 lingtai-agent daemon check em-1 [--agent-dir ~/agents/foo]
+lingtai-agent daemon run-sync "<prompt>" --agent-dir ~/agents/foo [--tools file,shell] [--preset P] [--stream]
 ```
 
 `--tasks` takes the tool's own `emanate` input object (`tasks`, and optionally
@@ -149,8 +150,31 @@ Behavior worth knowing before wiring it into a job:
 - **Secrets are redacted from CLI output** (`backend_options.env`, MCP
   `env`/`headers`, credential-shaped keys), using the same policy as the
   durable daemon manifest.
-- `ask` and `reclaim` are deliberately not exposed: this surface causes no side
-  effect beyond spawning daemons.
+- **`run-sync` is the `claude -p` / `codex exec` shape**: one prompt argument
+  in, one result on stdout, blocking. It builds a single-task `emanate` request
+  in memory and puts it through the same schema validation, preset allowlist,
+  capability policy, and dispatch as `emanate --yes`, then polls the same
+  read-only `check` binding until the run is terminal. Specifics:
+  - `--tools` is comma-separated. Omitting it defaults to this agent's granted
+    share of the borrowable host tool floor (`file`, `shell`, `task_card`) —
+    the one parent surface reachable both with and without a preset, so an
+    implicit default can never ask a preset's sandbox for tools it lacks.
+    Optional/provider capabilities are opt-in via `--tools`. `--tools ""` runs
+    a result-only daemon with no tools.
+  - `--preset` falls back to `$LINGTAI_P_PRESET`; with neither, the daemon
+    inherits the parent's model and tool surface exactly as an `emanate` task
+    that omits `preset` does.
+  - `--timeout` is both the daemon's own watchdog timeout and a wall-clock
+    ceiling on the command. If the ceiling expires the command exits non-zero
+    and says so on stderr; the daemon keeps running under its watchdog and is
+    still reachable via `check` / `reclaim`.
+  - `--output-format text` (default) prints the result and nothing else on
+    stdout; `json` prints the full envelope (status, ids, result, tokens,
+    paths). `--stream` tails the run's `events.jsonl` to **stderr** while
+    waiting, so stdout stays a clean result channel either way.
+  - Exit code is 0 only for state `done`; `failed`, `cancelled`, `timeout`, and
+    a give-up-waiting all exit 1.
+- `ask` is deliberately not exposed.
 
 ## Router table
 

--- a/tests/test_cli_daemon.py
+++ b/tests/test_cli_daemon.py
@@ -1186,3 +1186,619 @@ def test_daemon_manual_documents_the_cli():
     ).read_text(encoding="utf-8")
     assert "## Programmatic use / CLI" in manual
     assert "lingtai-agent daemon emanate" in manual
+
+
+# ---------------------------------------------------------------------------
+# run-sync — one prompt in, one result out
+#
+# The engine is untouched by this action, so these pin the composition: that
+# the request is held to the same schema/gates as a tasks file, that the wait
+# is the read-only check binding, and what each terminal state prints and exits.
+# ---------------------------------------------------------------------------
+
+
+def _parse_daemon_args(argv: list[str]):
+    """Parse an argv through the real ``daemon`` parser tree, without running it."""
+    import argparse
+
+    from lingtai.cli_daemon import add_daemon_parser
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command", required=True)
+    add_daemon_parser(sub)
+    return parser.parse_args(argv)
+
+
+@pytest.fixture
+def stub_clock(monkeypatch):
+    """Replace ``cli_daemon``'s ``time`` with a clock only its poll loop drives.
+
+    Scoped to the module attribute rather than the ``time`` module so the
+    engine's own timestamps stay real, and so a wall-clock-ceiling test costs
+    no wall clock: ``sleep`` advances the same counter ``monotonic`` reads.
+    """
+    from lingtai import cli_daemon
+
+    class _Clock:
+        def __init__(self) -> None:
+            self.now = 0.0
+            self.slept: list[float] = []
+
+        def monotonic(self) -> float:
+            return self.now
+
+        def sleep(self, seconds: float) -> None:
+            self.slept.append(seconds)
+            self.now += seconds
+
+    clock = _Clock()
+    monkeypatch.setattr(cli_daemon, "time", clock)
+    return clock
+
+
+@pytest.fixture
+def finishing_spawn(monkeypatch):
+    """Spawn replaced by an immediate terminal transition on the real run dir.
+
+    Everything before the process boundary stays live (validation, gates, run
+    directory, prompt build) exactly as ``no_spawn`` leaves it; this fixture
+    additionally drives the run dir to a terminal state through ``DaemonRunDir``'s
+    own writers, so ``run-sync``'s poll observes the same ``daemon.json`` /
+    ``result.txt`` / ``events.jsonl`` a real detached run would have written.
+    Set ``outcome["state"] = "running"`` to model a run that never finishes.
+    """
+    from lingtai.tools.daemon import DaemonManager
+
+    outcome = {"state": "done", "text": "the daemon's answer"}
+    spawns: list[dict] = []
+
+    def _record(self, run_dir, **kwargs):
+        spawns.append({"run_dir": run_dir, **kwargs})
+        if outcome["state"] == "done":
+            run_dir.mark_done(outcome["text"])
+        elif outcome["state"] == "failed":
+            run_dir.mark_failed(RuntimeError(outcome["text"]))
+        elif outcome["state"] == "cancelled":
+            run_dir.mark_cancelled()
+
+    monkeypatch.setattr(DaemonManager, "_spawn_detached_lingtai_run", _record)
+    outcome["spawns"] = spawns
+    return outcome
+
+
+def _run_sync(monkeypatch, agent_dir: Path, prompt: str = "answer me",
+              *extra: str) -> int:
+    return _run_cli(monkeypatch, [
+        "daemon", "run-sync", prompt, "--agent-dir", str(agent_dir),
+        "--tools", "file", "--poll-interval", "0.01", *extra,
+    ])
+
+
+# -- argparse wiring --------------------------------------------------------
+
+
+def test_run_sync_argparse_defaults():
+    args = _parse_daemon_args(["daemon", "run-sync", "do a thing",
+                               "--agent-dir", "/tmp/agent"])
+    assert args.daemon_command == "run-sync"
+    assert args.prompt == "do a thing"
+    assert args.agent_dir == Path("/tmp/agent")
+    assert args.tools is None and args.preset is None
+    assert args.max_turns is None and args.timeout is None
+    assert args.poll_interval == 2.0
+    assert args.output_format == "text"
+    assert args.stream is False
+
+
+def test_run_sync_argparse_flags():
+    args = _parse_daemon_args([
+        "daemon", "run-sync", "p", "--agent-dir", "/tmp/a",
+        "--tools", "file,shell", "--preset", "/p.json", "--max-turns", "7",
+        "--timeout", "30", "--poll-interval", "0.5",
+        "--output-format", "json", "--stream",
+    ])
+    assert args.tools == "file,shell" and args.preset == "/p.json"
+    assert args.max_turns == 7 and args.timeout == 30.0
+    assert args.poll_interval == 0.5
+    assert args.output_format == "json" and args.stream is True
+
+
+def test_run_sync_requires_an_agent_dir():
+    with pytest.raises(SystemExit):
+        _parse_daemon_args(["daemon", "run-sync", "p"])
+
+
+def test_run_sync_rejects_an_unknown_output_format():
+    with pytest.raises(SystemExit):
+        _parse_daemon_args(["daemon", "run-sync", "p", "--agent-dir", "/tmp/a",
+                            "--output-format", "yaml"])
+
+
+def test_run_sync_is_registered_as_a_handler():
+    from lingtai.cli_daemon import _HANDLERS, _handle_run_sync
+
+    assert _HANDLERS["run-sync"] is _handle_run_sync
+
+
+# -- preset selection: flag beats env, env beats nothing --------------------
+
+
+@pytest.mark.parametrize("flag,env,expected", [
+    ("/flag.json", None, "/flag.json"),
+    (None, "/env.json", "/env.json"),
+    ("/flag.json", "/env.json", "/flag.json"),  # the flag wins
+    (None, None, None),                          # neither: inherit
+    (None, "   ", None),                         # a blank env var is not a preset
+])
+def test_run_sync_preset_priority(monkeypatch, flag, env, expected):
+    import argparse
+
+    from lingtai.cli_daemon import _RUN_SYNC_PRESET_ENV, _resolve_run_sync_preset
+
+    if env is None:
+        monkeypatch.delenv(_RUN_SYNC_PRESET_ENV, raising=False)
+    else:
+        monkeypatch.setenv(_RUN_SYNC_PRESET_ENV, env)
+    assert _resolve_run_sync_preset(argparse.Namespace(preset=flag)) == expected
+
+
+def test_run_sync_env_preset_reaches_the_dispatched_task(tmp_path, monkeypatch,
+                                                         capsys, no_spawn):
+    """``LINGTAI_P_PRESET`` is a real default, not just a resolved string."""
+    from lingtai.cli_daemon import _RUN_SYNC_PRESET_ENV
+
+    allowed = _write_preset(tmp_path, "cheap")
+    agent_dir = _write_agent_dir(tmp_path, allowed=[allowed])
+    monkeypatch.setenv(_RUN_SYNC_PRESET_ENV, allowed)
+
+    captured: list[dict] = []
+
+    def fake_dispatch(agent, action, action_input):
+        captured.append({"action": action, "input": action_input})
+        return {"status": "error", "message": "stopped after capture"}
+
+    monkeypatch.setattr("lingtai.cli_daemon._dispatch_through_tool_family", fake_dispatch)
+
+    assert _run_sync(monkeypatch, agent_dir) == 1
+    capsys.readouterr()
+    assert captured[0]["action"] == "emanate"
+    assert captured[0]["input"]["tasks"][0]["preset"] == allowed
+
+
+def test_run_sync_omits_preset_entirely_when_none_is_selected(tmp_path, monkeypatch,
+                                                              capsys, no_spawn):
+    """Omission — not ``null`` — is the engine's existing inherit-the-parent path."""
+    from lingtai.cli_daemon import _RUN_SYNC_PRESET_ENV
+
+    monkeypatch.delenv(_RUN_SYNC_PRESET_ENV, raising=False)
+    agent_dir = _write_agent_dir(tmp_path)
+    captured: list[dict] = []
+
+    def fake_dispatch(agent, action, action_input):
+        captured.append(action_input)
+        return {"status": "error", "message": "stopped after capture"}
+
+    monkeypatch.setattr("lingtai.cli_daemon._dispatch_through_tool_family", fake_dispatch)
+
+    assert _run_sync(monkeypatch, agent_dir) == 1
+    capsys.readouterr()
+    assert "preset" not in captured[0]["tasks"][0]
+
+
+# -- default tool surface ---------------------------------------------------
+
+
+def test_run_sync_default_tools_are_the_granted_host_floor(tmp_path):
+    """The default is the one surface reachable with *and* without a preset."""
+    from lingtai.cli_daemon import _CliDaemonAgent, _default_run_sync_tools
+    from lingtai.tools.daemon import _parent_host_tool_floor
+
+    agent_dir = _write_agent_dir(tmp_path)
+    agent = _CliDaemonAgent.for_dispatch(agent_dir)
+    tools = _default_run_sync_tools(agent)
+
+    assert set(tools) == set(agent.effective_capabilities()) & _parent_host_tool_floor()
+    assert "file" in tools and "shell" in tools
+    # Only what actually registered is requested, so a capability whose setup
+    # was skipped cannot turn an implicit default into "Unknown tools".
+    assert set(tools) == {s.name for s in agent._tool_schemas}
+
+
+def test_run_sync_default_tools_respect_manifest_disable(tmp_path):
+    """An implicit default must not hand back a capability the agent disabled."""
+    from lingtai.cli_daemon import _CliDaemonAgent, _default_run_sync_tools
+
+    agent_dir = _write_agent_dir(tmp_path, disable=["shell"])
+    tools = _default_run_sync_tools(_CliDaemonAgent.for_dispatch(agent_dir))
+
+    assert "shell" not in tools
+    assert "file" in tools
+
+
+def test_run_sync_default_tools_reach_the_dispatched_task(tmp_path, monkeypatch,
+                                                          capsys, no_spawn):
+    """Omitting ``--tools`` is a real default, not an empty ``tools`` list."""
+    agent_dir = _write_agent_dir(tmp_path)
+    captured: list[dict] = []
+
+    def fake_dispatch(agent, action, action_input):
+        captured.append(action_input)
+        return {"status": "error", "message": "stopped after capture"}
+
+    monkeypatch.setattr("lingtai.cli_daemon._dispatch_through_tool_family", fake_dispatch)
+
+    assert _run_cli(monkeypatch, [
+        "daemon", "run-sync", "x", "--agent-dir", str(agent_dir),
+        "--poll-interval", "0.01",
+    ]) == 1
+    capsys.readouterr()
+    assert "file" in captured[0]["tasks"][0]["tools"]
+
+
+@pytest.mark.parametrize("raw,expected", [
+    (None, None),
+    ("", []),
+    ("file", ["file"]),
+    (" file , shell ,", ["file", "shell"]),
+])
+def test_run_sync_tools_flag_parsing(raw, expected):
+    from lingtai.cli_daemon import _parse_tools_flag
+
+    assert _parse_tools_flag(raw) == expected
+
+
+# -- blocking poll to a terminal state --------------------------------------
+
+
+def test_run_sync_blocks_until_done_and_prints_only_the_result(
+        tmp_path, monkeypatch, capsys, finishing_spawn, stub_clock):
+    agent_dir = _write_agent_dir(tmp_path)
+    assert _run_sync(monkeypatch, agent_dir, "summarize the docs") == 0
+
+    captured = capsys.readouterr()
+    assert captured.out == "the daemon's answer\n"
+    assert captured.err == ""
+    assert finishing_spawn["spawns"], "the dispatch never reached the engine"
+
+
+def test_run_sync_waits_for_a_run_that_is_not_terminal_yet(
+        tmp_path, monkeypatch, capsys, finishing_spawn, stub_clock):
+    """The loop must poll again rather than report the first non-terminal read."""
+    from lingtai.tools.daemon import DaemonManager
+
+    finishing_spawn["state"] = "running"
+    agent_dir = _write_agent_dir(tmp_path)
+
+    real_check = DaemonManager._handle_check
+    calls: list[str] = []
+
+    def finishing_check(self, em_id, *args, **kwargs):
+        calls.append(em_id)
+        if len(calls) == 3:  # the run finishes between the second and third poll
+            finishing_spawn["spawns"][0]["run_dir"].mark_done("late answer")
+        return real_check(self, em_id, *args, **kwargs)
+
+    monkeypatch.setattr(DaemonManager, "_handle_check", finishing_check)
+
+    assert _run_sync(monkeypatch, agent_dir) == 0
+    assert capsys.readouterr().out == "late answer\n"
+    assert len(calls) == 3
+    assert stub_clock.slept == [0.01, 0.01]
+
+
+def test_run_sync_polls_the_read_only_check_binding(
+        tmp_path, monkeypatch, capsys, finishing_spawn, stub_clock):
+    """Waiting must not reconcile, repair, or reap — it is the `check` surface.
+
+    ``_ReadOnlyDaemonView`` binds the manager's own unmodified ``_handle_check``
+    through ``__getattr__``, so spying on the manager unit is what proves *who*
+    the poll loop called it as.
+    """
+    from lingtai.cli_daemon import _ReadOnlyDaemonView
+    from lingtai.tools.daemon import DaemonManager
+
+    agent_dir = _write_agent_dir(tmp_path)
+    seen: list[object] = []
+    real_check = DaemonManager._handle_check
+
+    def spy(self, em_id, *args, **kwargs):
+        seen.append(type(self))
+        return real_check(self, em_id, *args, **kwargs)
+
+    monkeypatch.setattr(DaemonManager, "_handle_check", spy)
+
+    assert _run_sync(monkeypatch, agent_dir) == 0
+    capsys.readouterr()
+    assert seen and set(seen) == {_ReadOnlyDaemonView}
+    assert not (agent_dir / ".notification").exists()
+
+
+def test_run_sync_json_output_carries_the_whole_envelope(
+        tmp_path, monkeypatch, capsys, finishing_spawn, stub_clock):
+    agent_dir = _write_agent_dir(tmp_path)
+    assert _run_sync(monkeypatch, agent_dir, "answer me",
+                     "--output-format", "json") == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    run_dir = finishing_spawn["spawns"][0]["run_dir"]
+    assert payload["status"] == "done"
+    assert payload["result"] == "the daemon's answer"
+    assert payload["id"] == run_dir.path.name
+    assert payload["agent_dir"] == str(agent_dir)
+    assert payload["tools"] == ["file"]
+    assert payload["preset"] is None
+    assert payload["gave_up_waiting"] is False
+    assert payload["path"] == str(run_dir.path)
+    assert Path(payload["result_path"]).read_text(encoding="utf-8") == \
+        "the daemon's answer"
+
+
+def test_run_sync_reads_the_full_result_not_the_bounded_preview(
+        tmp_path, monkeypatch, capsys, finishing_spawn, stub_clock):
+    """``result_preview`` in daemon.json is capped; ``result.txt`` is the answer."""
+    from lingtai.tools.daemon.run_dir import DaemonRunDir
+
+    long_answer = "x" * (DaemonRunDir._RESULT_PREVIEW_MAX + 500)
+    finishing_spawn["text"] = long_answer
+    agent_dir = _write_agent_dir(tmp_path)
+
+    assert _run_sync(monkeypatch, agent_dir) == 0
+    assert capsys.readouterr().out == long_answer + "\n"
+
+
+# -- non-zero exits ---------------------------------------------------------
+
+
+@pytest.mark.parametrize("state", ["failed", "cancelled"])
+def test_run_sync_exits_nonzero_on_a_non_done_terminal_state(
+        tmp_path, monkeypatch, capsys, finishing_spawn, stub_clock, state):
+    finishing_spawn["state"] = state
+    finishing_spawn["text"] = "the daemon blew up"
+    agent_dir = _write_agent_dir(tmp_path)
+
+    assert _run_sync(monkeypatch, agent_dir) == 1
+    captured = capsys.readouterr()
+    assert f"finished {state}" in captured.err
+
+
+def test_run_sync_gives_up_at_the_wall_clock_ceiling(
+        tmp_path, monkeypatch, capsys, finishing_spawn, stub_clock):
+    """``--timeout`` bounds the command; the daemon keeps its own watchdog."""
+    finishing_spawn["state"] = "running"
+    agent_dir = _write_agent_dir(tmp_path)
+
+    code = _run_sync(monkeypatch, agent_dir, "answer me", "--timeout", "10")
+    assert code == 1
+    err = capsys.readouterr().err
+    assert "gave up waiting after --timeout 10.0s" in err
+    assert "daemon check" in err and "reclaim" in err
+    assert stub_clock.now >= 10.0
+
+    # The run itself was never marked terminal by the CLI.
+    state = json.loads(
+        (finishing_spawn["spawns"][0]["run_dir"].path / "daemon.json")
+        .read_text(encoding="utf-8")
+    )
+    assert state["state"] == "running"
+
+
+def test_run_sync_timeout_reports_status_timeout_in_json(
+        tmp_path, monkeypatch, capsys, finishing_spawn, stub_clock):
+    finishing_spawn["state"] = "running"
+    agent_dir = _write_agent_dir(tmp_path)
+
+    assert _run_sync(monkeypatch, agent_dir, "answer me",
+                     "--timeout", "10", "--output-format", "json") == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "timeout"
+    assert payload["gave_up_waiting"] is True
+
+
+def test_run_sync_passes_timeout_through_as_the_daemon_watchdog(
+        tmp_path, monkeypatch, capsys, no_spawn):
+    """One flag, both roles: the engine gets it too, not just the poll loop."""
+    agent_dir = _write_agent_dir(tmp_path)
+    captured: list[dict] = []
+
+    def fake_dispatch(agent, action, action_input):
+        captured.append(action_input)
+        return {"status": "error", "message": "stopped after capture"}
+
+    monkeypatch.setattr("lingtai.cli_daemon._dispatch_through_tool_family", fake_dispatch)
+
+    assert _run_sync(monkeypatch, agent_dir, "answer me",
+                     "--timeout", "45", "--max-turns", "3") == 1
+    capsys.readouterr()
+    assert captured[0]["timeout"] == 45.0
+    assert captured[0]["max_turns"] == 3
+    assert captured[0]["backend"] is None
+
+
+def test_run_sync_refuses_a_non_positive_poll_interval(tmp_path, monkeypatch,
+                                                       capsys, no_spawn):
+    agent_dir = _write_agent_dir(tmp_path)
+    code = _run_cli(monkeypatch, [
+        "daemon", "run-sync", "x", "--agent-dir", str(agent_dir),
+        "--tools", "file", "--poll-interval", "0",
+    ])
+    assert code == 1
+    assert "--poll-interval must be > 0" in capsys.readouterr().err
+    assert no_spawn == []
+
+
+# -- the same validation and gates as a tasks file --------------------------
+
+
+@pytest.mark.parametrize("extra,fragment", [
+    (["--max-turns", "0"], "max_turns must be >= 1"),
+    (["--timeout", "1"], "timeout must be >= 5"),
+])
+def test_run_sync_is_held_to_the_emanate_schema(tmp_path, monkeypatch, capsys,
+                                                no_spawn, extra, fragment):
+    """The in-memory request meets the same schema a ``--tasks`` file meets."""
+    agent_dir = _write_agent_dir(tmp_path)
+    assert _run_sync(monkeypatch, agent_dir, "x", *extra) == 1
+    err = capsys.readouterr().err
+    assert fragment in err
+    assert "run-sync does not match the daemon emanate schema" in err
+    assert "--tasks file" not in err  # it was never given one
+    assert no_spawn == []
+
+
+def test_run_sync_refuses_an_empty_prompt(tmp_path, monkeypatch, capsys, no_spawn):
+    agent_dir = _write_agent_dir(tmp_path)
+    assert _run_sync(monkeypatch, agent_dir, "   ") == 1
+    assert "must be a non-empty string" in capsys.readouterr().err
+    assert no_spawn == []
+
+
+def test_run_sync_refuses_a_preset_outside_the_allowlist(tmp_path, monkeypatch,
+                                                         capsys, no_spawn):
+    agent_dir = _write_agent_dir(tmp_path, allowed=[str(tmp_path / "ok.json")])
+    code = _run_sync(monkeypatch, agent_dir, "x",
+                     "--preset", str(tmp_path / "evil.json"))
+    assert code == 1
+    assert "not in this agent's allowed list" in capsys.readouterr().err
+    assert no_spawn == []
+    assert not (agent_dir / "daemons").exists()
+
+
+def test_run_sync_refuses_a_capability_the_agent_disabled(tmp_path, monkeypatch,
+                                                          capsys, no_spawn):
+    agent_dir = _write_agent_dir(tmp_path, disable=["shell"])
+    code = _run_cli(monkeypatch, [
+        "daemon", "run-sync", "x", "--agent-dir", str(agent_dir),
+        "--tools", "shell", "--poll-interval", "0.01",
+    ])
+    assert code == 1
+    assert "does not grant" in capsys.readouterr().err
+    assert no_spawn == []
+
+
+def test_run_sync_refuses_an_unusable_init(tmp_path, monkeypatch, capsys, no_spawn):
+    agent_dir = _write_agent_dir(tmp_path)
+    (agent_dir / "init.json").write_text(
+        json.dumps({"manifest": {"agent_name": "x"}}), encoding="utf-8",
+    )
+    assert _run_sync(monkeypatch, agent_dir) == 1
+    assert "is not usable" in capsys.readouterr().err
+    assert no_spawn == []
+
+
+# -- --stream tail ----------------------------------------------------------
+
+
+def test_event_tail_returns_only_new_complete_lines(tmp_path):
+    """A line still mid-write is held back, and nothing is replayed."""
+    from lingtai.cli_daemon import _EventTail
+
+    events = tmp_path / "events.jsonl"
+    events.write_text('{"event": "a"}\n{"event": "b"}\n', encoding="utf-8")
+    tail = _EventTail(events)
+
+    assert [e["event"] for e in tail.drain()] == ["a", "b"]
+    assert tail.drain() == []
+
+    # A partial line: not an event until its newline lands.
+    with open(events, "a", encoding="utf-8") as handle:
+        handle.write('{"event": "c"}')
+    assert tail.drain() == []
+    with open(events, "a", encoding="utf-8") as handle:
+        handle.write('\n{"event": "d"}\n')
+    assert [e["event"] for e in tail.drain()] == ["c", "d"]
+
+
+def test_event_tail_survives_a_missing_file_and_bad_lines(tmp_path):
+    from lingtai.cli_daemon import _EventTail
+
+    events = tmp_path / "events.jsonl"
+    tail = _EventTail(events)
+    assert tail.drain() == []  # not created yet
+
+    events.write_text('not json\n\n{"event": "ok"}\n"scalar"\n', encoding="utf-8")
+    assert [e["event"] for e in tail.drain()] == ["ok"]
+
+
+def test_event_tail_resumes_after_the_file_is_replaced(tmp_path):
+    from lingtai.cli_daemon import _EventTail
+
+    events = tmp_path / "events.jsonl"
+    events.write_text('{"event": "old"}\n' * 3, encoding="utf-8")
+    tail = _EventTail(events)
+    tail.drain()
+
+    events.write_text('{"event": "new"}\n', encoding="utf-8")  # shorter than before
+    assert [e["event"] for e in tail.drain()] == ["new"]
+
+
+def test_stream_event_lines_are_compact_and_redacted():
+    from lingtai.cli_daemon import _format_stream_event
+
+    line = _format_stream_event({
+        "event": "tool_call", "name": "file", "turn": 2,
+        "args_preview": '{"action": "read",\n  "path": "notes.md"}',
+        "ts": "2026-08-20T00:00:00Z",
+    })
+    assert line.startswith("· tool_call name=file turn=2")
+    assert "\n" not in line
+
+    secret = _format_stream_event({
+        "event": "mcp_start", "env": {"TOKEN": "s3cr3t-value"},
+    })
+    assert "s3cr3t-value" not in secret
+
+
+def test_run_sync_stream_tails_events_to_stderr(
+        tmp_path, monkeypatch, capsys, finishing_spawn, stub_clock):
+    """The tail is over the run's own events.jsonl, and stdout stays the result."""
+    agent_dir = _write_agent_dir(tmp_path)
+    assert _run_sync(monkeypatch, agent_dir, "answer me", "--stream") == 0
+
+    captured = capsys.readouterr()
+    assert captured.out == "the daemon's answer\n"
+    # Written by DaemonRunDir itself: construction, then the terminal transition.
+    assert "· daemon_start" in captured.err
+    assert "· daemon_done" in captured.err
+
+
+def test_run_sync_without_stream_prints_no_events(
+        tmp_path, monkeypatch, capsys, finishing_spawn, stub_clock):
+    agent_dir = _write_agent_dir(tmp_path)
+    assert _run_sync(monkeypatch, agent_dir) == 0
+    assert "daemon_start" not in capsys.readouterr().err
+
+
+def test_run_sync_stream_does_not_replay_events_across_polls(
+        tmp_path, monkeypatch, capsys, finishing_spawn, stub_clock):
+    """Each event is printed once, however many polls the wait takes."""
+    from lingtai.tools.daemon import DaemonManager
+
+    finishing_spawn["state"] = "running"
+    agent_dir = _write_agent_dir(tmp_path)
+
+    real_check = DaemonManager._handle_check
+    polls: list[int] = []
+
+    def finishing_check(self, em_id, *args, **kwargs):
+        polls.append(1)
+        if len(polls) == 4:
+            finishing_spawn["spawns"][0]["run_dir"].mark_done("done at last")
+        return real_check(self, em_id, *args, **kwargs)
+
+    monkeypatch.setattr(DaemonManager, "_handle_check", finishing_check)
+
+    assert _run_sync(monkeypatch, agent_dir, "answer me", "--stream") == 0
+    err = capsys.readouterr().err
+    assert err.count("· daemon_start") == 1
+    assert err.count("· daemon_done") == 1
+
+
+# -- documentation ----------------------------------------------------------
+
+
+def test_daemon_manual_documents_run_sync():
+    manual = (
+        Path(__file__).resolve().parents[1]
+        / "src/lingtai/tools/daemon/manual/SKILL.md"
+    ).read_text(encoding="utf-8")
+    assert "lingtai-agent daemon run-sync" in manual


### PR DESCRIPTION
## Summary

Adds `lingtai-agent daemon run-sync`: a headless, blocking, single-prompt CLI subcommand for LingTai daemons — the `claude -p` / `codex exec` shape, for a script or CI job rather than an agent. This is the first slice of the `lingtai -p` headless-mode feature Jason asked for directly (Telegram, 2026-08-19).

Pure composition over the *existing* `emanate`/`check`/dispatch units in `cli_daemon.py` — **no engine file is touched** (`tools/daemon/__init__.py`, `_tool_family.py`, `run_dir.py` are all unmodified).

```
lingtai-agent daemon run-sync "<prompt>" --agent-dir DIR \
    [--tools a,b] [--preset P] [--max-turns N] [--timeout S] \
    [--poll-interval S] [--output-format text|json] [--stream]
```

## Design decisions

- **Preset resolution:** `--preset` > `LINGTAI_P_PRESET` env var > existing inherit-the-parent path (per Jason's explicit request for the env-var + flag pattern already used elsewhere in the kernel, e.g. `LINGTAI_NUDGE_ENABLED`). Neither given → the task's `preset` key is omitted entirely, which is the engine's existing no-preset inherit path; no new fallback logic invented.
- **Default `--tools`** (when the flag is omitted) is the granted host tool floor (`file`/`shell`/`task_card` intersected with `manifest.disable`), not the agent's whole effective surface. Rationale (detailed in code comments): only the floor is borrowable by a preset emanation, `_CliDaemonAgent` is not a live `Agent` and crashes on capabilities that reconcile a system-prompt section, and blacklisted capabilities (`knowledge`, `skills`, `avatar`, `daemon`, `context`, `psyche`) register no emanation-usable tool anyway. `--tools ""` is kept distinct from an absent flag and gives an explicit result-only daemon.
- **Validation:** the single-task request built in memory is run through the *same* schema validator, preset-allowlist gate, and capability-policy gate that `emanate --yes` uses against a tasks file — no parallel/looser validation path.
- **Blocking poll** reuses the read-only `_ReadOnlyDaemonView` binding `daemon check` uses; terminal states come from `DaemonRunDir._TERMINAL_STATES`, not restated.
- **`--stream`** tails the run's own `logs/events.jsonl` (byte-offset, resumable, zero new kernel infrastructure) to **stderr**; stdout stays clean so `run-sync ... > answer.txt` and `$(run-sync ...)` work with `--stream` on or off, and `--output-format json` stays parseable.
- **`--timeout`** serves both roles: the command's own wall-clock ceiling AND the daemon's watchdog timeout. On ceiling expiry the CLI exits 1 with guidance (`daemon check` / `daemon reclaim`); the daemon itself is left running under its own watchdog, not force-terminated by the CLI.
- Exit code 0 only for terminal state `done`.

## Testing

- 44 new tests appended to `tests/test_cli_daemon.py` (79 → 123 total). **All 123 pass** — verified independently by me (not just the implementing daemon's self-report): `python3 -m pytest tests/test_cli_daemon.py -q` → `123 passed in 2.08s`.
- `compileall` clean on `cli_daemon.py`, `test_cli_daemon.py`, and all of `src/lingtai`.
- Coverage includes: argparse defaults/flags/required-args/bad-choice + handler registration; preset flag-vs-env priority (5 cases); default tool surface (floor, `manifest.disable`, reaching dispatch) and `--tools` parsing; blocking poll to `done` including a run still in progress on the first polls; poll target is the read-only `check` binding; text vs json output; full result vs bounded preview; `failed`/`cancelled` exit codes; wall-clock give-up behavior (exit code, stderr guidance, run left `running`, json `status: timeout`); `--timeout`/`--max-turns` passthrough; non-positive `--poll-interval` refusal; schema/empty-prompt/preset-allowlist/capability-policy/unusable-init refusals, all with no real spawn; `_EventTail` edge cases (partial lines, missing file, bad lines, replaced file); stream redaction and no-replay-across-polls; manual documentation.
- A broader same-directory suite run (`test_cli_daemon.py` + 5 adjacent daemon test files) showed 5 pre-existing failures, all in `tests/test_daemon_central_manager.py`. **Verified these are pre-existing and unrelated**: re-ran the identical file extracted from pristine `HEAD` via `git archive` in a separate temp directory — same 5 failures at baseline. They spawn real central-manager subprocesses and fail on this machine independent of this change.

## ⚠️ Known gap — please read before merge

**No live-credential end-to-end smoke test.** This development environment has no real provider credentials, so the actual detached daemon spawn + real-provider round-trip is not exercised — only stubbed. Everything up to and including the process/dispatch boundary is covered by the real test suite (real schema validation, real preset/capability gates, real `DaemonRunDir` writes, real read-only `check` polling against real `daemon.json`/`events.jsonl`/`result.txt`). **A credentialed smoke run (`lingtai-agent daemon run-sync "hello" --agent-dir <real agent dir>`) is recommended before merge.**

## Not done, deliberately

A top-level `lingtai -p` alias (thin wrapper invoking `daemon run-sync`) is a natural fast-follow, intentionally out of scope for this first slice.

---
Telegram: @lingtaidev3bot | Nickname: 澄一

Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
