### PR TITLE
feat(taskcard): show Codex service tier

### DIFF
--- a/src/lingtai/agent.py
+++ b/src/lingtai/agent.py
@@ -645,7 +645,14 @@ class Agent(BaseAgent):
     #: as defense-in-depth — init.json's ``manifest.llm`` may carry api_key /
     #: api_key_env values that must never reach the on-disk manifest or the
     #: system prompt's identity section.
-    _LLM_PUBLIC_KEYS = ("provider", "model", "base_url", "api_compat", "context_limit")
+    _LLM_PUBLIC_KEYS = (
+        "provider",
+        "model",
+        "base_url",
+        "api_compat",
+        "context_limit",
+        "service_tier",
+    )
 
     #: Safelist for the public ``preset`` block. ``active`` and ``default`` are
     #: path strings, ``allowed`` is a list of path strings — none of these

--- a/src/lingtai/kernel/base_agent/identity.py
+++ b/src/lingtai/kernel/base_agent/identity.py
@@ -70,7 +70,14 @@ def _update_identity(agent) -> None:
 #: field is enough to break the contract, so anything outside this set is
 #: dropped silently. ``base_url`` is included because operators rely on it
 #: to disambiguate self-hosted endpoints from upstream providers.
-_LLM_PUBLIC_KEYS = ("provider", "model", "base_url", "api_compat", "context_limit")
+_LLM_PUBLIC_KEYS = (
+    "provider",
+    "model",
+    "base_url",
+    "api_compat",
+    "context_limit",
+    "service_tier",
+)
 
 
 def _build_manifest(agent) -> dict:
@@ -150,6 +157,19 @@ def _safe_llm_from_service(agent) -> dict:
     api_compat = _provider_default_from_service(service, "api_compat")
     if isinstance(api_compat, str) and api_compat:
         llm["api_compat"] = api_compat
+
+    # The native Codex adapter always uses the Responses API. Its configured
+    # service tier is safe runtime identity metadata; other adapters do not
+    # consume this option and must not claim one in presentation surfaces.
+    provider = llm.get("provider")
+    if isinstance(provider, str) and provider.lower() in {
+        "codex",
+        "codex-pool",
+        "codex_pool",
+    }:
+        service_tier = _provider_default_from_service(service, "service_tier")
+        if isinstance(service_tier, str) and service_tier.strip():
+            llm["service_tier"] = service_tier.strip()
 
     return llm
 

--- a/src/lingtai/mcp_servers/task_card/event_projection.py
+++ b/src/lingtai/mcp_servers/task_card/event_projection.py
@@ -691,6 +691,13 @@ class TaskCardEventProjection:
         thinking = metadata.get("thinking")
         if isinstance(thinking, str) and thinking.strip() and len(thinking.strip()) <= 48:
             session_parts.append(thinking.strip())
+        service_tier = metadata.get("service_tier")
+        if (
+            isinstance(service_tier, str)
+            and service_tier.strip()
+            and len(service_tier.strip()) <= 48
+        ):
+            session_parts.append(f"tier {service_tier.strip()}")
         endpoint = metadata.get("endpoint")
         if isinstance(endpoint, str) and endpoint.strip() and len(endpoint.strip()) <= 96:
             session_parts.append(f"@{endpoint.strip()}")

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -2680,6 +2680,8 @@ class TelegramManager:
                 snapshot["endpoint"] = llm_extra["endpoint"]
             if "thinking" in llm_extra:
                 snapshot["thinking"] = llm_extra["thinking"]
+            if "service_tier" in llm_extra:
+                snapshot["service_tier"] = llm_extra["service_tier"]
         try:
             snapshot["device_short_name"] = socket.gethostname()
         except (OSError, ValueError):
@@ -2918,6 +2920,9 @@ class TelegramManager:
                 thinking = None
         if isinstance(thinking, str) and thinking.strip():
             out["thinking"] = thinking.strip()
+        service_tier = llm.get("service_tier")
+        if isinstance(service_tier, str) and service_tier.strip():
+            out["service_tier"] = service_tier.strip()
         return out or None
 
     def _task_card_agent_lifecycle_status(self) -> str | None:

--- a/tests/test_agent_preset_manifest.py
+++ b/tests/test_agent_preset_manifest.py
@@ -162,6 +162,15 @@ def test_safe_llm_from_service_uses_provider_default_base_url():
     assert out["context_limit"] == 123456
 
 
+def test_safe_llm_from_service_exposes_codex_responses_service_tier():
+    agent = MagicMock()
+    svc = _mock_service("codex-pool", "gpt-5.6-terra", None)
+    svc._provider_defaults = {"codex-pool": {"service_tier": "fast"}}
+    agent.service = svc
+
+    assert _safe_llm_from_service(agent)["service_tier"] == "fast"
+
+
 def test_safe_llm_from_service_with_no_service():
     agent = MagicMock()
     agent.service = None

--- a/tests/test_task_card_event_projection_shared.py
+++ b/tests/test_task_card_event_projection_shared.py
@@ -202,6 +202,13 @@ def test_metadata_renders_device_and_working_dir_lines() -> None:
     assert " | " in identity
 
 
+def test_metadata_renders_service_tier_when_supplied() -> None:
+    lines = TaskCardEventProjection.format_metadata(
+        {"model": "gpt-5.6-terra", "service_tier": "fast"}
+    )
+    assert lines == ["Session · gpt-5.6-terra · tier fast"]
+
+
 def test_metadata_omits_device_line_when_only_bad_values() -> None:
     """Missing or malformed device identity degrades to no device/path groups."""
     metadata = {"agent_lifecycle": "active", "device_short_name": 42, "working_dir": ""}


### PR DESCRIPTION
## Summary
- Surface the configured `fast` service tier only for native Codex, whose adapter is forced onto the Responses API.
- Carry that safe field through the public agent LLM manifest and render it in Telegram's automatic Task Card session line.
- Preserve omission for absent tiers and all non-Codex providers.

## Validation
- `PYTHONPATH="$repo/src" python3 -m pytest -q -x tests/test_agent_preset_manifest.py tests/test_task_card_event_projection_shared.py tests/test_telegram_task_card_rows.py` (96 passed)
- `git diff --check`

Telegram: @lingtaijobhuntbot | Nickname: 衡枢

Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai