### PR TITLE
fix(taskcard): label default Codex tier

### DIFF
--- a/src/lingtai/kernel/base_agent/identity.py
+++ b/src/lingtai/kernel/base_agent/identity.py
@@ -170,6 +170,10 @@ def _safe_llm_from_service(agent) -> dict:
         service_tier = _provider_default_from_service(service, "service_tier")
         if isinstance(service_tier, str) and service_tier.strip():
             llm["service_tier"] = service_tier.strip()
+        else:
+            # The request omits service_tier, so label the known request-side
+            # default rather than inventing a provider-returned tier.
+            llm["service_tier"] = "default"
 
     return llm
 

--- a/tests/test_agent_preset_manifest.py
+++ b/tests/test_agent_preset_manifest.py
@@ -171,6 +171,15 @@ def test_safe_llm_from_service_exposes_codex_responses_service_tier():
     assert _safe_llm_from_service(agent)["service_tier"] == "fast"
 
 
+def test_safe_llm_from_service_labels_omitted_codex_service_tier_default():
+    agent = MagicMock()
+    svc = _mock_service("codex-pool", "gpt-5.6-terra", None)
+    svc._provider_defaults = {"codex-pool": {}}
+    agent.service = svc
+
+    assert _safe_llm_from_service(agent)["service_tier"] == "default"
+
+
 def test_safe_llm_from_service_with_no_service():
     agent = MagicMock()
     agent.service = None
@@ -370,6 +379,7 @@ def test_wrapper_manifest_includes_preset_from_init(tmp_path):
         "provider": "codex",
         "model": "gpt-5.5",
         "base_url": "https://chatgpt.com/backend-api/codex",
+        "service_tier": "default",
     }
     agent.stop(timeout=1.0)
 


### PR DESCRIPTION
## Summary
- Label native Codex/Responses requests with `service_tier: default` when the request omits an explicit tier.
- Preserve explicit configured tiers such as `fast`; `default` explicitly describes request-side default semantics, not a provider-returned value.
- TUI #917 already reads this same safe public field, so no companion TUI change is needed.

## Validation
- `PYTHONPATH="$repo/src" python3 -m pytest -q -x tests/test_agent_preset_manifest.py tests/test_task_card_event_projection_shared.py tests/test_telegram_task_card_rows.py` (97 passed)
- `git diff --check`

Telegram: @lingtaijobhuntbot | Nickname: 衡枢

Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai