### PR TITLE
fix(cpr): avoid false failure during slow startup

### DIFF
--- a/src/lingtai/agent.py
+++ b/src/lingtai/agent.py
@@ -1097,9 +1097,10 @@ class Agent(BaseAgent):
     def _cpr_agent(self, address: str) -> bool | dict | None:
         """Resuscitate a suspended agent by launching it as a detached process.
 
-        Uses the resolved venv Python to run `lingtai run <dir>`.  Success is
-        reported only after the target writes a fresh heartbeat; quick child
-        exits and startup timeouts are returned as explicit errors.
+        Uses the resolved venv Python to run `lingtai run <dir>`. A fresh
+        heartbeat confirms the launch; an observed child exit is an explicit
+        error. A child still running after the bounded confirmation interval is
+        logged as unconfirmed and returns the established truthy sentinel.
         """
         import shlex
         import subprocess
@@ -1164,6 +1165,14 @@ class Agent(BaseAgent):
 
         self._log("cpr_launched", target=str(target), pid=proc.pid, log=str(log_path))
 
+        def _launch_failure(code: int) -> dict:
+            tail = _tail_log()
+            self._log("cpr_failed", target=str(target), pid=proc.pid, exit_code=code, log=str(log_path))
+            message = f"CPR launch exited before heartbeat (exit code {code}); see {log_path}"
+            if tail.strip():
+                message += f"\n\nLast log output:\n{tail}"
+            return {"error": True, "message": message, "exit_code": code, "log": str(log_path)}
+
         # Poll with the kernel-fixed liveness window (shared default), NOT a
         # local 3.0: karma's CPR gate and this relaunch poll must use the same
         # threshold, so a heartbeat fresh enough to satisfy the poll is by
@@ -1181,21 +1190,24 @@ class Agent(BaseAgent):
                 return True
             code = proc.poll()
             if code is not None:
-                tail = _tail_log()
-                self._log("cpr_failed", target=str(target), pid=proc.pid, exit_code=code, log=str(log_path))
-                message = f"CPR launch exited before heartbeat (exit code {code}); see {log_path}"
-                if tail.strip():
-                    message += f"\n\nLast log output:\n{tail}"
-                return {"error": True, "message": message, "exit_code": code, "log": str(log_path)}
+                return _launch_failure(code)
             time.sleep(0.2)
 
-        self._log("cpr_timeout", target=str(target), pid=proc.pid, log=str(log_path))
-        return {
-            "error": True,
-            "message": f"CPR launch did not produce a fresh heartbeat within 10s (pid {proc.pid}); see {log_path}",
-            "pid": proc.pid,
-            "log": str(log_path),
-        }
+        # One final presence observation accepts a heartbeat written at the
+        # confirmation boundary. Absent that evidence, only an observed child
+        # exit proves CPR launch failure; a still-running detached child may
+        # still be initializing and remains unconfirmed rather than failed.
+        if _presence_observe_alive(
+            target_presence,
+            wall_now=time.time(),
+        ):
+            self._log("cpr_alive", target=str(target), pid=proc.pid)
+            return True
+        code = proc.poll()
+        if code is not None:
+            return _launch_failure(code)
+        self._log("cpr_launch_unconfirmed", target=str(target), pid=proc.pid, log=str(log_path))
+        return True
 
     def start(self) -> None:
         super().start()

--- a/src/lingtai/tools/system/BEHAVIORS.md
+++ b/src/lingtai/tools/system/BEHAVIORS.md
@@ -177,3 +177,38 @@ an agent can interrupt itself.
 ### Pass / Fail
 Pass when nirvana is refused AND the target is untouched. Fail if nirvana
 succeeds with only karma privilege.
+
+## Behavior B007 — CPR distinguishes an observed exit from an unconfirmed live launch
+
+- **id**: B007
+- **title**: CPR does not report a still-running child failed solely for a delayed heartbeat
+- **guards**: `system-contract` § [CPR launch confirmation](CONTRACT.md#cpr-launch-confirmation)
+- **supersedes**: `tests/test_karma.py::TestCPRLingtai::test_cpr_agent_returns_unconfirmed_running_child`,
+  `tests/test_karma.py::TestCPRLingtai::test_cpr_agent_reports_early_exit_before_heartbeat`,
+  `tests/test_karma.py::TestCPRLingtai::test_cpr_agent_reports_exit_observed_at_confirmation_deadline`
+- **runner**: an agent with `admin: {"karma": true}` and the hermetic CPR-launch harness
+- **prerequisites**: a disposable non-human target agent directory with `init.json`; the
+  harness can hold its heartbeat observation false, advance the 10-second confirmation
+  interval without wall-clock waiting, and control the detached child's `poll()` result
+- **estimate**: 1 min
+
+### Steps
+1. Launch CPR against the disposable target with its fresh-heartbeat observation held
+   false while the fake detached child remains running (`poll()` returns `None`), then
+   advance the confirmation interval to its boundary.
+2. Inspect the CPR result and the reviver's lifecycle events.
+3. Repeat with no fresh heartbeat and a child exit observed by `poll()` (including exit
+   code zero); inspect the result and relaunch-log diagnostic.
+
+### Expected evidence
+- [ ] The still-running case returns the established `resuscitated` receipt and records
+  `cpr_launch_unconfirmed`; it does not record `cpr_timeout` or return a launch error.
+- [ ] The observed-exit case returns an error with the exact `exit_code`, relaunch-log
+  path, and bounded log-tail diagnostic; it does not report `resuscitated`.
+- [ ] Both cases retain the bounded 10-second confirmation interval; the live-child
+  receipt is not evidence of continuing health after CPR returns.
+
+### Pass / Fail
+Pass when absence of heartbeat evidence is distinguished from an observed child exit as
+above. Fail if CPR calls a still-running child failed solely for missing confirmation, or
+if any observed exit is reported as `resuscitated`.

--- a/src/lingtai/tools/system/CONTRACT.md
+++ b/src/lingtai/tools/system/CONTRACT.md
@@ -114,7 +114,7 @@ siblings.
 | `sleep` | — | `reason`, `force` | `{status: "ok", message}` (self-sleep; refuses with an ok+message when notifications pending and not `force`) | — |
 | `lull` | `address` | `reason` | `{status: "asleep", address}` | `{error: True, message}` (no karma, no/invalid address, self-target, target not running) |
 | `suspend` | `address` | `reason` | `{status: "suspended", address}` | `{error: True, message}` (as above) |
-| `cpr` | `address` | `reason` | `{status: "resuscitated", address}` | `{error: True, message}` (target already running, CPR unsupported/failed) |
+| `cpr` | `address` | `reason` | `{status: "resuscitated", address}` | `{error: True, message}` (target already running, CPR unsupported, or observed child exit before a fresh heartbeat) |
 | `interrupt` | `address` | `reason` | `{status: "interrupted", address}` | `{error: True, message}` (as above) |
 | `clear` | `address` | `reason` | `{status: "cleared", address, source}` | `{error: True, message}` (as above) |
 | `nirvana` | `address` | `reason` | `{status: "nirvana", address}` | `{error: True, message}` (requires karma AND nirvana; shutdown-timeout error) |
@@ -169,9 +169,21 @@ by [`BEHAVIORS.md`](BEHAVIORS.md) — authorization gate
 ([B001](BEHAVIORS.md#behavior-b001)), signal-file effects
 ([B002](BEHAVIORS.md#behavior-b002), [B003](BEHAVIORS.md#behavior-b003)),
 refusal paths ([B004](BEHAVIORS.md#behavior-b004),
-[B005](BEHAVIORS.md#behavior-b005)), and nirvana privilege
-([B006](BEHAVIORS.md#behavior-b006)). Change any of these behaviors, update the
+[B005](BEHAVIORS.md#behavior-b005)), nirvana privilege
+([B006](BEHAVIORS.md#behavior-b006)), and CPR launch confirmation
+([B007](BEHAVIORS.md#behavior-b007)). Change any of these behaviors, update the
 matching behavior entry and this clause together.
+
+### CPR launch confirmation
+
+After `cpr` spawns its detached child, it waits at most 10 seconds for a fresh
+heartbeat as confirmation. At that boundary it makes one final heartbeat
+observation and checks the child process: an observed exit (including exit code
+zero) returns the existing launch-failure error with its relaunch-log tail; a
+still-running child with no fresh heartbeat is logged as `cpr_launch_unconfirmed`
+and returns the established `{status: "resuscitated", address}` receipt. The
+latter records absence of confirmation evidence, not an ongoing-health guarantee.
+This observable distinction is guarded by [B007](BEHAVIORS.md#behavior-b007).
 
 ## State & storage
 
@@ -218,7 +230,7 @@ drive it are `context`'s.
 | `refresh` with an unauthorized preset is refused | `src/lingtai/tools/system/preset.py:_refresh` | `tests/test_system.py::test_refresh_with_unauthorized_preset_returns_error` |
 | `refresh` cannot combine `preset` and `revert_preset` | `src/lingtai/tools/system/preset.py:_refresh` | `tests/test_system.py::test_refresh_revert_preset_with_preset_arg_errors` |
 | `presets` lists the allowed library and strips credentials | `src/lingtai/tools/system/preset.py:_presets` | `tests/test_system.py::test_presets_action_lists_full_library`, `tests/test_system.py::test_presets_action_strips_credentials` |
-| `cpr` propagates launch failure instead of reporting success | `src/lingtai/tools/system/karma.py:_cpr` | `tests/test_system.py::test_cpr_propagates_launch_failure_instead_of_resuscitated` |
+| `cpr` reports an observed launch exit as failure, but retains its established receipt for a child still running after bounded heartbeat confirmation | `src/lingtai/tools/system/karma.py:_cpr` | `tests/test_system.py::test_cpr_propagates_launch_failure_instead_of_resuscitated`, `tests/test_karma.py::TestCPRLingtai` |
 | The two name actions preserve live identity, `.agent.json`, and the protected prompt `identity` section, and mutate neither address nor workdir | `src/lingtai/tools/system/name.py` | `tests/test_tool_family_system_migration.py::test_name_actions_preserve_identity_semantics` |
 | The public `summarize` action is gone from `system` with no alias | `src/lingtai/tools/system/schema.py:ACTION_ORDER` | `tests/test_tool_family_system_migration.py::test_public_summarize_action_is_gone_and_fails_loudly`, `tests/test_notification_tool.py::test_system_schema_drops_notification_and_dismiss` |
 | `items`/`rebuild` belong to no `system` action | `src/lingtai/tools/system/schema.py:INPUT_SCHEMAS` | `tests/test_tool_family_system_migration.py::test_departed_summarize_fields_are_rejected_on_every_action` |

--- a/tests/test_karma.py
+++ b/tests/test_karma.py
@@ -5,7 +5,7 @@ from lingtai.tools.registry import INTRINSICS as _TEST_INTRINSICS
 import threading
 import time
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -194,60 +194,171 @@ class TestCPRLingtai:
         assert llm_config["provider"] == "mock"
         assert llm_config["model"] == "test-model"
 
-    def test_cpr_agent_hook_returns_truthy(self, tmp_path):
-        """_cpr_agent now launches the target as a detached subprocess and
-        returns a truthy sentinel (not a reconstructed Agent). The test
-        validates the hook fires and yields a non-None signal — actual
-        process spawning is mocked out so no real lingtai child is forked."""
-        import json as _json
-        from lingtai.agent import Agent
-        from unittest.mock import patch
-
+    @staticmethod
+    def _cpr_service():
         svc = MagicMock()
         svc.create_session.return_value = MagicMock()
         svc.provider = "mock"
         svc.model = "test-model"
         svc._base_url = None
+        return svc
 
-        agents_dir = tmp_path / "agents"
-        agents_dir.mkdir()
-        target = Agent(svc, working_dir=agents_dir / "bobbob000001",
-                       agent_name="bob")
-        target_dir = str(target.working_dir)
+    @staticmethod
+    def _stage_cpr_target(target: Path) -> None:
+        """Create the non-human target shape needed to reach CPR's watchdog."""
+        import json
 
-        # _cpr_agent reads init.json before launching; Agent.__init__ doesn't
-        # persist it, so the test stages a minimal one.
-        (target.working_dir / "init.json").write_text(_json.dumps({
+        target.mkdir(parents=True)
+        (target / ".agent.json").write_text(json.dumps({
+            "agent_id": "target",
+            "admin": {},
+        }), encoding="utf-8")
+        (target / "init.json").write_text(json.dumps({
             "manifest": {
-                "agent_name": "bob",
+                "agent_name": "target",
                 "llm": {"provider": "mock", "model": "test-model"},
             },
-        }))
+        }), encoding="utf-8")
+
+    @staticmethod
+    def _cpr_reviver(tmp_path, svc):
+        from lingtai.agent import Agent
 
         reviver_dir = tmp_path / "reviver"
         reviver_dir.mkdir()
-        reviver = Agent(svc, working_dir=reviver_dir / "admin000001",
-                        agent_name="admin", admin={"karma": True})
+        return Agent(
+            svc,
+            working_dir=reviver_dir / "admin000001",
+            agent_name="admin",
+            admin={"karma": True},
+        )
 
-        target._workdir_lease.release()
-
-        # Stub Popen so no real subprocess is forked. Also short-circuit
-        # the venv resolver, which otherwise probes the runtime via
-        # subprocess.run (no real venv available in the test env).
-        # _cpr_agent imports these inside the function body, so the patch
-        # targets the source module rather than lingtai.agent.
+    def test_cpr_agent_hook_returns_truthy(self, tmp_path):
+        """A confirmed fresh heartbeat keeps the established truthy path."""
+        target = tmp_path / "agents" / "bobbob000001"
+        self._stage_cpr_target(target)
+        reviver = self._cpr_reviver(tmp_path, self._cpr_service())
         fake_proc = MagicMock()
         fake_proc.pid = 99999
-        from pathlib import Path as _Path
-        with patch("subprocess.Popen", return_value=fake_proc),\
-             patch("lingtai.venv_resolve.resolve_venv",
-                   return_value=_Path("/fake/venv")),\
-             patch("lingtai.venv_resolve.venv_python",
-                   return_value="/fake/venv/bin/python"):
-            resuscitated = reviver._cpr_agent(target_dir)
 
-        assert resuscitated is not None
-        assert resuscitated  # truthy sentinel
+        # Stub Popen and venv resolution so no child process or venv probe runs.
+        # Patching the Core observation at its imported source makes this a
+        # confirmed-heartbeat test even though the staged target is non-human.
+        with (
+            patch.object(reviver, "_log") as log,
+            patch("subprocess.Popen", return_value=fake_proc),
+            patch("lingtai.venv_resolve.resolve_venv", return_value=Path("/fake/venv")),
+            patch("lingtai.venv_resolve.venv_python", return_value="/fake/venv/bin/python"),
+            patch("lingtai.kernel.agent_presence.observe_alive", return_value=True),
+        ):
+            resuscitated = reviver._cpr_agent(str(target))
+
+        assert resuscitated is True
+        assert fake_proc.poll.call_count == 0
+        log.assert_any_call("cpr_alive", target=str(target), pid=99999)
+
+    def test_cpr_agent_returns_unconfirmed_running_child(self, tmp_path):
+        """A live child with delayed heartbeat is not a false CPR failure."""
+        target = tmp_path / "agents" / "delayed00001"
+        self._stage_cpr_target(target)
+        reviver = self._cpr_reviver(tmp_path, self._cpr_service())
+        fake_proc = MagicMock()
+        fake_proc.pid = 99999
+        fake_proc.poll.return_value = None
+        log_path = target / "logs" / "cpr_relaunch.log"
+
+        # The fake clock enters one poll iteration then reaches the 10-second
+        # boundary. The final values drive the required final observation.
+        with (
+            patch.object(reviver, "_log") as log,
+            patch("subprocess.Popen", return_value=fake_proc),
+            patch("lingtai.venv_resolve.resolve_venv", return_value=Path("/fake/venv")),
+            patch("lingtai.venv_resolve.venv_python", return_value="/fake/venv/bin/python"),
+            patch("lingtai.kernel.agent_presence.observe_alive", return_value=False) as observe_alive,
+            patch("time.time", side_effect=[0.0, 0.0, 0.0, 10.0, 10.0]),
+            patch("time.sleep"),
+        ):
+            resuscitated = reviver._cpr_agent(str(target))
+
+        assert resuscitated is True
+        assert observe_alive.call_count == 2
+        assert fake_proc.poll.call_count == 2
+        log.assert_any_call(
+            "cpr_launch_unconfirmed",
+            target=str(target),
+            pid=99999,
+            log=str(log_path),
+        )
+        assert all(call.args[0] != "cpr_timeout" for call in log.call_args_list)
+
+    @pytest.mark.parametrize("exit_code", [0, 23])
+    def test_cpr_agent_reports_early_exit_before_heartbeat(self, tmp_path, exit_code):
+        """Any observed child exit, including zero, remains a launch failure."""
+        target = tmp_path / "agents" / "exited000001"
+        self._stage_cpr_target(target)
+        reviver = self._cpr_reviver(tmp_path, self._cpr_service())
+        fake_proc = MagicMock()
+        fake_proc.pid = 99999
+        fake_proc.poll.return_value = exit_code
+        log_path = target / "logs" / "cpr_relaunch.log"
+
+        with (
+            patch.object(reviver, "_log") as log,
+            patch("subprocess.Popen", return_value=fake_proc),
+            patch("lingtai.venv_resolve.resolve_venv", return_value=Path("/fake/venv")),
+            patch("lingtai.venv_resolve.venv_python", return_value="/fake/venv/bin/python"),
+            patch("lingtai.kernel.agent_presence.observe_alive", return_value=False),
+            patch("time.time", side_effect=[0.0, 0.0, 0.0]),
+        ):
+            result = reviver._cpr_agent(str(target))
+
+        assert result["error"] is True
+        assert result["exit_code"] == exit_code
+        assert result["log"] == str(log_path)
+        assert f"exit code {exit_code}" in result["message"]
+        assert "Last log output:" in result["message"]
+        log.assert_any_call(
+            "cpr_failed",
+            target=str(target),
+            pid=99999,
+            exit_code=exit_code,
+            log=str(log_path),
+        )
+
+    def test_cpr_agent_reports_exit_observed_at_confirmation_deadline(self, tmp_path):
+        """The final status poll also classifies a just-exited child as failed."""
+        target = tmp_path / "agents" / "deadline00001"
+        self._stage_cpr_target(target)
+        reviver = self._cpr_reviver(tmp_path, self._cpr_service())
+        fake_proc = MagicMock()
+        fake_proc.pid = 99999
+        fake_proc.poll.side_effect = [None, 0]
+        log_path = target / "logs" / "cpr_relaunch.log"
+
+        with (
+            patch.object(reviver, "_log") as log,
+            patch("subprocess.Popen", return_value=fake_proc),
+            patch("lingtai.venv_resolve.resolve_venv", return_value=Path("/fake/venv")),
+            patch("lingtai.venv_resolve.venv_python", return_value="/fake/venv/bin/python"),
+            patch("lingtai.kernel.agent_presence.observe_alive", return_value=False) as observe_alive,
+            patch("time.time", side_effect=[0.0, 0.0, 0.0, 10.0, 10.0]),
+            patch("time.sleep"),
+        ):
+            result = reviver._cpr_agent(str(target))
+
+        assert result["error"] is True
+        assert result["exit_code"] == 0
+        assert result["log"] == str(log_path)
+        assert observe_alive.call_count == 2
+        assert fake_proc.poll.call_count == 2
+        log.assert_any_call(
+            "cpr_failed",
+            target=str(target),
+            pid=99999,
+            exit_code=0,
+            log=str(log_path),
+        )
+        assert all(call.args[0] != "cpr_launch_unconfirmed" for call in log.call_args_list)
 
 
 class TestSelfSleepPendingNotificationsGuard:


### PR DESCRIPTION
## Summary
- Retain CPR's bounded 10-second heartbeat-confirmation interval.
- At its boundary, distinguish an observed child-process exit (existing error/log-tail path) from a child still running without confirmation (factual `cpr_launch_unconfirmed`, established receipt).
- Add hermetic watchdog coverage and system Contract/B007 linkage.

## Validation
- `python -m pytest -q tests/test_karma.py tests/test_system.py` — 60 passed
- `git diff --check`

## Scope
No MCP, Telegram, catalog/startup-data, liveness-threshold, schema, or configuration change. Repository-wide documentation validation currently reports unrelated tracked-document violations; this patch does not modify those files.