### PR TITLE
fix(telegram): show daemon API calls

### DIFF
--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -2807,11 +2807,9 @@ class TelegramManager:
                 if isinstance(usage, dict):
                     for source_key, total_key in (("input", "input"), ("output", "output"), ("cached", "cached")):
                         totals[total_key] += _task_card_nonnegative_count(usage.get(source_key))
-                # API call statistics are meaningful only for the external CLI
-                # ledger; daemon tool_call_count is deliberately not substituted.
-                cli_calls += _task_card_nonnegative_count(
-                    cli_tokens.get("calls") if cli_tokens is not None else None
-                )
+                    # API calls come from the same selected ledger as the displayed
+                    # token totals. daemon tool_call_count is deliberately not substituted.
+                    cli_calls += _task_card_nonnegative_count(usage.get("calls"))
             except (OSError, ValueError, TypeError, UnicodeDecodeError, json.JSONDecodeError):
                 continue
         if not included:

--- a/tests/test_telegram_task_card_rows.py
+++ b/tests/test_telegram_task_card_rows.py
@@ -864,7 +864,9 @@ def test_daemon_snapshot_scans_daemons_dir_and_windows(tmp_path):
     assert snap["input_tokens"] == 1000 + 2000 + 3000
     assert snap["output_tokens"] == 500 + 700 + 100
     assert snap["cached_tokens"] == 800 + 1500 + 0
-    assert snap["cli_calls"] == 1
+    # In-window selected ledgers: LingTai tokens 3 + external fallback tokens 4 + CLI ledger 1.
+    # em-4 is outside the window and its 99 calls remain excluded.
+    assert snap["cli_calls"] == 8
     # Only actual LingTai backend model values are eligible; external and
     # backend-less records remain visible in their existing lanes but are not
     # misrepresented as LingTai model statistics.
@@ -954,7 +956,7 @@ def test_async_work_snapshot_mixes_daemon_and_shell_lanes(tmp_path, monkeypatch)
     assert "daemon" in snapshot and "shell" in snapshot
 
 
-def test_daemon_real_schema_cli_ledger_not_shadowed_and_kernel_calls_not_fabricated(tmp_path):
+def test_daemon_real_schema_cli_ledger_not_shadowed_and_kernel_api_calls_use_tokens(tmp_path):
     import datetime as _datetime
     daemons = tmp_path / "daemons"
     daemons.mkdir()
@@ -971,7 +973,7 @@ def test_daemon_real_schema_cli_ledger_not_shadowed_and_kernel_calls_not_fabrica
     kernel.mkdir()
     (kernel / "daemon.json").write_text(json.dumps({
         "state": "running", "backend": "lingtai",
-        "tokens": {"input": 9, "output": 4, "cached": 2},
+        "tokens": {"input": 9, "output": 4, "cached": 2, "calls": 4},
         "tool_call_count": 17,
     }), encoding="utf-8")
     mgr, _ = _integration_manager(tmp_path)
@@ -979,4 +981,5 @@ def test_daemon_real_schema_cli_ledger_not_shadowed_and_kernel_calls_not_fabrica
     assert snapshot["input_tokens"] == 109
     assert snapshot["output_tokens"] == 44
     assert snapshot["cached_tokens"] == 22
-    assert snapshot["cli_calls"] == 3
+    # 3 external CLI calls + 4 LingTai API calls; tool_call_count 17 is not an API ledger.
+    assert snapshot["cli_calls"] == 7


### PR DESCRIPTION
## Summary

- Include `calls` from the same selected ledger as the displayed daemon token totals, so LingTai daemon `tokens.calls` appears in the existing Telegram Task Card `api calls` stats row.
- Preserve external CLI ledger precedence and keep `daemon tool_call_count` excluded from API-call reporting.
- Extend the existing Task Card rows regression coverage for LingTai, external fallback, window exclusion, and non-substitution of tool calls.

## Validation

- [x] `git diff --check`
- [x] `python -m pytest -q tests/test_telegram_task_card_rows.py -k 'metadata_renders_daemon_status_and_stats or daemon_snapshot_scans_daemons_dir_and_windows or daemon_real_schema_cli_ledger_not_shadowed_and_kernel_api_calls_use_tokens'` — 3 passed, 57 deselected
- [x] Independent no-tools review (`em-8a38`) — APPROVE
- [x] Full `tests/test_telegram_task_card_rows.py` module: 59 passed; one unrelated metadata-order failure reproduces unchanged on clean `origin/main` at `8a60a53e`.

## Notes

- No Task Card layout redesign, daemon telemetry/schema change, configuration change, or i18n expansion.
- Telegram: @lingtaidev2bot | Nickname: N/A
- Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
