### PR TITLE
Centralize published agent-record staleness classification

### DIFF
--- a/src/lingtai/cli.py
+++ b/src/lingtai/cli.py
@@ -6,6 +6,7 @@ import json
 import os
 import signal
 import sys
+import time
 from pathlib import Path
 
 from lingtai.adapters.posix.event_journal import PosixJsonlEventJournalAdapter
@@ -502,6 +503,17 @@ def main() -> None:
 
     sub.add_parser("check-caps", help="Output capability provider metadata as JSON")
 
+    liveness_parser = sub.add_parser(
+        "liveness",
+        help="Emit the kernel-owned published-Agent liveness result as JSON",
+    )
+    liveness_parser.add_argument(
+        "--agent-dir",
+        type=Path,
+        required=True,
+        help="Agent working directory to inspect without booting it",
+    )
+
     log_parser = sub.add_parser("log", help="Inspect the additive SQLite log index")
     log_sub = log_parser.add_subparsers(dest="log_command", required=True)
 
@@ -565,6 +577,19 @@ def main() -> None:
     elif args.command == "check-caps":
         from lingtai.tools.registry import get_all_providers
         print(json.dumps(get_all_providers()))
+    elif args.command == "liveness":
+        agent_dir = args.agent_dir.resolve()
+        if not agent_dir.is_dir():
+            print(f"error: {agent_dir} is not a directory", file=sys.stderr)
+            sys.exit(1)
+        from lingtai.kernel.session_stats import (
+            query_published_agent_liveness,
+            read_agent_record,
+        )
+        _emit_json(query_published_agent_liveness(
+            read_agent_record(agent_dir),
+            wall_now=time.time(),
+        ))
     elif args.command == "log":
         _handle_log_command(args)
     elif args.command == "daemon":

--- a/src/lingtai/kernel/session_stats/ANATOMY.md
+++ b/src/lingtai/kernel/session_stats/ANATOMY.md
@@ -2,6 +2,9 @@
 related_files:
   - src/lingtai/kernel/session_stats/CONTRACT.md
   - src/lingtai/kernel/session_stats/__init__.py
+  - src/lingtai/cli.py
+  - tests/test_session_stats.py
+  - tests/test_cli_liveness.py
   - src/lingtai/kernel/ANATOMY.md
   - src/lingtai/kernel/base_agent/ANATOMY.md
   - src/lingtai/kernel/base_agent/CONTRACT.md
@@ -40,9 +43,16 @@ state (confirmed alignment: Telegram 14238/14242/14248).
 
 ## Components
 
-- `build_agent_record` / `write_agent_record` / `read_agent_record`
-  (`__init__.py`) — the Agent record projector, atomic writer, and best-effort
-  reader. Publishes to `system/agent_record.json`.
+- `build_agent_record` / `write_agent_record` / `read_agent_record` /
+  `classify_published_agent_record` / `query_published_agent_liveness`
+  (`__init__.py`) — the Agent record projector, atomic writer, best-effort
+  reader, pure classifier, and one-key consumer dict projection. The projection
+  receives the reader's current wall time, ignores persisted `health.liveness`,
+  maps a stale active/idle/asleep record to `offline`, and makes malformed or
+  absent records `unavailable`. `lingtai-agent liveness --agent-dir <dir>`
+  (`cli.py`) is the read-only cross-process JSON wrapper around that projection;
+  neither Python nor cross-process consumers reconstruct heartbeat semantics.
+  Publishes to `system/agent_record.json`.
 - `build_daemon_record` / `write_daemon_record` (`__init__.py`) — the compact
   daemon self-record projector and atomic writer. Publishes to
   `<run_dir>/session_stats.json`, a sibling of `daemon.json`.
@@ -77,10 +87,12 @@ state (confirmed alignment: Telegram 14238/14242/14248).
   tool dispatch, CLI output/usage, terminal markers, …); it now also calls
   `write_daemon_record`, so the daemon self-record refreshes on every daemon
   turn without a second scattered set of call sites.
-- `TelegramManager._task_card_agent_lifecycle_status` /
-  `_task_card_active_seconds` (`mcp_servers/telegram/manager.py`) and
+- `TelegramManager._task_card_agent_lifecycle_status` delegates the automatic
+  Task Card lifecycle to `classify_published_agent_record` after
+  `read_agent_record`; `_task_card_active_seconds`
+  (`mcp_servers/telegram/manager.py`) and
   `LocalCommandCore.collect_kanban_data` (`mcp_servers/local_commands/core.py`)
-  read `read_agent_record` instead of `.status.json`/token-ledger scans.
+  read the record instead of `.status.json`/token-ledger scans.
 
 ## Composition
 

--- a/src/lingtai/kernel/session_stats/CONTRACT.md
+++ b/src/lingtai/kernel/session_stats/CONTRACT.md
@@ -5,6 +5,7 @@ root_contract: CONTRACT.md
 related_files:
   - src/lingtai/kernel/session_stats/ANATOMY.md
   - src/lingtai/kernel/session_stats/__init__.py
+  - src/lingtai/cli.py
   - src/lingtai/kernel/base_agent/CONTRACT.md
   - src/lingtai/kernel/base_agent/__init__.py
   - src/lingtai/kernel/base_agent/lifecycle.py
@@ -18,6 +19,7 @@ related_files:
   - src/lingtai/mcp_servers/local_commands/core.py
   - ENVIRONMENT_VARIABLES.md
   - tests/test_session_stats.py
+  - tests/test_cli_liveness.py
   - tests/test_daemon_run_dir.py
   - tests/test_status_snapshot.py
   - tests/test_architecture_documents.py
@@ -115,6 +117,18 @@ Telegram bot username) and MCP integration labels from
 pattern rather than inventing a second composition mechanism (a callback
 attribute, a service locator, or a hidden Core import).
 
+Consumers MUST use `query_published_agent_liveness(record, wall_now=...)`
+for current lifecycle presentation rather than duplicating record-shape or
+heartbeat-age logic. It always returns exactly `{"liveness": <value>}`:
+`active`/`idle`/`asleep` for a strictly fresh recognized heartbeat, `stuck` or
+`suspended` for an explicit published state, `offline` for a recognized running
+or sleeping state with missing/non-finite/expired heartbeat, and `unavailable`
+for a missing/malformed/unrecognized record. Its underlying classifier defaults
+to the canonical `HEARTBEAT_LIVENESS_SECONDS` and ignores frozen
+`health.liveness`. Cross-process consumers MUST invoke the read-only
+`lingtai-agent liveness --agent-dir <agent-dir>` command and consume its JSON
+instead of parsing record fields, environment variables, or legacy sources.
+
 ## Shapes
 
 Agent record (`system/agent_record.json`, schema
@@ -184,7 +198,9 @@ this module nor its aggregation ever writes to a token ledger.
 `tests/test_session_stats.py` locks: atomic-write behavior (temp-sibling +
 `os.replace`, no partial reads) for both record types; `schema`/
 `schema_version`/`generated_at` presence; the Agent-record redaction
-allowlist (no working-dir path, no secrets, no prompts); `should_refresh_agent_record`'s
+allowlist (no working-dir path, no secrets, no prompts); published-record
+classification's strict freshness boundary, missing/non-finite heartbeat, and
+explicit terminal-state invariants; `should_refresh_agent_record`'s
 throttle/first-write/backwards-clock behavior; `session_stats_refresh_seconds`/
 `session_stats_daemon_limit` fallback on missing/blank/non-numeric/zero/
 negative values; `aggregate_daemon_records`'s bounded newest-first scan,

--- a/src/lingtai/kernel/session_stats/__init__.py
+++ b/src/lingtai/kernel/session_stats/__init__.py
@@ -42,6 +42,7 @@ from pathlib import Path
 from typing import Any
 
 from .._fsutil import atomic_write_json
+from ..config import HEARTBEAT_LIVENESS_SECONDS
 
 # ---------------------------------------------------------------------------
 # Schema / filenames
@@ -299,6 +300,70 @@ def read_agent_record(working_dir: Path | str) -> dict | None:
     return data if isinstance(data, dict) else None
 
 
+def classify_published_agent_record(
+    record: object,
+    *,
+    wall_now: float,
+    liveness_seconds: float = HEARTBEAT_LIVENESS_SECONDS,
+) -> str | None:
+    """Classify a published Agent Record against an injected wall-clock value.
+
+    ``health.liveness`` is a write-time snapshot, so consumers must not treat it
+    as live evidence. Explicit ``stuck`` and ``suspended`` states remain
+    authoritative. The running states require a finite heartbeat with an age
+    strictly below ``liveness_seconds``; otherwise they are offline. Missing or
+    unrecognized records return ``None`` for an unavailable presentation.
+    """
+    if not isinstance(record, dict):
+        return None
+    if (
+        record.get("schema") != AGENT_RECORD_SCHEMA
+        or record.get("schema_version") != AGENT_RECORD_VERSION
+    ):
+        return None
+
+    session = record.get("session")
+    if not isinstance(session, dict):
+        return None
+    state = session.get("state")
+    if state not in {"active", "idle", "asleep", "stuck", "suspended"}:
+        return None
+    if state in {"stuck", "suspended"}:
+        return state
+
+    health = record.get("health")
+    heartbeat_at = health.get("heartbeat_at") if isinstance(health, dict) else None
+    if isinstance(heartbeat_at, bool) or not isinstance(heartbeat_at, (int, float)):
+        return "offline"
+    if not math.isfinite(heartbeat_at):
+        return "offline"
+    if isinstance(wall_now, bool) or not isinstance(wall_now, (int, float)):
+        return "offline"
+    if not math.isfinite(wall_now):
+        return "offline"
+
+    age = wall_now - heartbeat_at
+    if not math.isfinite(age) or age >= liveness_seconds:
+        return "offline"
+    return state
+
+
+def query_published_agent_liveness(
+    record: object,
+    *,
+    wall_now: float,
+) -> dict[str, str]:
+    """Project the canonical published-record liveness decision as one dict.
+
+    The result is always exactly ``{"liveness": <value>}``, where a malformed
+    or unavailable record becomes ``"unavailable"``. This is the consumer
+    contract: callers must not read legacy status sources or reconstruct the
+    heartbeat policy from record fields.
+    """
+    lifecycle = classify_published_agent_record(record, wall_now=wall_now)
+    return {"liveness": lifecycle if lifecycle is not None else "unavailable"}
+
+
 # ---------------------------------------------------------------------------
 # Daemon self-record — written by DaemonRunDir on every daemon turn
 # ---------------------------------------------------------------------------
@@ -462,6 +527,7 @@ __all__ = [
     "session_stats_refresh_seconds", "session_stats_daemon_limit",
     "should_refresh_agent_record",
     "agent_record_path", "build_agent_record", "write_agent_record", "read_agent_record",
+    "classify_published_agent_record", "query_published_agent_liveness",
     "daemon_record_path", "build_daemon_record", "write_daemon_record",
     "aggregate_daemon_records",
 ]

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -30,7 +30,7 @@ import logging
 import threading
 
 from lingtai.kernel._frontmatter import strip_frontmatter
-from lingtai.kernel.session_stats import read_agent_record
+from lingtai.kernel.session_stats import query_published_agent_liveness, read_agent_record
 from lingtai.kernel.state import AgentState
 from lingtai.tools.bash._async_supervisor import load_state
 from lingtai.mcp_servers.task_card import (
@@ -2940,53 +2940,18 @@ class TelegramManager:
         return out or None
 
     def _task_card_agent_lifecycle_status(self) -> str | None:
-        """Read this agent's own canonical lifecycle for the footer.
+        """Classify this agent's published record for the automatic footer.
 
-        Sources the owning agent's published Agent record
-        (``session.state`` / ``health.heartbeat_at`` — see
-        ``lingtai.kernel.session_stats``), the same redacted live snapshot
-        ``BaseAgent`` publishes on every turn, instead of reading
-        ``.status.json``/presence files directly — Telegram curates and
-        renders the record, it does not re-collect underlying facts itself.
-        Only for the non-terminal ``active``/``idle``/``asleep`` states is
-        heartbeat freshness consulted, catching a process that died without
-        ever writing ``stuck``. ``stuck`` and ``suspended`` are trusted
-        as-is: both are the process explicitly reporting its own state, and
-        a stale heartbeat proves nothing more in either case.
-
-        The record's own ``health.liveness`` string is a write-time snapshot
-        baked in by the agent that was alive when it wrote the record; it
-        never changes once that process dies, so it cannot be trusted here.
-        Freshness is instead recomputed against the *current* wall clock from
-        ``health.heartbeat_at`` using the same ``HEARTBEAT_LIVENESS_SECONDS``
-        threshold the writer used, so a dead process's last record correctly
-        reads as offline once the heartbeat goes stale. A missing record,
-        missing blocks, or an unrecognized state degrades to ``None`` — no
-        line is rendered rather than fabricating a state.
+        Telegram reads and curates the redacted Agent Record rather than
+        re-collecting status or heartbeat files. The kernel helper owns the
+        lifecycle/heartbeat policy, including rejection of frozen
+        ``health.liveness`` snapshots.
         """
-        from lingtai.kernel.config import HEARTBEAT_LIVENESS_SECONDS
-
-        record = read_agent_record(self._working_dir)
-        if record is None:
-            return None
-        session = record.get("session")
-        if not isinstance(session, dict):
-            return None
-        state = session.get("state")
-        if state not in _TASK_CARD_AGENT_STATES:
-            return None
-        if state in (AgentState.SUSPENDED.value, AgentState.STUCK.value):
-            return state
-        health = record.get("health")
-        heartbeat_at = health.get("heartbeat_at") if isinstance(health, dict) else None
-        if not isinstance(heartbeat_at, (int, float)) or isinstance(heartbeat_at, bool):
-            return state
-        if not math.isfinite(heartbeat_at):
-            return state
-        age = time.time() - heartbeat_at
-        if not math.isfinite(age):
-            return state
-        return state if age < HEARTBEAT_LIVENESS_SECONDS else "offline"
+        liveness = query_published_agent_liveness(
+            read_agent_record(self._working_dir),
+            wall_now=time.time(),
+        )["liveness"]
+        return None if liveness == "unavailable" else liveness
 
     def _task_card_active_seconds(self) -> float | None:
         """Seconds since the agent's last API call while it is active.

--- a/tests/test_cli_liveness.py
+++ b/tests/test_cli_liveness.py
@@ -1,0 +1,50 @@
+import json
+import sys
+
+from lingtai.kernel import session_stats
+
+
+def _run_cli(monkeypatch, argv: list[str]) -> int:
+    from lingtai.cli import main
+
+    monkeypatch.setattr(sys, "argv", ["lingtai-agent", *argv])
+    try:
+        main()
+    except SystemExit as exc:
+        return int(exc.code or 0)
+    return 0
+
+
+def _record(state: str, heartbeat_at: float) -> dict:
+    return {
+        "schema": session_stats.AGENT_RECORD_SCHEMA,
+        "schema_version": session_stats.AGENT_RECORD_VERSION,
+        "session": {"state": state},
+        "health": {"heartbeat_at": heartbeat_at, "liveness": "fresh"},
+    }
+
+
+def test_liveness_cli_emits_only_kernel_owned_liveness_dict(tmp_path, monkeypatch, capsys):
+    session_stats.write_agent_record(tmp_path, _record("active", 100.0))
+    before = session_stats.agent_record_path(tmp_path).read_bytes()
+    monkeypatch.setattr("lingtai.cli.time.time", lambda: 100.0)
+
+    assert _run_cli(monkeypatch, ["liveness", "--agent-dir", str(tmp_path)]) == 0
+    assert json.loads(capsys.readouterr().out) == {"liveness": "active"}
+    assert session_stats.agent_record_path(tmp_path).read_bytes() == before
+
+
+def test_liveness_cli_degrades_to_unavailable_without_legacy_fallback(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr("lingtai.cli.time.time", lambda: 100.0)
+
+    assert _run_cli(monkeypatch, ["liveness", "--agent-dir", str(tmp_path)]) == 0
+    assert json.loads(capsys.readouterr().out) == {"liveness": "unavailable"}
+
+
+def test_liveness_cli_rejects_a_non_directory(monkeypatch, capsys, tmp_path):
+    missing = tmp_path / "missing"
+
+    assert _run_cli(monkeypatch, ["liveness", "--agent-dir", str(missing)]) == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "is not a directory" in captured.err

--- a/tests/test_session_stats.py
+++ b/tests/test_session_stats.py
@@ -179,6 +179,72 @@ def test_read_agent_record_missing_and_corrupt_return_none(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# Published Agent Record lifecycle classification
+# ---------------------------------------------------------------------------
+
+
+def _published_agent_record(state: str, health: dict) -> dict:
+    return {
+        "schema": session_stats.AGENT_RECORD_SCHEMA,
+        "schema_version": session_stats.AGENT_RECORD_VERSION,
+        "session": {"state": state},
+        "health": health,
+    }
+
+
+def test_published_agent_record_liveness_boundary_is_strict():
+    heartbeat_at = 100.0
+    record = _published_agent_record("active", {
+        "heartbeat_at": heartbeat_at,
+        "liveness": "fresh",
+    })
+
+    assert session_stats.classify_published_agent_record(
+        record,
+        wall_now=heartbeat_at + session_stats.HEARTBEAT_LIVENESS_SECONDS - 0.001,
+    ) == "active"
+    assert session_stats.classify_published_agent_record(
+        record,
+        wall_now=heartbeat_at + session_stats.HEARTBEAT_LIVENESS_SECONDS,
+    ) == "offline"
+
+
+@pytest.mark.parametrize("health", [
+    {"liveness": "fresh"},
+    {"heartbeat_at": float("nan"), "liveness": "fresh"},
+    {"heartbeat_at": float("inf"), "liveness": "fresh"},
+])
+def test_published_agent_record_missing_or_nonfinite_heartbeat_is_offline(health):
+    assert session_stats.classify_published_agent_record(
+        _published_agent_record("idle", health), wall_now=100.0,
+    ) == "offline"
+
+
+@pytest.mark.parametrize("state", ["stuck", "suspended"])
+def test_published_agent_record_keeps_explicit_terminal_state(state):
+    assert session_stats.classify_published_agent_record(
+        _published_agent_record(state, {"heartbeat_at": 0.0}), wall_now=10_000.0,
+    ) == state
+
+
+@pytest.mark.parametrize(
+    ("record", "expected"),
+    [
+        (_published_agent_record("active", {"heartbeat_at": 100.0}), "active"),
+        (_published_agent_record("idle", {"heartbeat_at": 90.0}), "offline"),
+        (_published_agent_record("stuck", {"heartbeat_at": 0.0}), "stuck"),
+        (_published_agent_record("suspended", {"heartbeat_at": 0.0}), "suspended"),
+        ({}, "unavailable"),
+    ],
+)
+def test_query_published_agent_liveness_is_the_complete_consumer_dict(record, expected):
+    assert session_stats.query_published_agent_liveness(
+        record,
+        wall_now=100.0,
+    ) == {"liveness": expected}
+
+
+# ---------------------------------------------------------------------------
 # should_refresh_agent_record / env var validation
 # ---------------------------------------------------------------------------
 

--- a/tests/test_telegram_task_card_rows.py
+++ b/tests/test_telegram_task_card_rows.py
@@ -641,10 +641,10 @@ def test_lifecycle_status_fresh_heartbeat_wins_over_frozen_stale_liveness(tmp_pa
     assert mgr._task_card_agent_lifecycle_status() == "idle"
 
 
-def test_lifecycle_status_missing_heartbeat_falls_back_to_raw_state(tmp_path):
+def test_lifecycle_status_missing_heartbeat_becomes_offline(tmp_path):
     mgr, _ = _integration_manager(tmp_path)
     _write_agent_record(tmp_path, state="idle")
-    assert mgr._task_card_agent_lifecycle_status() == "idle"
+    assert mgr._task_card_agent_lifecycle_status() == "offline"
 
 
 # ---------------------------------------------------------------------------
@@ -665,7 +665,7 @@ def test_event_metadata_snapshot_none_when_nothing_available(tmp_path):
 
 def test_event_metadata_snapshot_adds_lifecycle_alone(tmp_path):
     mgr, _ = _integration_manager(tmp_path)
-    _write_agent_record(tmp_path, state="active", liveness="fresh")
+    _write_agent_record(tmp_path, state="active", liveness="fresh", heartbeat_at=time.time())
     snapshot = mgr._task_card_event_metadata_snapshot()
     assert snapshot["agent_lifecycle"] == "active"
     assert "device_short_name" in snapshot
@@ -700,7 +700,7 @@ def test_event_metadata_snapshot_adds_current_model(tmp_path):
         _json.dumps({"llm": {"model": "deepseek-v4-flash"}}), encoding="utf-8"
     )
     mgr, _ = _integration_manager(tmp_path)
-    _write_agent_record(tmp_path, state="active", liveness="fresh")
+    _write_agent_record(tmp_path, state="active", liveness="fresh", heartbeat_at=time.time())
     snapshot = mgr._task_card_event_metadata_snapshot()
     assert snapshot["agent_lifecycle"] == "active"
     assert snapshot["model"] == "deepseek-v4-flash"


### PR DESCRIPTION
## Summary

- Centralize published Agent-Record liveness classification in the kernel.
- Add `query_published_agent_liveness(...)`, the single pure consumer projection returning exactly `{"liveness": ...}`.
- Add the read-only cross-process command: `lingtai-agent liveness --agent-dir <agent-dir>`.
- Migrate Telegram automatic Task Card to consume the kernel dict while preserving its existing choice to omit an unavailable lifecycle line.

## Contract

Consumers no longer interpret heartbeat fields, the liveness environment variable, or legacy status sources. The kernel alone maps the published record to `active`, `idle`, `asleep`, `stuck`, `suspended`, `offline`, or `unavailable`; cross-process consumers consume the JSON command result.

## Validation

- Source-pinned independent review: **APPROVED** (P0/P1/P2: 0/0/0), canonical full diff SHA-256 `d2d774148cf183d5f7020c3c72a6b398978c4005f33ded1184d6f9f334959657`
- `pytest -q tests/test_session_stats.py tests/test_cli_liveness.py` — 54 passed
- Targeted Telegram lifecycle/metadata cases — 17 passed
- Actual candidate CLI smoke returned `{"liveness":"active"}`
- `git diff --check` passed

## Known unrelated baselines

The combined focused suite retains two unchanged base failures: one Task Card formatter-layout expectation and a duplicate `reasoning_effort.py` entry in the kernel LLM Anatomy. Neither is in this PR's staged diff.

## Scope and boundaries

This remains the kernel liveness contract slice. It does not merge, refresh runtime, release, deploy, delete, clean up, or perform the separate TUI/Portal migration.

Telegram: @lingtaidev3bot | Nickname: 澄一
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai