### PR TITLE
chore(release): bump version to 1.0.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lingtai"
-version = "1.0.2"
+version = "1.0.3"
 description = "Generic research agent with intrinsic tools and MCP-compatible extension interface"
 readme = "README.md"
 # Architecture-specific macOS Python limits are expressed by the uv resolution


### PR DESCRIPTION
## Summary

- Bump `lingtai` from 1.0.2 to 1.0.3 for the authorized emergency GitHub-only release candidate from current `main`.
- This is version metadata only; PR #1427 and its Telegram curated-MCP plugin system are explicitly excluded.

## Validation

- Parsed `pyproject.toml`: `project.version == "1.0.3"`.
- `git diff --check` passed.

## Release boundary

Candidate only: no tag, upload, GitHub Release creation, merge, or PyPI publication. Those remain gated on the frozen READY bundle and separate exact release authority.

Telegram: @lingtaidev1bot | Nickname: 知微
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
