### PR TITLE
refactor(email): localize model-facing descriptor and manual

### DIFF
--- a/src/lingtai/tools/email/CONTRACT.md
+++ b/src/lingtai/tools/email/CONTRACT.md
@@ -102,6 +102,17 @@ Nullable-and-required is how an optional field is expressed (per
 *absent* before the manager runs, so `folder`/`n`/`filter` defaulting and
 `edit_contact`'s `if "name" in args` semantics are preserved exactly.
 
+### Package-local root/manual ownership
+
+`EmailToolDescriptor` / `EMAIL_TOOL_DESCRIPTOR` in `__init__.py` own Email's
+canonical model-facing root (`email`) and installed manual destination (`email`).
+Both the schema-only and per-call dispatching `ToolFamily` builders consume
+`root_name`; the dispatched `build_manual_child` consumes `manual_skill_name`;
+the existing notification dismissal guard and boot-time mailbox marker consume
+the same root. This is a package-local identity seam for every-tool
+pluginization, **not** plugin discovery or activation: Agent/Host registration,
+the intrinsic registry, provider wires, and mailbox lifecycle remain unchanged.
+
 The tables below list each action's inputs. Under the envelope they are that
 action's `input` properties — e.g. `email(action='read', input={'email_id':
 [...]}, reasoning='...')`.
@@ -205,6 +216,7 @@ mailbox/contacts.json                 — contact book (list of {address,name,no
 | Sender identity is carried on inbound mail and surfaced on read | `src/lingtai/tools/email/manager.py:_inject_identity` | `tests/test_email_identity.py` |
 | Abs-mode replies resolve via `_return_route`, guarding the `#145` ambiguous self-route | `src/lingtai/tools/email/manager.py:_resolve_reply_target` | `tests/test_email_abs_reply_route.py` |
 | The model-facing root is the closed LTP v2 envelope and nothing else | `src/lingtai/tools/email/__init__.py:get_schema` | `tests/test_tool_family_email_migration.py::test_root_is_the_closed_ltp_v2_envelope_and_nothing_else` |
+| One package-local descriptor owns the canonical root and installed manual destination consumed by both families and the actual manual child | `src/lingtai/tools/email/__init__.py:EMAIL_TOOL_DESCRIPTOR` | `tests/test_tool_family_email_migration.py::test_package_local_descriptor_is_consumed_by_schema_dispatch_and_manual_child` |
 | All 14 public action values and their order are unchanged | `src/lingtai/tools/email/_family_schema.py:ACTION_ORDER` | `tests/test_tool_family_email_migration.py::test_public_action_values_and_order_are_unchanged` |
 | One child registry drives both the advertised schema and dispatch | `src/lingtai/tools/email/__init__.py:_build_family` | `tests/test_tool_family_email_migration.py::test_one_canonical_child_registry_drives_schema_and_dispatch` |
 | A cross-action key is rejected before any mailbox I/O or delivery | `src/lingtai/tools/tool_family/__init__.py:ToolFamily.handle` | `tests/test_tool_family_email_migration.py::test_cross_action_key_is_rejected_before_any_mailbox_io`, `::test_send_fields_cannot_be_smuggled_through_a_read_call` |

--- a/src/lingtai/tools/email/__init__.py
+++ b/src/lingtai/tools/email/__init__.py
@@ -37,6 +37,7 @@ tool is now request/response only.
 """
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any, Mapping
 
 from lingtai.kernel.notifications import register_generic_dismiss_guard
@@ -44,11 +45,35 @@ from .._manual import load_installed_manual  # noqa: F401  (public re-export)
 from ..tool_family import ChildTool, ToolFamily
 from ..tool_family.manual import build_manual_child
 
+
+@dataclass(frozen=True, slots=True)
+class EmailToolDescriptor:
+    """Package-local identity for Email's one canonical ToolFamily root.
+
+    This is deliberately not an activation or registration API: Agent/Host
+    registration remains where it was.  It owns only the values Email itself
+    passes to the generic family and manual-child helpers, so the advertised
+    root, dispatch family, notification guard, mailbox marker, and installed
+    manual destination cannot silently drift apart.
+    """
+
+    root_name: str
+    manual_skill_name: str
+
+
+EMAIL_TOOL_DESCRIPTOR = EmailToolDescriptor(
+    root_name="email",
+    manual_skill_name="email",
+)
+
+
 register_generic_dismiss_guard(
-    "email",
+    EMAIL_TOOL_DESCRIPTOR.root_name,
     (
-        "email(action='dismiss', input={'email_id': [...]}, reasoning='handled') "
-        "or email(action='read', input={'email_id': [...]}, reasoning='refresh')"
+        f"{EMAIL_TOOL_DESCRIPTOR.root_name}(action='dismiss', "
+        "input={'email_id': [...]}, reasoning='handled') "
+        f"or {EMAIL_TOOL_DESCRIPTOR.root_name}(action='read', "
+        "input={'email_id': [...]}, reasoning='refresh')"
     ),
 )
 
@@ -101,10 +126,6 @@ from .manager import EmailManager  # noqa: F401
 # LTP v2 family composition — one model-facing root, one child per action
 # ---------------------------------------------------------------------------
 
-# The installed intrinsic-skill directory ``manual`` reads. Unchanged from the
-# pre-migration ``load_installed_manual(agent, "email")`` call.
-_MANUAL_SKILL_NAME = "email"
-
 # The exact pre-migration reserved-action rejection for ``unread``. It is a
 # kernel-synthesized digest action, NOT a public child: it is absent from
 # ``ACTION_ORDER`` and therefore from the ``action`` enum, so the generic
@@ -116,9 +137,9 @@ _MANUAL_SKILL_NAME = "email"
 _UNREAD_RESERVED_RESULT: dict[str, Any] = {
     "status": "error",
     "message": (
-        "email(action='unread', ...) is reserved for kernel-"
+        f"{EMAIL_TOOL_DESCRIPTOR.root_name}(action='unread', ...) is reserved for kernel-"
         "synthesized unread-mail digests and cannot be invoked "
-        "directly. Use email(action='check') to view your inbox."
+        f"directly. Use {EMAIL_TOOL_DESCRIPTOR.root_name}(action='check') to view your inbox."
     ),
 }
 
@@ -142,7 +163,7 @@ def _schema_only_family() -> ToolFamily:
         raise AssertionError("the module-level schema-only ToolFamily never dispatches")
 
     return ToolFamily(
-        "email",
+        EMAIL_TOOL_DESCRIPTOR.root_name,
         [
             ChildTool(action, INPUT_SCHEMAS[action], _unused, title=f"{action} input")
             for action in ACTION_ORDER
@@ -276,7 +297,9 @@ def _build_family(agent) -> ToolFamily:
     children = []
     for action in ACTION_ORDER:
         if action == "manual":
-            children.append(build_manual_child(agent, _MANUAL_SKILL_NAME))
+            children.append(
+                build_manual_child(agent, EMAIL_TOOL_DESCRIPTOR.manual_skill_name)
+            )
         else:
             children.append(
                 ChildTool(
@@ -286,7 +309,7 @@ def _build_family(agent) -> ToolFamily:
                     title=f"{action} input",
                 )
             )
-    return ToolFamily("email", children)
+    return ToolFamily(EMAIL_TOOL_DESCRIPTOR.root_name, children)
 
 
 # ---------------------------------------------------------------------------
@@ -340,7 +363,7 @@ def handle(agent, args: dict) -> dict:
         # distinction is restored here at Email's own Host boundary.
         if not action:
             return {"error": "action is required"}
-        return {"error": f"Unknown email action: {action}"}
+        return {"error": f"Unknown {EMAIL_TOOL_DESCRIPTOR.root_name} action: {action}"}
     return result
 
 
@@ -359,4 +382,4 @@ def boot(agent) -> None:
     mgr = EmailManager(agent)
     agent._email_manager = mgr
     agent._mailbox_name = "email box"
-    agent._mailbox_tool = "email"
+    agent._mailbox_tool = EMAIL_TOOL_DESCRIPTOR.root_name

--- a/tests/test_tool_family_email_migration.py
+++ b/tests/test_tool_family_email_migration.py
@@ -107,6 +107,49 @@ def test_root_is_the_closed_ltp_v2_envelope_and_nothing_else():
         assert legacy not in schema["properties"]
 
 
+def test_package_local_descriptor_is_consumed_by_schema_dispatch_and_manual_child(
+    tmp_path,
+):
+    """Email owns its canonical root/manual identity without an activation API.
+
+    Both ToolFamily instances consume the descriptor's root, the dispatcher's
+    generic error is consequently rooted at that same name, and the actual
+    generic ManualTool child reads the descriptor-selected installed manual.
+    Agent/global registration is deliberately outside this package-local seam.
+    """
+    descriptor = email_tool.EMAIL_TOOL_DESCRIPTOR
+    assert descriptor.root_name == "email"
+    assert descriptor.manual_skill_name == "email"
+    assert email_tool._FAMILY.name == descriptor.root_name
+
+    agent = _agent(tmp_path)
+    family = email_tool._build_family(agent)
+    assert family.name == descriptor.root_name
+    assert agent._mailbox_tool == descriptor.root_name
+    assert family.handle({"action": "contacts", "input": {"query": "x"}}) == {
+        "status": "failed",
+        "error_code": "INVALID_ARGUMENT",
+        "message": f"unsupported {descriptor.root_name} input field",
+    }
+
+    body = "# Email manual\n\nDescriptor-owned installed destination.\n"
+    path = (
+        agent._working_dir
+        / ".library"
+        / "intrinsic"
+        / "capabilities"
+        / descriptor.manual_skill_name
+        / "SKILL.md"
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    assert family.handle({"action": "manual", "input": {}}) == {
+        "status": "ok",
+        "content": [{"type": "text", "text": body}],
+        "structuredContent": {"manual_path": str(path)},
+    }
+
+
 def test_public_action_values_and_order_are_unchanged():
     assert email_tool.get_schema()["properties"]["action"]["enum"] == _PUBLIC_ACTIONS
     assert list(ACTION_ORDER) == _PUBLIC_ACTIONS


### PR DESCRIPTION
## Summary
- localizes the model-facing `email` descriptor and its owned manual binding
- preserves the strict action family, mailbox manager, unread guard, and host registration boundary

## Validation
- 179 focused email tests passed
- independent read-only review: APPROVE
- `git diff --check` passed

Telegram: @lingtaidev1bot | Nickname: 知微
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai