### PR TITLE
refactor(context): isolate model-facing tool surface

### DIFF
--- a/src/lingtai/tools/context/ANATOMY.md
+++ b/src/lingtai/tools/context/ANATOMY.md
@@ -12,6 +12,7 @@ related_files:
   - src/lingtai/tools/system/ANATOMY.md
   - src/lingtai/tools/system/summarize.py
   - src/lingtai/tools/context/__init__.py
+  - src/lingtai/tools/context/_plugin.py
   - src/lingtai/tools/context/_molt.py
   - src/lingtai/tools/context/_session_journal.py
   - src/lingtai/tools/context/_snapshots.py
@@ -37,15 +38,23 @@ passive lifecycle scenarios.
 ## Components
 
 - `__init__.py`
-  - strict per-action schemas, including genuinely optional `rebuild.items` so
-    bare `{}` is schema-valid;
+  - owns the strict per-action schemas and handlers, including genuinely optional
+    `rebuild.items` so bare `{}` is schema-valid;
   - `_summarize_action` pins record-only engine mode;
   - `_rebuild_action` calls `agent._reconstruct_context` before invoking the
     private summary engine, handles reconstruction failures as result dicts, and
     marks successful engine results `prompt_reconstructed: true`;
-  - `_CHILD_SPECS`, `_build_children`, `_FAMILY`, `get_schema`, `handle` provide
-    single-registry schema/dispatch and isolate `_tc_id` to molt;
-  - manual adaptation resolves `context-manual` once after dispatch.
+  - its one `_CONTEXT_PLUGIN` construction keeps the existing intrinsic root and
+    delegates the public `get_schema`/`handle` bridges without Agent registration
+    or plugin activation.
+- `_plugin.py`
+  - `ContextToolPlugin` is Context's package-local model-facing surface: it
+    composes the schema-only and agent-bound `ToolFamily` instances from the one
+    live `_CHILD_SPECS` source, binds only validated child input, and carries the
+    intrinsic `_tc_id`/reasoning metadata only to `molt`;
+  - it registers the real unwrapped `context-manual` child and, only after
+    dispatch, restores Context's flat manual result; it owns no prompt lifecycle,
+    durable state, global registry entry, or activation descriptor.
 - `../system/summarize.py` — private history-summary engine. It records pending
   marker replacements, marks the applied set done, persists history, and only
   then calls `chat.request_history_rebuild`. It is not a public `system` action.

--- a/src/lingtai/tools/context/CONTRACT.md
+++ b/src/lingtai/tools/context/CONTRACT.md
@@ -5,6 +5,7 @@ contract_version: 5
 related_files:
   - src/lingtai/tools/context/BEHAVIORS.md
   - src/lingtai/tools/context/__init__.py
+  - src/lingtai/tools/context/_plugin.py
   - src/lingtai/tools/context/_molt.py
   - src/lingtai/tools/context/_session_journal.py
   - src/lingtai/tools/context/ANATOMY.md
@@ -70,6 +71,13 @@ Schema and dispatch derive from one child registry.
 Unknown actions and branch/root shape errors fail before handler I/O. `_tc_id` is
 stripped from the closed root and reaches `molt` only. No retired Pad/LingTai or
 system-summarize spelling is accepted.
+
+`_plugin.py::ContextToolPlugin` is the package-local model-facing ownership seam:
+the existing intrinsic module constructs it once, and its actual `get_schema`,
+`handle`, and reserved-manual-child paths serve this same `context` root. It is
+not an Agent Plugin descriptor and neither registers nor activates anything;
+Agent/global registration, prompt reconstruction, session-journal validation,
+and provider lifecycle stay in their current owners.
 
 ## Full reconstruction ordering
 

--- a/src/lingtai/tools/context/__init__.py
+++ b/src/lingtai/tools/context/__init__.py
@@ -48,10 +48,11 @@ the model-facing text lives in the schema descriptions below and in the
 Sub-modules:
     _snapshots.py — Snapshot and summary persistence for the molt machinery.
     _molt.py      — Context molt core and the system-initiated forced molt.
+    _plugin.py    — package-local model-facing schema/dispatch/manual surface.
 """
 from __future__ import annotations
 
-from typing import Any, Mapping
+from typing import Any
 
 # --- Re-exports from sub-modules for backward compatibility ---
 
@@ -60,14 +61,8 @@ from ._snapshots import SNAPSHOT_SCHEMA_VERSION, _write_molt_snapshot, _write_mo
 
 # Molt (the public surface)
 from ._molt import _context_molt, context_forget  # noqa: F401
-from .._manual import load_installed_manual  # noqa: F401
-from ..tool_family import (
-    TRIGGER_UNSUPPORTED_INPUT_FIELD,
-    ChildTool,
-    DiagnosticDescriptor,
-    ToolFamily,
-)
-from ..tool_family.manual import build_manual_child
+from ..tool_family import TRIGGER_UNSUPPORTED_INPUT_FIELD, DiagnosticDescriptor
+from ._plugin import ContextToolPlugin
 
 # The summarize/rebuild engine. It stays in ``system/summarize.py`` — moving
 # the ~700-line engine and its marker constants is not required to move public
@@ -295,83 +290,11 @@ ACTION_ORDER: tuple[str, ...] = tuple(name for name, _s, _h in _CHILD_SPECS) + (
 #: ``load_installed_manual`` skill name, not the family name.
 _MANUAL_SKILL_NAME = "context-manual"
 
-#: Envelope metadata the family threads to a handler out-of-band rather than
-#: as action ``input``. ``_tc_id`` is the wire tool_use_id
-#: ``base_agent._dispatch_tool`` injects into every intrinsic's args; ``molt``
-#: is the one operation that genuinely *consumes* it (it locates the molt's own
-#: ToolCallBlock in the live interface to replay it), so — unlike ``soul``/
-#: ``notification``/``system``, which merely drop it — this family strips it
-#: from the closed root and hands it to that one handler directly. Root
-#: ``reasoning``/``_reasoning`` is threaded the same way for the post-molt
-#: reminder, exactly as ``avatar`` threads its spawn mission brief.
+#: Envelope metadata Context owns out-of-band rather than as action input.
+# ``molt`` alone consumes these values; the package-local model-facing surface
+# lifts them from the closed root and threads them only to that handler.
 _MOLT_ENVELOPE_KEYS = ("_tc_id", "_reasoning", "reasoning", "_initiator")
 
-
-def _strip_nulls(action_input: Mapping[str, Any]) -> dict[str, Any]:
-    """Drop explicit nulls so "absent" and "null" mean the same downstream.
-
-    Strict provider schemas express an optional field as a REQUIRED nullable
-    property, so the model sends ``{"keep_tool_calls": null, "keep_last": null}``
-    for a plain molt. ``rebuild.items`` is the one field this package leaves
-    genuinely optional (a bare ``{}`` is its ordinary call), but a provider that
-    materializes every declared property may still send ``{"items": null}``. The
-    handlers key off ``args.get(...)`` / ``"x" not in args``, so stripping nulls
-    here makes absent and null identical downstream — including ``rebuild``'s
-    no-new-items path — without touching the handlers themselves.
-    """
-    return {key: value for key, value in action_input.items() if value is not None}
-
-
-def _build_children(agent, envelope: Mapping[str, Any] | None = None) -> list[ChildTool]:
-    """Build the four children from the one canonical registry.
-
-    ``agent`` may be ``None`` for the module-level schema-only family, whose
-    children are never dispatched — only their schemas are read.
-
-    ``envelope`` carries the out-of-band metadata keys in
-    :data:`_MOLT_ENVELOPE_KEYS`. ``ToolFamily`` correctly passes no envelope
-    field to any child, so the one handler that consumes transport metadata
-    (``molt``, which needs ``_tc_id`` to locate and replay its own
-    ToolCallBlock) receives it here, merged beneath the validated ``input``
-    rather than smuggled through it.
-    """
-    extra = dict(envelope or {})
-
-    def _bind(handler, name: str):
-        def _dispatch(action_input: Mapping[str, Any]) -> dict:
-            args = _strip_nulls(action_input)
-            if name == "molt":
-                # Envelope metadata never overwrites validated action input.
-                for key, value in extra.items():
-                    args.setdefault(key, value)
-            return handler(agent, args)
-
-        return _dispatch
-
-    return [
-        ChildTool(
-            name,
-            schema,
-            _bind(handler, name),
-            title=f"{name} input",
-            diagnostics=_CHILD_DIAGNOSTICS.get(name),
-        )
-        for name, schema, handler in _CHILD_SPECS
-    ] + [build_manual_child(agent, _MANUAL_SKILL_NAME)]
-
-
-# Composes the model-facing schema. Building it at import time is also the
-# registry's duplicate/reserved-name collision check: a collision raises
-# ``ToolFamilyError`` here rather than shipping silently. It never dispatches —
-# ``context`` is an intrinsic *module*, not a per-Agent manager object, so
-# there is no instance to hang a family off; ``handle()`` binds one to the
-# passed agent per call from this same registry.
-_FAMILY = ToolFamily("context", _build_children(None))
-
-
-# ---------------------------------------------------------------------------
-# Schema / description
-# ---------------------------------------------------------------------------
 
 #: This family's own per-action routing prose. The generic composer writes a
 #: neutral "Required operation within the context family." description; the
@@ -393,89 +316,43 @@ _ACTION_ENUM_DESCRIPTION = (
     'context operation.\n'
     'Your name is not here: use system(action=\'name_set\'|\'name_nickname\').'
 )
+_CONTEXT_DESCRIPTION = "Your context: shed it, compact it, rebuild it. One tool, four actions, each with its own strict input object: context(action=..., input={...}, reasoning='why'). molt: 凝蜕 — shed the conversation, keep the durable stores; requires a written session journal. summarize: record compact replacements for bulky prior tool results (records only, does NOT rebuild). rebuild: re-read and recompose every canonical prompt source, then apply pending/new summaries, then replay provider context with the new prompt/history; bare input is valid even with zero pending summaries. manual: return the installed context-manual skill. Your name lives on system(action='name_set'|'name_nickname'); your 灵台 and pad are lingtai(...) and pad(...). Note the two levels: the ACTION named summarize is this domain operation, while the optional ROOT summarize boolean is the unrelated result-presentation control — leave it false here (results are small), and call manual with summarize=false so the exact molt procedure is not summarized away."
+
+
+# The one live package-local model-facing surface.  It owns actual schema
+# composition, dispatch binding, and ManualTool adaptation; it is not an Agent
+# Plugin descriptor and performs no registration or activation.  Keeping the
+# action-spec getter live preserves the existing single source for the
+# schema-only family and every agent-bound dispatch.
+_CONTEXT_PLUGIN = ContextToolPlugin(
+    root_name="context",
+    action_specs=lambda: _CHILD_SPECS,
+    child_diagnostics=_CHILD_DIAGNOSTICS,
+    manual_skill_name=_MANUAL_SKILL_NAME,
+    molt_envelope_keys=_MOLT_ENVELOPE_KEYS,
+    action_enum_description=_ACTION_ENUM_DESCRIPTION,
+    description=_CONTEXT_DESCRIPTION,
+)
+
+# Backward-compatible private seam for focused package tests and consumers that
+# inspect the schema-only family.  Construction still occurred at import time in
+# ``ContextToolPlugin`` and remains the collision check.
+_FAMILY = _CONTEXT_PLUGIN.schema_family
+
+
+def _build_children(agent, envelope=None):
+    """Return Context's real children through its package-local surface."""
+    return _CONTEXT_PLUGIN.build_children(agent, envelope)
 
 
 def get_description(lang: str = "en") -> str:
-    return 'Your context: shed it, compact it, rebuild it. One tool, four actions, each with its own strict input object: context(action=..., input={...}, reasoning=\'why\'). molt: 凝蜕 — shed the conversation, keep the durable stores; requires a written session journal. summarize: record compact replacements for bulky prior tool results (records only, does NOT rebuild). rebuild: re-read and recompose every canonical prompt source, then apply pending/new summaries, then replay provider context with the new prompt/history; bare input is valid even with zero pending summaries. manual: return the installed context-manual skill. Your name lives on system(action=\'name_set\'|\'name_nickname\'); your 灵台 and pad are lingtai(...) and pad(...). Note the two levels: the ACTION named summarize is this domain operation, while the optional ROOT summarize boolean is the unrelated result-presentation control — leave it false here (results are small), and call manual with summarize=false so the exact molt procedure is not summarized away.'
+    return _CONTEXT_PLUGIN.get_description(lang)
 
 
 def get_schema(lang: str = "en") -> dict:
-    # Composed by the generic ToolFamily infra from each child's own canonical
-    # ``input_schema`` above, rather than hand-assembled: root ``action`` +
-    # per-action ``input`` + required ``reasoning`` + optional ``summarize``,
-    # with a root ``allOf`` correlating each ``action`` const to that exact
-    # action's ``input`` shape on both the Chat and Responses wires.
-    #
-    # ``lang`` is accepted for source compatibility and ignored: schema prose
-    # is canonical English and language-independent.
-    schema = _FAMILY.build_schema()
-    schema["properties"]["action"]["description"] = _ACTION_ENUM_DESCRIPTION
-    return schema
-
-
-# ---------------------------------------------------------------------------
-# Dispatch
-# ---------------------------------------------------------------------------
-
-
-def _adapt_manual_result(mcp_result: dict) -> dict:
-    """Flatten the reserved ``manual`` child's canonical result to this family's shape.
-
-    The reserved child is registered unwrapped, so ``ToolFamily.handle()``
-    returns its canonical ``content``/``structuredContent`` result verbatim.
-    The public manual result predates that generic contract and must stay the
-    flat ``load_installed_manual`` shape (``status``, ``manual``,
-    ``manual_path``, plus ``error`` when degraded), so this Host-owned adapter
-    runs strictly *after* dispatch — never inside the child, and never as a
-    second envelope around it.
-    """
-    flat: dict[str, Any] = {
-        "status": mcp_result.get("status", "ok"),
-        "manual": mcp_result["content"][0]["text"],
-        "manual_path": mcp_result["structuredContent"]["manual_path"],
-    }
-    if "error" in mcp_result:
-        flat["error"] = mcp_result["error"]
-    return flat
+    return _CONTEXT_PLUGIN.get_schema(lang)
 
 
 def handle(agent, args: dict) -> dict:
-    """Handle the ``context`` family root — validate the envelope, dispatch one action.
-
-    Envelope validation and cross-action rejection belong to the generic
-    dispatcher (``tool_family/CONTRACT.md``). This function owns only what is
-    context-specific: lifting the intrinsic transport/audit metadata out of the
-    closed root, and the two post-dispatch presentation adaptations below.
-
-    ``_tc_id`` is transport metadata ``base_agent._dispatch_tool`` injects into
-    EVERY intrinsic's args (capabilities like ``web`` never see it). This is
-    the one family that genuinely *consumes* it — ``molt`` locates the molt's
-    own ToolCallBlock by that wire id to replay it into the fresh session — so
-    it is stripped here, at this family's own Host boundary, and threaded to
-    that single handler out-of-band. The shared ``_ROOT_FIELDS`` set is not
-    widened for it, and no other action can observe it.
-    """
-    raw = dict(args or {})
-    envelope = {key: raw.pop(key) for key in _MOLT_ENVELOPE_KEYS if key in raw}
-    # ``reasoning``/``_reasoning`` remain admitted root fields for the generic
-    # dispatcher, so put back the public spelling it knows about; only the
-    # molt handler sees the copy in ``envelope``.
-    for key in ("reasoning", "_reasoning"):
-        if key in envelope:
-            raw[key] = envelope[key]
-
-    action = raw.get("action")
-    result = ToolFamily("context", _build_children(agent, envelope)).handle(raw)
-
-    if action == "manual" and "content" in result:
-        return _adapt_manual_result(result)
-    if result.get("error_code") == "ACTION_REQUIRED":
-        # Preserve a context-shaped unknown-action error rather than the
-        # generic envelope failure.
-        return {
-            "error": (
-                f"Unknown context action: {action if action is not None else ''}. "
-                f"Must be one of: {', '.join(ACTION_ORDER)}."
-            )
-        }
-    return result
+    """Dispatch Context through its package-local model-facing surface."""
+    return _CONTEXT_PLUGIN.handle(agent, args)

--- a/src/lingtai/tools/context/_plugin.py
+++ b/src/lingtai/tools/context/_plugin.py
@@ -1,0 +1,173 @@
+"""Package-local model-facing surface for the ``context`` root.
+
+``ContextToolPlugin`` is deliberately a small ownership seam, not an Agent
+Plugin descriptor and not an activation mechanism.  The existing intrinsic
+registration continues to import ``context.__init__`` under the same root name;
+that module constructs the one surface below and delegates its public schema
+and dispatch entry points to it.
+
+The seam owns work that is genuinely model-facing and context-specific:
+
+* composing the exact action registry into the ``context`` schema;
+* binding validated action input to the existing molt/summarize/rebuild engines;
+* threading intrinsic transport metadata only to ``molt``; and
+* registering the real reserved manual child, then flattening its dispatched
+  result at Context's own presentation boundary.
+
+It deliberately does *not* own Agent registration, prompt reconstruction,
+summary persistence, session-journal validation, provider lifecycle, or plugin
+activation.  Those remain in their current owners and the handlers supplied by
+``context.__init__`` are invoked unchanged.
+"""
+from __future__ import annotations
+
+from typing import Any, Callable, Mapping, Sequence
+
+from ..tool_family import ChildTool, DiagnosticDescriptor, ToolFamily
+from ..tool_family.manual import build_manual_child
+
+
+ActionSpec = tuple[str, Mapping[str, Any], Callable[[Any, dict], dict]]
+
+
+class ContextToolPlugin:
+    """Own Context's one actual model-facing schema/dispatch/manual surface.
+
+    The supplied action-spec getter deliberately remains live rather than taking
+    a copied registry: Context's module-level schema-only family and every
+    agent-bound dispatcher must keep deriving from the same source.  This object
+    creates the import-time schema family only to preserve the existing
+    duplicate/reserved-name collision check; each dispatch still binds the
+    current Agent exactly once.
+    """
+
+    def __init__(
+        self,
+        *,
+        root_name: str,
+        action_specs: Callable[[], Sequence[ActionSpec]],
+        child_diagnostics: Mapping[str, Mapping[str, DiagnosticDescriptor]],
+        manual_skill_name: str,
+        molt_envelope_keys: tuple[str, ...],
+        action_enum_description: str,
+        description: str,
+    ) -> None:
+        self.root_name = root_name
+        self._action_specs = action_specs
+        self._child_diagnostics = child_diagnostics
+        self._manual_skill_name = manual_skill_name
+        self._molt_envelope_keys = molt_envelope_keys
+        self._action_enum_description = action_enum_description
+        self._description = description
+        # Construction retains Context's existing import-time registry collision
+        # check.  It never dispatches: its children are schema-only bindings.
+        self._schema_family = ToolFamily(root_name, self.build_children(None))
+
+    @property
+    def action_order(self) -> tuple[str, ...]:
+        """The current public action order derived from the one child registry."""
+        return tuple(name for name, _schema, _handler in self._action_specs()) + ("manual",)
+
+    @property
+    def schema_family(self) -> ToolFamily:
+        """Return the import-time schema-only family used by ``get_schema``."""
+        return self._schema_family
+
+    @staticmethod
+    def _strip_nulls(action_input: Mapping[str, Any]) -> dict[str, Any]:
+        """Normalize explicit nullable provider values to absent handler input."""
+        return {key: value for key, value in action_input.items() if value is not None}
+
+    def build_children(
+        self, agent: Any, envelope: Mapping[str, Any] | None = None
+    ) -> list[ChildTool]:
+        """Bind Context's one canonical registry to a schema or a live Agent.
+
+        No envelope field reaches a child generically.  Context's molt is the
+        narrow exception: it consumes the intrinsic ``_tc_id`` transport value
+        in order to replay its own call, so only that handler receives the
+        explicitly lifted metadata out-of-band.
+        """
+        extra = dict(envelope or {})
+        children: list[ChildTool] = []
+        for name, schema, handler in self._action_specs():
+
+            def dispatch(action_input: Mapping[str, Any], *, _name=name, _handler=handler) -> dict:
+                args = self._strip_nulls(action_input)
+                if _name == "molt":
+                    # Transport metadata never overwrites validated action input.
+                    for key, value in extra.items():
+                        args.setdefault(key, value)
+                return _handler(agent, args)
+
+            children.append(
+                ChildTool(
+                    name,
+                    schema,
+                    dispatch,
+                    title=f"{name} input",
+                    diagnostics=self._child_diagnostics.get(name),
+                )
+            )
+        # Registered directly and unwrapped.  The family adapts the result only
+        # after ToolFamily.handle() has returned this canonical child result.
+        children.append(build_manual_child(agent, self._manual_skill_name))
+        return children
+
+    def get_description(self, lang: str = "en") -> str:
+        """Return Context's established model-facing description unchanged."""
+        del lang  # Canonical English prose is intentionally language-independent.
+        return self._description
+
+    def get_schema(self, lang: str = "en") -> dict[str, Any]:
+        """Compose the Context root schema from the real child registry."""
+        del lang  # Canonical English prose is intentionally language-independent.
+        schema = self._schema_family.build_schema()
+        schema["properties"]["action"]["description"] = self._action_enum_description
+        return schema
+
+    @staticmethod
+    def _adapt_manual_result(mcp_result: dict) -> dict:
+        """Flatten the dispatched ManualTool result to Context's public shape."""
+        flat: dict[str, Any] = {
+            "status": mcp_result.get("status", "ok"),
+            "manual": mcp_result["content"][0]["text"],
+            "manual_path": mcp_result["structuredContent"]["manual_path"],
+        }
+        if "error" in mcp_result:
+            flat["error"] = mcp_result["error"]
+        return flat
+
+    def handle(self, agent: Any, args: Mapping[str, Any] | None) -> dict:
+        """Validate one Context envelope and dispatch it to the selected action.
+
+        The generic family remains the closed-root and cross-action validator.
+        This Context-owned boundary performs only its established special cases:
+        lift molt-only intrinsic metadata, restore root reasoning for generic
+        validation, flatten the real manual-child result after dispatch, and
+        preserve Context's public unknown-action wording.
+        """
+        raw = dict(args or {})
+        envelope = {
+            key: raw.pop(key) for key in self._molt_envelope_keys if key in raw
+        }
+        # ``reasoning``/``_reasoning`` are still generic root fields; only molt
+        # sees their envelope copies for its post-molt reminder.
+        for key in ("reasoning", "_reasoning"):
+            if key in envelope:
+                raw[key] = envelope[key]
+
+        action = raw.get("action")
+        result = ToolFamily(self.root_name, self.build_children(agent, envelope)).handle(raw)
+
+        if action == "manual" and "content" in result:
+            return self._adapt_manual_result(result)
+        if result.get("error_code") == "ACTION_REQUIRED":
+            return {
+                "error": (
+                    f"Unknown {self.root_name} action: "
+                    f"{action if action is not None else ''}. Must be one of: "
+                    f"{', '.join(self.action_order)}."
+                )
+            }
+        return result

--- a/tests/test_tool_family_context_migration.py
+++ b/tests/test_tool_family_context_migration.py
@@ -195,6 +195,50 @@ def test_each_action_advertises_only_its_own_input():
         assert cond["then"]["properties"]["input"]["additionalProperties"] is False
 
 
+def test_context_package_plugin_is_the_live_model_facing_surface(tmp_path, monkeypatch):
+    """The package-local candidate owns actual Context entry points, not metadata.
+
+    It is intentionally not registered or activated as a separate Agent Plugin:
+    the existing intrinsic root remains ``context``.  This verifies that Context's
+    public schema and dispatch bridges call the one local surface, while that
+    surface builds the real reserved manual child used by the family dispatcher.
+    """
+    from lingtai.tools.context._plugin import ContextToolPlugin
+    from lingtai.tools.tool_family import ToolFamily
+
+    plugin = context_tool._CONTEXT_PLUGIN
+    assert isinstance(plugin, ContextToolPlugin)
+    assert plugin.root_name == "context"
+    assert plugin.action_order == ACTION_ORDER
+    assert plugin.schema_family is context_tool._FAMILY
+
+    agent = _agent(tmp_path)
+    try:
+        # The live surface builds the actual direct/unwrapped ManualTool child;
+        # the public context bridge later performs its existing flattening.
+        family = ToolFamily(plugin.root_name, plugin.build_children(agent))
+        manual = family.handle({"action": "manual", "input": {}})
+        assert manual["content"][0]["text"]
+        assert manual["structuredContent"]["manual_path"]
+
+        schema_sentinel = {"surface": "schema"}
+        dispatch_sentinel = {"surface": "dispatch"}
+        seen: list[tuple[object, object]] = []
+        monkeypatch.setattr(plugin, "get_schema", lambda lang="en": schema_sentinel)
+
+        def dispatch_spy(agent_arg, args):
+            seen.append((agent_arg, args))
+            return dispatch_sentinel
+
+        monkeypatch.setattr(plugin, "handle", dispatch_spy)
+        assert context_tool.get_schema() is schema_sentinel
+        call = {"action": "manual", "input": {}}
+        assert context_tool.handle(agent, call) is dispatch_sentinel
+        assert seen == [(agent, call)]
+    finally:
+        agent.stop(timeout=1.0)
+
+
 # ---------------------------------------------------------------------------
 # Strict schema / dispatch rejection for every action.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- moves the context model-facing schema/dispatch/manual seam into its owning package without changing context lifecycle behavior

## Validation
- focused migration, session-journal, and context tests passed
- independent read-only review: APPROVE
- `git diff --check` passed

Telegram: @lingtaidev1bot | Nickname: 知微
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai