### PR TITLE
feat(notification): localize tool descriptor and manual

### DIFF
--- a/src/lingtai/tools/notification/ANATOMY.md
+++ b/src/lingtai/tools/notification/ANATOMY.md
@@ -5,7 +5,11 @@ related_files:
   - src/lingtai/tools/ANATOMY.md
   - src/lingtai/services/LICC_NOTIFICATION_CONTRACT.md
   - src/lingtai/tools/notification/__init__.py
+  - src/lingtai/tools/notification/descriptor.py
   - src/lingtai/tools/notification/schema.py
+  - src/lingtai/tools/notification/manual/SKILL.md
+  - src/lingtai/tools/notification/manual/reference/channel-model/SKILL.md
+  - src/lingtai/tools/notification/manual/reference/dismissal-safety/SKILL.md
   - src/lingtai/tools/tool_family/ANATOMY.md
   - src/lingtai/tools/registry.py
   - src/lingtai/kernel/notifications.py
@@ -13,9 +17,6 @@ related_files:
   - src/lingtai/kernel/tool_result_summary.py
   - src/lingtai/agent.py
   - src/lingtai/intrinsic_skills/system-manual/SKILL.md
-  - src/lingtai/intrinsic_skills/notification-manual/SKILL.md
-  - src/lingtai/intrinsic_skills/notification-manual/reference/channel-model/SKILL.md
-  - src/lingtai/intrinsic_skills/notification-manual/reference/dismissal-safety/SKILL.md
   - tests/test_notification_tool.py
   - tests/test_notification_delay_alarm.py
   - tests/test_daemon_attention_delay.py
@@ -64,37 +65,42 @@ action values are unchanged; the four hook-registry actions are new.
   `get_description()` hold the canonical-English prose
   (`src/lingtai/tools/notification/schema.py:48-178`). It deliberately defines
   no `get_schema`.
-- `_schema_only_family()` / `_FAMILY` build the import-time `ToolFamily` used
-  only to compose the schema; constructing it at import proves the fixed
-  ten-child registry has no duplicate or reserved-`manual` collision
-  (`src/lingtai/tools/notification/__init__.py:95-122`).
+- `descriptor.py::NOTIFICATION_TOOL` is the active package-local root record:
+  its canonical `ACTION_ORDER`/`INPUT_SCHEMAS` input drives both schema-only
+  and agent-bound family construction, while `manual_skill_name="notification"`
+  selects the installed destination for the shared dispatched manual child.
+  Its complete-handler check prevents an advertised operational action from
+  losing a bound dispatcher (`src/lingtai/tools/notification/descriptor.py`).
+- `_FAMILY` is the descriptor-built import-time schema-only `ToolFamily`;
+  constructing it proves the fixed ten-child registry has no duplicate or
+  reserved-`manual` collision.
 - `get_schema()` returns the composed family schema and substitutes
   notification's own action prose for the generic composer's neutral
-  placeholder (`src/lingtai/tools/notification/__init__.py:125-140`).
-- `_build_family()` builds the per-call dispatching `ToolFamily` with handlers
-  bound to the calling `agent`, registering the shared `manual` child directly
-  and unwrapped (`src/lingtai/tools/notification/__init__.py:362-410`).
+  placeholder (`src/lingtai/tools/notification/__init__.py:100-115`).
+- `_build_family()` binds existing operation handlers to the calling `agent`
+  and asks `NOTIFICATION_TOOL` to build the per-call dispatching `ToolFamily`,
+  including the shared manual child directly and unwrapped.
 - `handle()` strips kernel-injected `_tc_id`, delegates envelope validation and
   dispatch to that family, adapts the `manual` child result, and normalizes the
   generic `ACTION_REQUIRED` error back to the pinned unknown-action shape
-  (`src/lingtai/tools/notification/__init__.py:412-451`).
+  (`src/lingtai/tools/notification/__init__.py:376-415`).
 - `_strip_nulls()` converts explicit `null` optionals back to absent so the
   handlers' `args.get(..., default)` defaulting is preserved
-  (`src/lingtai/tools/notification/__init__.py:143-153`).
+  (`src/lingtai/tools/notification/__init__.py:118-128`).
 - `_check()` returns the dict-shaped placeholder onto which the turn loop can
   stamp the current notification payload
-  (`src/lingtai/tools/notification/__init__.py:156-161`).
+  (`src/lingtai/tools/notification/__init__.py:131-136`).
 - `_adapt_manual_result()` flattens the shared ManualTool child's canonical
   `content`/`structuredContent` result to notification's pinned public
   `status`/`notification_manual`/`manual_path` shape, restating the exact
   contract-pinned degraded sentence
-  (`src/lingtai/tools/notification/__init__.py:164-197`).
+  (`src/lingtai/tools/notification/__init__.py:139-166`).
 - `_dismiss_channel()` adapts a whole-channel request and retains the inner
   event/ref rejection as defense in depth behind the envelope's earlier,
-  no-I/O rejection (`src/lingtai/tools/notification/__init__.py:200-239`).
+  no-I/O rejection (`src/lingtai/tools/notification/__init__.py:169-211`).
 - `_dismiss_event()` and `_dismiss_ref()` adapt targeted system-event removal
   while defaulting the channel to `system`
-  (`src/lingtai/tools/notification/__init__.py:245-288`).
+  (`src/lingtai/tools/notification/__init__.py:214-257`).
 - `_delay()` delegates to `notifications.delay_notification_channel()`, which
   persists one active private `.notification/.delay_state.json` record, arms a
   request-id-guarded process timer, and never mutates the target producer file.
@@ -103,7 +109,7 @@ action values are unchanged; the four hook-registry actions are new.
   `lingtai.kernel.notifications.add_hook` / `drop_hook` / `edit_hook` /
   `list_hooks`, which validate manifests, enforce name/channel uniqueness, and
   write `.notification/hooks.json` through Store family 8
-  (`src/lingtai/tools/notification/__init__.py:291-359`).
+  (`src/lingtai/tools/notification/__init__.py:265-333`).
 - `registry.INTRINSICS` registers `notification` as a mandatory intrinsic next
   to email, system, context, pad, lingtai, and soul
   (`src/lingtai/tools/registry.py:48-69`).
@@ -127,11 +133,11 @@ action values are unchanged; the four hook-registry actions are new.
   `add_hook`/`drop_hook`/`edit_hook`/`list_hooks`, which own manifest
   validation, uniqueness, and the family-8 Store writes
   (`src/lingtai/kernel/notifications.py:358-512`).
-- `Agent._install_intrinsic_manuals()` copies the kernel-shipped
-  `system-manual` skill tree into the per-agent intrinsic library that the
-  `manual` child reads through `tool_family.manual.build_manual_child` and the
-  shared `tools/_manual.py::load_installed_manual` loader
-  (`src/lingtai/agent.py:311-372`).
+- The unchanged generic `Agent._install_intrinsic_manuals()` discovers this
+  package's `manual/` tree and copies it to
+  `.library/intrinsic/capabilities/notification/`; the descriptor passes that
+  same destination to `tool_family.manual.build_manual_child`, which reads it
+  through the shared `tools/_manual.py::load_installed_manual` loader.
 - `base_agent.tools._dispatch_tool()` injects `_tc_id` into every intrinsic's
   args; only `context.molt` consumes it, so `handle()` strips it before the
   closed envelope is validated (`src/lingtai/kernel/base_agent/tools.py:28-35`).

--- a/src/lingtai/tools/notification/CONTRACT.md
+++ b/src/lingtai/tools/notification/CONTRACT.md
@@ -1,11 +1,15 @@
 ---
 name: notification-tool
-contract_version: 6
+contract_version: 7
 root_contract: CONTRACT.md
 related_files:
   - src/lingtai/tools/notification/ANATOMY.md
   - src/lingtai/tools/notification/__init__.py
+  - src/lingtai/tools/notification/descriptor.py
   - src/lingtai/tools/notification/schema.py
+  - src/lingtai/tools/notification/manual/SKILL.md
+  - src/lingtai/tools/notification/manual/reference/channel-model/SKILL.md
+  - src/lingtai/tools/notification/manual/reference/dismissal-safety/SKILL.md
   - src/lingtai/tools/tool_family/CONTRACT.md
   - src/lingtai/tools/CONTRACT.md
   - src/lingtai/kernel/tool_result_summary.py
@@ -22,9 +26,6 @@ related_files:
   - src/lingtai/tools/notification/glossary-zh.md
   - src/lingtai/tools/notification/glossary-wen.md
   - src/lingtai/intrinsic_skills/system-manual/SKILL.md
-  - src/lingtai/intrinsic_skills/notification-manual/SKILL.md
-  - src/lingtai/intrinsic_skills/notification-manual/reference/channel-model/SKILL.md
-  - src/lingtai/intrinsic_skills/notification-manual/reference/dismissal-safety/SKILL.md
 maintenance: |
   <!-- CANONICAL-MAINTENANCE v2 BEGIN -->
   This component contract is governed by the root CONTRACT.md. Keep
@@ -138,7 +139,7 @@ Observable action contracts are:
   on successful (`cleared: true`) dismissals, and stale-version refusals remain
   a `status: "error"` contract without `cause`.
 - `manual` reads only
-  `<agent>/.library/intrinsic/capabilities/notification-manual/SKILL.md`.
+  `<agent>/.library/intrinsic/capabilities/notification/SKILL.md`.
   Success contains exactly `{status: "ok", notification_manual, manual_path}`.
   Absence contains exactly `{status: "degraded", notification_manual: "",
   manual_path, error}`, where `error` is `notification manual missing —
@@ -243,16 +244,22 @@ installer) — and marks a workdir seeded only after a successful load, logging 
 transient failure (`notification_hook_registry_error`, `phase=...`) for retry on
 the next sync.
 
-The `manual` action is the reserved family child built by
-`tool_family.manual.build_manual_child` over the shared
+`descriptor.py::NOTIFICATION_TOOL` is the package-local composition
+record: it names the public root, consumes `schema.py`'s canonical action order
+and strict input schemas for both schema and dispatch families, and names the
+installed manual destination `notification`. Its dispatch builder refuses a
+partial operational handler map, so the descriptor cannot advertise an action
+that no bound family child handles. The `manual` action is the reserved family
+child built by `tool_family.manual.build_manual_child` over the shared
 `tools/_manual.py::load_installed_manual` loader: one `is_file` check and one
-UTF-8 read at the fixed path. It does not call notification Core,
-`NotificationStorePort`, the post-hook, or a producer. That child's canonical
-`content`/`structuredContent` result is returned by the family dispatcher
-verbatim; flattening it to this Port's pinned `notification_manual` shape is a
-Host presentation step that runs strictly after dispatch, never inside the
-child. Agent initialization copies the bundled first-level
-`notification-manual` skill tree into the installed per-agent intrinsic library.
+UTF-8 read at that descriptor-selected fixed path. It does not call notification
+Core, `NotificationStorePort`, the post-hook, or a producer. That child's
+canonical `content`/`structuredContent` result is returned by the family
+dispatcher verbatim; flattening it to this Port's pinned
+`notification_manual` shape is a Host presentation step that runs strictly
+after dispatch, never inside the child. The existing generic Agent initializer
+copies this package's bundled `notification/manual/` tree into that destination;
+there is no registry, host lifecycle, or activation-path change.
 
 `handle()` strips the kernel-injected `_tc_id` before envelope validation.
 `base_agent.tools._dispatch_tool` adds that field to every intrinsic's args as
@@ -304,6 +311,9 @@ is not a second inbound adapter.
   glossaries require review when this enum changes; the LTP v2 envelope
   restructures how arguments are carried, and the hook-registry change adds
   four new action values (`add`/`drop`/`edit`/`list`) to the enum.
+- `contract_version` `7`: the package-owned manual tree installs and dispatches
+  under the root-matching `notification` destination through the active
+  descriptor; the former standalone manual remains outside this focused change.
 - `contract_version` is `6`: a `delay` whose target is the aggregate `daemon`
   channel now masks that channel's attention token instead of omitting it from
   the coherent consumer read, so daemon truth, delivered version, and dismissal
@@ -321,7 +331,8 @@ is not a second inbound adapter.
 ordered ten-action schema, the closed LTP v2 root, each action's strict input
 branch and its `allOf` action/input correlation, Chat/Responses wire parity,
 the `manual` branch matching the shared ManualTool child, canonical
-description, absent aggregate actions, manual success/degraded envelopes, delay schema ordering, and
+description, descriptor-backed schema/dispatch/manual projection, absent aggregate actions,
+manual success/degraded envelopes, delay schema ordering, the descriptor-selected
 fixed path, no-double-wrap flattening, read-only state/log behavior, check
 placeholder shape, all atomic dismiss semantics, hook add/drop/edit/list
 lifecycle and whitelist gating, null-optional defaulting,

--- a/src/lingtai/tools/notification/__init__.py
+++ b/src/lingtai/tools/notification/__init__.py
@@ -56,14 +56,14 @@ from typing import Any, Mapping
 # Schema data — canonical per-action input schemas and registration prose.
 # ``get_schema`` is composed below from ``INPUT_SCHEMAS``; ``schema.py``
 # deliberately defines no second one.
+from .descriptor import NOTIFICATION_TOOL
 from .schema import (  # noqa: F401
     ACTION_ENUM_DESCRIPTION,
     ACTION_ORDER,
     INPUT_SCHEMAS,
     get_description,
 )
-from ..tool_family import ChildTool, ToolFamily
-from ..tool_family.manual import build_manual_child
+from ..tool_family import ToolFamily
 
 # Single-source delegate — the canonical dismissal helper.  No notification
 # logic is reimplemented here.
@@ -90,39 +90,11 @@ _MANUAL_MISSING_ERROR = (
     "capability not installed correctly"
 )
 
-# The installed intrinsic-skill directory ``manual`` reads. This is the
-# ``load_installed_manual`` skill name, not the family name.
-_MANUAL_SKILL_NAME = "notification-manual"
-
-
-def _schema_only_family() -> ToolFamily:
-    """Build the module-level ``ToolFamily`` used only to compose the schema.
-
-    Notification is an *intrinsic*: the kernel imports this module once and
-    calls ``get_schema()``/``handle(agent, args)`` on the module itself, so
-    unlike ``web`` there is no per-Agent manager instance to hang a family
-    off.  The real handlers need an ``agent``, which only arrives per call,
-    so :func:`handle` builds a per-call family with bound handlers and this
-    module-level one never dispatches.  Constructing it at import time is
-    still load-bearing: it proves the fixed ten-child registry has no
-    duplicate and no reserved-name collision on ``manual``
-    (``ToolFamilyError`` raises here, at import, rather than shipping
-    silently).
-    """
-
-    def _unused(_input: Mapping[str, Any]) -> dict[str, Any]:
-        raise AssertionError("the module-level schema-only ToolFamily never dispatches")
-
-    return ToolFamily(
-        "notification",
-        [
-            ChildTool(action, INPUT_SCHEMAS[action], _unused, title=f"{action} input")
-            for action in ACTION_ORDER
-        ],
-    )
-
-
-_FAMILY = _schema_only_family()
+# The package-owned ``manual/`` tree is installed under this descriptor's
+# matching capability name by the existing generic Agent installer.  The
+# descriptor is also the exact value the real ToolFamily manual child reads;
+# keeping this mapping package-local avoids a registry or lifecycle exception.
+_FAMILY = NOTIFICATION_TOOL.build_schema_family()
 
 
 def get_schema(lang: str = "en") -> dict[str, Any]:
@@ -178,17 +150,11 @@ def _adapt_manual_result(mcp_result: dict) -> dict:
     this Host-owned adapter runs strictly *after* dispatch, in :func:`handle`
     — never inside a registered child.
 
-    The degraded ``error`` sentence is restated here rather than forwarded.
-    The shared loader builds it as ``f"{skill_name} manual missing — ..."``
-    from the *installed directory* name, which for this family is
-    ``notification-manual`` — so forwarding it verbatim would silently change
-    the contract-pinned sentence from "notification manual missing" to
-    "notification-manual manual missing". Restating the exact pinned text is
-    Host presentation of an unchanged fact (the manual is absent), not a
-    rewrite of the child's canonical result, which stays canonical and
-    untouched. The alternative — renaming the loader's argument or its
-    message — would change every other family's error text, which no evidence
-    supports.
+    The descriptor installs and reads the manual as ``notification``.  The
+    shared loader therefore already reports the contract-pinned missing-manual
+    sentence (``notification manual missing — ...``).  Restating that exact
+    sentence keeps this family's historical flat presentation while the
+    dispatched child's canonical result remains untouched.
     """
     flat: dict[str, Any] = {
         "status": mcp_result.get("status", "ok"),
@@ -402,20 +368,9 @@ def _build_family(agent) -> ToolFamily:
 
         return _dispatch
 
-    children = []
-    for action in ACTION_ORDER:
-        if action == "manual":
-            children.append(build_manual_child(agent, _MANUAL_SKILL_NAME))
-        else:
-            children.append(
-                ChildTool(
-                    action,
-                    INPUT_SCHEMAS[action],
-                    _bind(action),
-                    title=f"{action} input",
-                )
-            )
-    return ToolFamily("notification", children)
+    return NOTIFICATION_TOOL.build_dispatch_family(
+        {action: _bind(action) for action in dismiss_handlers}, agent
+    )
 
 
 def handle(agent, args: dict) -> dict:

--- a/src/lingtai/tools/notification/descriptor.py
+++ b/src/lingtai/tools/notification/descriptor.py
@@ -1,0 +1,95 @@
+"""Package-local composition descriptor for the ``notification`` root.
+
+The mandatory-intrinsic registry continues to import ``lingtai.tools.notification``
+directly; it does not gain a second activation path.  This descriptor keeps the
+model-facing root's identity, action schema ownership, and installed manual
+projection beside the action implementation so the package can be inspected or
+extracted without relying on registry or Agent changes.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping
+
+from ..tool_family import ChildTool, ToolFamily
+from ..tool_family.manual import build_manual_child
+from .schema import ACTION_ORDER, INPUT_SCHEMAS
+
+
+ActionHandler = Callable[[Mapping[str, Any]], dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class NotificationToolDescriptor:
+    """The one model-facing notification family owned by this package.
+
+    ``action_order`` and ``input_schemas`` are the canonical strict action
+    declarations from :mod:`.schema`.  Both schema projection and dispatch
+    construction consume those same objects, while ``manual_skill_name`` names
+    the package's ``manual/`` installation destination.  The existing Agent
+    installer already copies every ``lingtai.tools.<package>/manual/`` tree to
+    that destination; no global registration or lifecycle behavior changes.
+    """
+
+    name: str
+    action_order: tuple[str, ...]
+    input_schemas: Mapping[str, Mapping[str, Any]]
+    manual_skill_name: str
+
+    def build_schema_family(self) -> ToolFamily:
+        """Build the schema-only family from the exact dispatched schemas."""
+
+        def _unused(_input: Mapping[str, Any]) -> dict[str, Any]:
+            raise AssertionError("the notification schema-only family never dispatches")
+
+        return ToolFamily(
+            self.name,
+            [
+                ChildTool(action, self.input_schemas[action], _unused, title=f"{action} input")
+                for action in self.action_order
+            ],
+        )
+
+    def build_dispatch_family(
+        self, handlers: Mapping[str, ActionHandler], agent: Any
+    ) -> ToolFamily:
+        """Bind all operational children and the one package-owned manual child.
+
+        Passing a complete operational mapping is deliberate: a descriptor
+        cannot silently advertise an action that dispatch does not bind.  The
+        shared manual child is the real family child and receives this
+        descriptor's installed destination, so manual schema, dispatch, and
+        package-local ``manual/`` projection remain one composition.
+        """
+        operational_actions = tuple(action for action in self.action_order if action != "manual")
+        if set(handlers) != set(operational_actions):
+            raise ValueError(
+                f"{self.name} handlers must match operational actions "
+                f"{operational_actions!r}, got {tuple(handlers)!r}"
+            )
+
+        children: list[ChildTool] = []
+        for action in self.action_order:
+            if action == "manual":
+                children.append(build_manual_child(agent, self.manual_skill_name))
+            else:
+                children.append(
+                    ChildTool(
+                        action,
+                        self.input_schemas[action],
+                        handlers[action],
+                        title=f"{action} input",
+                    )
+                )
+        return ToolFamily(self.name, children)
+
+
+NOTIFICATION_TOOL = NotificationToolDescriptor(
+    name="notification",
+    action_order=ACTION_ORDER,
+    input_schemas=INPUT_SCHEMAS,
+    # Agent._install_intrinsic_manuals already maps <tool>/manual/ to this
+    # exact flat capability name.  The ToolFamily manual child reads the same
+    # installed destination; this is not an unused packaging hint.
+    manual_skill_name="notification",
+)

--- a/src/lingtai/tools/notification/manual/SKILL.md
+++ b/src/lingtai/tools/notification/manual/SKILL.md
@@ -1,0 +1,276 @@
+---
+name: notification-manual
+description: >
+  Router for LingTai's notification filesystem protocol and the standalone
+  `notification` tool. Read it when interpreting `.notification/<channel>.json`
+  or deciding between producer-specific handling and safe mirror dismissal.
+  Routes channel/sync mechanics and dismissal safety into nested references;
+  large-result compaction is owned by
+  `context-manual` → `reference/summarize-manual/SKILL.md`.
+version: 0.10.0
+tags: [lingtai, notifications, channels, dismiss, delay, alarm, manual, force, stale, nudge, hooks, whitelist]
+last_changed_at: "2026-08-20"
+related_files:
+- src/lingtai/tools/notification/__init__.py
+- src/lingtai/tools/notification/schema.py
+- src/lingtai/tools/notification/descriptor.py
+- src/lingtai/tools/notification/manual/reference/channel-model/SKILL.md
+- src/lingtai/tools/notification/manual/reference/dismissal-safety/SKILL.md
+maintenance: |
+  Tracks the routed source/resources it summarizes; update when the underlying capability or its sub-references change.
+---
+
+# Notification Manual — Router
+
+LingTai notifications are a filesystem protocol: producers publish allowlisted
+`.notification/<channel>.json` surfaces, and the kernel exposes their current
+model-visible state. The always-available `notification` tool is the sole
+agent-callable home for reading and clearing those surfaces. `system` has no
+notification or dismiss alias, and context hygiene is not a notification
+operation either — that is `context(action='summarize')`.
+
+## Quick start
+
+The resident tool schema is the source of truth for the ten actions, their
+per-action `input` fields, and the `action` + `input` + `reasoning` envelope
+(arguments live inside `input`, never at the root). What it does not say:
+
+- `manual` returns **this router body** — it is documentation retrieval, not a
+  notification-state read.
+- Optional fields are declared required-but-nullable, and `null` is treated
+  exactly like omission. The one trap: `reason: null` does **not** satisfy the
+  post-molt acknowledgement requirement.
+- After handling a notification, use the narrowest correct dismiss action and end
+  the turn; do not voluntarily call `check` again merely to confirm the clear.
+
+## Consumer delay and expiry alarm
+
+`notification(action='delay', input={'channel': '<allowed>', 'seconds': 1..LINGTAI_NOTIFICATION_DELAY_MAX_SECONDS},
+reasoning='...')` hides **only consumer delivery** for one allowed target while
+the timer is live. The nonzero cap is read live from
+`LINGTAI_NOTIFICATION_DELAY_MAX_SECONDS` (default `600` seconds), so a current
+environment setting applies to each action without restart; blank, invalid, zero,
+or negative values log a fallback to `600`. It does not clear, rewrite, or pause
+the producer; target messages keep accumulating in their original channel file. Every other channel
+continues delivering normally. A nonzero call explicitly replaces the one prior
+live delay. Use `seconds: 0` with that same channel to cancel early and
+re-expose it.
+
+At expiry (including after a refresh/restart recovery) the target becomes visible
+in the same consumer sync that adds one high-priority `delay-alarm` mirror. The
+alarm records target, requested/actual duration, changed/no-change, and only
+conservative current measurements: producer-reported counts and retained event
+entries are never asserted to be an exact total for overwritten/capped mirrors.
+Handle the re-exposed target, then dismiss `delay-alarm` as a mirror when done.
+Delaying `daemon` is the one exception to hiding: the daemon channel stays
+readable (check, snapshot, and the bounded daemon summary keep working) and only
+stops waking you until the delay ends. `delay-alarm` itself cannot be delayed. A damaged private delay record fails open
+(target visible) rather than silently suppressing notification delivery.
+
+## Root `summarize`
+
+Notification is a **short-result** family, so leave the root `summarize` boolean
+false — especially for `manual`, where summarizing would drop the exact
+procedures and constraints you called it for.
+
+## Installed manual retrieval
+
+`notification(action='manual', input={})` reads only:
+
+```text
+<agent>/.library/intrinsic/capabilities/notification/SKILL.md
+```
+
+Success returns exactly `status`, `notification_manual`, and `manual_path`. A
+missing installed file returns `status: degraded`, an empty
+`notification_manual`, the same fixed `manual_path`, and an actionable `error`
+naming an initializer or capability-install problem. It never falls back to a
+source checkout, and it touches neither notification nor producer state.
+
+## Hooks & whitelist
+
+External hooks deliver notifications through channels that are **not** on the
+static allowlist (which covers kernel intrinsics and `mcp.` bridge servers).
+Registering a hook is the whitelist gate: only registered hook channels pass
+through; everything else is ignored (and, when the kernel observes a blocked
+attempt, surfaced as a warn-and-flag system event so the agent can investigate).
+
+Hook channels are **per-agent**: registering a hook allowlists its channel for
+this agent's working directory only — a hook channel is not visible to other
+agents' workdirs. The registry (`.notification/hooks.json`) is re-read whenever
+its `(mtime, size)` stat changes, so an out-of-band write by another process (a
+sibling CLI, the Telegram server, or the hook installer itself) is picked up on
+the next sync without a restart.
+
+### Setup flow
+
+1. **Write the hook script** that polls a source (a file, a service, a remote
+   node) and, on an event, publishes `.notification/<channel>.json` with the
+   standard envelope (`header`, `icon`, `priority`, `published_at`, `data`,
+   optional `instructions`).
+2. **Register its manifest** with the notification tool:
+   `notification(action='add', input={...})`. `add` validates the manifest,
+   appends it to the disk registry (`.notification/hooks.json`), and
+   **allowlists the manifest's `channel`** — from then on the channel passes
+   the kernel's allow predicate.
+3. **Publish** `.notification/<channel>.json` from the hook process. The
+   notification now appears in `check` / the meta-block payload like any other
+   channel.
+4. **Read and dismiss** per the producer's `instructions` / the manifest's
+   `description`, using the narrowest correct dismiss action. Dismissing the
+   mirror does not touch the hook process; `drop` only revokes the
+   registration.
+
+### Manifest fields
+
+- `name` — unique hook identifier (required).
+- `channel` — the `.notification/<channel>.json` stem this hook owns
+  (required; must be unique across hooks). It must not be a built-in static
+  channel (`system`/`email`/`soul`/`goal`/`molt`/`nudge`/`post-molt`/`bash`/`btw`/`cron`/`daemon`/`delay-alarm`/`tool_loop_guard`)
+  nor a Store-reserved non-channel stem (`hooks`/`large_result_acks`); `add`
+  refuses those with a clear error.
+- `source` — what the hook polls (required, e.g. `G:`).
+- `description` — one-line purpose (required).
+- `how_to_modify` / `how_to_cancel` — how the agent updates or stops the hook
+  (required; cancellation is the owner's job — `drop` never kills a process).
+- `version` — manifest version (optional, defaults to `1.0.0`).
+- `instructions` — agent-facing handling guidance (optional).
+
+### drop / edit / list semantics
+
+- `list` — read-only; returns the registered manifests in registry order, or
+  `hook_registry_load_failed` when the registry is corrupt or unreadable.
+- `edit` — update a manifest's fields by `name`; changing `channel` moves the
+  allowlist entry (and is refused with `channel_in_use` if another hook owns
+  that channel). Moving `channel` onto a built-in static channel or a
+  Store-reserved stem (`hooks`/`large_result_acks`) is refused with
+  `invalid_manifest`. An `edit` providing no non-null fields is a `no_change`
+  no-op.
+- `drop` — remove the manifest **and revoke its channel** from the allowlist;
+  unknown names return `not_found`. `drop` is registration evidence only —
+  stopping the hook process follows the manifest's `how_to_cancel`.
+
+### Warn-and-flag
+
+When a channel that is neither statically allowlisted nor registered attempts
+notification, the kernel emits one `notification_hook` system event
+(`ref_id: blocked_channel:<channel>`) per workdir+channel — deduped until the
+channel registers (then a later re-block can warn again). The scan only flags
+stems that can become channels: kernel-private dotfiles (`.nudge_state.json`),
+non-`.json` entries, and syntactically invalid stems are skipped. If you see
+such an event, run `list` to inspect hooks and
+`add` to register the hook if the producer is legitimate.
+
+### Worked example: `comm_watcher`
+
+```text
+1. A watcher script polls a G: node (source) for changes.
+2. On a change it writes .notification/comm_watcher.json with the standard
+   envelope and instructions (e.g. "read the relayed message, then dismiss").
+3. The agent (or operator) registers it once:
+   notification(action='add', input={
+     'name': 'comm_watcher', 'channel': 'comm_watcher', 'source': 'G:',
+     'description': 'poll G: node and relay',
+     'how_to_modify': 'notification(action=edit, ...)',
+     'how_to_cancel': 'stop the watcher process',
+     'instructions': 'read the relayed message and dismiss the channel'})
+4. The channel is now allowlisted: notifications pass through to check, and
+   the agent reads/dismisses per the manifest's instructions.
+5. To decommission: notification(action='drop', input={'name': 'comm_watcher'})
+   revokes the channel, then stop the watcher process per how_to_cancel.
+```
+
+## Block size cap (persistent and attention lanes)
+
+Two model-visible notification envelopes are re-serialized into provider
+context: the persistent block
+(`_meta.agent_meta.notifications.persistent`, the `notification_persistent`
+block, rebuilt per payload build) and the attention lane
+(`_meta.agent_meta.notifications.attention`, the transient per-channel routing
+payload re-stamped on every eligible tool batch and every IDLE/ASLEEP pair).
+A busy hub agent with many unread emails plus several IM lanes could otherwise
+grow context fast and pay a large per-call cache miss. The kernel caps BOTH
+lanes with ONE shared bar (`LINGTAI_NOTIFICATION_MAX_CHARS`):
+
+- **At or under the cap** (default `10000` characters): the block is delivered
+  byte-identical, no spill file, no marker.
+- **Over the cap - persistent lane**: the FULL block is written atomically to
+  `<workdir>/logs/notification-overflow-<ts>.json`, and the model-visible copy
+  is compacted (heavy free-text fields 200 → 100 → 50 → 0, then id-only
+  message stubs) until it fits; a terminal marker-only envelope with the exact
+  spill basename is returned BY CONSTRUCTION when even id-only stubs exceed
+  the cap. The compacted block carries an `overflow` marker
+  `{path, full_chars, truncated}` (and `path_omitted` + `spill_file` when the
+  absolute path is stripped). Message ids are never dropped, so delivery
+  tracking still sees every message and never re-delivers a truncated one.
+- **Over the cap - attention lane**: the FULL lane is written once to
+  `<workdir>/logs/notification-attention-overflow-<digest8>.json` — the name
+  is content-addressed (short sha256 of the lane's canonical serialization),
+  so an unchanged oversized lane reuses the SAME file instead of re-spilling
+  every batch, and exclusive creation never overwrites an existing recovery
+  handle (a different-content collision allocates `<digest8>-<N>.json`; the
+  exact allocated basename, including any `-N` suffix, is returned as
+  `overflow.spill_file`). The model-visible copy is compacted (heavy fields
+  truncated; routing ids including `message_ids` preserved) and carries the
+  same `overflow` marker. If even the routing stub cannot fit, the lane
+  degrades deterministically to a marker-only envelope that is capped BY
+  CONSTRUCTION: a pathologically long absolute spill path is stripped from the
+  marker (`path = None`, `path_omitted`, exact `spill_file` basename retained)
+  so the envelope always satisfies the cap; the full payload remains on disk
+  under the deterministic content-addressed name. If the spill file itself
+  cannot be written, the marker carries `spill_failed` and the block points
+  the agent at the producer tool for the full content.
+
+The cap is **live-configurable** with the environment variable
+`LINGTAI_NOTIFICATION_MAX_CHARS` (positive integer; values above `10000` clamp
+back to `10000`; values below `2048` clamp UP to `2048` on BOTH lanes so the
+terminal recovery envelope always fits; missing/blank/
+non-numeric/zero/negative values fall back to `10000`). It is read at every
+payload build, so setting it in the agent's `env_file` and refreshing applies
+it without editing `init.json`. This is a context-size steering knob only: it
+never grants access and never changes which messages are considered
+delivered.
+
+## Nested reference catalog
+
+```yaml
+- name: notification-manual-channel-model
+  location: reference/channel-model/SKILL.md
+  description: |
+    Nested notification-manual reference for the filesystem channel protocol,
+    allowlist, envelopes and instructions, nudge routing, kernel sync, voluntary
+    check behavior, and producer canonical-state versus mirror boundaries. Read
+    this when interpreting or producing notification payloads.
+- name: notification-manual-dismissal-safety
+  location: reference/dismissal-safety/SKILL.md
+  description: |
+    Nested notification-manual reference for atomic dismissal, producer-specific
+    verbs, stale-version and force rules, protected channels, post-molt
+    acknowledgement, and legacy large_tool_result reminder escape hatches. Read
+    this before clearing notification state or diagnosing a refusal.
+```
+
+## Routing table
+
+| Need / keywords | Read |
+|---|---|
+| Channel names; `.notification/*.json`; allowlist; `mcp.` channels; envelope fields; `instructions`; nudge/update checks; `_meta.agent_meta.notifications.attention`; voluntary `check`; producer state versus mirror | `reference/channel-model/SKILL.md` |
+| `notification_persistent` and `notification.attention` block size cap; `LINGTAI_NOTIFICATION_MAX_CHARS` (floor `2048` / ceiling `10000`); `notification-overflow-<ts>.json` and `notification-attention-overflow-<digest8>.json` spill files; compacted copy; message-id preservation; marker-only degradation | this section (`Block size cap (persistent and attention lanes)`) |
+| External-hook registration; `.notification/hooks.json`; `add`/`drop`/`edit`/`list`; whitelist gate; warn-and-flag on blocked channels | this section (`Hooks & whitelist`) + `reference/channel-model/SKILL.md` (effective allowlist) |
+| Temporarily hide one channel; `delay`; 0 or live configured seconds (default cap 600); replacement/cancellation; expiry, restart recovery, or `delay-alarm` | this section (`Consumer delay and expiry alarm`) + `reference/channel-model/SKILL.md` |
+| Which dismiss action; producer-specific handling; guarded/stale mirror; `force`; protected `goal`; post-molt reason; legacy `large_tool_result` event | `reference/dismissal-safety/SKILL.md` |
+| Tool-result ranking, digest quality, `context(action='summarize')`, recovery by `tool_call_id`, summarize versus molt | `../context-manual/reference/summarize-manual/SKILL.md` |
+| Active goal source-of-truth and cancellation/completion | `../system-manual/reference/goal-manual/SKILL.md` |
+| Runtime/kernel update nudges | `../system-manual/reference/runtime-update-checks/SKILL.md` |
+
+## Safety boundaries to keep resident
+
+The producer-verb preference and `force` semantics are resident (meta_guidance
+`notification_handling` and the schema's `_FORCE_DESCRIPTION`). The two facts
+neither of them states:
+
+- Neither `check` nor `manual` writes notification state.
+- `force=true` does **not** override protected source-of-truth channels.
+
+Producer guards exist so that clearing a mirror is never mistaken for handling
+the producer's canonical state.

--- a/src/lingtai/tools/notification/manual/reference/channel-model/SKILL.md
+++ b/src/lingtai/tools/notification/manual/reference/channel-model/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: notification-manual-channel-model
+description: >
+  Nested notification-manual reference for LingTai's notification filesystem
+  channel protocol, allowlist, payload envelopes and instructions, nudge routing,
+  kernel sync, voluntary check behavior, and canonical producer state versus
+  notification mirrors. Read after notification-manual when interpreting,
+  producing, or debugging notification payloads; skip for dismissal policy.
+version: 0.5.0
+tags: [lingtai, notifications, channels, protocol, sync, delay, alarm, nudge, hooks, whitelist]
+last_changed_at: "2026-08-20T00:00:00Z"
+related_files:
+- src/lingtai/tools/notification/manual/SKILL.md
+- src/lingtai/tools/notification/schema.py
+- src/lingtai/kernel/notification_store/__init__.py
+maintenance: |
+  Tracks the notification channel-model/protocol topic it documents; update when that integration changes.
+---
+
+# Notification Channel Model
+
+## Files and allowlist
+
+A channel is the filename stem in `.notification/<channel>.json`:
+
+- `.notification/email.json` becomes `_meta.agent_meta.notifications.attention.email`;
+- `.notification/system.json` becomes `_meta.agent_meta.notifications.attention.system`;
+- `.notification/mcp.telegram.json` becomes
+  `_meta.agent_meta.notifications.attention["mcp.telegram"]`;
+- `.notification/goal.json` becomes `_meta.agent_meta.notifications.attention.goal`.
+
+The kernel accepts built-in channels including `email`, `system`, `soul`,
+`nudge`, `post-molt`, `tool_loop_guard`, `bash`, `btw`, `cron`, `molt`, `goal`,
+`daemon`, and `delay-alarm`; MCP bridge channels use the `mcp.` prefix. The **effective allowlist**
+is `static ∪ mcp.* ∪ the agent's own registered hook channels`, and it is
+**per-agent, not process-global**: a hook channel is allowed only for the agent
+whose workdir registered it (external hooks register manifests via
+`notification(action='add', ...)`, which appends to
+`.notification/hooks.json` and allowlists the manifest's `channel` for that
+workdir — see the
+parent manual's `Hooks & whitelist` section). Unknown JSON filenames are
+ignored by collection, and kernel publish/dismiss helpers reject names outside
+the effective allowlist, so arbitrary workdir files cannot enter the
+model-visible notification lane. Blocked attempts by unregistered channels are
+now observable: the kernel emits a deduped `notification_hook` system
+warn-and-flag event (`ref_id: blocked_channel:<channel>`) so the agent can
+investigate and register the hook if legitimate.
+
+The D2 warn-and-flag scan runs only when a present channel file appears for a
+channel that is not on the effective allowlist, and only for stems that can
+actually become channels: kernel-private dotfiles (e.g. `.nudge_state.json`),
+non-`.json` entries, and syntactically invalid stems are skipped, so no
+unresolvable "register this hook" event is emitted for files that could never
+be a channel.
+
+`nudge` is the formal channel for mechanical, throttled checks: runtime update
+checks publish `data.nudges[]` entries with `kind: kernel_version`, and
+source-freshness checks may publish `kind: source_drift` — which stays local and
+never enters release-migration routing. The sole normal install/update route is
+`https://lingtai.ai/install.sh` (let Shell run its `--help` and follow that), and
+real updates, configuration writes, and refresh require
+explicit human/config-owner authority. Those rules are owned in full by
+`../../../system-manual/reference/runtime-update-checks/SKILL.md`; this manual
+owns only the generic channel protocol.
+
+## Envelope and producer instructions
+
+Producer helpers write the current channel surface as a standard envelope:
+
+```json
+{
+  "header": "1 system notification",
+  "icon": "🔔",
+  "priority": "normal",
+  "published_at": "2026-06-10T00:00:00Z",
+  "instructions": "Optional agent-facing handling guidance.",
+  "data": {"events": []}
+}
+```
+
+`instructions` is an optional field inside one channel payload, not a channel
+name. It tells the agent how that producer expects the event to be handled or
+cleared. Producers own that directive because only they know whether the file is
+a disposable output, a mirror over canonical state, a coalesced event summary,
+or protected source of truth.
+
+External producers that can write the workdir may publish the same envelope to
+an allowlisted `mcp.<server>.json` path. They must use atomic sibling-temp
+replacement so readers never observe a partial JSON file.
+
+## Voluntary check and model-visible delivery
+
+`check` returns a dict placeholder that the turn-loop post-hook stamps with the
+canonical live payload; the handler assembles no second channel representation
+and writes no notification state.
+
+When notifications arrive while an agent is IDLE or ASLEEP, the kernel can
+synthesize the same `notification(action='check')` tool-call/result shape —
+same `action`/`input`/`reasoning` envelope, indistinguishable from a read you
+issued yourself — and wake the agent. During ACTIVE work the post-hook moves the
+single live payload onto a suitable dict-shaped tool result only on first
+appearance, material change, or a deliberate check. Delivery fingerprints and
+the live holder belong to kernel synchronization, not to the `manual` action.
+
+## Consumer delay filtering
+
+The `daemon` target is masked, not filtered: its payload and byte version stay
+visible while its attention entry collapses to a constant token, so daemon
+arrivals stay readable but do not wake until the delay expires.
+
+`notification(action='delay', input={'channel': ..., 'seconds': 0 or a live configured cap})` is
+not a producer operation. Its private `.notification/.delay_state.json` record
+causes the coherent consumer snapshot, delivery fingerprint, synthetic wake, and
+voluntary `check` projection to omit exactly one allowed target while it is live;
+the target file itself continues receiving and retaining producer updates. A
+nonzero delay replaces the prior one, and `seconds: 0` cancels the matching target
+and makes it visible again. The nonzero limit is read at each action from
+`LINGTAI_NOTIFICATION_DELAY_MAX_SECONDS` (default 600); invalid/non-positive
+values log and fall back to that finite default.
+
+The process timer is only a prompt path. Every coherent sync also recovers a
+persisted overdue delay. Recovery stops filtering and publishes one high-priority
+`delay-alarm` mirror in the same read/wake cycle. Its state uses the established
+native notification mutation lock plus atomic sibling replacement, and a stable
+request id makes a stale callback/restart retry overwrite the same latest-only
+alarm rather than append a duplicate. The alarm contains only byte-level change
+comparison plus producer-reported or retained-event measurements; such values are
+not claimed to be exact totals for overwrite/capped payloads. `delay-alarm` is a
+built-in mirror consumers may dismiss, but it cannot itself be delayed. Missing or
+malformed delay state fails toward visible target delivery.
+
+## Canonical producer state versus mirror
+
+A generic channel clear changes only the `.notification/<channel>.json` surface.
+It does not mark an email read, change a goal, consume an MCP source queue, or
+mutate any other producer-owned state. A producer whose notification is a mirror
+over canonical state must register a generic-dismiss guard and teach the
+producer-specific verb in `instructions`.
+
+This separation is deliberate: the filesystem protocol gives the kernel one
+current high-attention surface, while canonical state remains under the
+producer's own schema and lifecycle.
+
+## Footprint
+
+The protocol footprint is `.notification/<channel>.json` plus kernel-owned
+notification metadata such as legacy acknowledgement state
+(`.notification/large_result_acks.json`), the hook-manifest registry
+(`.notification/hooks.json`, a single non-channel file invisible to collection),
+and consumer-delay state (`.notification/.delay_state.json`, a private dotfile
+invisible to collection). Inspect it read-only
+before diagnosing a producer. Never delete the directory or bulk-remove files —
+that bypasses the guards and stale checks that only the producer verb or an
+atomic notification action honor.

--- a/src/lingtai/tools/notification/manual/reference/dismissal-safety/SKILL.md
+++ b/src/lingtai/tools/notification/manual/reference/dismissal-safety/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: notification-manual-dismissal-safety
+description: >
+  Nested notification-manual reference for choosing safe atomic notification
+  dismissal, producer-specific verbs, stale-version and force behavior,
+  protected channels, post-molt acknowledgement, and legacy large_tool_result
+  reminder escape hatches. Read after notification-manual before clearing a
+  channel or diagnosing a dismissal refusal; summarization mechanics live in
+  summarize-manual instead.
+version: 0.4.0
+tags: [lingtai, notifications, dismiss, force, stale, safety, hooks]
+last_changed_at: "2026-08-10T00:00:00Z"
+related_files:
+- src/lingtai/tools/notification/manual/SKILL.md
+- src/lingtai/tools/notification/__init__.py
+- src/lingtai/tools/notification/schema.py
+maintenance: |
+  Tracks the notification dismissal-safety topic it documents; update when that integration changes.
+---
+
+# Notification Dismissal Safety
+
+## Choose the narrowest owner and target
+
+Use a producer-specific verb first when a notification mirrors producer-owned
+state (e.g. `email(action='read'|'dismiss', ...)`) — a generic channel dismissal
+would clear only the high-attention mirror.
+
+For a dismissible notification-owned surface, choose one atomic target:
+
+```text
+notification(action='dismiss_channel',
+             input={'channel': 'nudge', 'force': null, 'reason': null},
+             reasoning='...')
+```
+
+`dismiss_event` and `dismiss_ref` take the same envelope with `event_id` /
+`ref_id` instead of `channel`; the schema is the exact-shape source of truth.
+What it does not say: those two **default to the `system` channel** and remove
+only matching entries from `system.data.events`, and **removing the final event
+clears the file**.
+
+All three actions delegate to the canonical notification Core dismissal helper.
+That one policy path enforces allowlists, producer guards, stale-version checks,
+protected channels, post-molt acknowledgement, and legacy reminder
+acknowledgement. The standalone tool does not reimplement Store or producer
+policy.
+
+## Stale versions, guards, and force
+
+A non-force generic dismiss compares the delivered notification version with the
+current on-disk version. If a producer updated the channel after delivery, the
+call refuses with `reason='stale_channel_version'` rather than erase unseen
+state. Read the newly delivered state first.
+
+`force=true` (semantics in the schema) is for a confirmed stale mirror — not a
+routine retry, and not a substitute for handling the producer.
+
+## Protected and acknowledgement-sensitive channels
+
+`goal` is protected source of truth. A generic
+`notification(action='dismiss_channel', input={'channel': 'goal', ...})`
+refuses even with `force=true`; use `../../../system-manual/reference/goal-manual/SKILL.md` to cancel or complete active goal
+state correctly.
+
+The kernel-owned `post-molt` continuation channel requires a non-empty reason
+recording the decision in `continue|defer|obsolete` form — e.g.
+`reason='continue: recovered the pending work'` on
+`dismiss_channel(channel='post-molt')`.
+
+## Hook channels and producer-guard interplay
+
+A registered hook channel (see the parent manual's `Hooks & whitelist`
+section) is dismissed exactly like any other allowlisted channel: the atomic
+dismiss actions clear only the `.notification/<channel>.json` mirror. Hook
+registration widens the **allowlist** for the registering agent's workdir
+(hook channels are per-agent, not process-global), not the dismissal policy —
+a hook producer whose notification mirrors canonical state should still
+register a generic-dismiss guard and teach its producer-specific verb in
+`instructions`, and the guarded refusal still applies.
+
+`notification(action='drop', input={'name': ...})` removes the hook's manifest
+and revokes its channel from the allowlist; it does **not** kill the hook
+process. Stopping the hook is the owner's job, documented in the manifest's
+`how_to_cancel` field. After a drop, an unregistered channel's notifications
+stop passing through and the kernel's warn-and-flag event may reappear if the
+process keeps publishing — the blocked-channel warning is cleared when a
+channel registers, so a later re-block can warn again. The warn-and-flag scan
+only flags present stems that can become channels (skipping kernel-private
+dotfiles like `.nudge_state.json`, non-`.json` entries, and syntactically
+invalid stems), so an unregistered file that could never be a channel does not
+produce a spurious "register this hook" event.
+
+## Large results and legacy reminder escape hatch
+
+New large tool results are not notification events — they are ranked under
+`_meta.agent_meta.agent_state.current_tool_result_chars`, and
+`../../../context-manual/reference/summarize-manual/SKILL.md` owns the digest,
+`context(action='summarize')`, recovery, and summarize-versus-molt procedure.
+
+A persisted or pre-molt `source='large_tool_result'` system event may still
+exist. A successful summarize of the matching `tool_call_id` clears it. If
+summarization is no longer possible, use
+`dismiss_ref` with `ref_id='large_tool_result:<tool_call_id>'`. Whole-channel
+system dismissal also covers it but may clear unrelated system events, so prefer
+ref/event targeting. Either way the original tool result stays unchanged in chat
+history and `events.jsonl`.
+
+## On a refusal
+
+1. Check whether the channel's `instructions` name a producer action; if so, use
+   it instead of retrying the generic dismiss.
+2. Stale — read the current delivered payload before deciding on `force=true`.
+3. Protected — follow the channel's owning manual; do not retry.
+4. `post-molt` without a reason — record the real continue/defer/obsolete
+   decision.
+5. Targeting one system event — use `dismiss_event`/`dismiss_ref`, not a
+   whole-channel clear.
+
+No dismissal ever removes producer history, mailbox state, or goal semantics.

--- a/tests/test_notification_tool.py
+++ b/tests/test_notification_tool.py
@@ -234,17 +234,20 @@ def test_each_action_input_branch_is_strict_and_exact() -> None:
         assert then_input == {k: v for k, v in branch.items() if k != "title"}, action
 
 
-def test_manual_branch_matches_the_shared_manual_child_schema() -> None:
-    """The advertised ``manual`` input equals the child that actually dispatches.
+def test_manual_branch_matches_the_descriptor_selected_manual_child_schema() -> None:
+    """The advertised ``manual`` input equals the child dispatch uses.
 
-    ``schema.py`` declares ``_MANUAL_INPUT_SCHEMA`` for composition while
-    ``handle`` registers ``tool_family.manual.build_manual_child``. If those
-    two ever drift, the model would be shown an input shape dispatch does not
-    enforce.
+    The active package descriptor supplies both the manual's installed
+    destination and the shared manual child. If it drifted from ``schema.py``,
+    the model would be shown an input shape dispatch does not enforce.
     """
+    from lingtai.tools.notification.descriptor import NOTIFICATION_TOOL
     from lingtai.tools.tool_family.manual import build_manual_child
 
-    child = build_manual_child(object(), "notification-manual")
+    assert NOTIFICATION_TOOL.name == "notification"
+    assert NOTIFICATION_TOOL.manual_skill_name == "notification"
+    assert NOTIFICATION_TOOL.action_order == tuple(_ACTIONS)
+    child = build_manual_child(object(), NOTIFICATION_TOOL.manual_skill_name)
     assert notif_intrinsic.INPUT_SCHEMAS["manual"] == dict(child.input_schema)
 
 
@@ -344,7 +347,7 @@ def _notification_manual_path(workdir: Path) -> Path:
         / ".library"
         / "intrinsic"
         / "capabilities"
-        / "notification-manual"
+        / "notification"
         / "SKILL.md"
     )
 

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -343,14 +343,14 @@ def test_skills_setup_hard_copies_standalone_intrinsic_skills(tmp_path):
             / ".library"
             / "intrinsic"
             / "capabilities"
-            / "notification-manual"
+            / "notification"
             / "SKILL.md"
         )
         assert notification_manual_md.is_file()
         notification_manual_body = notification_manual_md.read_text(encoding="utf-8")
         assert "name: notification-manual" in notification_manual_body
         assert "# Notification Manual" in notification_manual_body
-        assert "<agent>/.library/intrinsic/capabilities/notification-manual/SKILL.md" in notification_manual_body
+        assert "<agent>/.library/intrinsic/capabilities/notification/SKILL.md" in notification_manual_body
         assert "location: reference/channel-model/SKILL.md" in notification_manual_body
         assert "location: reference/dismissal-safety/SKILL.md" in notification_manual_body
         assert (

--- a/tests/test_tools_package_data.py
+++ b/tests/test_tools_package_data.py
@@ -81,9 +81,9 @@ _BACKEND_MANUAL = (
 )
 
 _NOTIFICATION_MANUAL_FILES = (
-    "lingtai/intrinsic_skills/notification-manual/SKILL.md",
-    "lingtai/intrinsic_skills/notification-manual/reference/channel-model/SKILL.md",
-    "lingtai/intrinsic_skills/notification-manual/reference/dismissal-safety/SKILL.md",
+    "lingtai/tools/notification/manual/SKILL.md",
+    "lingtai/tools/notification/manual/reference/channel-model/SKILL.md",
+    "lingtai/tools/notification/manual/reference/dismissal-safety/SKILL.md",
 )
 
 # The three per-tool glossary languages that each package must ship.
@@ -240,9 +240,9 @@ def test_wheel_keeps_daemon_backend_manuals(wheel_entries: set[str]):
     assert not missing, "daemon backend manuals missing from wheel: %r" % missing
 
 
-def test_wheel_ships_first_level_notification_manual(wheel_entries: set[str]):
+def test_wheel_ships_package_local_notification_manual(wheel_entries: set[str]):
     missing = [path for path in _NOTIFICATION_MANUAL_FILES if path not in wheel_entries]
-    assert not missing, "notification manual files missing from wheel: %r" % missing
+    assert not missing, "notification package manual files missing from wheel: %r" % missing
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- localizes notification schema/dispatch descriptor and its tool-owned manual while retaining producer and dismissal safety boundaries

## Validation
- 93 focused notification tests and package-data checks passed
- independent read-only review: APPROVE
- `git diff --check` passed

Telegram: @lingtaidev1bot | Nickname: 知微
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai