### PR TITLE
refactor(plugin): own family descriptor locally

### DIFF
--- a/src/lingtai/tools/plugin/ANATOMY.md
+++ b/src/lingtai/tools/plugin/ANATOMY.md
@@ -3,6 +3,7 @@ related_files:
   - src/lingtai/tools/ANATOMY.md
   - src/lingtai/tools/plugin/BEHAVIORS.md
   - src/lingtai/tools/plugin/__init__.py
+  - src/lingtai/tools/plugin/descriptor.py
   - src/lingtai/tools/plugin/CONTRACT.md
   - src/lingtai/tools/plugin/manual/SKILL.md
   - src/lingtai/tools/plugin/glossary-en.md
@@ -60,26 +61,23 @@ registry-level only: a registered server is registered, never running.
 
 ## Components
 
-- `plugin/__init__.py` — the tool slice (~351 lines). One model-facing LTP v2
-  family: public tool name `plugin`, public actions `info`/`manual`, carried in
-  the canonical `action` + `input` + `reasoning` + `summarize` envelope composed
-  by the generic `lingtai.tools.tool_family` infrastructure
-  (`src/lingtai/tools/tool_family/ANATOMY.md`).
-  `get_description` (`src/lingtai/tools/plugin/__init__.py:287`),
-  `get_schema` (`src/lingtai/tools/plugin/__init__.py:291`) returns
-  `ToolFamily.build_schema()` with the family's own `action` description
-  substituted, and `_build_family`
-  (`src/lingtai/tools/plugin/__init__.py:250`) is the single source of the
-  two-child registry — called with `None` at import for the module-level
-  schema-only family `_FAMILY` (`src/lingtai/tools/plugin/__init__.py:284`),
-  which fails loudly on a duplicate/reserved-name collision and never
-  dispatches, and called with the agent from `setup`
-  (`src/lingtai/tools/plugin/__init__.py:300`) for the real dispatching family
-  whose `manual` child comes straight from
-  `tool_family.manual.build_manual_child`. Both children share the one
-  `_EMPTY_INPUT` literal (`src/lingtai/tools/plugin/__init__.py:237`)
-  re-exported from `tool_family.manual.MANUAL_INPUT_SCHEMA`, so the advertised
-  and validated shapes cannot drift. `_reconcile`
+- `plugin/descriptor.py` — the package-local declarative public-family owner.
+  `PLUGIN_TOOL` fixes the `plugin` identity, its read-only `info` action, and
+  its `manual` binding to the Host-installed `plugin` skill destination. It
+  composes the actual strict two-child `ToolFamily`, registering the generic
+  `build_manual_child` directly and unwrapped; it does not read package manual
+  source, discover paths, mount plugins, touch MCP records, or activate a
+  server.
+- `plugin/__init__.py` — the tool slice. One model-facing LTP v2 family: public
+  tool name `plugin`, public actions `info`/`manual`, carried in the canonical
+  `action` + `input` + `reasoning` + `summarize` envelope composed by the
+  generic `lingtai.tools.tool_family` infrastructure
+  (`src/lingtai/tools/tool_family/ANATOMY.md`). `get_schema` returns
+  `ToolFamily.build_schema()` with the family's action description substituted;
+  `_build_family` binds the read-only `info` handler and delegates the fixed
+  child inventory to `PLUGIN_TOOL`, both for the import-time schema-only family
+  and agent-bound dispatch. The generic builder retains installed
+  skill/prompt-lifecycle ownership for `manual`. `_reconcile`
   (`src/lingtai/tools/plugin/__init__.py:144`) backs the `info` child: it reads
   the boot snapshot off `agent._plugin_registration`, re-scans discovery live,
   splits the result into the registered and discovered tiers, and renders both.
@@ -223,6 +221,12 @@ my-plugin/
 ## Internal Module Layout
 
 ```
+plugin/descriptor.py
+  ├── PLUGIN_TOOL               — package identity, info/manual action inventory
+  ├── info_child()              — strict-empty read-only info child
+  ├── manual_child()            — direct Host-installed manual child binding
+  └── build_family()            — descriptor-owned strict two-child composition
+
 plugin/__init__.py
   ├── Path collection
   │   └── _collect_paths()          — own ∪ declared ∪ skills paths, in that order, deduped
@@ -316,7 +320,9 @@ services/plugin_registry.py
 
 ## Dependencies
 
-- `lingtai.tools.tool_family` — `ChildTool` / `ToolFamily` / `build_manual_child`
+- `lingtai.tools.tool_family` — `ChildTool` / `ToolFamily` /
+  `build_manual_child`, consumed by `plugin/descriptor.py` for strict family
+  composition and the Host-installed manual child
 - `lingtai.services.plugin_registry` — lazily imported inside `_reconcile`
   (the `lingtai.tools → lingtai` back-edge)
 - `lingtai.services.mcp_registry` — lazily imported inside the registration

--- a/src/lingtai/tools/plugin/CONTRACT.md
+++ b/src/lingtai/tools/plugin/CONTRACT.md
@@ -4,6 +4,7 @@ tool: plugin
 contract_version: 1
 related_files:
   - src/lingtai/tools/plugin/__init__.py
+  - src/lingtai/tools/plugin/descriptor.py
   - src/lingtai/tools/plugin/ANATOMY.md
   - src/lingtai/services/plugin_registry.py
   - src/lingtai/tools/CONTRACT.md
@@ -169,8 +170,12 @@ alone still reports its health here. `problems` entries are
 `plugin_manual` and an `error` string when
 `.library/intrinsic/capabilities/plugin/SKILL.md` is missing.
 
-`manual` is the family-owned reserved child, registered directly from
-`tool_family.manual.build_manual_child(agent, "plugin")`. `ToolFamily.handle()`
+`descriptor.py` owns the package's fixed `info` identity and the binding of
+its reserved `manual` child to the Host-installed `plugin` skill destination;
+it composes the family by registering
+`tool_family.manual.build_manual_child(agent, "plugin")` directly and unwrapped.
+The descriptor does not read the package source manual itself: the generic Host
+builder retains installed skill/prompt lifecycle ownership. `ToolFamily.handle()`
 returns that child's canonical `content`/`structuredContent` result verbatim
 (no double wrap); the flat public shape — body under the tool-specific key
 `plugin_manual`, matching the `mcp_manual` precedent — is reconstructed by the

--- a/src/lingtai/tools/plugin/__init__.py
+++ b/src/lingtai/tools/plugin/__init__.py
@@ -47,8 +47,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Mapping
 
-from ..tool_family import ChildTool, ToolFamily
-from ..tool_family.manual import MANUAL_INPUT_SCHEMA, build_manual_child
+from ..tool_family import ToolFamily
+from .descriptor import PLUGIN_TOOL
 
 if TYPE_CHECKING:
     from lingtai.kernel.base_agent import BaseAgent
@@ -234,14 +234,6 @@ _DESCRIPTION = (
     "uninstall, remove it from that list and refresh."
 )
 
-# Both actions are flagpost-only reads that take no arguments at all, so both
-# children share the one canonical strict-empty ``input`` — the same literal
-# the generic ``manual`` child registers, reused rather than hand-copied so the
-# schema-only and dispatching families cannot advertise different shapes.
-# ``ToolFamily.build_schema`` deep-copies per child, and dispatch reads only
-# ``properties``, so one shared object is safe.
-_EMPTY_INPUT: dict[str, Any] = MANUAL_INPUT_SCHEMA
-
 _ACTION_DESCRIPTION = (
     "info: read-only action; re-scans the configured plugin paths and returns "
     "the boot registration snapshot (registered plugins with what mounted and "
@@ -254,37 +246,24 @@ _ACTION_DESCRIPTION = (
 
 
 def _build_family(agent: "BaseAgent | None", paths: list[str] | None = None) -> ToolFamily:
-    """Build the two-child ``plugin`` family; the registry is declared exactly once.
+    """Build the descriptor-owned strict ``plugin`` family.
 
-    With an ``agent``, children are bound to real handlers for dispatch. With
-    ``None``, the module-level schema-only family is built: its handlers raise
-    if ever called, and constructing it at import time proves the fixed
-    registry has no duplicate or reserved-name collision (``ToolFamilyError``
-    raises here rather than shipping silently). Both paths declare the same
-    ordered children, so the composed schema and the dispatching family can
-    never drift apart.
+    With an ``agent``, ``info`` is bound to the read-only reconciliation handler.
+    With ``None``, its handler is deliberately unreachable and import-time family
+    construction proves the fixed descriptor has no duplicate/reserved-name
+    collision. In both cases ``PLUGIN_TOOL`` registers the same ``info`` child
+    and its direct, Host-installed ``manual`` child, so schema and dispatch
+    cannot drift. The descriptor merely binds the manual destination; the Host
+    generic builder retains installed skill/prompt lifecycle ownership.
     """
     if agent is None:
-        def _unused(_input: Mapping[str, Any]) -> dict[str, Any]:
+        def info_handler(_input: Mapping[str, Any]) -> dict[str, Any]:
             raise AssertionError("the module-level schema-only ToolFamily never dispatches")
-
-        info_handler: Any = _unused
-        manual_child = ChildTool("manual", _EMPTY_INPUT, _unused, title="manual input")
     else:
-        info_handler = lambda _input: _reconcile(agent, paths)  # noqa: E731
-        # Registered directly, unwrapped: ``ToolFamily.handle()`` must dispatch
-        # this child's own canonical MCP-compatible result verbatim (no double
-        # wrap). This capability's flat public shape is reconstructed from that
-        # canonical result strictly *after* dispatch, in ``handle_plugin`` —
-        # never inside a registered child.
-        manual_child = build_manual_child(agent, "plugin")
-    return ToolFamily(
-        "plugin",
-        [
-            ChildTool("info", _EMPTY_INPUT, info_handler, title="info input"),
-            manual_child,
-        ],
-    )
+        def info_handler(_input: Mapping[str, Any]) -> dict[str, Any]:
+            return _reconcile(agent, paths)
+
+    return PLUGIN_TOOL.build_family(agent, info_handler)
 
 
 _FAMILY = _build_family(None)

--- a/src/lingtai/tools/plugin/descriptor.py
+++ b/src/lingtai/tools/plugin/descriptor.py
@@ -1,0 +1,103 @@
+"""Package-local declaration of the model-facing ``plugin`` family.
+
+This descriptor is deliberately declarative, not an Agent Plugin runtime.  It
+owns only the stable public identity and the two-child family composition for
+this package: ``info`` is package-owned, and the reserved ``manual`` child is
+bound to this package's installed-manual destination.  The generic manual
+builder still owns loading from the Host-installed intrinsic library; this
+module must not read ``manual/SKILL.md`` directly and thereby bypass the Host's
+skill/prompt lifecycle.
+
+Nothing here discovers plugin directories, mounts skills, writes MCP records,
+or activates servers.  Those boot-time, containment, registration, and
+lifecycle concerns stay in their existing Host/service owners.  The descriptor
+only makes the package's strict ``info``/``manual`` family impossible to drift
+from its own manual binding.
+"""
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from ..tool_family import RESERVED_MANUAL_NAME, ChildTool, ToolFamily
+from ..tool_family.manual import MANUAL_INPUT_SCHEMA, build_manual_child
+
+__all__ = ["PLUGIN_TOOL", "PluginToolDescriptor", "PluginToolDescriptorError"]
+
+
+class PluginToolDescriptorError(ValueError):
+    """Raised when this package's fixed public-family declaration is invalid."""
+
+
+@dataclass(frozen=True, slots=True)
+class PluginToolDescriptor:
+    """The package-owned model-tool identity and strict family composition.
+
+    ``manual_skill_name`` names the *Host-installed* intrinsic-manual
+    destination, not a package file to load.  :meth:`manual_child` delegates
+    the actual loading and truthful degraded result to
+    :func:`build_manual_child`; that preserves the Host's installed skill and
+    prompt lifecycle while keeping the package's binding to ``plugin`` local.
+    """
+
+    name: str
+    info_action: str
+    manual_skill_name: str
+
+    def __post_init__(self) -> None:
+        for attribute in ("name", "info_action", "manual_skill_name"):
+            value = getattr(self, attribute)
+            if not isinstance(value, str) or not value.strip():
+                raise PluginToolDescriptorError(
+                    f"PluginToolDescriptor {attribute!r} must be a non-empty string"
+                )
+        if self.info_action == RESERVED_MANUAL_NAME:
+            raise PluginToolDescriptorError(
+                "PluginToolDescriptor info_action must not use the reserved 'manual' action"
+            )
+
+    @property
+    def actions(self) -> tuple[str, str]:
+        """The complete public action inventory, with the reserved manual last."""
+        return self.info_action, RESERVED_MANUAL_NAME
+
+    def info_child(
+        self, handler: Callable[[Mapping[str, Any]], dict[str, Any]]
+    ) -> ChildTool:
+        """Build this package's read-only ``info`` child.
+
+        ``info`` has no action-specific arguments.  It shares the generic
+        canonical strict-empty schema with the reserved manual child rather
+        than restating a near-duplicate in this package.
+        """
+        return ChildTool(
+            self.info_action,
+            MANUAL_INPUT_SCHEMA,
+            handler,
+            title=f"{self.info_action} input",
+        )
+
+    def manual_child(self, agent: Any) -> ChildTool:
+        """Build the reserved child bound to this package's installed manual.
+
+        The returned child is registered directly by :meth:`build_family`,
+        unwrapped, so ``ToolFamily.handle`` dispatches its canonical result
+        before this package's outer presentation adapter flattens it.
+        """
+        return build_manual_child(agent, self.manual_skill_name)
+
+    def build_family(
+        self,
+        agent: Any,
+        info_handler: Callable[[Mapping[str, Any]], dict[str, Any]],
+    ) -> ToolFamily:
+        """Compose the one strict package family without any runtime activation."""
+        return ToolFamily(self.name, [self.info_child(info_handler), self.manual_child(agent)])
+
+
+PLUGIN_TOOL = PluginToolDescriptor(
+    name="plugin",
+    info_action="info",
+    manual_skill_name="plugin",
+)

--- a/src/lingtai/tools/plugin/manual/SKILL.md
+++ b/src/lingtai/tools/plugin/manual/SKILL.md
@@ -29,6 +29,7 @@ version: 2.1.0
 last_changed_at: 2026-08-08T00:00:00Z
 related_files:
 - src/lingtai/tools/plugin/__init__.py
+- src/lingtai/tools/plugin/descriptor.py
 - src/lingtai/tools/plugin/ANATOMY.md
 - src/lingtai/tools/plugin/CONTRACT.md
 - src/lingtai/services/plugin_registry.py

--- a/tests/test_plugin_tool.py
+++ b/tests/test_plugin_tool.py
@@ -539,9 +539,31 @@ def test_both_actions_declare_the_canonical_strict_empty_input():
 
 def test_schema_only_and_dispatching_families_declare_identical_children(tmp_path):
     from lingtai.tools.plugin import _FAMILY, _build_family
+    from lingtai.tools.plugin.descriptor import PLUGIN_TOOL
 
     agent, _workdir = _mk_agent(tmp_path)
-    assert _build_family(agent).child_names == _FAMILY.child_names == ("info", "manual")
+    assert PLUGIN_TOOL.actions == ("info", "manual")
+    assert _build_family(agent).child_names == _FAMILY.child_names == PLUGIN_TOOL.actions
+
+
+def test_descriptor_binds_the_direct_manual_child_to_the_host_installed_skill(tmp_path):
+    """The package descriptor owns the binding; the Host still owns loading."""
+    from lingtai.tools.plugin import _build_family
+
+    agent, workdir = _mk_agent(tmp_path)
+    canonical = _build_family(agent).handle({
+        "action": "manual", "input": {}, "reasoning": "inspect the direct child",
+    })
+
+    # This is the direct ToolFamily child result, before plugin's outer adapter
+    # flattens it. Its path proves the descriptor did not read package source or
+    # sidestep the Host-installed intrinsic manual lifecycle.
+    assert canonical["status"] == "ok"
+    assert "declaration is what mounts" in canonical["content"][0]["text"]
+    assert canonical["structuredContent"]["manual_path"] == str(
+        workdir / ".library" / "intrinsic" / "capabilities" / "plugin" / "SKILL.md"
+    )
+    assert "plugin_manual" not in canonical
 
 
 def test_info_returns_catalog_snapshot(tmp_path):


### PR DESCRIPTION
## Summary
- Add a package-local `PluginToolDescriptor` that owns the public `plugin` identity and strict `info`/`manual` inventory.
- Bind the host-installed manual child at the plugin destination while retaining the outer adapter’s existing `plugin_manual` result shape.
- Keep discovery, mounting, security, manifests/config, registry, activation, lifecycle, and prompts host-owned and unchanged.

## Validation
- `tests/test_plugin_tool.py`: 103 passed
- Generic ToolFamily/manual-contract suites: 46 passed
- Changed-package `compileall`, focused Ruff, anatomy-drift suite (9 passed), and `git diff --check` passed
- Broader Ruff found one pre-existing unused test import at base (unrelated)

Telegram: @lingtaidev1bot | Nickname: 知微
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai