### PR TITLE
refactor(task-card): add local tool descriptor

### DIFF
--- a/src/lingtai/tools/task_card/ANATOMY.md
+++ b/src/lingtai/tools/task_card/ANATOMY.md
@@ -4,6 +4,7 @@ related_files:
   - src/lingtai/tools/task_card/BEHAVIORS.md
   - src/lingtai/tools/task_card/CONTRACT.md
   - src/lingtai/tools/task_card/__init__.py
+  - src/lingtai/tools/task_card/descriptor.py
   - src/lingtai/tools/task_card/manual/SKILL.md
   - src/lingtai/tools/ANATOMY.md
   - src/lingtai/tools/CONTRACT.md
@@ -45,13 +46,17 @@ Normative promises live in [`CONTRACT.md`](CONTRACT.md).
 
 ## Components
 
-- `__init__.py` — the full capability owner: schema/description, one-watch
-  lifecycle, renderer execution, atomic file writes, error/limit notifications,
-  persisted config loading/validation (`TaskCardManager._load_config`), the
-  one-way legacy-config migration (`TaskCardManager._migrate_legacy_config`),
-  and `setup(agent)` registration.
+- `descriptor.py` — static model-facing `task_card` identity, exact action
+  inventory, public prose, and manual-skill binding. It is consumed by the
+  package's schema, runtime manual, and existing registration paths; it does not
+  activate the tool or own host/channel behavior.
+- `__init__.py` — the full capability controller: one-watch lifecycle,
+  renderer execution, atomic file writes, error/limit notifications, persisted
+  config loading/validation (`TaskCardManager._load_config`), the one-way
+  legacy-config migration (`TaskCardManager._migrate_legacy_config`), and
+  `setup(agent)` registration using the local descriptor.
 - `manual/SKILL.md` — the progressive-disclosure manual for renderer authors
-  and lifecycle use.
+  and lifecycle use, bound by the local descriptor.
 
 ## Connections
 

--- a/src/lingtai/tools/task_card/CONTRACT.md
+++ b/src/lingtai/tools/task_card/CONTRACT.md
@@ -5,6 +5,7 @@ root_contract: CONTRACT.md
 related_files:
   - src/lingtai/tools/task_card/ANATOMY.md
   - src/lingtai/tools/task_card/__init__.py
+  - src/lingtai/tools/task_card/descriptor.py
   - src/lingtai/tools/task_card/manual/SKILL.md
   - src/lingtai/tools/CONTRACT.md
   - src/lingtai/tools/registry.py
@@ -153,6 +154,13 @@ declarative artifact and one active watch per agent.
 
 Public LTP-v2 family root `task_card` with actions `start`, `inspect`, `retry`,
 `stop`, `remove`, and `manual`.
+
+`descriptor.py` is the package-local static owner of that root name, exact action
+inventory, model-facing prose, and the `manual/SKILL.md` binding. `__init__.py`
+consumes it for schema composition, runtime manual dispatch, and the existing
+registration call. The descriptor has no activation, host, or transport authority:
+threads, renderer subprocesses, artifact writes, notifications, and channel
+projections remain in their current owners.
 
 ## Adapters
 

--- a/src/lingtai/tools/task_card/__init__.py
+++ b/src/lingtai/tools/task_card/__init__.py
@@ -30,6 +30,7 @@ from lingtai.kernel._fsutil import atomic_write_json, read_json
 
 from ..tool_family import ChildTool, ToolFamily
 from ..tool_family.manual import MANUAL_INPUT_SCHEMA, build_manual_child
+from .descriptor import DESCRIPTOR
 
 if TYPE_CHECKING:
     from lingtai.kernel.base_agent import BaseAgent
@@ -73,7 +74,6 @@ _LEGACY_CONFIG_DIR = "telegram"
 # value forward would silently cap most real agents below the new built-in
 # default instead of leaving them on it.
 _LEGACY_UNTOUCHED_MAX_REFRESHES = 1000
-_MANUAL_SKILL_NAME = "task_card"
 notifications.register_notification_channel("task_card")
 
 
@@ -123,19 +123,23 @@ _START_INPUT_SCHEMA = _object(
 _WATCH_INPUT_SCHEMA = _object({"watch_id": {"type": "string"}}, required=["watch_id"])
 _REMOVE_INPUT_SCHEMA = _object({}, required=[])
 
-_CHILDREN: tuple[tuple[str, dict[str, Any]], ...] = (
-    ("start", _START_INPUT_SCHEMA),
-    ("inspect", _WATCH_INPUT_SCHEMA),
-    ("retry", _WATCH_INPUT_SCHEMA),
-    ("stop", _WATCH_INPUT_SCHEMA),
-    ("remove", _REMOVE_INPUT_SCHEMA),
-    ("manual", MANUAL_INPUT_SCHEMA),
+_INPUT_SCHEMAS_BY_ACTION: dict[str, dict[str, Any]] = {
+    "start": _START_INPUT_SCHEMA,
+    "inspect": _WATCH_INPUT_SCHEMA,
+    "retry": _WATCH_INPUT_SCHEMA,
+    "stop": _WATCH_INPUT_SCHEMA,
+    "remove": _REMOVE_INPUT_SCHEMA,
+    "manual": MANUAL_INPUT_SCHEMA,
+}
+_CHILDREN: tuple[tuple[str, dict[str, Any]], ...] = tuple(
+    (action_name, _INPUT_SCHEMAS_BY_ACTION[action_name])
+    for action_name in DESCRIPTOR.action_names
 )
 
 
 def _schema_family() -> ToolFamily:
     return ToolFamily(
-        "task_card",
+        DESCRIPTOR.name,
         [ChildTool(name, schema, lambda _input: {}) for name, schema in _CHILDREN],
     )
 
@@ -144,32 +148,11 @@ _SCHEMA_FAMILY = _schema_family()
 
 
 def get_schema() -> dict[str, Any]:
-    schema = _SCHEMA_FAMILY.build_schema()
-    schema["properties"]["action"]["description"] = (
-        "Declarative Task Card action. start keeps one renderer watch writing the "
-        "agent-local taskcard/status and taskcard/taskcard.md files; inspect, retry, "
-        "and stop read or control that one artifact; remove is the terminal "
-        "lifecycle cleanup; manual explains the full contract."
-    )
-    return schema
+    return DESCRIPTOR.decorate_schema(_SCHEMA_FAMILY.build_schema())
 
 
 def get_description() -> str:
-    return (
-        "Manage the intrinsic declarative Task Card artifact. Provide a Python "
-        "renderer under your working directory whose stdout is the full Task Card "
-        "body to write into taskcard/taskcard.md. The capability writes taskcard/"
-        "taskcard.md atomically, writes taskcard/status as exact active/inactive, "
-        "keeps at most one active watch per agent, and leaves projection to "
-        "channel-specific readers. Use it proactively for meaningful long-running, "
-        "multi-step, or parallel work so a human can follow progress; skip it for "
-        "quick single-step work, ritual updates, or a body you cannot keep truthful "
-        "and current. Restart a new watch when one expires mid-task. Use stop to "
-        "pause a watch while preserving its last body, and "
-        "remove once the work is completed, cancelled, or abandoned so the artifact "
-        "cannot mislead a consumer as stale. Actions: start, inspect, retry, stop, "
-        "remove, manual."
-    )
+    return DESCRIPTOR.description
 
 
 class TaskCardError(Exception):
@@ -257,9 +240,9 @@ class TaskCardManager:
             ChildTool("retry", _WATCH_INPUT_SCHEMA, self._retry_child),
             ChildTool("stop", _WATCH_INPUT_SCHEMA, self._stop_child),
             ChildTool("remove", _REMOVE_INPUT_SCHEMA, self._remove_child),
-            build_manual_child(self._agent, _MANUAL_SKILL_NAME),
+            build_manual_child(self._agent, DESCRIPTOR.manual_skill_name),
         ]
-        return ToolFamily("task_card", children)
+        return ToolFamily(DESCRIPTOR.name, children)
 
     def _start_child(self, input_: dict[str, Any]) -> dict[str, Any]:
         renderer_path = self._validate_renderer_path(input_.get("renderer_path"))
@@ -1213,7 +1196,7 @@ def setup(agent: BaseAgent, **_ignored: Any) -> TaskCardManager:
     else:
         manager._agent = agent
     agent.add_tool(
-        "task_card",
+        DESCRIPTOR.name,
         schema=get_schema(),
         handler=manager.handle,
         description=get_description(),

--- a/src/lingtai/tools/task_card/descriptor.py
+++ b/src/lingtai/tools/task_card/descriptor.py
@@ -1,0 +1,56 @@
+"""Static model-facing descriptor for the intrinsic ``task_card`` family.
+
+This is deliberately package-local and consumed by the existing Task Card
+controller.  It names the one public root, its closed action inventory, and the
+manual binding without registering, activating, or hosting the capability.
+Threads, renderer subprocess execution, artifact writes, notifications, and
+channel projections remain in their existing owners.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class TaskCardToolDescriptor:
+    """Model-facing facts shared by Task Card schema and registration paths."""
+
+    name: str
+    action_names: tuple[str, ...]
+    manual_skill_name: str
+    description: str
+    action_description: str
+
+    def decorate_schema(self, schema: dict[str, Any]) -> dict[str, Any]:
+        """Add Task Card's action guidance to its freshly composed LTP schema."""
+        schema["properties"]["action"]["description"] = self.action_description
+        return schema
+
+
+DESCRIPTOR = TaskCardToolDescriptor(
+    name="task_card",
+    action_names=("start", "inspect", "retry", "stop", "remove", "manual"),
+    manual_skill_name="task_card",
+    description=(
+        "Manage the intrinsic declarative Task Card artifact. Provide a Python "
+        "renderer under your working directory whose stdout is the full Task Card "
+        "body to write into taskcard/taskcard.md. The capability writes taskcard/"
+        "taskcard.md atomically, writes taskcard/status as exact active/inactive, "
+        "keeps at most one active watch per agent, and leaves projection to "
+        "channel-specific readers. Use it proactively for meaningful long-running, "
+        "multi-step, or parallel work so a human can follow progress; skip it for "
+        "quick single-step work, ritual updates, or a body you cannot keep truthful "
+        "and current. Restart a new watch when one expires mid-task. Use stop to "
+        "pause a watch while preserving its last body, and remove once the work is "
+        "completed, cancelled, or abandoned so the artifact cannot mislead a consumer "
+        "as stale. Actions: start, inspect, retry, stop, remove, manual."
+    ),
+    action_description=(
+        "Declarative Task Card action. start keeps one renderer watch writing the "
+        "agent-local taskcard/status and taskcard/taskcard.md files; inspect, retry, "
+        "and stop read or control that one artifact; remove is the terminal "
+        "lifecycle cleanup; manual explains the full contract."
+    ),
+)

--- a/src/lingtai/tools/task_card/manual/SKILL.md
+++ b/src/lingtai/tools/task_card/manual/SKILL.md
@@ -6,6 +6,7 @@ description: >
 last_changed_at: 2026-08-01T00:00:00Z
 related_files:
 - src/lingtai/tools/task_card/__init__.py
+- src/lingtai/tools/task_card/descriptor.py
 - src/lingtai/tools/task_card/ANATOMY.md
 - src/lingtai/tools/task_card/CONTRACT.md
 maintenance: |
@@ -50,6 +51,23 @@ on boot and leaves the card `inactive` rather than silently resurrecting a
 dead watch.
 
 Actions are `start`, `inspect`, `retry`, `stop`, `remove`, and `manual`.
+
+## Model-facing call shape and ownership
+
+`task_card` is one LTP-v2 family: pass the selected `action` and that action's
+strict `input` object, with `reasoning` and the result-postprocessing boolean
+`summarize` only at the root. `manual` takes `{}` as its input. `summarize` is
+never a renderer, watch, or artifact option; no Task Card action consumes it.
+Leave it false when exact artifact paths, `status_value`, watch IDs, or an
+`inspect` body's exact text matters. It is normally unnecessary for the short
+lifecycle receipts, and calls to `manual` should leave it false so this procedure
+is not summarized away.
+
+The package-local `descriptor.py` owns this root's name, exact action inventory,
+model-facing prose, and this manual binding; the existing controller consumes it
+for schema composition, manual dispatch, and registration. It does not activate
+the tool or move threads, renderer subprocesses, atomic artifact writes,
+notifications, or Telegram/Feishu projection out of their current owners.
 
 ## Resident meta projection and the 2000-char cap
 


### PR DESCRIPTION
## Summary
- Add a consumed package-local `TaskCardToolDescriptor` for the root name, action inventory, public/action prose, and manual binding.
- Use it for static schema composition, manual routing, and registration while retaining existing child schemas and dispatch behavior.
- Preserve Task Card lifecycle, rendering, persistence, retry, notification, and host boundaries.

## Validation
- Task Card controller suite: 65 passed
- Controller plus Telegram LTP-v2/programmable suites: 89 passed
- Anatomy-drift and tool-prose gates: 29 passed
- Descriptor/schema smoke checks, changed-package `compileall`, and `git diff --check` passed
- Feishu programmable Task Card tests were not collected because the available `mcp.server` lacks `ServerRequestContext` before test execution (dependency/API mismatch)

Telegram: @lingtaidev1bot | Nickname: 知微
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai