### PR TITLE
refactor(vision): add local tool descriptor seam

### DIFF
--- a/src/lingtai/tools/vision/ANATOMY.md
+++ b/src/lingtai/tools/vision/ANATOMY.md
@@ -3,6 +3,7 @@ related_files:
   - src/lingtai/tools/ANATOMY.md
   - src/lingtai/tools/vision/BEHAVIORS.md
   - src/lingtai/tools/vision/__init__.py
+  - src/lingtai/tools/vision/descriptor.py
   - src/lingtai/tools/vision/CONTRACT.md
   - src/lingtai/tools/vision/glossary-en.md
   - src/lingtai/tools/vision/glossary-zh.md
@@ -23,20 +24,16 @@ maintenance: |
 # src/lingtai/tools/vision/
 
 The `vision` tool registers one action-separated public family: direct
-current-preset image analysis (`analyze`) plus a provider-neutral, family-owned
-`manual` route when direct setup is unavailable. Schema composition and envelope
-dispatch delegate to the generic `tool_family` infrastructure; this package
-retains ownership of provider routing, identity resolution, and every action
-result shape.
+current-preset image analysis (`analyze`), mechanical route discovery
+(`check`/`list`), plus a provider-neutral, family-owned `manual` route when
+direct setup is unavailable. Schema composition and envelope dispatch delegate
+to the generic `tool_family` infrastructure; this package retains ownership of
+provider routing, identity resolution, and every action result shape.
 
 ## Components
 
-- `__init__.py:46-99` — Codex-family gate and bucket-driven route resolution plus the same-provider alias check; GLM/Zhipu and Codex spelling pairs share current identity, provider spelling is only a Codex-family compatibility gate, `_normalize_codex_auth_path` trims the bucket `codex_auth_path` once, and `_codex_bucket_route` picks direct (nonblank trimmed `codex_auth_path` in the active bucket) vs pool exactly as the canonical Codex factory does.
-- `__init__.py:120-128` — exact advertised provider registry; the local pseudo-provider remains explicit opt-in and intentionally excluded.
-- `__init__.py:130-150` — the two canonical child input schemas: `analyze` owns the strict `image_path`/nullable-`question` object, `manual` is strict empty.
-- `__init__.py:152-199` — `_build_family`, the one canonical child declaration consumed by both the module-level schema-only family and every `VisionManager`, plus `get_description`/`get_schema`; the reserved `manual` child registers the generic `tool_family.manual.MANUAL_INPUT_SCHEMA` rather than a local copy, and the composed root exposes both exact child inputs and correlates each `action` const with its own `input`.
-- `__init__.py:202-316` — `VisionManager`; builds its family through `_build_family` with the `analyze` handler bound to instance state and the reserved `manual` child from `tool_family.manual.build_manual_child`, `handle()` owns the canonical dispatch/presentation ordering and flattens the manual child's canonical result afterwards, `_dispatch_analyze` validates and reads the image.
-- `__init__.py:319-614` — `setup`; resolves only the same current model/endpoint/credential/headers/wire, routes active Codex-family services by the bucket-driven direct (trimmed `codex_auth_path`) vs pool (pool-selected candidate token path) rule, creates supported services, fails closed to manual guidance when identity is incomplete, and always registers the one public `vision` tool.
+- `descriptor.py` — the package-local `VISION_TOOL_DESCRIPTOR`: the one ordered `analyze`/`check`/`list`/`manual` action inventory, strict input schemas, and vision-installed-manual name. It is pure composition: it does not select providers, resolve credentials, connect, or register a capability. It builds both the schema-only `ToolFamily` and each manager-bound family; with an agent it registers `build_manual_child(agent, "vision")` directly and verifies that the generic child still matches the descriptor's strict manual branch.
+- `__init__.py` — provider aliases, current-route identity, service construction, and capability setup remain host-facing. `_FAMILY` is built from `VISION_TOOL_DESCRIPTOR` for `get_schema()`, while `VisionManager` binds only the analyze/check/list handlers through that same descriptor, then owns post-dispatch manual flattening and every provider result shape.
 
 - `settings.py` — strict per-Agent settings for the `provider: local` route. `settings/vision.json` is the family-owned provider configuration holding the operator-configured local OpenAI-compatible endpoint (`base_url`, `model`, optional `api_key`/`max_tokens`). It mirrors the `settings/web.json` pattern from `lingtai.tools.web_search.settings`: a bounded, race-checked read with a stable digest, so "default applied" is a truthful, verifiable fact (`src/lingtai/tools/vision/settings.py:1-8`).
 

--- a/src/lingtai/tools/vision/BEHAVIORS.md
+++ b/src/lingtai/tools/vision/BEHAVIORS.md
@@ -8,6 +8,7 @@ related_files:
   - src/lingtai/tools/vision/CONTRACT.md
   - src/lingtai/tools/vision/ANATOMY.md
   - src/lingtai/tools/vision/__init__.py
+  - src/lingtai/tools/vision/descriptor.py
   - src/lingtai/tools/vision/settings.py
 maintenance: |
   Created during the every-contract-needs-behaviors sweep. Keep this file

--- a/src/lingtai/tools/vision/CONTRACT.md
+++ b/src/lingtai/tools/vision/CONTRACT.md
@@ -4,6 +4,7 @@ tool: vision
 contract_version: 1
 related_files:
   - src/lingtai/tools/vision/__init__.py
+  - src/lingtai/tools/vision/descriptor.py
   - src/lingtai/tools/vision/ANATOMY.md
   - src/lingtai/tools/vision/manual/SKILL.md
   - src/lingtai/tools/CONTRACT.md
@@ -29,15 +30,20 @@ Guarded by: [VN001](BEHAVIORS.md#behavior-vn001)
 `vision` is one action-separated family in the LingTai Tool Protocol v2 shape
 defined in `src/lingtai/tools/CONTRACT.md`, built on the generic
 `src/lingtai/tools/tool_family/` infrastructure (`ToolFamily`/`ChildTool` plus
-the reusable ManualTool builder). The public tool name stays `vision` and the
-public action values stay exactly `analyze` and `manual`; adopting the shared
-infrastructure changed no provider route, identity rule, or result shape in this
-file. Exactly one public model-facing `vision` root is registered; the two
-canonical children are not separate tools and consume no model tool slots.
+the reusable ManualTool builder). The public tool name stays `vision` and its
+public action values stay exactly `analyze`, `check`, `list`, and `manual`;
+adopting the shared infrastructure changed no provider route, identity rule, or
+result shape in this file. The package-local `descriptor.py`
+`VISION_TOOL_DESCRIPTOR` is the one action/schema and installed-manual-name seam
+consumed by both schema composition and manager binding. It owns no provider
+selection, credential resolution, connectivity, or capability registration;
+those remain in the host-facing manager/setup layer. Exactly one public
+model-facing `vision` root is registered; its canonical children are not
+separate tools and consume no model tool slots.
 
 The model shape is the strict envelope `action` + `input` + `reasoning` +
 optional `summarize`, with `required: [action, input, reasoning]` and
-`additionalProperties: false`. The root exposes both children's exact input
+`additionalProperties: false`. The root exposes all four children' exact input
 schemas before invocation (`input.oneOf`, one titled branch per action) and
 correlates each `action` const with that child's own `input` at the root
 (`allOf`/`if`/`then`), on both the Chat Completions and Responses wires.

--- a/src/lingtai/tools/vision/__init__.py
+++ b/src/lingtai/tools/vision/__init__.py
@@ -38,8 +38,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Mapping
 
-from ..tool_family import ChildTool, ToolFamily
-from ..tool_family.manual import MANUAL_INPUT_SCHEMA, build_manual_child
+from .descriptor import VISION_TOOL_DESCRIPTOR
 
 
 if TYPE_CHECKING:
@@ -193,99 +192,7 @@ PROVIDERS = {
     "fallback_on_inherit": None,  # no agnostic fallback for vision
 }
 
-_ANALYZE_INPUT_SCHEMA: dict[str, Any] = {
-    "type": "object",
-    "properties": {
-        "image_path": {
-            "type": "string",
-            "description": "Path to the image file",
-        },
-        "question": {
-            # Strict OpenAI object branches express an optional field as a
-            # required nullable property. Null means absent, and the analyze
-            # handler then applies the same default prompt it always has.
-            "type": ["string", "null"],
-            "description": (
-                "Question about the image, or null for the default "
-                "\"Describe what you see in this image.\""
-            ),
-        },
-        "preset": {
-            "type": ["string", "null"],
-            "description": (
-                "Optional preset name/path whose vision service should be "
-                "borrowed for this call (e.g. \"codex-pool\" for gpt-5.6 "
-                "vision). Must be a path listed in manifest.preset.allowed. "
-                "Null/absent uses the default route (active provider or the "
-                "configured vision capability)."
-            ),
-        },
-    },
-    "required": ["image_path", "question"],
-    "additionalProperties": False,
-}
-
-def _unused(_input: Mapping[str, Any]) -> dict[str, Any]:
-    raise AssertionError("the module-level schema-only ToolFamily never dispatches")
-
-
-_CHECK_INPUT_SCHEMA: dict[str, Any] = {
-    "type": "object",
-    "properties": {
-        "preset": {
-            "type": ["string", "null"],
-            "description": (
-                "Optional preset name/path whose vision service should be "
-                "checked (e.g. \"codex-pool\" for gpt-5.6 vision). Must be a "
-                "path listed in manifest.preset.allowed. Null/absent checks "
-                "the default route (active provider or the configured vision "
-                "capability). The check resolves the service identity without "
-                "sending an image request."
-            ),
-        },
-    },
-    "required": ["preset"],
-    "additionalProperties": False,
-}
-
-_LIST_INPUT_SCHEMA: dict[str, Any] = {
-    "type": "object",
-    "properties": {},
-    "required": [],
-    "additionalProperties": False,
-}
-
-
-def _build_family(
-    analyze_handler: Any = _unused,
-    check_handler: Any = _unused,
-    list_handler: Any = _unused,
-    manual_child: ChildTool | None = None,
-) -> ToolFamily:
-    """Build vision's family from the one canonical child declaration.
-
-    The single source of truth for vision's children: both the module-level
-    schema-only family (which composes the model-facing schema and proves at
-    import time that the registry has no duplicate or reserved-name collision)
-    and each ``VisionManager``'s dispatching family come from here, so child
-    names, schemas, titles, and order cannot drift between the wire surface
-    and the dispatcher. Defaults build the non-dispatching variant; the
-    manager passes its bound ``analyze``/``check``/``list`` handlers and the
-    real reserved ``manual`` child from ``build_manual_child``.
-    """
-    return ToolFamily(
-        "vision",
-        [
-            ChildTool("analyze", _ANALYZE_INPUT_SCHEMA, analyze_handler, title="analyze input"),
-            ChildTool("check", _CHECK_INPUT_SCHEMA, check_handler, title="check input"),
-            ChildTool("list", _LIST_INPUT_SCHEMA, list_handler, title="list input"),
-            manual_child
-            or ChildTool("manual", MANUAL_INPUT_SCHEMA, _unused, title="manual input"),
-        ],
-    )
-
-
-_FAMILY = _build_family()
+_FAMILY = VISION_TOOL_DESCRIPTOR.build_family()
 
 
 def get_description(lang: str = "en") -> str:
@@ -304,8 +211,8 @@ def get_description(lang: str = "en") -> str:
 
 
 def get_schema(lang: str = "en") -> dict:
-    # Composed by the generic ToolFamily infra from ``_build_family``'s child
-    # declaration, never hand-assembled.
+    # Composed by generic ToolFamily infrastructure from the package-local
+    # descriptor, never hand-assembled or read from provider configuration.
     return _FAMILY.build_schema()
 
 
@@ -321,14 +228,17 @@ class VisionManager:
         self._agent = agent
         self._vision_service = vision_service
         self._manual_reason = manual_reason
-        # Same canonical child declaration the module-level schema-only family
-        # uses, with this instance's bound analyze/check/list handlers and the
-        # real reserved ``manual`` child registered directly (unwrapped).
-        self._family = _build_family(
-            self._dispatch_analyze,
-            self._dispatch_check,
-            self._dispatch_list,
-            build_manual_child(agent, "vision"),
+        # Bind this package's one descriptor to instance-owned operation
+        # handlers. The descriptor itself creates and registers the generic
+        # manual child directly, so the strict root schema, dispatch registry,
+        # and installed-manual ownership cannot drift apart.
+        self._family = VISION_TOOL_DESCRIPTOR.build_family(
+            agent=agent,
+            handlers={
+                "analyze": self._dispatch_analyze,
+                "check": self._dispatch_check,
+                "list": self._dispatch_list,
+            },
         )
 
     def _build_service_from_preset(self, preset_ref: str) -> tuple[Any, str]:

--- a/src/lingtai/tools/vision/descriptor.py
+++ b/src/lingtai/tools/vision/descriptor.py
@@ -1,0 +1,183 @@
+"""Package-local model-root descriptor for the ``vision`` family.
+
+This module owns only the public action inventory, each action's strict input
+schema, and the mapping from the family-owned ``manual`` action to vision's
+installed manual.  It deliberately owns no provider selection, credential
+resolution, connectivity, capability registration, or presentation adaptation;
+those remain in :mod:`lingtai.tools.vision`'s host-facing manager/setup layer.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping
+
+from ..tool_family import ChildTool, ToolFamily
+from ..tool_family.manual import MANUAL_INPUT_SCHEMA, build_manual_child
+
+
+Handler = Callable[[Mapping[str, Any]], dict[str, Any]]
+
+
+def _unreachable(_input: Mapping[str, Any]) -> dict[str, Any]:
+    """Guard the schema-only family, which must never dispatch."""
+    raise AssertionError("the schema-only vision descriptor family never dispatches")
+
+
+@dataclass(frozen=True, slots=True)
+class VisionActionDescriptor:
+    """One vision-owned action's canonical schema and model-facing title."""
+
+    name: str
+    input_schema: Mapping[str, Any]
+    title: str
+
+
+@dataclass(frozen=True, slots=True)
+class VisionToolDescriptor:
+    """The package-local seam for vision's one model-facing root.
+
+    ``build_family()`` is the only place that turns the descriptor into generic
+    ``ChildTool`` instances.  Both the schema-only family and the manager-bound
+    dispatcher therefore use this same fixed action registry.  When an agent is
+    supplied, the reserved ``manual`` child is the generic builder's actual,
+    unwrapped child for this descriptor's ``manual_skill_name``; the caller may
+    adapt its result only after generic dispatch returns.
+    """
+
+    name: str
+    manual_skill_name: str
+    actions: tuple[VisionActionDescriptor, ...]
+
+    @property
+    def action_names(self) -> tuple[str, ...]:
+        """Return the one ordered action inventory for schema and dispatch."""
+        return tuple(action.name for action in self.actions)
+
+    def build_family(
+        self,
+        *,
+        agent: Any | None = None,
+        handlers: Mapping[str, Handler] | None = None,
+    ) -> ToolFamily:
+        """Build a schema-only or manager-bound family from this descriptor.
+
+        Supplying ``handlers`` binds exactly the non-manual action names the
+        descriptor owns.  The reserved ``manual`` action cannot be replaced by
+        a caller-supplied handler: with an agent it is built directly by
+        ``build_manual_child``; without one it remains unreachable in the
+        schema-only family.  This prevents a second registry or a manual wrapper
+        from drifting away from the strict model-facing schema.
+        """
+        if handlers is None:
+            bound_handlers: dict[str, Handler] = {}
+        else:
+            bound_handlers = dict(handlers)
+            expected = set(self.action_names) - {"manual"}
+            supplied = set(bound_handlers)
+            if supplied != expected:
+                missing = ", ".join(sorted(expected - supplied)) or "none"
+                unknown = ", ".join(sorted(supplied - expected)) or "none"
+                raise ValueError(
+                    "vision descriptor handlers must bind exactly its non-manual "
+                    f"actions (missing: {missing}; unknown: {unknown})"
+                )
+
+        children: list[ChildTool] = []
+        for action in self.actions:
+            if action.name == "manual" and agent is not None:
+                # Register the generic ManualTool child directly and unwrapped.
+                # Its name/schema are checked against this local declaration so
+                # a future generic change cannot silently disconnect vision's
+                # advertised strict empty branch from its dispatched handler.
+                manual_child = build_manual_child(agent, self.manual_skill_name)
+                if (
+                    manual_child.name != action.name
+                    or manual_child.input_schema != action.input_schema
+                    or manual_child.branch_title() != action.title
+                ):
+                    raise ValueError("vision manual child no longer matches its descriptor")
+                children.append(manual_child)
+                continue
+            children.append(
+                ChildTool(
+                    action.name,
+                    action.input_schema,
+                    bound_handlers.get(action.name, _unreachable),
+                    title=action.title,
+                )
+            )
+        return ToolFamily(self.name, children)
+
+
+_ANALYZE_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "image_path": {
+            "type": "string",
+            "description": "Path to the image file",
+        },
+        "question": {
+            # Strict OpenAI object branches express an optional field as a
+            # required nullable property. Null means absent, and the analyze
+            # handler then applies the same default prompt it always has.
+            "type": ["string", "null"],
+            "description": (
+                "Question about the image, or null for the default "
+                "\"Describe what you see in this image.\""
+            ),
+        },
+        "preset": {
+            "type": ["string", "null"],
+            "description": (
+                "Optional preset name/path whose vision service should be "
+                "borrowed for this call (e.g. \"codex-pool\" for gpt-5.6 "
+                "vision). Must be a path listed in manifest.preset.allowed. "
+                "Null/absent uses the default route (active provider or the "
+                "configured vision capability)."
+            ),
+        },
+    },
+    "required": ["image_path", "question"],
+    "additionalProperties": False,
+}
+
+_CHECK_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "preset": {
+            "type": ["string", "null"],
+            "description": (
+                "Optional preset name/path whose vision service should be "
+                "checked (e.g. \"codex-pool\" for gpt-5.6 vision). Must be a "
+                "path listed in manifest.preset.allowed. Null/absent checks "
+                "the default route (active provider or the configured vision "
+                "capability). The check resolves the service identity without "
+                "sending an image request."
+            ),
+        },
+    },
+    "required": ["preset"],
+    "additionalProperties": False,
+}
+
+_LIST_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {},
+    "required": [],
+    "additionalProperties": False,
+}
+
+
+VISION_TOOL_DESCRIPTOR = VisionToolDescriptor(
+    name="vision",
+    manual_skill_name="vision",
+    actions=(
+        VisionActionDescriptor("analyze", _ANALYZE_INPUT_SCHEMA, "analyze input"),
+        VisionActionDescriptor("check", _CHECK_INPUT_SCHEMA, "check input"),
+        VisionActionDescriptor("list", _LIST_INPUT_SCHEMA, "list input"),
+        VisionActionDescriptor("manual", MANUAL_INPUT_SCHEMA, "manual input"),
+    ),
+)
+
+
+__all__ = ["VISION_TOOL_DESCRIPTOR", "VisionActionDescriptor", "VisionToolDescriptor"]

--- a/src/lingtai/tools/vision/manual/SKILL.md
+++ b/src/lingtai/tools/vision/manual/SKILL.md
@@ -7,6 +7,7 @@ description: >
 last_changed_at: 2026-08-09T00:00:00Z
 related_files:
   - src/lingtai/tools/vision/__init__.py
+  - src/lingtai/tools/vision/descriptor.py
   - src/lingtai/tools/vision/ANATOMY.md
   - src/lingtai/tools/vision/CONTRACT.md
 maintenance: |

--- a/tests/test_tool_family_vision_migration.py
+++ b/tests/test_tool_family_vision_migration.py
@@ -507,7 +507,7 @@ def test_family_registers_the_reserved_manual_child_once(tmp_path):
 def test_wire_and_dispatch_families_come_from_one_child_declaration(tmp_path):
     """The schema-only family and the manager's family cannot drift apart.
 
-    Both are built by `_build_family`, so child names, order, and per-action
+    Both are built by the package-local descriptor, so child names, order, and per-action
     input schemas are identical objects/values on the wire surface and at the
     dispatch boundary — the duplication that a second hand-written registry
     would allow is structurally impossible.
@@ -538,6 +538,63 @@ def test_manual_child_input_schema_is_the_generic_owners_object(tmp_path):
     assert manual_branch["properties"] == MANUAL_INPUT_SCHEMA["properties"]
     assert manual_branch["additionalProperties"] is False
     assert manual_branch.get("required") == MANUAL_INPUT_SCHEMA["required"] == []
+
+
+
+def test_package_local_descriptor_owns_schema_dispatch_and_manual(tmp_path):
+    """Vision's local descriptor is the active one-root/manual seam.
+
+    It owns all four public actions and is consumed by both the schema-only
+    family and the manager-bound dispatcher. The manager's actual ``manual``
+    child is still the generic direct child for the descriptor's installed
+    manual name; only after dispatch does vision flatten that canonical result.
+    """
+    from lingtai.tools.vision import _FAMILY
+    from lingtai.tools.vision.descriptor import VISION_TOOL_DESCRIPTOR
+
+    assert VISION_TOOL_DESCRIPTOR.name == "vision"
+    assert VISION_TOOL_DESCRIPTOR.manual_skill_name == "vision"
+    assert VISION_TOOL_DESCRIPTOR.action_names == ("analyze", "check", "list", "manual")
+
+    body, manual_path = _install_manual(tmp_path)
+    mgr = _manager(tmp_path, _never_called_service())
+    assert mgr._family.child_names == _FAMILY.child_names == VISION_TOOL_DESCRIPTOR.action_names
+    assert mgr._family.build_schema() == _FAMILY.build_schema() == get_schema()
+
+    manual_call = {"action": "manual", "input": {}, "reasoning": "load vision guidance"}
+    raw = mgr._family.handle(manual_call)
+    assert raw == {
+        "status": "ok",
+        "content": [{"type": "text", "text": body}],
+        "structuredContent": {"manual_path": str(manual_path)},
+    }
+    assert mgr.handle(manual_call) == {
+        "status": "ok",
+        "action": "manual",
+        "manual": body,
+        "manual_path": str(manual_path),
+    }
+
+
+def test_descriptor_rejects_partial_or_manual_handler_replacement(tmp_path):
+    """Provider-facing handlers must bind every non-manual descriptor action."""
+    from lingtai.tools.vision.descriptor import VISION_TOOL_DESCRIPTOR
+
+    def handler(_input):
+        return {"status": "ok"}
+
+    with pytest.raises(ValueError, match="missing: check, list"):
+        VISION_TOOL_DESCRIPTOR.build_family(handlers={"analyze": handler})
+    with pytest.raises(ValueError, match="unknown: manual"):
+        VISION_TOOL_DESCRIPTOR.build_family(
+            agent=_StubAgent(tmp_path),
+            handlers={
+                "analyze": handler,
+                "check": handler,
+                "list": handler,
+                "manual": handler,
+            },
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add a package-local `VISION_TOOL_DESCRIPTOR` for the ordered model-facing `analyze`, `check`, `list`, and `manual` contract.
- Back schema-only and manager-bound families with that descriptor, including the installed manual child and existing canonical result flattening.
- Preserve provider selection, credentials, connectivity, service construction, registration, sanitized errors, and fail-closed/no-fallback behavior.

## Validation
- Targeted vision/intrinsic-manual pytest suites: 201 passed
- Changed-file Ruff, vision `compileall`, glossary validation (63 resources / 21 packages), and `git diff --check` passed
- Repository docs-governance check remains blocked by unrelated pre-existing documentation issues; no vision-owned violation found

Telegram: @lingtaidev1bot | Nickname: 知微
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai