### PR TITLE
refactor(web): add package-local tool descriptor

### DIFF
--- a/src/lingtai/tools/web_search/ANATOMY.md
+++ b/src/lingtai/tools/web_search/ANATOMY.md
@@ -7,6 +7,7 @@ related_files:
   - src/lingtai/tools/web_search/BEHAVIORS.md
   - src/lingtai/tools/web_search/CONTRACT.md
   - src/lingtai/tools/web_search/__init__.py
+  - src/lingtai/tools/web_search/descriptor.py
   - src/lingtai/tools/web_search/settings.py
   - src/lingtai/tools/web_search/_spill.py
   - src/lingtai/tools/web_search/manual/SKILL.md
@@ -67,14 +68,18 @@ action implementations, settings, and diagnostics.
 
 ## Components
 
-- `WebManager`, `setup()`, and the single `web` schema — builds a per-instance
-  `ToolFamily` (`lingtai.tools.tool_family`) with `search`/`browse` handlers
-  bound to instance state and a `manual` child from
-  `tool_family.manual.build_manual_child`; `handle()` delegates envelope
-  validation and dispatch to that `ToolFamily` and stamps
-  `current_setting`/`action` onto envelope-level failures; lazy engine
-  composition, settings diagnostics, and registration
-  (`src/lingtai/tools/web_search/__init__.py:1-426`).
+- `descriptor.py::WebToolDescriptor` plus
+  `__init__.py::WEB_TOOL_DESCRIPTOR` — package-local declaration of the
+  canonical `web` root, its strict `search`/`browse` child schemas, description,
+  and installed `web` manual destination. Its schema-only and handler-bound
+  family builders consume those same declarations; the latter registers the
+  generic manual child directly, never a second manual wrapper.
+- `WebManager`, `setup()`, and the single `web` schema — obtains its
+  per-instance `ToolFamily` from that descriptor with `search`/`browse` handlers
+  bound to instance state; `handle()` delegates envelope validation and dispatch
+  then adapts only Web's public manual result, while `setup()` retains host
+  registration, lazy engine composition, and settings diagnostics
+  (`src/lingtai/tools/web_search/__init__.py`).
 - `_EngineSpec`, `_specs_from_kwargs`, `_canonical_default_specs()` —
   immutable operator engine wiring. `_specs_from_kwargs` rejects a retired
   provider name (`minimax`, `zhipu` — `_RETIRED_PROVIDERS`) supplied via the

--- a/src/lingtai/tools/web_search/CONTRACT.md
+++ b/src/lingtai/tools/web_search/CONTRACT.md
@@ -6,6 +6,7 @@ related_files:
   - src/lingtai/tools/web_search/ANATOMY.md
   - src/lingtai/tools/CONTRACT.md
   - src/lingtai/tools/web_search/__init__.py
+  - src/lingtai/tools/web_search/descriptor.py
   - src/lingtai/tools/web_search/settings.py
   - src/lingtai/tools/web_search/_spill.py
   - src/lingtai/tools/web_search/manual/SKILL.md
@@ -35,9 +36,13 @@ maintenance: |
 `web` is exactly one model-facing capability with explicit `search`, `browse`,
 and metadata-only `manual` actions. It is implemented in the retained
 `tools.web_search` composition owner; browser and SearchService are internal
-subcomponents. `web` is the first family migrated to the LingTai Tool Protocol
-v2 shape defined in `src/lingtai/tools/CONTRACT.md`, and the first family to
-build its schema composition and envelope dispatch on the generic
+subcomponents. Its package-local `WebToolDescriptor` owns only the fixed root
+metadata, strict action schemas, and installed `web` manual destination that
+both schema and per-Agent dispatch consume; host capability registration,
+provider composition, and browser-transport injection stay outside it. `web`
+is the first family migrated to the LingTai Tool Protocol v2 shape defined in
+`src/lingtai/tools/CONTRACT.md`, and the first family to build its schema
+composition and envelope dispatch on the generic
 `src/lingtai/tools/tool_family/` infrastructure (`ToolFamily`/`ChildTool`);
 using it changed no observable promise in this file.
 

--- a/src/lingtai/tools/web_search/__init__.py
+++ b/src/lingtai/tools/web_search/__init__.py
@@ -12,11 +12,9 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Mapping
 
-from .._manual import load_installed_manual
 from ..browser.core import BrowserEngine
-from ..tool_family import ChildTool, ToolFamily
-from ..tool_family.manual import MANUAL_INPUT_SCHEMA, build_manual_child
 from ._spill import spill_if_over_threshold
+from .descriptor import WebActionDescriptor, WebToolDescriptor
 from .settings import (
     OutputSettingsSnapshot,
     SettingsSnapshot,
@@ -158,56 +156,39 @@ _BROWSE_INPUT_SCHEMA: dict[str, Any] = {
     "additionalProperties": False,
 }
 
-# The single source of truth for web's own children: one ``(name, schema,
-# title)`` triple per child, consumed both by the module-level schema-only
-# family below and by ``WebManager.__init__``, which binds real handlers to
-# the same specs. The reserved ``manual`` child is not listed here: its schema
-# is the owner-exported ``MANUAL_INPUT_SCHEMA`` and its real child comes from
-# ``build_manual_child``.
-_CHILD_SPECS: tuple[tuple[str, dict[str, Any], str], ...] = (
-    ("search", _SEARCH_INPUT_SCHEMA, "search input"),
-    ("browse", _BROWSE_INPUT_SCHEMA, "browse input"),
-)
-
-
-def _schema_only_family() -> ToolFamily:
-    # A throwaway ``ToolFamily`` used only to compose the model-facing schema
-    # and to prove the fixed three-child registry has no duplicate or
-    # reserved-name collision (``ToolFamilyError`` would raise here, at
-    # import time, rather than shipping silently). ``WebManager`` builds its
-    # own per-instance ``ToolFamily`` in ``__init__`` with real handlers
-    # bound to that instance; this module-level one never dispatches.
-    def _unused(_input: Mapping[str, Any]) -> dict[str, Any]:
-        raise AssertionError("the module-level schema-only ToolFamily never dispatches")
-
-    return ToolFamily(
-        "web",
-        [
-            *(ChildTool(name, schema, _unused, title=title) for name, schema, title in _CHILD_SPECS),
-            ChildTool("manual", MANUAL_INPUT_SCHEMA, _unused, title="manual input"),
-        ],
-    )
-
-
-_FAMILY = _schema_only_family()
-
-
-def get_description(lang: str = "en") -> str:
-    return (
+# ``WEB_TOOL_DESCRIPTOR`` is the package-local public-root declaration. Both
+# the schema-only family and each per-Agent dispatch family consume these same
+# strict action schemas; manual keeps the generic ManualTool input/result
+# protocol while the descriptor owns the installed ``web`` destination.
+WEB_TOOL_DESCRIPTOR = WebToolDescriptor(
+    name="web",
+    description=(
         "Unified web capability. Use web(action='search', input={'query': '...'}, "
         "reasoning='discover current sources') for current discovery, then "
         "web(action='browse', input={'link_ref': '...'}, reasoning='read the "
         "selected source') for a known result. Use web(action='manual', input={}, "
         "reasoning='load web guidance') for the procedure and settings guidance."
-    )
+    ),
+    manual_skill_name="web",
+    actions=(
+        WebActionDescriptor("search", _SEARCH_INPUT_SCHEMA, "search input"),
+        WebActionDescriptor("browse", _BROWSE_INPUT_SCHEMA, "browse input"),
+    ),
+)
+
+# Construct at import time so ToolFamily still proves the fixed registry has no
+# duplicate/reserved-name collision before this capability can be registered.
+# It composes model schema only; ``WebManager`` builds its own handler-bound
+# family through the same descriptor for every Agent.
+_FAMILY = WEB_TOOL_DESCRIPTOR.build_schema_family()
+
+
+def get_description(lang: str = "en") -> str:
+    return WEB_TOOL_DESCRIPTOR.description
 
 
 def get_schema(lang: str = "en") -> dict[str, Any]:
-    # Composed by the generic ToolFamily infra from each child's own
-    # canonical ``input_schema`` (``_SEARCH_INPUT_SCHEMA`` etc. above), rather
-    # than hand-assembled — verified field-equivalent to the pre-migration
-    # schema, except the documented authorized differences, by
-    # ``tests/test_tool_family_web_migration_parity.py``.
+    """Compose the strict public ``web`` schema from the local descriptor."""
     return _FAMILY.build_schema()
 
 
@@ -251,23 +232,11 @@ class WebManager:
         self._services: dict[str, Any] = {}
         self._service_errors: dict[str, str] = {}
         handlers = {"search": self._dispatch_search, "browse": self._dispatch_browse}
-        self._family = ToolFamily(
-            "web",
-            [
-                *(
-                    ChildTool(name, schema, handlers[name], title=title)
-                    for name, schema, title in _CHILD_SPECS
-                ),
-                # Registered directly, unwrapped: ``ToolFamily.handle()`` must
-                # dispatch this child's own canonical MCP-compatible result
-                # verbatim for ``action="manual"`` (no double wrap). Web's
-                # flat public shape is reconstructed from that canonical
-                # result strictly *after* ``self._family.handle(...)``
-                # returns, in ``handle()`` below — never inside a registered
-                # child.
-                build_manual_child(agent, "web"),
-            ],
-        )
+        # The descriptor binds the same strict schemas used by ``get_schema``
+        # to these per-Agent action handlers, then registers the generic manual
+        # child directly and unwrapped. ``handle()`` below remains the sole
+        # post-dispatch adapter for Web's preserved flat manual result.
+        self._family = WEB_TOOL_DESCRIPTOR.build_dispatch_family(agent, handlers)
 
     @property
     def browser_engine(self) -> BrowserEngine:
@@ -597,14 +566,6 @@ class WebManager:
                 spilled[key] = payload[key]
         spilled.update(artifact)
         return spilled
-
-    def manual(self, diagnostic: dict[str, Any]) -> dict[str, Any]:
-        # This path never reads settings/web.search.json and performs no
-        # provider construction or search operation, even when settings are
-        # malformed: manual does not own that file.
-        loaded = load_installed_manual(self._agent, "web")
-        loaded.update({"action": "manual", "current_setting": diagnostic})
-        return loaded
 
     def _adapt_manual_result(self, mcp_result: dict[str, Any]) -> dict[str, Any]:
         # ``self._family.handle(...)`` has already dispatched to the
@@ -949,8 +910,10 @@ def setup(
         agent, browser_port, specs=specs, default_engine=chosen,
         default_source=source, legacy_fallback_from=legacy_fallback_from,
     )
+    # Host registration remains here; the package-local descriptor supplies
+    # only the canonical root identity it registers under.
     agent.add_tool(
-        "web", schema=get_schema(), handler=manager.handle,
+        WEB_TOOL_DESCRIPTOR.name, schema=get_schema(), handler=manager.handle,
         description=get_description(), glossary_package=__package__,
     )
     return manager

--- a/src/lingtai/tools/web_search/descriptor.py
+++ b/src/lingtai/tools/web_search/descriptor.py
@@ -1,0 +1,94 @@
+"""Package-owned descriptor for the one public ``web`` tool root.
+
+This module is deliberately a local composition aid, not a second capability
+registry.  The host still decides whether to register ``web``, while this
+package owns the stable public root metadata and turns its two strict action
+schemas plus reserved manual action into the generic ``ToolFamily`` used for
+both model schema composition and per-Agent dispatch.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping
+
+from ..tool_family import ChildTool, ToolFamily
+from ..tool_family.manual import MANUAL_INPUT_SCHEMA, build_manual_child
+
+WebHandler = Callable[[Mapping[str, Any]], dict[str, Any]]
+
+
+@dataclass(frozen=True, slots=True)
+class WebActionDescriptor:
+    """One strict non-manual action owned by the public ``web`` root."""
+
+    name: str
+    input_schema: Mapping[str, Any]
+    title: str
+
+
+@dataclass(frozen=True, slots=True)
+class WebToolDescriptor:
+    """Stable local metadata and family builders for canonical ``web``.
+
+    The descriptor intentionally owns only public-root metadata, strict action
+    schemas, and the installed manual destination.  It never registers a
+    capability, selects a search provider, constructs a browser transport, or
+    reads settings: those remain at the existing host/composition and action
+    boundaries in :mod:`lingtai.tools.web_search`.
+    """
+
+    name: str
+    description: str
+    manual_skill_name: str
+    actions: tuple[WebActionDescriptor, ...]
+
+    @property
+    def action_names(self) -> tuple[str, ...]:
+        """The fixed public action order, including the reserved manual child."""
+        return (*tuple(action.name for action in self.actions), "manual")
+
+    def build_schema_family(self) -> ToolFamily:
+        """Build the schema-only family from this descriptor's exact actions.
+
+        The manual child deliberately uses the generic owner's canonical strict
+        empty schema.  It has a no-op handler because this family is used only
+        by ``get_schema``; a per-Agent family below owns actual dispatch.
+        """
+        def unused(_input: Mapping[str, Any]) -> dict[str, Any]:
+            raise AssertionError("the schema-only web ToolFamily never dispatches")
+
+        return ToolFamily(
+            self.name,
+            [
+                *(
+                    ChildTool(action.name, action.input_schema, unused, title=action.title)
+                    for action in self.actions
+                ),
+                ChildTool("manual", MANUAL_INPUT_SCHEMA, unused, title="manual input"),
+            ],
+        )
+
+    def build_dispatch_family(
+        self, agent: Any, handlers: Mapping[str, WebHandler],
+    ) -> ToolFamily:
+        """Bind the descriptor's actions and direct generic ManualTool child.
+
+        Rejecting a mismatched handler map at construction preserves the one
+        descriptor-to-schema-to-dispatch source of truth.  The manual child is
+        registered directly from ``build_manual_child`` so generic dispatch
+        returns its canonical result verbatim; the web manager remains solely
+        responsible for its existing post-dispatch public-shape adaptation.
+        """
+        action_names = tuple(action.name for action in self.actions)
+        if set(handlers) != set(action_names):
+            raise ValueError("web dispatch handlers must match the descriptor's non-manual actions")
+        return ToolFamily(
+            self.name,
+            [
+                *(
+                    ChildTool(action.name, action.input_schema, handlers[action.name], title=action.title)
+                    for action in self.actions
+                ),
+                build_manual_child(agent, self.manual_skill_name),
+            ],
+        )

--- a/src/lingtai/tools/web_search/manual/SKILL.md
+++ b/src/lingtai/tools/web_search/manual/SKILL.md
@@ -7,6 +7,7 @@ version: 8.2.0
 last_changed_at: "2026-08-05T08:40:00-07:00"
 related_files:
   - src/lingtai/tools/web_search/__init__.py
+  - src/lingtai/tools/web_search/descriptor.py
   - src/lingtai/tools/web_search/settings.py
   - src/lingtai/tools/web_search/_spill.py
   - src/lingtai/tools/web_search/ANATOMY.md
@@ -14,8 +15,9 @@ related_files:
   - src/lingtai/tools/web_search/manual/scripts/extract_page.py
   - src/lingtai/tools/browser/core.py
 maintenance: |
-  This is the sole installed web-manual source. Keep the search-first route,
-  settings schema, bounded browse contract, root `summarize` guidance, and one
+  This is the sole installed web-manual source and the `web` descriptor's
+  manual destination. Keep the search-first route, settings schema, bounded
+  browse contract, root `summarize` guidance, and one
   explicit legacy fallback in sync; retain useful scripts and references under
   this bundle. Never create a second public browser or web-search manual.
 ---

--- a/tests/test_unified_web_capability.py
+++ b/tests/test_unified_web_capability.py
@@ -58,6 +58,51 @@ def test_registry_has_one_web_surface_and_preserves_opaque_identity():
     assert normalized == {"web": {"search_service": service, "browser_port": port}}
 
 
+def test_package_descriptor_drives_web_root_schema_dispatch_and_manual(tmp_path):
+    from lingtai.tools.web_search import WEB_TOOL_DESCRIPTOR, get_description, get_schema
+
+    descriptor = WEB_TOOL_DESCRIPTOR
+    assert descriptor.name == "web"
+    assert descriptor.manual_skill_name == "web"
+    assert descriptor.action_names == ("search", "browse", "manual")
+    assert get_description() == descriptor.description
+
+    schema = get_schema()
+    assert schema["properties"]["action"]["enum"] == list(descriptor.action_names)
+    assert [branch["title"] for branch in schema["properties"]["input"]["oneOf"]] == [
+        "search input", "browse input", "manual input",
+    ]
+
+    manual_path = tmp_path / ".library" / "intrinsic" / "capabilities" / "web" / "SKILL.md"
+    manual_path.parent.mkdir(parents=True)
+    manual_path.write_text("descriptor-owned web manual", encoding="utf-8")
+    agent = _Agent(tmp_path)
+    manager = setup(agent, search_service=_Search(), browser_port=_Port())
+
+    # Host registration retains ownership, but it consumes the local descriptor
+    # rather than a second root string or a host-level plugin registry.
+    assert agent.tool_name == descriptor.name
+    assert agent.schema == schema
+    assert manager._family.name == descriptor.name
+    assert manager._family.child_names == descriptor.action_names
+
+    # The descriptor binds the real generic ManualTool child directly. Its
+    # canonical result exists at dispatch before Web's public flat adaptation.
+    child = manager._family.handle({"action": "manual", "input": {}})
+    assert child == {
+        "status": "ok",
+        "content": [{"type": "text", "text": "descriptor-owned web manual"}],
+        "structuredContent": {"manual_path": str(manual_path)},
+    }
+    assert manager.handle({"action": "manual", "input": {}}) == {
+        "status": "ok",
+        "manual": "descriptor-owned web manual",
+        "manual_path": str(manual_path),
+        "action": "manual",
+        "current_setting": manager._no_settings_diagnostic(),
+    }
+
+
 def test_search_link_ref_browse_uses_same_agent_state(tmp_path):
     agent = _Agent(tmp_path)
     search = _Search()


### PR DESCRIPTION
## Summary
- Add a package-local web descriptor for the canonical root description, strict `search`/`browse` children, and manual destination.
- Drive schema, description, dispatch-family construction, root naming, and generic ManualTool handling through that descriptor.
- Preserve public web schema/description equivalence and host-owned registration; remove only unused parallel `WebManager.manual()` loading.

## Validation
- `tests/test_unified_web_capability.py`: 26 passed
- Focused web/manual/generic family suites: 164 passed
- Candidate/base public schema and description hashes matched
- YAML graph proof plus `git diff --check` passed
- Repository-wide docs checks have identical base/candidate failures from unrelated existing defects

Telegram: @lingtaidev1bot | Nickname: 知微
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai