### PR TITLE
refactor(avatar): own package-local tool descriptor

### DIFF
--- a/src/lingtai/tools/avatar/CONTRACT.md
+++ b/src/lingtai/tools/avatar/CONTRACT.md
@@ -4,6 +4,7 @@ tool: avatar
 contract_version: 4
 related_files:
   - src/lingtai/tools/avatar/__init__.py
+  - src/lingtai/tools/avatar/_descriptor.py
   - src/lingtai/tools/avatar/_launcher.py
   - src/lingtai/tools/avatar/ANATOMY.md
   - src/lingtai/tools/avatar/manual/SKILL.md
@@ -76,6 +77,17 @@ choice, not a contract requirement: per that package's "Implementation
 independence" rule, avatar could hand-write an equivalent `handle()` without
 changing any promise in this file.
 
+## Ownership boundaries
+
+`src/lingtai/tools/avatar/_descriptor.py` owns only static package-local
+model-facing metadata: the `avatar` root name/description, its strict action
+schemas and action order, and the package-manual resource lookup/result shape.
+`AvatarManager` remains the host-side owner of every supplied action handler:
+agent/network directory construction, inherited-init and parent-prompt
+boundaries, privilege checks, ledger/rules I/O, boot observation, and launcher
+lifecycle. `setup()` remains the one host registration call. The descriptor
+never activates a tool, constructs an agent, or manages a process.
+
 ## Routing Card
 Guarded by: [AV001](BEHAVIORS.md#behavior-av001)
 
@@ -121,11 +133,11 @@ storage; detached-process launch -> §Cross-platform invariants.
 - `action="manual"` is read-only: it returns the exact packaged
   `src/lingtai/tools/avatar/manual/SKILL.md` body plus its host-local
   `manual_path`, and performs no filesystem mutation (no spawn, no ledger
-  write, no `.rules` write). Avatar's manual ships inside this package rather
-  than being installed into the agent's `.library` intrinsic catalog, so this
-  action owns its own loader instead of the shared
-  `load_installed_manual`/`build_manual_child` pair — that builder would
-  report a `.library` path this family never reads.
+  write, no `.rules` write). Avatar's package-local `AvatarToolDescriptor`
+  owns that resource lookup and flat result shape because the manual ships
+  inside this package rather than in the agent's `.library` intrinsic catalog.
+  It must not use the shared `load_installed_manual`/`build_manual_child` pair:
+  that builder would report a `.library` path this family never reads.
 
 **Non-goals:** the parent holds no in-process handle to the avatar — liveness is
 checked purely via the filesystem handshake. The tool does not manage the

--- a/src/lingtai/tools/avatar/__init__.py
+++ b/src/lingtai/tools/avatar/__init__.py
@@ -32,7 +32,7 @@ import os
 import re
 import shutil
 import time
-from importlib import resources
+from importlib import resources as resources
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Mapping
 
@@ -41,9 +41,9 @@ from lingtai.kernel.i18n import t
 from ..tool_family import ToolFamily
 from ._descriptor import (
     AVATAR_TOOL_DESCRIPTOR,
-    _CHILD_SPECS,
-    _RULES_INPUT_SCHEMA,
-    _SPAWN_INPUT_SCHEMA,
+    _CHILD_SPECS as _CHILD_SPECS,
+    _RULES_INPUT_SCHEMA as _RULES_INPUT_SCHEMA,
+    _SPAWN_INPUT_SCHEMA as _SPAWN_INPUT_SCHEMA,
 )
 from ._launcher import AvatarLaunchReceipt, AvatarLaunchRequest, AvatarLauncherPort
 

--- a/src/lingtai/tools/avatar/__init__.py
+++ b/src/lingtai/tools/avatar/__init__.py
@@ -38,8 +38,13 @@ from typing import TYPE_CHECKING, Any, Mapping
 
 from lingtai.kernel.agent_presence import observe_alive as _presence_observe_alive
 from lingtai.kernel.i18n import t
-from ..tool_family import ChildTool, ToolFamily
-from ..tool_family.manual import MANUAL_INPUT_SCHEMA
+from ..tool_family import ToolFamily
+from ._descriptor import (
+    AVATAR_TOOL_DESCRIPTOR,
+    _CHILD_SPECS,
+    _RULES_INPUT_SCHEMA,
+    _SPAWN_INPUT_SCHEMA,
+)
 from ._launcher import AvatarLaunchReceipt, AvatarLaunchRequest, AvatarLauncherPort
 
 
@@ -98,101 +103,14 @@ if TYPE_CHECKING:
 
 PROVIDERS = {"providers": [], "default": "builtin"}
 
-# Canonical, strict per-action input schemas. Optionals are expressed as
-# nullable required properties because that is what strict OpenAI-style
-# validators demand of a closed object; null means "absent" to the action
-# implementations (see ``_strip_nulls``).
-#
-# The spawn mission brief is deliberately NOT a property here: it is root
-# ``reasoning``, and nested ``input`` must never carry
-# ``reasoning``/``_reasoning``/``summarize``.
-_SPAWN_INPUT_SCHEMA: dict[str, Any] = {
-    "type": "object",
-    "properties": {
-        "name": {
-            "type": "string",
-            "description": (
-                "True name for the avatar. Also the working-directory basename "
-                "under .lingtai/. Single segment: letters/digits/underscore/"
-                "hyphen, max 64 chars."
-            ),
-        },
-        "type": {
-            "type": ["string", "null"],
-            "enum": ["shallow", "deep", None],
-            "description": (
-                "'shallow' (default): blank slate — init.json only. 'deep': "
-                "full copy of character, pad, and codex. Null for the default."
-            ),
-        },
-        "comment": {
-            "type": ["string", "null"],
-            "description": (
-                "Persistent system note in the avatar's prompt (survives molt/"
-                "refresh/wake). Not inherited. Null or empty unless you have "
-                "something the avatar must never forget."
-            ),
-        },
-        "dry_run": {
-            "type": ["boolean", "null"],
-            "description": (
-                "Preview the spawn without creating a process. Use to "
-                "sanity-check before committing. Null for the default false."
-            ),
-        },
-        "confirm": {
-            "type": ["boolean", "null"],
-            "description": (
-                "Confirm you have reviewed the mission and intend to spawn. "
-                "Required when the mission looks empty/short/test-like. Null "
-                "for the default false."
-            ),
-        },
-    },
-    "required": ["name", "type", "comment", "dry_run", "confirm"],
-    "additionalProperties": False,
-}
-
-_RULES_INPUT_SCHEMA: dict[str, Any] = {
-    "type": "object",
-    "properties": {
-        "rules_content": {
-            "type": "string",
-            "description": (
-                "Plain text, one rule per line. Non-negotiable constraints "
-                "distributed to self and all descendants. Requires karma."
-            ),
-        },
-    },
-    "required": ["rules_content"],
-    "additionalProperties": False,
-}
-
-# The one child spec: canonical action name → its own strict input schema, in
-# model-facing enum order. Both the module-level schema-only family and each
-# manager's handler-bound family are built from this single source by
-# ``_build_family`` below, so the two listings cannot drift apart.
-_CHILD_SPECS: tuple[tuple[str, dict[str, Any]], ...] = (
-    ("spawn", _SPAWN_INPUT_SCHEMA),
-    ("rules", _RULES_INPUT_SCHEMA),
-    ("manual", MANUAL_INPUT_SCHEMA),
-)
-
-
 def _build_family(handlers: Mapping[str, Any]) -> ToolFamily:
-    """Build avatar's family, binding each spec'd action to *handlers[name]*.
+    """Bind Avatar's package-local descriptor to instance-specific handlers.
 
-    Construction validates the registry, so a duplicate or reserved-name
-    collision raises ``ToolFamilyError`` here — at import time for ``_FAMILY``
-    — rather than shipping silently.
+    The descriptor owns the strict model-facing child declarations; the manager
+    retains all host-side spawn, privilege, lifecycle, and process behavior in
+    the handlers it supplies here.
     """
-    return ToolFamily(
-        "avatar",
-        [
-            ChildTool(name, schema, handlers[name], title=f"{name} input")
-            for name, schema in _CHILD_SPECS
-        ],
-    )
+    return AVATAR_TOOL_DESCRIPTOR.bind_family(handlers)
 
 
 def _unused(_input: Mapping[str, Any]) -> dict[str, Any]:
@@ -201,21 +119,13 @@ def _unused(_input: Mapping[str, Any]) -> dict[str, Any]:
 
 # Composes the model-facing schema only; ``AvatarManager`` builds its own
 # per-instance family with real handlers bound to that instance.
-_FAMILY = _build_family({name: _unused for name, _ in _CHILD_SPECS})
+_FAMILY = _build_family(
+    {name: _unused for name in AVATAR_TOOL_DESCRIPTOR.action_names}
+)
 
 
 def get_description(lang: str = "en") -> str:
-    return (
-        "Spawn an independent agent (他我), set network rules for descendants, "
-        "or read the avatar manual. Requires an explicit action — no default. "
-        "avatar(action='spawn', input={'name': 'researcher', ...}, "
-        "reasoning='<the avatar's mission>'): inherits init.json, boots on "
-        "default preset; your reasoning becomes the avatar's first prompt. "
-        "avatar(action='rules', input={'rules_content': '...'}, reasoning='...'): "
-        "distribute rules to self + all descendants (requires karma). "
-        "avatar(action='manual', input={}, reasoning='...'): return the "
-        "avatar-manual skill body. See avatar-manual skill for full guidance."
-    )
+    return AVATAR_TOOL_DESCRIPTOR.description()
 
 
 def get_schema(lang: str = "en") -> dict[str, Any]:
@@ -299,31 +209,8 @@ class AvatarManager:
         return self._manual()
 
     def _manual(self) -> dict:
-        """Return the exact packaged avatar-manual body; performs no mutation.
-
-        Avatar's manual ships inside this package (``manual/SKILL.md``) rather
-        than in the agent's installed ``.library`` catalog, so this action owns
-        its own loader instead of the shared
-        ``load_installed_manual``/``build_manual_child`` pair — reusing that
-        builder here would report a ``.library`` path this family never reads.
-        """
-        resource = resources.files(__package__).joinpath("manual/SKILL.md")
-        try:
-            body = resource.read_text(encoding="utf-8")
-        except (FileNotFoundError, ModuleNotFoundError, AttributeError, OSError):
-            return {
-                "status": "degraded",
-                "action": "manual",
-                "manual": "",
-                "manual_path": str(resource),
-                "error": "avatar manual missing",
-            }
-        return {
-            "status": "ok",
-            "action": "manual",
-            "manual": body,
-            "manual_path": str(resource),
-        }
+        """Return Avatar's descriptor-owned packaged manual without mutation."""
+        return AVATAR_TOOL_DESCRIPTOR.manual_result()
 
     # ------------------------------------------------------------------
     # Ledger (append-only JSONL log of avatar spawn events)

--- a/src/lingtai/tools/avatar/_descriptor.py
+++ b/src/lingtai/tools/avatar/_descriptor.py
@@ -1,0 +1,170 @@
+"""Avatar's package-local model-facing descriptor and packaged manual owner.
+
+This is deliberately a narrow static seam.  It owns the model-facing root's
+name, description, strict action schemas, and the resource that backs Avatar's
+flat ``manual`` result.  It does not construct agents, decide privileges,
+register tools, create network state, or manage processes; those remain in
+:class:`AvatarManager` and ``setup``.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib import resources
+from typing import Any, Callable, Mapping
+
+from ..tool_family import ChildTool, ToolFamily
+from ..tool_family.manual import MANUAL_INPUT_SCHEMA
+
+__all__ = ["AVATAR_TOOL_DESCRIPTOR", "AvatarToolDescriptor"]
+
+# Canonical, strict per-action input schemas. Optionals are expressed as
+# nullable required properties because that is what strict OpenAI-style
+# validators demand of a closed object; null means "absent" to the action
+# implementations (see ``AvatarManager._strip_nulls``).
+#
+# The spawn mission brief is deliberately NOT a property here: it is root
+# ``reasoning``, and nested ``input`` must never carry
+# ``reasoning``/``_reasoning``/``summarize``.
+_SPAWN_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "description": (
+                "True name for the avatar. Also the working-directory basename "
+                "under .lingtai/. Single segment: letters/digits/underscore/"
+                "hyphen, max 64 chars."
+            ),
+        },
+        "type": {
+            "type": ["string", "null"],
+            "enum": ["shallow", "deep", None],
+            "description": (
+                "'shallow' (default): blank slate — init.json only. 'deep': "
+                "full copy of character, pad, and codex. Null for the default."
+            ),
+        },
+        "comment": {
+            "type": ["string", "null"],
+            "description": (
+                "Persistent system note in the avatar's prompt (survives molt/"
+                "refresh/wake). Not inherited. Null or empty unless you have "
+                "something the avatar must never forget."
+            ),
+        },
+        "dry_run": {
+            "type": ["boolean", "null"],
+            "description": (
+                "Preview the spawn without creating a process. Use to "
+                "sanity-check before committing. Null for the default false."
+            ),
+        },
+        "confirm": {
+            "type": ["boolean", "null"],
+            "description": (
+                "Confirm you have reviewed the mission and intend to spawn. "
+                "Required when the mission looks empty/short/test-like. Null "
+                "for the default false."
+            ),
+        },
+    },
+    "required": ["name", "type", "comment", "dry_run", "confirm"],
+    "additionalProperties": False,
+}
+
+_RULES_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "rules_content": {
+            "type": "string",
+            "description": (
+                "Plain text, one rule per line. Non-negotiable constraints "
+                "distributed to self and all descendants. Requires karma."
+            ),
+        },
+    },
+    "required": ["rules_content"],
+    "additionalProperties": False,
+}
+
+# Canonical action name → strict input schema, in model-facing enum order.
+# ``ToolFamily`` deep-copies these schemas when it exposes them, and manager
+# bindings only replace handlers; the public schemas therefore cannot drift.
+_CHILD_SPECS: tuple[tuple[str, dict[str, Any]], ...] = (
+    ("spawn", _SPAWN_INPUT_SCHEMA),
+    ("rules", _RULES_INPUT_SCHEMA),
+    ("manual", MANUAL_INPUT_SCHEMA),
+)
+
+
+@dataclass(frozen=True, slots=True)
+class AvatarToolDescriptor:
+    """Static package-local descriptor for the one model-facing ``avatar`` root.
+
+    ``bind_family`` is intentionally only composition: Host code supplies the
+    instance-bound handlers.  This keeps agent/network creation, authorization,
+    lifecycle/process ownership, and registration out of the descriptor while
+    making the public schema and packaged-manual resource one owned unit.
+    """
+
+    name: str = "avatar"
+
+    @property
+    def action_names(self) -> tuple[str, ...]:
+        """Canonical action order for schema-only and handler-bound families."""
+        return tuple(name for name, _schema in _CHILD_SPECS)
+
+    def bind_family(
+        self, handlers: Mapping[str, Callable[[Mapping[str, Any]], dict[str, Any]]]
+    ) -> ToolFamily:
+        """Build one family from this descriptor's strict child declarations."""
+        return ToolFamily(
+            self.name,
+            [
+                ChildTool(name, schema, handlers[name], title=f"{name} input")
+                for name, schema in _CHILD_SPECS
+            ],
+        )
+
+    def description(self) -> str:
+        """Return the static model-facing root description."""
+        return (
+            "Spawn an independent agent (他我), set network rules for descendants, "
+            "or read the avatar manual. Requires an explicit action — no default. "
+            "avatar(action='spawn', input={'name': 'researcher', ...}, "
+            "reasoning='<the avatar's mission>'): inherits init.json, boots on "
+            "default preset; your reasoning becomes the avatar's first prompt. "
+            "avatar(action='rules', input={'rules_content': '...'}, reasoning='...'): "
+            "distribute rules to self + all descendants (requires karma). "
+            "avatar(action='manual', input={}, reasoning='...'): return the "
+            "avatar-manual skill body. See avatar-manual skill for full guidance."
+        )
+
+    def manual_result(self) -> dict[str, Any]:
+        """Return Avatar's own flat packaged-manual result without agent I/O.
+
+        Unlike generic family manuals, Avatar's manual is not installed in an
+        agent ``.library``.  Keeping its resource lookup here prevents an
+        accidental substitution of ``build_manual_child`` and its incompatible
+        installed-manual path/result contract.
+        """
+        resource = resources.files(__package__).joinpath("manual/SKILL.md")
+        try:
+            body = resource.read_text(encoding="utf-8")
+        except (FileNotFoundError, ModuleNotFoundError, AttributeError, OSError):
+            return {
+                "status": "degraded",
+                "action": "manual",
+                "manual": "",
+                "manual_path": str(resource),
+                "error": "avatar manual missing",
+            }
+        return {
+            "status": "ok",
+            "action": "manual",
+            "manual": body,
+            "manual_path": str(resource),
+        }
+
+
+AVATAR_TOOL_DESCRIPTOR = AvatarToolDescriptor()


### PR DESCRIPTION
## Summary
- Add `AvatarToolDescriptor` as the package-local owner of the `avatar` root’s name, description, strict action schemas/order, and packaged manual result.
- Bind manager-owned handlers through the descriptor while preserving agent/network construction, privilege, ledger, rules, and launcher lifecycle ownership.
- Preserve Avatar’s package-local flat manual result rather than substituting the incompatible installed-manual helper.
- Fix four Ruff F401 findings with explicit same-name compatibility re-exports for existing resource/private-schema seams.

## Validation
- Targeted no-cache Ruff passed
- Full `tests/test_tool_family_avatar_migration.py`: 50 passed in 16.00s with `PYTHONDONTWRITEBYTECODE=1` and pytest cache disabled
- Independent final rereview APPROVE; exact repaired head was clean before and after validation, and `git diff --check` passed

Telegram: @lingtaidev1bot | Nickname: 知微
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai