### PR TITLE
feat: make file a real agent plugin

### DIFF
--- a/reports/ANATOMY.md
+++ b/reports/ANATOMY.md
@@ -49,6 +49,7 @@ related_files:
   - reports/kernel-release-v0.15.2-20260627/release-report.md
   - reports/kernel-release-v0.15.2-20260627/release_version.txt
   - reports/pr297-tool-result-replay-explainer.html
+  - reports/real-plugin-candidates/file.md
   - reports/t3-relaunch-watcher-redaction-explainer.html
 maintenance: |
   Keep related_files repo-relative, duplicate-free, and linked to real files.
@@ -97,6 +98,12 @@ re-running the tooling. This is an archive, not a component, so it owns no
   `pr297-tool-result-replay-explainer.html`, and
   `t3-relaunch-watcher-redaction-explainer.html`. Each embeds its own styling
   and depends on no repository asset.
+- `real-plugin-candidates/` — one Markdown record per model-facing tool
+  converted to a real Plugin package, written at conversion time: what the
+  reference slice actually was, the equivalent contract for that tool, what was
+  implemented, what behavior and host boundaries were preserved, and the
+  validation run. `file.md` is the first (`file`, against the Telegram curated
+  plugin reference).
 
 ## Connections
 

--- a/reports/real-plugin-candidates/file.md
+++ b/reports/real-plugin-candidates/file.md
@@ -1,0 +1,221 @@
+# Real Plugin conversion — `file` (model-facing tool)
+
+- **Date:** 2026-08-22
+- **Worktree:** `lingtai-kernel-worktrees/file-real-plugin-20260822`
+- **Branch:** `feat/file-real-plugin-20260822`
+- **Base:** `c0ce8c98` (`docs(daemon): discourage undersized max turns (#1438)`)
+- **Reference slice:** `telegram-curated-mcp-plugin-20260821` @ `348c0bd1`
+  (`feat(mcp): package Telegram as curated plugin`)
+
+## What the Telegram reference actually is
+
+Telegram's conversion is not a manual move and not an inventory descriptor. It
+is three concrete things bound in one place:
+
+1. **A plugin package.** `src/lingtai/mcp_servers/_plugin.py` defines
+   `CuratedMcpPlugin`, a frozen descriptor that loads the package's bundled
+   `SKILL.md` at construction and fails loudly if the frontmatter name, the
+   package/module identity, or the body is wrong.
+2. **A shipped manifest.** `mcp_declaration()` returns the *existing runtime
+   record shape* (`mcp_catalog.json`'s stdio entry). The catalog file stays the
+   file the host reads; the descriptor is what that entry must equal, proven by
+   test rather than generated at runtime.
+3. **Manual-as-owned-skill + a reserved-action promise.** The package declares
+   only its own actions; `actions()`, `action_input_schemas()`, and
+   `build_family()` append `manual` themselves and raise
+   `CuratedMcpPluginError` if the package tries to declare, re-schema, or
+   rebind it. `_family.py`, `server.py`, and `manager.py` all consume the
+   descriptor rather than restating its facts.
+
+## The equivalent contract for `file`
+
+`file` is a built-in model-facing tool, not an MCP server, so its runtime
+discovery/mount contract lives in different files — but it is the same three
+facts:
+
+| Telegram | File |
+|---|---|
+| `mcp_catalog.json` stdio record | `registry.BUILTIN_TOOLS["file"]` (module), `registry.CORE_DEFAULTS["file"]` (boot kwargs), `registry.get_all_providers()` (module `PROVIDERS`) |
+| `python -m <package>` launcher | `registry.setup_capability` → `file.setup(agent)` → `agent.add_tool(...)` |
+| bundled `<package>/SKILL.md` | bundled `<package>/manual/SKILL.md`, swept by `Agent._install_intrinsic_manuals` into `.library/intrinsic/capabilities/<name>/` |
+| `CuratedMcpPlugin` | `ToolPlugin` (`src/lingtai/tools/_plugin.py`) |
+| `telegram/plugin.py` → `TELEGRAM_PLUGIN` | `file/plugin.py` → `FILE_PLUGIN` |
+
+Before this change `file` was the outlier among built-in tools: every other
+tool with a manual (`email`, `bash`→`shell`, `web_search`→`web`, `daemon`,
+`plugin`, `mcp`, `avatar`, `task_card`, `vision`, `knowledge`, `skills`) ships
+its own `manual/` bundle, while `file`'s manual shipped as a *kernel-owned*
+standalone bundle at `src/lingtai/intrinsic_skills/file-manual/`. The manual was
+therefore not the package's to own, and nothing bound the capability's module,
+defaults, providers, actions, and manual together.
+
+## What was implemented
+
+### 1. Plugin package + manifest — `src/lingtai/tools/_plugin.py` (new)
+
+`ToolPlugin` / `ToolPluginError`, the `lingtai.tools` twin of
+`mcp_servers/_plugin.py`, with the same deliberate limits stated in its
+docstring: **declarative only** — no discovery, import-by-name, mounting,
+registration, or config reading. It loads the package's `manual/SKILL.md` at
+construction and raises on a missing bundle, a frontmatter `name` that is not
+the declared `skill_name`, an empty body, a package whose last segment is not
+its `module_dir`, a blank identity field, or a non-mapping
+`defaults`/`providers`.
+
+`capability_declaration()` is the manifest: `{name, module, defaults,
+providers, manual_destination}` — the four facts the host already publishes
+about a built-in tool, in one place. It registers and mounts nothing.
+
+`manual_destination` is the *canonical capability name*, because that is
+exactly what `_install_intrinsic_manuals` computes for a package's `manual/`
+directory (it is stated separately from `module_dir` precisely because
+`bash`→`shell` and `web_search`→`web` differ).
+
+### 2. Manual-as-owned-skill
+
+`src/lingtai/intrinsic_skills/file-manual/SKILL.md` →
+`src/lingtai/tools/file/manual/SKILL.md` (`git mv`, frontmatter `name:
+file-manual` unchanged, `related_files` gains `plugin.py`). The host installer
+now discovers it in the same `install_from(tools_pkg, "capabilities")` sweep as
+every other tool manual and mounts it at
+`.library/intrinsic/capabilities/file/`.
+
+`read-manual` deliberately stays a standalone kernel bundle: it is a nested
+reference the file manual points at, not a second top-level manual action.
+
+### 3. `file/plugin.py` (new) and real consumption in `file/__init__.py`
+
+`FILE_PLUGIN` declares name/package/module_dir/summary/skill_name plus the
+`defaults` and `providers` the registry publishes. `FILE_DECLARED_ACTIONS` is
+`("read", "write", "edit", "glob", "grep")` — `manual` is absent by
+construction; `FILE_ACTIONS` is the plugin-composed public list.
+
+`file/__init__.py` now composes *through* the descriptor rather than restating
+it:
+
+- child order comes from `FILE_DECLARED_ACTIONS` (with an import-time
+  `ToolPluginError` if the declared actions and the declared input schemas
+  disagree);
+- `ACTION_INPUT_SCHEMAS` comes from `FILE_PLUGIN.action_input_schemas(...)`;
+- `_build_family()` declares only the five operations and hands them to
+  `FILE_PLUGIN.build_family(children, agent)`, which appends the reserved
+  `manual` child — `FileManager` no longer registers `manual` at all, so no
+  manager change can drop or rebind it;
+- `PROVIDERS = FILE_PLUGIN.providers_declaration()`;
+- `FAMILY_MANUAL_SKILL = FILE_PLUGIN.manual_destination`;
+- `get_description()` interpolates `FILE_PLUGIN.skill_name`;
+- `setup()` mounts with `FILE_PLUGIN.name` and `FILE_PLUGIN.package`.
+
+### 4. Runtime discovery/mount contract, documented and pinned
+
+Following the reference exactly, the host tables stay the runtime source and
+the descriptor is what they must agree with:
+
+- `registry.py` carries the agreement note on the `file` row and explains why
+  the table is *not* generated from the descriptor (resolving it there would
+  eagerly import the tool and break the module's documented lazy-import
+  discipline).
+- `agent.py`'s `_install_intrinsic_manuals` comment now names the mount half of
+  the contract.
+- `tests/test_file_tool_plugin_package.py` (new, 26 tests) pins:
+  declaration ↔ `BUILTIN_TOOLS`/`CORE_DEFAULTS`/`get_all_providers`; the
+  packaged skill is the manual this plugin owns and no longer exists as a
+  standalone kernel bundle; the host installs it byte-identically at the
+  declared destination and `action="manual"` returns exactly that copy; the
+  package cannot declare, re-schema, or rebind `manual`; descriptor defects
+  raise at construction; and the public envelope, dispatch, and
+  read/write/edit behavior are unchanged.
+
+## Preserved behavior and host boundaries
+
+- **Model-facing surface is byte-identical to base.** `get_schema()` and
+  `get_description()` were dumped from base `c0ce8c98` and from the converted
+  package and compared: identical.
+- **Sandbox / read / write / edit unchanged.** Every operation still reaches
+  the working tree only through the injected `agent._file_io` service via
+  `_file_paths.resolve_workdir_path`; no operation module was touched.
+- **Host boundary on the manual preserved.** The `manual` child is *built* by
+  the plugin but still loads through the kernel-owned
+  `tool_family.manual.build_manual_child`, so the body and the model-visible
+  `manual_path` come from the agent's own installed
+  `.library/intrinsic/capabilities/` tree — not from a package resource read.
+  This is the one deliberate divergence from Telegram, whose MCP server has no
+  installed-library boundary to respect.
+- **Mounting stays the host's.** Nothing here activates a capability, writes a
+  registry record, or spawns anything.
+
+### The one intentional behavior change
+
+The installed manual destination moves from
+`.library/intrinsic/capabilities/file-manual/SKILL.md` to
+`.library/intrinsic/capabilities/file/SKILL.md`. This is unavoidable and
+correct: it is what makes the manual package-owned, and it aligns `file` with
+every other tool whose manual destination is its canonical capability name. The
+skills-catalog entry the model sees is unchanged (`- name: file-manual`, from
+the frontmatter). Updated accordingly: `tests/test_file_tool_family.py`,
+`tests/test_intrinsic_manual_actions.py`, `tests/test_skills.py`,
+`tools/tool_family/BEHAVIORS.md`, `tools/file/ANATOMY.md`,
+`tools/file/CONTRACT.md`, `intrinsic_skills/ANATOMY.md`,
+`intrinsic_skills/read-manual/SKILL.md`.
+
+## Validation (run in this worktree, cache-safe `-p no:cacheprovider`)
+
+| Suite | Result |
+|---|---|
+| `tests/test_file_tool_plugin_package.py` | 26 passed |
+| `tests/test_file_tool_family.py`, `test_intrinsic_manual_actions.py`, `test_tool_family_manual_contract.py`, `test_layers_file.py` | 70 passed |
+| `tests/test_file_io_sidecar.py`, `test_services_file_io.py`, `test_read_continuation.py`, `test_plugin_tool.py` | 193 passed |
+| `tests/test_tools_package_data.py` | 13 passed |
+| `tests/test_skills.py`, `test_agent_capabilities.py` | 46 passed, 1 failed |
+| `tests/test_architecture_documents.py`, `test_docs_governance.py`, `test_anatomy_drift_checker.py`, `test_kernel_isolation.py` | 84 passed, 4 failed |
+
+**All 5 failures are pre-existing at base `c0ce8c98`**, verified by stashing the
+change and re-running:
+
+- `test_skills.py::test_lingtai_owned_skill_frontmatter_has_last_changed_at` —
+  `intrinsic_skills/notification-manual/SKILL.md` has a date-only
+  `last_changed_at`.
+- `test_architecture_documents.py::test_every_tracked_file_climbs_the_anatomy_graph`,
+  `test_docs_governance.py::test_every_in_scope_doc_has_required_fields`,
+  `test_docs_governance.py::test_all_four_notification_managers_preserve_exact_runtime_body`,
+  `test_kernel_isolation.py::test_kernel_has_no_lingtai_submodules`.
+
+The anatomy-graph violation list was diffed before/after: **no new violations**.
+
+Not run: `tests/test_mcp_skill_manuals.py` and
+`tests/test_outbound_file_containment.py` fail to *collect* in this environment
+(`ImportError: cannot import name 'ServerRequestContext' from 'mcp.server'` —
+installed `mcp` SDK predates the v2 API). This is an environment limitation, not
+a change effect; neither module touches the converted code paths.
+
+## Files changed
+
+New:
+- `src/lingtai/tools/_plugin.py`
+- `src/lingtai/tools/file/plugin.py`
+- `tests/test_file_tool_plugin_package.py`
+- `reports/real-plugin-candidates/file.md`
+
+Moved:
+- `src/lingtai/intrinsic_skills/file-manual/SKILL.md` → `src/lingtai/tools/file/manual/SKILL.md`
+
+Modified:
+- `src/lingtai/tools/file/__init__.py`, `src/lingtai/tools/file/ANATOMY.md`,
+  `src/lingtai/tools/file/CONTRACT.md`
+- `src/lingtai/tools/registry.py`, `src/lingtai/tools/ANATOMY.md`,
+  `src/lingtai/tools/tool_family/BEHAVIORS.md`
+- `src/lingtai/agent.py` (comment only)
+- `src/lingtai/intrinsic_skills/ANATOMY.md`,
+  `src/lingtai/intrinsic_skills/read-manual/SKILL.md`
+- `tests/test_file_tool_family.py`, `tests/test_intrinsic_manual_actions.py`,
+  `tests/test_skills.py`
+
+No other worktree, shared config, or auth material was touched. No push, PR,
+merge, delete, reset, or amend was performed.
+
+## Follow-on candidates
+
+`ToolPlugin` is generic. The next packages to convert are the ten other tools
+that already own a `manual/` bundle and only need a descriptor plus the same
+composition rewiring; `bash`→`shell` and `web_search`→`web` are the two that
+exercise the `module_dir` ≠ `name` split the descriptor already models.

--- a/src/lingtai/agent.py
+++ b/src/lingtai/agent.py
@@ -621,8 +621,11 @@ class Agent(BaseAgent):
         # intrinsic/capabilities/<name>/ — agents see one flat capability
         # namespace. Scanning the consolidated ``lingtai.tools`` package replaces the
         # former core/ + capabilities/ dual scan; tools without a manual/ (the
-        # file tools, the non-email intrinsics whose manuals ship as
-        # intrinsic_skills bundles below) are simply skipped.
+        # non-email intrinsics whose manuals ship as intrinsic_skills bundles
+        # below) are simply skipped. This scan is the mount half of a
+        # plugin-packaged tool's contract: ``file`` ships its own
+        # ``manual/SKILL.md`` and ``ToolPlugin.manual_destination`` declares the
+        # ``<name>`` this loop computes for it.
         install_from(tools_pkg, "capabilities")
         install_skills_from(skills_pkg, "capabilities")
 

--- a/src/lingtai/intrinsic_skills/ANATOMY.md
+++ b/src/lingtai/intrinsic_skills/ANATOMY.md
@@ -11,7 +11,6 @@ related_files:
   - src/lingtai/intrinsic_skills/context-manual/assets/molt-template.md
   - src/lingtai/intrinsic_skills/context-manual/assets/session-journal-entry-template.md
   - src/lingtai/intrinsic_skills/context-manual/reference/summarize-manual/SKILL.md
-  - src/lingtai/intrinsic_skills/file-manual/SKILL.md
   - src/lingtai/intrinsic_skills/lingtai-doctor/SKILL.md
   - src/lingtai/intrinsic_skills/lingtai-doctor/scripts/doctor.py
   - src/lingtai/intrinsic_skills/lingtai-kernel-anatomy/SKILL.md
@@ -86,9 +85,13 @@ code under `tools/` (`src/lingtai/intrinsic_skills/__init__.py:1-9`).
   `scripts/bench_agent_session_rebuild.py`.
 - `lingtai-doctor/` — read-only health diagnostics for agents and bots, with a
   bundled `scripts/doctor.py` for layered local checks that expose no secrets.
-- Single-file bundles — `file-manual/`, `lingtai-manual/`, `pad-manual/`,
-  `psyche-manual/`, `read-manual/`, and `soul-manual/`, each one `SKILL.md`
-  documenting its namesake surface.
+- Single-file bundles — `lingtai-manual/`, `pad-manual/`, `psyche-manual/`,
+  `read-manual/`, and `soul-manual/`, each one `SKILL.md` documenting its
+  namesake surface. `file-manual/` is deliberately absent: the `file` tool is
+  plugin-packaged and owns its manual as
+  `src/lingtai/tools/file/manual/SKILL.md`, which the same install sweep copies
+  to `capabilities/file/`. `read-manual/` stays here — it is a nested reference
+  the file manual points at, not a second top-level manual action.
 
 ## Connections
 

--- a/src/lingtai/intrinsic_skills/read-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/read-manual/SKILL.md
@@ -7,7 +7,7 @@ last_changed_at: "2026-07-19T00:00:00Z"
 related_files:
 - src/lingtai/tools/file/_read.py
 - src/lingtai/tools/file/__init__.py
-- src/lingtai/intrinsic_skills/file-manual/SKILL.md
+- src/lingtai/tools/file/manual/SKILL.md
 maintenance: |
   Tracks the tool/capability behavior it teaches; update when that tool's behavior changes.
 ---

--- a/src/lingtai/tools/ANATOMY.md
+++ b/src/lingtai/tools/ANATOMY.md
@@ -158,6 +158,18 @@ capability names and lazy adapters.
   (`src/lingtai/tools/email/ANATOMY.md`).
 - `_manual.py` — bounded installed-manual loader
   (`src/lingtai/tools/_manual.py:1-29`).
+- `_plugin.py` — tool **plugin packaging** descriptor, the `lingtai.tools` twin
+  of `mcp_servers/_plugin.py`. `ToolPlugin` binds one package's identity, its
+  bundled `manual/SKILL.md` (loaded and name-checked at construction), and its
+  capability declaration (`capability_declaration()`) — the record shape
+  `registry.BUILTIN_TOOLS`/`CORE_DEFAULTS`/`get_all_providers` and the
+  `Agent._install_intrinsic_manuals` destination publish. It also owns the
+  reserved-action promise: `actions()`, `action_input_schemas()`, and
+  `build_family()` append `manual` from the packaged skill and raise
+  `ToolPluginError` if a package declares, re-schemas, or rebinds it.
+  Declarative only — no discovery, import-by-name, mounting, registration, or
+  config reading; activation, defaults, guards, and the manual install sweep
+  stay with the host (`registry.py`, `lingtai/agent.py`).
 - `__init__.py` — the package docstring that fixes the flat one-directory-per-tool
   layout and the `lingtai → lingtai.tools → lingtai.kernel` import DAG enforced by
   `tests/test_kernel_isolation.py` (`src/lingtai/tools/__init__.py:1-12`).
@@ -192,7 +204,16 @@ emitted as a public name or a second schema.
 
 The public `file` row imports `lingtai.tools.file` lazily; that owner binds its
 five operation modules once per manager and reaches the working tree only
-through the injected `FileIOService`. Unlike `bash`/`web_search`, the file
+through the injected `FileIOService`. `file` is the one plugin-packaged tool
+today: `file/plugin.py`'s `FILE_PLUGIN` declares the capability's module, boot
+defaults, provider metadata, packaged manual, and its own five actions, and
+`file/__init__.py` composes the schema, the dispatching family (with the
+plugin-appended reserved `manual`), `PROVIDERS`, and the `setup()` mount from
+it. The registry tables here stay the runtime source `setup_capability` reads —
+generating them from the descriptor would eagerly import the tool and break
+this module's lazy-import discipline — and
+`tests/test_file_tool_plugin_package.py` pins that they equal
+`FILE_PLUGIN.capability_declaration()`. Unlike `bash`/`web_search`, the file
 migration kept no configuration aliases: `read`, `write`, `edit`, `glob`, and
 `grep` are unknown capability names that fail loudly. Capability groups no
 longer exist at all — `file` was `_GROUPS`' only entry, so the map,

--- a/src/lingtai/tools/_plugin.py
+++ b/src/lingtai/tools/_plugin.py
@@ -1,0 +1,293 @@
+"""Tool plugin packaging: one package owns its skill, declaration, and family shape.
+
+A built-in LingTai tool is not just a directory the registry happens to import.
+It is a *plugin-style package*: the same folder ships the operation code, the
+bundled ``manual/SKILL.md`` the host installs into the agent's intrinsic
+library, and the capability declaration the built-in registry publishes for it
+(module path, boot defaults, provider metadata, manual destination). This module
+is the small shared piece that binds those three together for one package, so a
+tool cannot drift into declaring its module in one place, its manual in another,
+and a public action list that silently disagrees with both.
+
+It is the ``lingtai.tools`` twin of :mod:`lingtai.mcp_servers._plugin`, which
+does the same job for a curated MCP package, and it keeps that module's
+deliberate limits. It is **not** a plugin runtime. Nothing here discovers
+packages, imports them by name, mounts them, registers them, or reads
+configuration: capability activation, boot defaults, guard/execution policy,
+prompt lifecycle, and the manual install sweep all remain the host's.
+``lingtai.tools.registry`` still owns :data:`~lingtai.tools.registry.BUILTIN_TOOLS`
+/ :data:`~lingtai.tools.registry.CORE_DEFAULTS` and ``setup_capability``,
+``lingtai.agent.Agent._install_intrinsic_manuals`` still owns the
+``.library/intrinsic/capabilities/`` sweep, and
+``lingtai.services.plugin_registry`` still owns external Agent Plugins v1.0.0
+directories. A :class:`ToolPlugin` is a declarative descriptor plus three
+composition helpers that its own package calls explicitly.
+
+The one hard promise it enforces is the reserved ``manual`` action
+(``tools/CONTRACT.md`` "Every LingTai-owned family MUST offer a ``manual``
+action"): a package declares only its *own* actions, and this module appends
+``manual`` itself, bound to the destination the host installs this package's
+bundled manual into. A package that tries to declare, re-schema, or re-handle
+``manual`` raises :class:`ToolPluginError` at import time rather than shipping a
+family whose manual is missing or points somewhere other than its packaged
+skill.
+"""
+from __future__ import annotations
+
+import copy
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from importlib import resources
+from typing import Any
+
+from lingtai.kernel._frontmatter import split_frontmatter
+
+from .tool_family import RESERVED_MANUAL_NAME, ChildTool, ToolFamily
+from .tool_family.manual import MANUAL_INPUT_SCHEMA, build_manual_child
+
+__all__ = [
+    "MANUAL_ACTION",
+    "MANUAL_BUNDLE_DIRNAME",
+    "SKILL_FILENAME",
+    "ToolPlugin",
+    "ToolPluginError",
+    "strict_empty_input_schema",
+]
+
+#: The reserved action name. Owned by ``lingtai.tools.tool_family``; re-exported
+#: here so a tool package never spells the literal itself.
+MANUAL_ACTION = RESERVED_MANUAL_NAME
+
+#: The per-package manual bundle directory ``Agent._install_intrinsic_manuals``
+#: scans for. Every tool package that owns its manual ships exactly this folder;
+#: the host copies it to ``.library/intrinsic/capabilities/<destination>/``.
+MANUAL_BUNDLE_DIRNAME = "manual"
+
+#: The bundled manual document inside :data:`MANUAL_BUNDLE_DIRNAME`.
+SKILL_FILENAME = "SKILL.md"
+
+
+class ToolPluginError(ValueError):
+    """Raised for a tool-plugin packaging defect (bad descriptor or shape)."""
+
+
+def strict_empty_input_schema() -> dict[str, Any]:
+    """The canonical closed, argument-free ``input`` schema for an action.
+
+    A deep copy of the one ``tool_family.manual``-owned literal, so a family
+    that *declares* this schema and the child that dispatches it cannot drift,
+    and so no two callers share a mutable nested ``properties`` map.
+    """
+    return copy.deepcopy(MANUAL_INPUT_SCHEMA)
+
+
+def _schema_only_manual_handler(_input: Mapping[str, Any]) -> dict[str, Any]:
+    raise AssertionError("the agent-less schema-only manual child never dispatches")
+
+
+@dataclass(frozen=True)
+class ToolPlugin:
+    """One built-in tool package's identity, packaged manual, and declaration.
+
+    ``name`` is the public capability name, the model-facing family name, and —
+    because that is exactly what ``Agent._install_intrinsic_manuals`` computes —
+    the directory this package's manual bundle is installed into. ``package`` is
+    the Python package that ships both the operation modules and the
+    ``manual/SKILL.md`` the ``manual`` action returns, and ``module_dir`` is that
+    package's own last path segment. The two are stated separately, and required
+    to agree, because a retained implementation directory may differ from the
+    canonical capability it serves (``lingtai.tools.bash`` → ``shell``,
+    ``lingtai.tools.web_search`` → ``web``): the registry publishes
+    ``package`` as this capability's module, and the installer maps
+    ``module_dir`` onto ``name``.
+
+    The bundled manual is loaded once at construction and its frontmatter
+    ``name`` is checked against ``skill_name``, so a package that renames or
+    loses its manual fails loudly at import instead of serving an empty or
+    foreign ``manual``.
+    """
+
+    name: str
+    package: str
+    module_dir: str
+    summary: str
+    skill_name: str
+    defaults: Mapping[str, Any] = field(default_factory=dict)
+    providers: Mapping[str, Any] = field(default_factory=lambda: {"providers": [], "default": "builtin"})
+
+    # Loaded from the package's bundled manual/SKILL.md at construction. Excluded
+    # from init/repr/eq: they are derived material, not part of the descriptor's
+    # declared identity.
+    _skill_frontmatter: dict[str, str] = field(init=False, repr=False, compare=False)
+    _skill_body: str = field(init=False, repr=False, compare=False)
+    _skill_path: str = field(init=False, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        for attribute in ("name", "package", "module_dir", "summary", "skill_name"):
+            value = getattr(self, attribute)
+            if not isinstance(value, str) or not value.strip():
+                raise ToolPluginError(
+                    f"ToolPlugin {attribute!r} must be a non-empty string"
+                )
+        if self.package.rpartition(".")[2] != self.module_dir:
+            raise ToolPluginError(
+                f"ToolPlugin package {self.package!r} must be the "
+                f"{self.module_dir!r} module so its declared capability module "
+                f"is its own package"
+            )
+        for attribute in ("defaults", "providers"):
+            if not isinstance(getattr(self, attribute), Mapping):
+                raise ToolPluginError(f"ToolPlugin {attribute!r} must be a mapping")
+        frontmatter, body, path = self._load_packaged_skill()
+        if frontmatter.get("name") != self.skill_name:
+            raise ToolPluginError(
+                f"ToolPlugin {self.name!r} bundled "
+                f"{MANUAL_BUNDLE_DIRNAME}/{SKILL_FILENAME} declares name "
+                f"{frontmatter.get('name')!r}, expected {self.skill_name!r}"
+            )
+        if not body.strip():
+            raise ToolPluginError(
+                f"ToolPlugin {self.name!r} bundled "
+                f"{MANUAL_BUNDLE_DIRNAME}/{SKILL_FILENAME} has an empty body"
+            )
+        object.__setattr__(self, "_skill_frontmatter", frontmatter)
+        object.__setattr__(self, "_skill_body", body)
+        object.__setattr__(self, "_skill_path", path)
+
+    def _load_packaged_skill(self) -> tuple[dict[str, str], str, str]:
+        resource = resources.files(self.package).joinpath(
+            MANUAL_BUNDLE_DIRNAME, SKILL_FILENAME
+        )
+        try:
+            text = resource.read_text(encoding="utf-8")
+        except (FileNotFoundError, OSError) as exc:
+            raise ToolPluginError(
+                f"ToolPlugin {self.name!r} ships no "
+                f"{MANUAL_BUNDLE_DIRNAME}/{SKILL_FILENAME} in {self.package!r}"
+            ) from exc
+        frontmatter, body = split_frontmatter(text)
+        return frontmatter, body, str(resource)
+
+    # -- packaged skill / manual ------------------------------------------
+
+    @property
+    def manual_destination(self) -> str:
+        """Where the host installs this package's manual bundle.
+
+        ``Agent._install_intrinsic_manuals`` copies ``<package>/manual/`` to
+        ``.library/intrinsic/capabilities/<canonical capability name>/``, so the
+        destination is the public :attr:`name` — never the retained
+        implementation directory. The reserved ``manual`` child reads back from
+        exactly this destination.
+        """
+        return self.name
+
+    @property
+    def skill_frontmatter(self) -> dict[str, str]:
+        """Parsed packaged ``SKILL.md`` frontmatter (the manual's catalog entry)."""
+        return dict(self._skill_frontmatter)
+
+    @property
+    def skill_body(self) -> str:
+        """The full packaged ``SKILL.md`` markdown body behind ``action='manual'``."""
+        return self._skill_body
+
+    @property
+    def skill_path(self) -> str:
+        """Absolute resolved path of the packaged ``manual/SKILL.md``."""
+        return self._skill_path
+
+    def manual_child(self, agent: Any | None = None) -> ChildTool:
+        """The plugin-owned reserved ``manual`` child.
+
+        With an *agent*, the child is the kernel-owned
+        :func:`~lingtai.tools.tool_family.manual.build_manual_child` bound to
+        this plugin's declared :attr:`manual_destination`, so ``manual`` never
+        routes through the package's business dispatcher and cannot be rebound
+        to other material. The host boundary is unchanged: the body and the
+        model-visible ``manual_path`` still come from the agent's own installed
+        ``.library/intrinsic/capabilities/`` tree, not from a package read.
+
+        Without an *agent* the child is schema-only — the same strict-empty
+        input with a handler that raises — which is what a package's
+        module-level schema composition uses before any agent exists.
+        """
+        if agent is None:
+            return ChildTool(
+                name=MANUAL_ACTION,
+                input_schema=strict_empty_input_schema(),
+                handler=_schema_only_manual_handler,
+                title=f"{MANUAL_ACTION} input",
+            )
+        return build_manual_child(agent, self.manual_destination)
+
+    # -- family composition -------------------------------------------------
+
+    def actions(self, declared: Sequence[str]) -> tuple[str, ...]:
+        """Declared actions plus the reserved ``manual``, in that order."""
+        self._check_declared_names(declared)
+        return tuple(declared) + (MANUAL_ACTION,)
+
+    def action_input_schemas(
+        self, declared: Mapping[str, Mapping[str, Any]]
+    ) -> dict[str, dict[str, Any]]:
+        """Declared ``input`` schemas plus the reserved ``manual`` schema."""
+        self._check_declared_names(declared.keys())
+        schemas: dict[str, dict[str, Any]] = {
+            action: dict(schema) for action, schema in declared.items()
+        }
+        schemas[MANUAL_ACTION] = strict_empty_input_schema()
+        return schemas
+
+    def build_family(
+        self, declared: Sequence[ChildTool], agent: Any | None = None
+    ) -> ToolFamily:
+        """Compose this plugin's one public family, manual always appended."""
+        self._check_declared_names([child.name for child in declared])
+        return ToolFamily(self.name, [*declared, self.manual_child(agent)])
+
+    def _check_declared_names(self, declared: "Sequence[str] | Any") -> None:
+        names = list(declared)
+        if not names:
+            raise ToolPluginError(
+                f"ToolPlugin {self.name!r} must declare at least one action"
+            )
+        if MANUAL_ACTION in names:
+            raise ToolPluginError(
+                f"ToolPlugin {self.name!r} must not declare the reserved "
+                f"{MANUAL_ACTION!r} action; it is appended from the packaged "
+                f"{MANUAL_BUNDLE_DIRNAME}/{SKILL_FILENAME}"
+            )
+        if len(set(names)) != len(names):
+            raise ToolPluginError(
+                f"ToolPlugin {self.name!r} declared a duplicate action"
+            )
+
+    # -- shipped capability declaration ------------------------------------
+
+    def capability_declaration(self) -> dict[str, Any]:
+        """This package's built-in capability record, in registry record shape.
+
+        The four facts the host publishes about a built-in tool, in one place:
+        the module ``registry.BUILTIN_TOOLS`` resolves for this capability, the
+        boot kwargs ``registry.CORE_DEFAULTS`` seeds it with, the provider
+        metadata ``registry.get_all_providers`` reads off the module, and the
+        ``.library/intrinsic/capabilities/`` directory the manual installer
+        writes this package's bundle into.
+
+        Returning it here does not register, mount, or activate anything: the
+        registry tables remain the runtime source the host reads and
+        ``setup_capability``/``_install_intrinsic_manuals`` remain the only
+        mount paths. This descriptor is what those entries must agree with.
+        """
+        return {
+            "name": self.name,
+            "module": self.package,
+            "defaults": dict(self.defaults),
+            "providers": self.providers_declaration(),
+            "manual_destination": self.manual_destination,
+        }
+
+    def providers_declaration(self) -> dict[str, Any]:
+        """The module-level ``PROVIDERS`` mapping ``get_all_providers`` reads."""
+        return copy.deepcopy(dict(self.providers))

--- a/src/lingtai/tools/file/ANATOMY.md
+++ b/src/lingtai/tools/file/ANATOMY.md
@@ -6,6 +6,9 @@ related_files:
   - src/lingtai/tools/file/BEHAVIORS.md
   - src/lingtai/tools/file/CONTRACT.md
   - src/lingtai/tools/file/__init__.py
+  - src/lingtai/tools/file/plugin.py
+  - src/lingtai/tools/file/manual/SKILL.md
+  - src/lingtai/tools/_plugin.py
   - src/lingtai/tools/file/_read.py
   - src/lingtai/tools/file/_write.py
   - src/lingtai/tools/file/_edit.py
@@ -13,7 +16,6 @@ related_files:
   - src/lingtai/tools/file/_grep.py
   - src/lingtai/tools/_file_paths.py
   - src/lingtai/tools/tool_family/ANATOMY.md
-  - src/lingtai/intrinsic_skills/file-manual/SKILL.md
   - src/lingtai/intrinsic_skills/read-manual/SKILL.md
   - src/lingtai/tools/file/glossary-en.md
   - src/lingtai/tools/file/glossary-wen.md
@@ -37,16 +39,35 @@ model-facing handler over six canonical children — `read`, `write`, `edit`,
 composition and envelope dispatch delegate to the generic `tool_family`
 infrastructure; everything else about the file surface lives here.
 
+It is a **plugin-packaged** tool: the same folder ships the operation code, the
+bundled `manual/SKILL.md` the host installs into the agent's intrinsic library,
+and the capability declaration the built-in registry publishes for it. One
+descriptor, `plugin.py`'s `FILE_PLUGIN`, states all three, and the five actions
+this package owns. `manual` is not one of them — the plugin appends the
+reserved action itself.
+
 ## Components
 
-- `__init__.py` — the six child input schemas, the one registry builder, the
-  `FileManager` dispatcher, and `setup()` registration
-  (`src/lingtai/tools/file/__init__.py:1-273`).
-- `_build_family()` — the single handler-parameterized registry builder. Called
-  with no arguments it yields the module-level schema-only `_FAMILY` used by
-  `get_schema()`; called with bound handlers it yields the dispatching family.
-  One builder means the advertised schema and the dispatch registry cannot
-  drift apart (`src/lingtai/tools/file/__init__.py:151-169`).
+- `plugin.py` — the package's plugin descriptor. `FILE_PLUGIN` states the
+  capability/family name, the module `registry.BUILTIN_TOOLS` resolves, the
+  `CORE_DEFAULTS` boot kwargs, the `PROVIDERS` metadata, and the packaged
+  manual's skill name; `FILE_DECLARED_ACTIONS` lists this package's own five
+  actions with `manual` deliberately absent, and `FILE_ACTIONS` is the
+  plugin-composed public list (`src/lingtai/tools/file/plugin.py:1-44`).
+- `manual/SKILL.md` — the plugin-owned manual (frontmatter `name: file-manual`)
+  that `Agent._install_intrinsic_manuals` copies to
+  `.library/intrinsic/capabilities/file/` and `action="manual"` returns.
+- `__init__.py` — the five declared child input schemas, the one registry
+  builder, the `FileManager` dispatcher, and `setup()` registration — the
+  schema, the family, `PROVIDERS`, and the mounted tool name all composed from
+  `FILE_PLUGIN` (`src/lingtai/tools/file/__init__.py:1-290`).
+- `_build_family()` — the single agent/handler-parameterized registry builder.
+  It declares only the five operations and hands them to
+  `FILE_PLUGIN.build_family()`, which appends the reserved `manual` child.
+  Called with no arguments it yields the module-level schema-only `_FAMILY`
+  used by `get_schema()`; called with an agent and bound handlers it yields the
+  dispatching family. One builder means the advertised schema and the dispatch
+  registry cannot drift apart, and the plugin means neither can drop `manual`.
 - `_read.py` — the read operation plus its paging/truncation math
   (`_apply_cap`), per-call cap resolution (`_resolve_call_cap`), the
   `DEFAULT_READ_CAP_CHARS`/`READ_HARD_CAP_CHARS` constants, and the spill-aware
@@ -72,9 +93,15 @@ Every operation reaches the working tree only through the injected
 `write` and `edit` stop at that durable I/O boundary: they have no prompt-manager
 or context-reconstruction connection and never hot-load a changed prompt source.
 Activation is owned separately by `context.rebuild` and passive refresh/molt.
-The reserved `manual` child loads the `file-manual` intrinsic skill bundle
-through `tool_family.manual`, which reads it from the agent's installed
-`.library/intrinsic/capabilities/` tree.
+The reserved `manual` child is built by `FILE_PLUGIN`, not by `FileManager`,
+and is bound to the destination the plugin declares — so no manager change can
+drop or rebind it. The host boundary is unchanged: it still loads through
+`tool_family.manual`, which reads the installed copy from the agent's
+`.library/intrinsic/capabilities/file/` tree rather than from the package.
+`registry.BUILTIN_TOOLS["file"]`, `CORE_DEFAULTS["file"]`, and that install
+destination must equal `FILE_PLUGIN.capability_declaration()`; those host
+tables and the install sweep stay the runtime source, and
+`tests/test_file_tool_plugin_package.py` pins the agreement.
 
 ## Composition
 

--- a/src/lingtai/tools/file/CONTRACT.md
+++ b/src/lingtai/tools/file/CONTRACT.md
@@ -4,6 +4,9 @@ tool: file
 contract_version: 3
 related_files:
   - src/lingtai/tools/file/__init__.py
+  - src/lingtai/tools/file/plugin.py
+  - src/lingtai/tools/file/manual/SKILL.md
+  - src/lingtai/tools/_plugin.py
   - src/lingtai/tools/file/_read.py
   - src/lingtai/tools/file/_write.py
   - src/lingtai/tools/file/_edit.py
@@ -15,7 +18,6 @@ related_files:
   - src/lingtai/tools/tool_family/CONTRACT.md
   - src/lingtai/services/file_io_sidecar.py
   - src/lingtai/kernel/tool_result_summary.py
-  - src/lingtai/intrinsic_skills/file-manual/SKILL.md
   - src/lingtai/intrinsic_skills/read-manual/SKILL.md
 maintenance: |
   Keep related_files as repo-relative paths to real files. If behavior and this
@@ -246,8 +248,14 @@ likewise stays false so exact procedure is not summarized away.
 
 ## Manual
 
-The family owns exactly one manual: `action="manual"` returns the installed
-`file-manual` intrinsic skill bundle. It performs no target file operation and
+The family owns exactly one manual, and it owns it as a **packaged skill**:
+`src/lingtai/tools/file/manual/SKILL.md` (frontmatter `name: file-manual`)
+ships inside this package. `action="manual"` returns the copy the host
+installed from it at `.library/intrinsic/capabilities/file/SKILL.md` — the
+destination `FILE_PLUGIN.manual_destination` declares. The child is built by
+`FILE_PLUGIN`, never by `FileManager`, so a manager change cannot drop or
+rebind it, and the package may not declare, re-schema, or re-handle `manual`
+(`ToolPluginError` at import time). It performs no target file operation and
 touches no path other than the manual's own, and its input is strict empty.
 The result is the canonical child shape — full body at `content[0].text`, the
 host-local path at `structuredContent.manual_path` — returned without double
@@ -279,6 +287,9 @@ is observed from the executor, never stored.
 | Write/edit receipts are returned verbatim | `file/__init__.py` (`handle`) | `tests/test_file_tool_family.py::test_write_and_edit_receipts_are_verbatim` |
 | Chat and Responses wires keep the correlation | `llm/openai/adapter.py` | `tests/test_file_tool_family.py::test_chat_and_responses_wire_parity` |
 | `summarize` is honored and never reaches a handler | `kernel/tool_result_summary.py` | `tests/test_file_tool_family.py::test_summarize_is_recognized_and_stripped` |
+| Registry entries equal the plugin's capability declaration | `file/plugin.py`, `tools/registry.py` | `tests/test_file_tool_plugin_package.py::test_declaration_matches_the_shipped_builtin_registry_entries` |
+| The package cannot declare, re-schema, or rebind `manual` | `tools/_plugin.py` | `tests/test_file_tool_plugin_package.py::test_a_package_cannot_declare_re_schema_or_rebind_the_reserved_manual` |
+| The host installs the packaged manual at the declared destination | `agent.py` (`_install_intrinsic_manuals`), `file/plugin.py` | `tests/test_file_tool_plugin_package.py::test_host_installs_the_packaged_bundle_and_manual_answers_from_it` |
 
 ## Verification matrix
 
@@ -289,12 +300,14 @@ is observed from the executor, never stored.
 | Per-operation behavior unchanged | `tests/test_layers_file.py`, `tests/test_read_continuation.py` | read a large file, resume via `next_offset` | silent data loss on long reads |
 | Receipts not obscured | `tests/test_file_tool_family.py` | `write` then inspect the raw result | agent cannot confirm a mutation |
 | Manual is no-I/O | `tests/test_file_tool_family.py` | call `action="manual"` on a read-only tree | manual becomes a side-effecting call |
+| Plugin packaging: declaration, packaged manual, mount destination | `tests/test_file_tool_plugin_package.py` | boot an agent, read `.library/intrinsic/capabilities/file/SKILL.md` | the capability's module, defaults, and manual drift into three disagreeing places |
 
 Run before merging:
 
 ```bash
 python -m pytest tests/test_file_tool_family.py tests/test_layers_file.py \
-  tests/test_read_continuation.py tests/test_intrinsic_manual_actions.py -q
+  tests/test_read_continuation.py tests/test_intrinsic_manual_actions.py \
+  tests/test_file_tool_plugin_package.py -q
 ```
 
 ## Schema and glossary ownership

--- a/src/lingtai/tools/file/__init__.py
+++ b/src/lingtai/tools/file/__init__.py
@@ -9,6 +9,13 @@ resolution, numbered-line read output, continuation metadata, ``max_chars``
 cap, ``line_truncated``, edit ambiguity/missing handling, the full-write
 receipt, glob sorting, and grep regex/line/path results and caps.
 
+The package is plugin-packaged (``plugin.py``, ``.._plugin``): ``FILE_PLUGIN``
+is the one declaration of the capability's identity — its registry module, boot
+defaults, provider metadata, packaged ``manual/SKILL.md``, and the five actions
+this package owns. The public schema, the dispatching family, ``PROVIDERS``, and
+the ``setup()`` mount are all composed from it, and the reserved ``manual`` child
+is appended by the plugin rather than registered by :class:`FileManager`.
+
 Per ``../CONTRACT.md`` "Implementation independence", the six children share
 nothing but the family name and the wire envelope: each operation module is
 self-contained and none imports another. Each child's canonical raw result is
@@ -19,21 +26,24 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Callable, Mapping, Sequence
 
+from .._plugin import ToolPluginError
 from ..tool_family import ChildTool, ToolFamily
-from ..tool_family.manual import build_manual_child
 from . import _edit, _glob, _grep, _read, _write
+from .plugin import FILE_ACTIONS, FILE_DECLARED_ACTIONS, FILE_PLUGIN
 
 if TYPE_CHECKING:
     from lingtai.kernel.base_agent import BaseAgent
 
-PROVIDERS = {"providers": [], "default": "builtin"}
+# Provider metadata for ``registry.get_all_providers``, sourced from the one
+# declaration rather than restated here.
+PROVIDERS = FILE_PLUGIN.providers_declaration()
 
-# The one family-owned manual. ``file-manual`` is the installed intrinsic skill
-# bundle (``src/lingtai/intrinsic_skills/file-manual/``) that already covers all
-# five operations; ``read-manual`` remains a nested parent-owned reference it
-# points at for read pagination/truncation depth, not a competing second
-# top-level manual action.
-FAMILY_MANUAL_SKILL = "file-manual"
+# The one family-owned manual, packaged in this plugin as ``manual/SKILL.md``
+# (frontmatter name ``file-manual``) and installed by the host into
+# ``.library/intrinsic/capabilities/file/``. ``read-manual`` remains a nested
+# parent-owned reference it points at for read pagination/truncation depth, not
+# a competing second top-level manual action.
+FAMILY_MANUAL_SKILL = FILE_PLUGIN.manual_destination
 
 _READ_INPUT_SCHEMA: dict[str, Any] = {
     "type": "object",
@@ -121,26 +131,39 @@ _GLOB_INPUT_SCHEMA: dict[str, Any] = {
     "additionalProperties": False,
 }
 
-_MANUAL_INPUT_SCHEMA: dict[str, Any] = {
-    "type": "object",
-    "properties": {},
-    "required": [],
-    "additionalProperties": False,
+# This package's own five actions, keyed by public action name. ``manual`` is
+# deliberately absent: the plugin appends the reserved action from the packaged
+# ``manual/SKILL.md`` and rejects any attempt to declare it here.
+_DECLARED_SCHEMAS_BY_ACTION: dict[str, dict[str, Any]] = {
+    "read": _READ_INPUT_SCHEMA,
+    "write": _WRITE_INPUT_SCHEMA,
+    "edit": _EDIT_INPUT_SCHEMA,
+    "glob": _GLOB_INPUT_SCHEMA,
+    "grep": _GREP_INPUT_SCHEMA,
+}
+if set(_DECLARED_SCHEMAS_BY_ACTION) != set(FILE_DECLARED_ACTIONS):
+    raise ToolPluginError(
+        "file declares an action without an input schema (or the reverse): "
+        f"{sorted(FILE_DECLARED_ACTIONS)} vs {sorted(_DECLARED_SCHEMAS_BY_ACTION)}"
+    )
+
+# Canonical child order comes from the plugin's declared action list, so the
+# schema branch order and the dispatch registry order are the same one fact.
+_DECLARED_SCHEMAS: dict[str, dict[str, Any]] = {
+    action: _DECLARED_SCHEMAS_BY_ACTION[action] for action in FILE_DECLARED_ACTIONS
 }
 
-# Canonical child order: the five operations, then the reserved ``manual``.
-# Each entry pairs a child's public action name with its own strict input
-# schema; the operation modules supply the matching handlers.
-_CHILD_SCHEMAS: tuple[tuple[str, dict[str, Any]], ...] = (
-    ("read", _READ_INPUT_SCHEMA),
-    ("write", _WRITE_INPUT_SCHEMA),
-    ("edit", _EDIT_INPUT_SCHEMA),
-    ("glob", _GLOB_INPUT_SCHEMA),
-    ("grep", _GREP_INPUT_SCHEMA),
-    ("manual", _MANUAL_INPUT_SCHEMA),
+# Every public action's own strict ``input`` schema — the five declared above
+# plus the plugin-appended reserved ``manual``.
+ACTION_INPUT_SCHEMAS: dict[str, dict[str, Any]] = FILE_PLUGIN.action_input_schemas(
+    _DECLARED_SCHEMAS
 )
 
-# The five operation modules, in the same order as their children above.
+#: The complete public action list. Aliases the plugin's composed list so this
+#: module never restates the action set the schema is built from.
+ACTIONS: tuple[str, ...] = FILE_ACTIONS
+
+# The five operation modules, in the plugin's declared action order.
 _OPERATION_MODULES = (_read, _write, _edit, _glob, _grep)
 
 
@@ -148,22 +171,31 @@ def _unused(_input: Mapping[str, Any]) -> dict[str, Any]:
     raise AssertionError("the module-level schema-only ToolFamily never dispatches")
 
 
-def _build_family(handlers: Sequence[Callable[[Mapping[str, Any]], dict[str, Any]]] | None = None) -> ToolFamily:
-    """Build the six-child ``file`` family from the one canonical registry.
+def _build_family(
+    agent: "BaseAgent | None" = None,
+    handlers: Sequence[Callable[[Mapping[str, Any]], dict[str, Any]]] | None = None,
+) -> ToolFamily:
+    """Build the six-child ``file`` family through the plugin descriptor.
 
-    One builder serves both uses, so the schema the model sees and the registry
-    that actually dispatches can never drift apart. With *handlers* omitted the
-    result is schema-only: every child gets a handler that raises, which is what
-    module-level :data:`_FAMILY` uses to compose :func:`get_schema` and to prove
-    at import time that the fixed registry has no duplicate or reserved-name
-    collision (``ToolFamilyError`` would raise here rather than shipping
-    silently). :class:`FileManager` passes real agent-bound handlers.
+    This builder declares only this package's five operations; the reserved
+    ``manual`` child is appended by :data:`~.plugin.FILE_PLUGIN`, bound to the
+    manual destination the plugin declares. One builder serves both uses, so
+    the schema the model sees and the registry that actually dispatches can
+    never drift apart. With *handlers* omitted the result is schema-only: every
+    declared child gets a handler that raises, which is what module-level
+    :data:`_FAMILY` uses to compose :func:`get_schema` and to prove at import
+    time that the fixed registry has no duplicate or reserved-name collision
+    (``ToolPluginError``/``ToolFamilyError`` would raise here rather than
+    shipping silently). :class:`FileManager` passes real agent-bound handlers
+    plus the agent the plugin binds ``manual`` to.
     """
     children = []
-    for index, (name, schema) in enumerate(_CHILD_SCHEMAS):
+    for index, name in enumerate(FILE_DECLARED_ACTIONS):
         handler = handlers[index] if handlers is not None else _unused
-        children.append(ChildTool(name, schema, handler, title=f"{name} input"))
-    return ToolFamily("file", children)
+        children.append(
+            ChildTool(name, ACTION_INPUT_SCHEMAS[name], handler, title=f"{name} input")
+        )
+    return FILE_PLUGIN.build_family(children, agent)
 
 
 _FAMILY = _build_family()
@@ -187,7 +219,8 @@ def get_description(lang: str = "en") -> str:
         "file(action='grep', ...) to search file contents by regex. Text files "
         "only — this tool cannot read binary, images, or audio. Use "
         "file(action='manual', input={}, reasoning='load file guidance') once "
-        "for the installed file-manual. Read file-manual before non-UTF-8 files "
+        f"for the installed {FILE_PLUGIN.skill_name}. Read "
+        f"{FILE_PLUGIN.skill_name} before non-UTF-8 files "
         "or a careful search/edit workflow; it also carries the nested "
         "read-manual reference for read pagination, truncation, and "
         "line_truncated depth, plus the bash/Python metadata workflow (file "
@@ -217,6 +250,8 @@ def _strip_nulls(action_input: Mapping[str, Any]) -> dict[str, Any]:
 class FileManager:
     """One per-Agent dispatcher over the six file children.
 
+    It binds this package's five declared operations; the sixth child,
+    ``manual``, belongs to :data:`~.plugin.FILE_PLUGIN` and is appended by it.
     Holds no mutable state of its own: each operation is bound once here and
     reaches the working tree only through the injected ``agent._file_io``
     service.
@@ -227,12 +262,14 @@ class FileManager:
         operations = [
             self._bind(module.build_operation(agent)) for module in _OPERATION_MODULES
         ]
-        # The reserved ``manual`` child is registered directly and unwrapped:
+        # Only the five declared operations are bound here. The reserved
+        # ``manual`` child is appended by ``FILE_PLUGIN`` from its packaged
+        # skill's declared destination, so no change to this manager can drop
+        # or rebind it. It is registered directly and unwrapped:
         # ``ToolFamily.handle()`` returns its own canonical MCP-compatible
         # result verbatim for ``action="manual"`` (no double wrap), and it
         # performs no target file operation.
-        operations.append(build_manual_child(agent, FAMILY_MANUAL_SKILL).handler)
-        self._family = _build_family(operations)
+        self._family = _build_family(agent, operations)
 
     @staticmethod
     def _bind(operation: Callable[[dict[str, Any]], dict[str, Any]]) -> Callable[[Mapping[str, Any]], dict[str, Any]]:
@@ -264,13 +301,20 @@ class FileManager:
 
 
 def setup(agent: "BaseAgent") -> FileManager:
-    """Compose the one public ``file`` tool on *agent*."""
+    """Compose the one public ``file`` tool on *agent*.
+
+    The mounted tool name and glossary package come from
+    :data:`~.plugin.FILE_PLUGIN`, so the capability the registry resolves, the
+    family the schema advertises, and the tool actually registered on the agent
+    are the same declared identity. Mounting itself stays the host's: this runs
+    only because ``registry.setup_capability`` called it.
+    """
     manager = FileManager(agent)
     agent.add_tool(
-        "file",
+        FILE_PLUGIN.name,
         schema=get_schema(),
         handler=manager.handle,
         description=get_description(),
-        glossary_package=__package__,
+        glossary_package=FILE_PLUGIN.package,
     )
     return manager

--- a/src/lingtai/tools/file/manual/SKILL.md
+++ b/src/lingtai/tools/file/manual/SKILL.md
@@ -6,6 +6,7 @@ tags: [files, read, write, edit, grep, glob, encoding, utf-8]
 last_changed_at: "2026-08-07T00:00:00Z"
 related_files:
 - src/lingtai/tools/file/__init__.py
+- src/lingtai/tools/file/plugin.py
 - src/lingtai/tools/file/CONTRACT.md
 - src/lingtai/tools/file/_read.py
 - src/lingtai/tools/file/_write.py

--- a/src/lingtai/tools/file/plugin.py
+++ b/src/lingtai/tools/file/plugin.py
@@ -1,0 +1,42 @@
+"""The ``file`` tool plugin descriptor.
+
+One place where this package states who it is: its public capability/family
+name, the module the built-in registry resolves for it, its boot defaults and
+provider metadata, the bundled ``manual/SKILL.md`` its ``manual`` action
+returns, and the actions it *itself* owns. ``manual`` is deliberately absent
+from :data:`FILE_DECLARED_ACTIONS` —
+:class:`~lingtai.tools._plugin.ToolPlugin` appends the reserved action from the
+packaged skill and rejects any attempt to declare it here.
+
+``__init__.py`` consumes this for the public schema, the dispatching family, the
+``PROVIDERS`` mapping, and the ``setup()`` mount. The registry entries
+``BUILTIN_TOOLS["file"]`` / ``CORE_DEFAULTS["file"]`` and the manual destination
+``Agent._install_intrinsic_manuals`` writes this package's ``manual/`` bundle
+into must equal
+:meth:`~lingtai.tools._plugin.ToolPlugin.capability_declaration`; those host
+tables and that install sweep stay the runtime source the host reads.
+"""
+from __future__ import annotations
+
+from .._plugin import ToolPlugin
+
+FILE_PLUGIN = ToolPlugin(
+    name="file",
+    package=__package__,
+    module_dir="file",
+    summary="Unified file capability over one working tree — read, write, edit, glob, grep.",
+    skill_name="file-manual",
+    # ``file`` boots on every agent with no configuration: it needs no provider,
+    # no credentials, and no policy file. This is the ``CORE_DEFAULTS`` entry.
+    defaults={},
+    # One built-in implementation over the injected ``agent._file_io`` service;
+    # there is no provider matrix to choose from.
+    providers={"providers": [], "default": "builtin"},
+)
+
+#: The file family's own public actions, in stable model-facing order. The
+#: reserved ``manual`` action is appended by the plugin, never declared here.
+FILE_DECLARED_ACTIONS: tuple[str, ...] = ("read", "write", "edit", "glob", "grep")
+
+#: The complete public action list, declared actions followed by ``manual``.
+FILE_ACTIONS: tuple[str, ...] = FILE_PLUGIN.actions(FILE_DECLARED_ACTIONS)

--- a/src/lingtai/tools/registry.py
+++ b/src/lingtai/tools/registry.py
@@ -128,6 +128,14 @@ BUILTIN_TOOLS: dict[str, str] = {
     # the envelope dispatch, and all five operation implementations. The
     # pre-migration ``read``/``write``/``edit``/``glob``/``grep`` capabilities
     # and packages are gone, with no alias — those names now fail loudly.
+    #
+    # ``file`` is the one plugin-packaged tool today: this entry and its
+    # ``CORE_DEFAULTS`` entry below must equal
+    # ``lingtai.tools.file.plugin.FILE_PLUGIN.capability_declaration()``
+    # (``tests/test_file_tool_plugin_package.py``). This table stays the
+    # runtime source ``setup_capability`` reads — it is not generated from the
+    # descriptor, because resolving one here would eagerly import the tool and
+    # break this module's lazy-import discipline.
     "file": "lingtai.tools.file",
     "vision": "lingtai.tools.vision",
     # Unified public web capability.  ``web_search`` is a one-way input alias

--- a/src/lingtai/tools/tool_family/BEHAVIORS.md
+++ b/src/lingtai/tools/tool_family/BEHAVIORS.md
@@ -187,7 +187,8 @@ the file or any state.
 - [ ] Step 5: the manual result has exactly the keys `status`, `content`,
       `structuredContent`; `status == "ok"`; `content[0].text` is the full
       body and starts with `name: file-manual`; `structuredContent.manual_path`
-      ends with `capabilities/file-manual/SKILL.md`; the file at that path
+      ends with `capabilities/file/SKILL.md` (the `file` plugin's declared
+      manual destination); the file at that path
       equals the body (the dispatched result is the canonical child result,
       verbatim, no double wrap).
 - [ ] Step 6: any non-empty manual `input` fails with
@@ -355,7 +356,9 @@ no `.rules` file and no ledger record.
       `content`, `structuredContent`; `content[0].text` is the full
       `file-manual` body (`name: file-manual` frontmatter) and equals the file
       read from `structuredContent.manual_path`; the path ends with
-      `capabilities/file-manual/SKILL.md`.
+      `capabilities/file/SKILL.md` — the destination
+      `src/lingtai/tools/file/plugin.py`'s `FILE_PLUGIN` declares for its
+      packaged `manual/SKILL.md`.
 - [ ] Step 2: every non-empty `input` on a strict-empty manual child fails
       with `error_code: "INVALID_ARGUMENT"` before the manual is loaded.
 - [ ] Step 3: avatar's manual returns its own flat shape `{status, action,

--- a/tests/ANATOMY.md
+++ b/tests/ANATOMY.md
@@ -170,6 +170,7 @@ related_files:
   - tests/test_feishu_toolfamily_ltpv2.py
   - tests/test_file_io_sidecar.py
   - tests/test_file_tool_family.py
+  - tests/test_file_tool_plugin_package.py
   - tests/test_filesystem_mail.py
   - tests/test_event_journal_count_nudge.py
   - tests/test_folder_size_nudge.py

--- a/tests/test_file_tool_family.py
+++ b/tests/test_file_tool_family.py
@@ -333,7 +333,7 @@ def test_manual_returns_body_and_path_without_double_wrapping(file_agent):
     body = result["content"][0]["text"]
     manual_path = result["structuredContent"]["manual_path"]
     assert "name: file-manual" in body
-    assert manual_path.endswith("capabilities/file-manual/SKILL.md")
+    assert manual_path.endswith("capabilities/file/SKILL.md")
     assert Path(manual_path).read_text(encoding="utf-8") == body
     # No nested child-result envelope inside the action result.
     assert "content" not in result["structuredContent"]
@@ -363,7 +363,7 @@ def test_manual_rejects_any_input_field(file_agent):
 def test_read_manual_is_a_nested_reference_not_an_action():
     """Read pagination depth stays nested under the one family manual."""
     assert "read-manual" not in get_schema()["properties"]["action"]["enum"]
-    body = Path("src/lingtai/intrinsic_skills/file-manual/SKILL.md").read_text(encoding="utf-8")
+    body = Path("src/lingtai/tools/file/manual/SKILL.md").read_text(encoding="utf-8")
     assert "read-manual" in body, "file-manual must point at the nested read reference"
 
 

--- a/tests/test_file_tool_plugin_package.py
+++ b/tests/test_file_tool_plugin_package.py
@@ -1,0 +1,319 @@
+"""Tool-plugin packaging invariants, proven on the ``file`` reference slice.
+
+A plugin-packaged built-in tool is a package that ships three things together:
+the operation code, the bundled ``manual/SKILL.md`` the host installs into the
+agent's intrinsic library, and the capability declaration the built-in registry
+publishes for it. ``lingtai.tools._plugin.ToolPlugin`` binds those three and
+owns the one promise a package must not be able to break — the reserved
+``manual`` action, appended from the packaged skill rather than declared by the
+package.
+
+These tests pin the packaging promise, the runtime discovery/mount agreement
+(registry tables and the manual install destination), and the *unchanged*
+public file surface around it. They touch only tmp_path working trees.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from lingtai.tools import _plugin
+from lingtai.tools import file as file_tool
+from lingtai.tools._plugin import ToolPlugin, ToolPluginError
+from lingtai.tools.file.plugin import (
+    FILE_ACTIONS,
+    FILE_DECLARED_ACTIONS,
+    FILE_PLUGIN,
+)
+from lingtai.agent import Agent
+from lingtai.tools.tool_family import ChildTool
+from tests._service_helpers import make_gemini_mock_service as make_mock_service
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture
+def file_agent(tmp_path):
+    """One booted agent with the ``file`` capability and its installed library."""
+    workdir = tmp_path / "test"
+    agent = Agent(
+        service=make_mock_service(),
+        agent_name="test",
+        working_dir=workdir,
+        capabilities=["file"],
+    )
+    yield agent, workdir
+    agent.stop(timeout=1.0)
+
+
+def _call(agent, action, input_, **root):
+    return agent._tool_handlers["file"](
+        {"action": action, "input": input_, "reasoning": "focused test", **root}
+    )
+
+
+# ---------------------------------------------------------------------------
+# The package ships its own capability declaration
+# ---------------------------------------------------------------------------
+
+def test_declaration_matches_the_shipped_builtin_registry_entries():
+    """The package owns its capability record; the registry publishes exactly it."""
+    from lingtai.tools import registry
+
+    declaration = FILE_PLUGIN.capability_declaration()
+    assert declaration["name"] == "file"
+    assert registry.BUILTIN_TOOLS["file"] == declaration["module"]
+    assert registry.CORE_DEFAULTS["file"] == declaration["defaults"]
+
+
+def test_declaration_names_the_declaring_package_and_its_own_providers():
+    declaration = FILE_PLUGIN.capability_declaration()
+    assert declaration["module"] == file_tool.__name__ == "lingtai.tools.file"
+    assert declaration["providers"] == file_tool.PROVIDERS
+    # ``get_all_providers`` reads the module attribute; the module aliases the
+    # plugin, so the CLI and the descriptor cannot disagree.
+    from lingtai.tools import registry
+
+    assert registry.get_all_providers()["file"] == declaration["providers"]
+
+
+def test_registry_lookup_is_unchanged_and_still_the_runtime_source():
+    """The descriptor documents the record; it does not replace registry lookup."""
+    from lingtai.tools import registry
+
+    assert registry.BUILTIN_TOOLS["file"] == FILE_PLUGIN.package
+    assert registry.canonical_capability_name("file") == FILE_PLUGIN.name
+
+
+# ---------------------------------------------------------------------------
+# `manual` is mandatory, reserved, and sourced from the packaged skill
+# ---------------------------------------------------------------------------
+
+def test_package_does_not_declare_manual_and_the_plugin_appends_it_last():
+    assert _plugin.MANUAL_ACTION not in FILE_DECLARED_ACTIONS
+    assert FILE_ACTIONS == (*FILE_DECLARED_ACTIONS, "manual")
+    assert FILE_ACTIONS[-1] == "manual"
+    assert file_tool.ACTIONS == FILE_ACTIONS
+
+
+@pytest.mark.parametrize(
+    "compose",
+    [
+        pytest.param(lambda: FILE_PLUGIN.actions(["read", "manual"]), id="actions"),
+        pytest.param(
+            lambda: FILE_PLUGIN.action_input_schemas({"read": {}, "manual": {}}),
+            id="schemas",
+        ),
+        pytest.param(
+            lambda: FILE_PLUGIN.build_family(
+                [
+                    ChildTool("read", {"type": "object"}, lambda _i: {}),
+                    ChildTool("manual", {"type": "object"}, lambda _i: {"hijacked": True}),
+                ]
+            ),
+            id="family",
+        ),
+    ],
+)
+def test_a_package_cannot_declare_re_schema_or_rebind_the_reserved_manual(compose):
+    with pytest.raises(ToolPluginError, match="reserved 'manual'"):
+        compose()
+
+
+def test_composed_family_always_carries_a_manual_child_with_a_strict_empty_input():
+    family = file_tool._build_family()
+    assert family.has_manual()
+    assert family.child_names == FILE_ACTIONS
+    assert file_tool.ACTION_INPUT_SCHEMAS["manual"] == {
+        "type": "object",
+        "properties": {},
+        "required": [],
+        "additionalProperties": False,
+    }
+
+
+def test_the_packaged_skill_is_the_manual_this_plugin_owns():
+    packaged = _REPO_ROOT / "src/lingtai/tools/file/manual/SKILL.md"
+    assert packaged.is_file()
+    assert Path(FILE_PLUGIN.skill_path).name == "SKILL.md"
+    assert FILE_PLUGIN.skill_frontmatter["name"] == "file-manual"
+    assert FILE_PLUGIN.skill_body.strip()
+    assert packaged.read_text(encoding="utf-8").endswith(FILE_PLUGIN.skill_body)
+    # The manual is no longer a standalone kernel skill bundle: the package owns it.
+    assert not (_REPO_ROOT / "src/lingtai/intrinsic_skills/file-manual").exists()
+
+
+# ---------------------------------------------------------------------------
+# The host mounts the packaged manual where the plugin declares
+# ---------------------------------------------------------------------------
+
+def test_manual_destination_is_the_capability_name_the_installer_computes():
+    assert FILE_PLUGIN.manual_destination == FILE_PLUGIN.name == "file"
+    assert file_tool.FAMILY_MANUAL_SKILL == FILE_PLUGIN.manual_destination
+
+
+def test_host_installs_the_packaged_bundle_and_manual_answers_from_it(file_agent):
+    agent, workdir = file_agent
+    installed = (
+        workdir
+        / ".library"
+        / "intrinsic"
+        / "capabilities"
+        / FILE_PLUGIN.manual_destination
+        / "SKILL.md"
+    )
+    assert installed.is_file()
+    installed_body = installed.read_text(encoding="utf-8")
+    packaged = Path(FILE_PLUGIN.skill_path).read_text(encoding="utf-8")
+    assert installed_body == packaged
+
+    result = _call(agent, "manual", {})
+    assert result["status"] == "ok"
+    assert result["content"][0]["text"] == installed_body
+    assert result["structuredContent"]["manual_path"] == str(installed)
+    # Host boundary preserved: the model-visible path is workdir-local, not the
+    # kernel's installed package path.
+    assert str(workdir) in result["structuredContent"]["manual_path"]
+
+
+def test_manual_does_not_reach_any_file_operation(file_agent, monkeypatch):
+    """The plugin-owned manual child never enters the manager's bound operations."""
+    agent, _workdir = file_agent
+
+    def explode(*args, **kwargs):  # pragma: no cover - must never run
+        raise AssertionError("manual must not perform target file I/O")
+
+    for method in ("read", "write", "glob", "grep"):
+        monkeypatch.setattr(agent._file_io, method, explode)
+
+    result = _call(agent, "manual", {})
+    assert result["status"] == "ok"
+    assert result["content"][0]["text"]
+
+
+def test_manual_still_rejects_a_non_empty_input_like_every_other_action(file_agent):
+    agent, _workdir = file_agent
+    rejected = _call(agent, "manual", {"topic": "read"})
+    assert rejected["status"] == "failed"
+    assert rejected["error_code"] == "INVALID_ARGUMENT"
+
+
+# ---------------------------------------------------------------------------
+# The public envelope shape is unchanged by the packaging
+# ---------------------------------------------------------------------------
+
+def test_public_schema_keeps_the_strict_action_family_shape():
+    schema = file_tool.get_schema()
+    assert set(schema["properties"]) == {"action", "input", "reasoning", "summarize"}
+    assert schema["additionalProperties"] is False
+    assert schema["properties"]["action"]["enum"] == list(FILE_ACTIONS)
+    assert len(schema["allOf"]) == len(FILE_ACTIONS)
+    branch_titles = [b["title"] for b in schema["properties"]["input"]["oneOf"]]
+    assert branch_titles == [f"{action} input" for action in FILE_ACTIONS]
+
+
+def test_declared_actions_still_reach_their_own_operations(file_agent):
+    """Sandbox/read/write/edit behavior is unchanged by the plugin packaging."""
+    agent, workdir = file_agent
+    target = workdir / "probe.txt"
+    written = _call(
+        agent, "write", {"file_path": str(target), "content": "alpha\nbeta\n"}
+    )
+    assert written["status"] == "ok"
+    read_back = _call(
+        agent,
+        "read",
+        {"file_path": str(target), "offset": None, "limit": None, "max_chars": None},
+    )
+    assert "alpha" in read_back["content"]
+    edited = _call(
+        agent,
+        "edit",
+        {
+            "file_path": str(target),
+            "old_string": "beta",
+            "new_string": "gamma",
+            "replace_all": None,
+        },
+    )
+    assert edited["status"] == "ok"
+    assert target.read_text(encoding="utf-8") == "alpha\ngamma\n"
+
+
+# ---------------------------------------------------------------------------
+# Descriptor defects fail loudly at import time
+# ---------------------------------------------------------------------------
+
+def test_descriptor_rejects_a_package_that_is_not_its_own_module():
+    with pytest.raises(ToolPluginError, match="must be the 'file' module"):
+        ToolPlugin(
+            name="file",
+            package="lingtai.tools.email",
+            module_dir="file",
+            summary="s",
+            skill_name="file-manual",
+        )
+
+
+def test_descriptor_rejects_a_manual_that_is_not_the_packaged_skill():
+    with pytest.raises(ToolPluginError, match="declares name"):
+        ToolPlugin(
+            name="file",
+            package="lingtai.tools.file",
+            module_dir="file",
+            summary="s",
+            skill_name="somebody-elses-manual",
+        )
+
+
+def test_descriptor_rejects_a_package_with_no_packaged_manual():
+    with pytest.raises(ToolPluginError, match="ships no manual/SKILL.md"):
+        ToolPlugin(
+            name="context",
+            package="lingtai.tools.context",
+            module_dir="context",
+            summary="s",
+            skill_name="context-manual",
+        )
+
+
+@pytest.mark.parametrize("blank_field", ["name", "package", "module_dir", "summary", "skill_name"])
+def test_descriptor_rejects_blank_identity_fields(blank_field):
+    fields = {
+        "name": "file",
+        "package": "lingtai.tools.file",
+        "module_dir": "file",
+        "summary": "s",
+        "skill_name": "file-manual",
+    }
+    fields[blank_field] = "  "
+    with pytest.raises(ToolPluginError, match="non-empty string"):
+        ToolPlugin(**fields)
+
+
+@pytest.mark.parametrize("bad_field", ["defaults", "providers"])
+def test_descriptor_rejects_non_mapping_declaration_fields(bad_field):
+    fields = {
+        "name": "file",
+        "package": "lingtai.tools.file",
+        "module_dir": "file",
+        "summary": "s",
+        "skill_name": "file-manual",
+        bad_field: ["not", "a", "mapping"],
+    }
+    with pytest.raises(ToolPluginError, match="must be a mapping"):
+        ToolPlugin(**fields)
+
+
+def test_descriptor_declaration_is_a_copy_callers_cannot_mutate():
+    first = FILE_PLUGIN.capability_declaration()
+    first["defaults"]["yolo"] = True
+    first["providers"]["default"] = "hijacked"
+    assert FILE_PLUGIN.capability_declaration() == {
+        "name": "file",
+        "module": "lingtai.tools.file",
+        "defaults": {},
+        "providers": {"providers": [], "default": "builtin"},
+        "manual_destination": "file",
+    }

--- a/tests/test_intrinsic_manual_actions.py
+++ b/tests/test_intrinsic_manual_actions.py
@@ -55,13 +55,14 @@ def test_manual_actions_return_their_installed_skills(tmp_path: Path) -> None:
             "system-manual",
             "web",
             "vision",
-            "file-manual",
+            "file",
             "task_card",
         )
     }
 
     # The five old file roots are gone; the one ``file`` family owns a single
-    # ``manual`` action returning ``file-manual``.
+    # ``manual`` action returning its plugin-packaged ``file-manual`` skill,
+    # installed by the host at ``capabilities/file/``.
     file_tool.setup(agent)
 
     shell_manager = shell_tool.ShellManager.__new__(shell_tool.ShellManager)
@@ -97,7 +98,7 @@ def test_manual_actions_return_their_installed_skills(tmp_path: Path) -> None:
         "task_card": ("task_card", lambda: task_card_manager.handle(
             {"action": "manual", "input": {}, "reasoning": "load task card guidance"}
         )),
-        "file": ("file-manual", lambda: agent.handlers["file"](
+        "file": ("file", lambda: agent.handlers["file"](
             {"action": "manual", "input": {}, "reasoning": "load file guidance"}
         )),
     }
@@ -379,7 +380,7 @@ def test_file_manual_bodies_explain_one_time_manual_guidance() -> None:
     asserted. The guidance that still matters is: manual is a one-time lookup,
     ordinary work resumes after it, and repeating it is an error loop.
     """
-    file_body = Path("src/lingtai/intrinsic_skills/file-manual/SKILL.md").read_text(encoding="utf-8")
+    file_body = Path("src/lingtai/tools/file/manual/SKILL.md").read_text(encoding="utf-8")
     read_body = Path("src/lingtai/intrinsic_skills/read-manual/SKILL.md").read_text(encoding="utf-8")
     for body in (file_body, read_body):
         assert "ordinary" in body

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -294,16 +294,17 @@ def test_skills_setup_hard_copies_standalone_intrinsic_skills(tmp_path):
     # copied next to capability manuals under .library/intrinsic/capabilities/.
     agent, workdir = _mk_agent(tmp_path)
     try:
-        skill_md = (
-            workdir
-            / ".library"
-            / "intrinsic"
-            / "capabilities"
-            / "file-manual"
-            / "SKILL.md"
-        )
+        capabilities = workdir / ".library" / "intrinsic" / "capabilities"
+        skill_md = capabilities / "read-manual" / "SKILL.md"
         assert skill_md.is_file()
-        body = skill_md.read_text(encoding="utf-8")
+        assert "name: read-manual" in skill_md.read_text(encoding="utf-8")
+
+        # ``file-manual`` is no longer standalone: it is the ``file`` plugin's
+        # packaged manual bundle, installed by the same sweep at the
+        # destination that plugin declares.
+        file_manual_md = capabilities / "file" / "SKILL.md"
+        assert file_manual_md.is_file()
+        body = file_manual_md.read_text(encoding="utf-8")
         assert "name: file-manual" in body
         assert "encoding='gbk'" in body
         assert "iconv -f gbk -t utf-8" in body


### PR DESCRIPTION
## Summary
- Turns `file` into a real Agent Plugin with its package manifest, runtime discovery/mount wiring, and a plugin-owned manual skill.
- Candidate head: `afa4c783`; this is one isolated tool PR and remains unmerged for Jason’s decision.

## Validation and review context
- Candidate-focused validation and independent review artifacts were completed locally before this PR.
- Any reviewer findings remain preserved with the candidate; this PR is opened under Jason’s explicit all-tool PR instruction (Telegram 14623).

Telegram: @lingtaidev1bot | Nickname: 知微
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
