### PR TITLE
feat: make avatar a real agent plugin

### DIFF
--- a/src/lingtai/tools/ANATOMY.md
+++ b/src/lingtai/tools/ANATOMY.md
@@ -37,6 +37,7 @@ related_files:
   - src/lingtai/tools/lingtai/CONTRACT.md
   - src/lingtai/tools/avatar/ANATOMY.md
   - src/lingtai/tools/avatar/CONTRACT.md
+  - src/lingtai/tools/avatar/plugin.py
   - src/lingtai/tools/bash/ANATOMY.md
   - src/lingtai/tools/bash/CONTRACT.md
   - src/lingtai/tools/bash/_tool_family.py
@@ -46,6 +47,7 @@ related_files:
   - ENVIRONMENT_VARIABLES.md
   - src/lingtai/tools/__init__.py
   - src/lingtai/tools/_manual.py
+  - src/lingtai/tools/_plugin.py
   - src/lingtai/tools/email/ANATOMY.md
   - src/lingtai/tools/i18n/__init__.py
   - src/lingtai/tools/i18n/en.json
@@ -158,6 +160,29 @@ capability names and lazy adapters.
   (`src/lingtai/tools/email/ANATOMY.md`).
 - `_manual.py` — bounded installed-manual loader
   (`src/lingtai/tools/_manual.py:1-29`).
+- `_plugin.py` — built-in tool **plugin packaging** descriptor: `BuiltinToolPlugin`
+  binds one package's identity, its bundled `manual/SKILL.md`, and the capability
+  declaration `registry.py` publishes for it (`capability_declaration()`, the
+  `BUILTIN_TOOLS`/`CORE_DEFAULTS` entry shape). It also owns the reserved-action
+  promise: `actions()`, `child_specs()`, and `build_family()` append `manual`
+  from the packaged skill and raise `BuiltinToolPluginError` if a package
+  declares, re-schemas, or rebinds it. Declarative only — no discovery,
+  import-by-name, spawning, registration, or config reading; activation,
+  privilege, and lifecycle stay with the host (`registry.py`, `BaseAgent.add_tool`,
+  `Agent._install_intrinsic_manuals`). It is the in-process twin of
+  `lingtai.mcp_servers._plugin` and is unrelated to `plugin/`, the catalog tool
+  for external Agent Plugins v1.0.0 directories
+  (`src/lingtai/tools/_plugin.py:98-300`).
+- `avatar/plugin.py` — the reference slice for `_plugin.py`. `AVATAR_PLUGIN`
+  states the capability name, module, boot kwargs, and packaged
+  `avatar-manual` skill; `AVATAR_DECLARED_ACTIONS` lists avatar's own two
+  actions with `manual` deliberately absent, and `AVATAR_ACTIONS` is the
+  plugin-composed public list. `avatar/__init__.py` builds the schema, family,
+  description, and its one `add_tool` registration from it. The other built-in
+  tools still declare these facts inline and are unchanged;
+  `tests/test_builtin_tool_plugin_package.py` pins the packaging invariants and
+  the agreement between `AVATAR_PLUGIN.capability_declaration()` and the
+  shipped `registry.py` entries (`src/lingtai/tools/avatar/plugin.py:25-45`).
 - `__init__.py` — the package docstring that fixes the flat one-directory-per-tool
   layout and the `lingtai → lingtai.tools → lingtai.kernel` import DAG enforced by
   `tests/test_kernel_isolation.py` (`src/lingtai/tools/__init__.py:1-12`).

--- a/src/lingtai/tools/ANATOMY.md
+++ b/src/lingtai/tools/ANATOMY.md
@@ -165,14 +165,17 @@ capability names and lazy adapters.
   declaration `registry.py` publishes for it (`capability_declaration()`, the
   `BUILTIN_TOOLS`/`CORE_DEFAULTS` entry shape). It also owns the reserved-action
   promise: `actions()`, `child_specs()`, and `build_family()` append `manual`
-  from the packaged skill and raise `BuiltinToolPluginError` if a package
-  declares, re-schemas, or rebinds it. Declarative only — no discovery,
+  and raise `BuiltinToolPluginError` if a package declares, re-schemas, or
+  rebinds it. The appended child answers from the host-local installed manual
+  via `_manual.load_installed_manual` — the packaged `manual/SKILL.md` is that
+  copy's source and what `validate_packaged_skill()` checks, never what the
+  action reports. Declarative only — no discovery,
   import-by-name, spawning, registration, or config reading; activation,
   privilege, and lifecycle stay with the host (`registry.py`, `BaseAgent.add_tool`,
   `Agent._install_intrinsic_manuals`). It is the in-process twin of
   `lingtai.mcp_servers._plugin` and is unrelated to `plugin/`, the catalog tool
   for external Agent Plugins v1.0.0 directories
-  (`src/lingtai/tools/_plugin.py:98-300`).
+  (`src/lingtai/tools/_plugin.py:100-330`).
 - `avatar/plugin.py` — the reference slice for `_plugin.py`. `AVATAR_PLUGIN`
   states the capability name, module, boot kwargs, and packaged
   `avatar-manual` skill; `AVATAR_DECLARED_ACTIONS` lists avatar's own two

--- a/src/lingtai/tools/_plugin.py
+++ b/src/lingtai/tools/_plugin.py
@@ -1,0 +1,330 @@
+"""Built-in tool plugin packaging: one package owns its skill, declaration, and family shape.
+
+A built-in tool is not just a module the capability registry happens to import.
+It is a *plugin-style package*: the same folder ships the tool code, the bundled
+``manual/SKILL.md`` the agent library installs, and the capability declaration
+``lingtai.tools.registry`` publishes for it. This module is the small shared
+piece that binds those three together for one package, so a built-in tool cannot
+drift into declaring its module in one place, its manual in another, and a
+public action list that silently disagrees with both.
+
+It is the in-process twin of ``lingtai.mcp_servers._plugin`` (the curated-MCP
+packaging descriptor, reference slice ``mcp_servers/telegram/plugin.py``), and
+it makes the same deliberate omission: it is **not** a plugin runtime. Nothing
+here discovers packages, imports them by name, spawns them, registers them, or
+reads configuration. Activation, execution policy, privilege, lifecycle, and
+namespace decisions all remain the host's: ``lingtai.tools.registry`` still owns
+``BUILTIN_TOOLS``/``CORE_DEFAULTS`` and ``setup_capability()``, ``BaseAgent``
+still owns ``add_tool()`` and boot order, ``Agent._install_intrinsic_manuals``
+still owns the ``.library`` install, and ``lingtai.services.plugin_registry``
+still owns external Agent Plugins v1.0.0 directories (an unrelated, third-party
+surface — do not confuse ``lingtai.tools._plugin`` with ``lingtai.tools.plugin``,
+which is the read-only *catalog tool* for those external plugins). A
+:class:`BuiltinToolPlugin` is a declarative descriptor plus composition helpers
+that its own package calls explicitly.
+
+The one hard promise it enforces is the reserved ``manual`` action
+(``tools/CONTRACT.md`` "Every LingTai-owned family MUST offer a ``manual``
+action"): a package declares only its *own* actions, and this module appends
+``manual`` itself, answered from the package's bundled ``manual/SKILL.md``. A
+package that tries to declare, re-schema, or re-handle ``manual`` raises
+:class:`BuiltinToolPluginError` at import time rather than shipping a family
+whose manual is missing or points somewhere other than its packaged skill.
+
+Deliberate divergence from the curated-MCP twin: that descriptor loads and
+validates its ``SKILL.md`` eagerly at construction and raises on a missing or
+foreign manual. A curated MCP that fails that way loses one subprocess. A
+built-in tool is imported in-process by an agent that may boot it as a core
+default, so an unreadable packaged file must never take agent boot down —
+:meth:`BuiltinToolPlugin.load_manual` therefore reads on demand and *degrades
+truthfully* (``status="degraded"`` plus a naming ``error``, never a foreign
+body), while :meth:`BuiltinToolPlugin.validate_packaged_skill` raises the same
+defect loudly for packaging tests and doctor-style checks. Descriptor-shape
+defects, which need no filesystem, still fail at import.
+"""
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from importlib import resources
+from typing import Any, Callable
+
+from lingtai.kernel._frontmatter import split_frontmatter
+
+from .tool_family import RESERVED_MANUAL_NAME, ChildTool, ToolFamily
+from .tool_family.manual import MANUAL_INPUT_SCHEMA
+
+__all__ = [
+    "BUILTIN_SOURCE",
+    "INSTALLED_MANUAL_ROOT",
+    "MANUAL_ACTION",
+    "MANUAL_RESOURCE",
+    "BuiltinToolPlugin",
+    "BuiltinToolPluginError",
+]
+
+#: ``source`` stamped on every built-in capability declaration — the value that
+#: tells a kernel-shipped built-in tool apart from an external
+#: ``plugin:<name>``-sourced or hand-registered capability.
+BUILTIN_SOURCE = "lingtai-builtin"
+
+#: The reserved action name. Owned by ``lingtai.tools.tool_family``; re-exported
+#: here so a built-in package never spells the literal itself.
+MANUAL_ACTION = RESERVED_MANUAL_NAME
+
+#: The packaged manual resource every built-in tool ships, relative to its own
+#: package root. ``Agent._install_intrinsic_manuals`` copies this ``manual/``
+#: directory verbatim; ``manual`` reads the packaged original, which is the
+#: source of truth for the installed copy.
+MANUAL_RESOURCE = "manual/SKILL.md"
+
+#: Where the host installs that packaged manual inside an agent working dir.
+#: Stated by the descriptor and *performed* by the host — this module writes
+#: nothing.
+INSTALLED_MANUAL_ROOT = ".library/intrinsic/capabilities"
+
+
+class BuiltinToolPluginError(ValueError):
+    """Raised for a built-in tool packaging defect (bad descriptor or skill)."""
+
+
+@dataclass(frozen=True)
+class BuiltinToolPlugin:
+    """One built-in tool package's identity, packaged skill, and capability declaration.
+
+    ``name`` is the public capability name, the model-facing tool name, and the
+    ``.library`` install destination; ``package`` is the Python package that
+    ships both the tool module and the ``manual/SKILL.md`` the ``manual`` action
+    returns. The two are required to agree (``package`` must end in ``name``,
+    or in ``module_name`` for a retained implementation directory whose public
+    name differs, as ``bash``→``shell`` and ``web_search``→``web`` do) because
+    :meth:`capability_declaration` publishes ``package`` as this capability's
+    import path — a descriptor whose module and capability name disagree would
+    advertise somebody else's implementation.
+
+    ``default_kwargs`` is the always-on boot configuration the host's
+    ``CORE_DEFAULTS`` carries for this capability, or ``{}`` for an opt-in one.
+    Stating it here does not enable anything: the registry mapping remains the
+    runtime source the host reads, and this descriptor is what that entry must
+    agree with (proven by test, not by generating the registry at runtime).
+    """
+
+    name: str
+    package: str
+    summary: str
+    skill_name: str
+    module_name: str = ""
+    default_kwargs: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        for attribute in ("name", "package", "summary", "skill_name"):
+            value = getattr(self, attribute)
+            if not isinstance(value, str) or not value.strip():
+                raise BuiltinToolPluginError(
+                    f"BuiltinToolPlugin {attribute!r} must be a non-empty string"
+                )
+        if not isinstance(self.module_name, str):
+            raise BuiltinToolPluginError(
+                "BuiltinToolPlugin 'module_name' must be a string"
+            )
+        if not isinstance(self.default_kwargs, Mapping):
+            raise BuiltinToolPluginError(
+                "BuiltinToolPlugin 'default_kwargs' must be a mapping"
+            )
+        if not self.package.startswith("lingtai.tools."):
+            raise BuiltinToolPluginError(
+                f"BuiltinToolPlugin package {self.package!r} must live under "
+                "'lingtai.tools.' — this descriptor packages a built-in tool, "
+                "not an external Agent Plugin"
+            )
+        if self.package.rpartition(".")[2] != self.module:
+            raise BuiltinToolPluginError(
+                f"BuiltinToolPlugin package {self.package!r} must be the "
+                f"{self.module!r} module so its declared capability imports its "
+                "own implementation"
+            )
+
+    @property
+    def module(self) -> str:
+        """The implementation directory name (``module_name`` or ``name``)."""
+        return self.module_name or self.name
+
+    # -- packaged skill / manual -------------------------------------------
+
+    def manual_resource(self) -> Any:
+        """The packaged ``manual/SKILL.md`` traversable, unread."""
+        return resources.files(self.package).joinpath(MANUAL_RESOURCE)
+
+    def load_manual(self) -> dict[str, Any]:
+        """Read the packaged skill → the flat installed-manual result shape.
+
+        Returns ``{status, manual, manual_path}`` — the same three keys
+        ``lingtai.tools._manual.load_installed_manual`` returns — plus ``error``
+        when degraded. ``manual`` is the *whole* ``SKILL.md`` text, frontmatter
+        included, because that is the document the skill catalog and the model
+        both read.
+
+        Read on demand rather than cached at construction: a built-in tool is
+        imported in-process during agent boot, and a packaging fault must
+        degrade this one action rather than fail the import. A manual that is
+        present but is not this plugin's declared skill is refused, not served:
+        the body comes back empty with an ``error`` naming the mismatch.
+        """
+        resource = self.manual_resource()
+        try:
+            text = resource.read_text(encoding="utf-8")
+        except (FileNotFoundError, ModuleNotFoundError, AttributeError, OSError):
+            return self._degraded(str(resource), f"{self.name} manual missing")
+
+        path = str(resource)
+        frontmatter, body = split_frontmatter(text)
+        declared = frontmatter.get("name", "")
+        if declared != self.skill_name:
+            return self._degraded(
+                path,
+                f"{self.name} manual declares skill {declared!r}, expected "
+                f"{self.skill_name!r}",
+            )
+        if not body.strip():
+            return self._degraded(path, f"{self.name} manual has an empty body")
+        return {"status": "ok", "manual": text, "manual_path": path}
+
+    @staticmethod
+    def _degraded(path: str, error: str) -> dict[str, Any]:
+        return {"status": "degraded", "manual": "", "manual_path": path, "error": error}
+
+    def manual_payload(self) -> dict[str, Any]:
+        """The ``action='manual'`` result: the packaged skill, named by its action."""
+        loaded = self.load_manual()
+        payload: dict[str, Any] = {
+            "status": loaded["status"],
+            "action": MANUAL_ACTION,
+            "manual": loaded["manual"],
+            "manual_path": loaded["manual_path"],
+        }
+        if "error" in loaded:
+            payload["error"] = loaded["error"]
+        return payload
+
+    def manual_child(self) -> ChildTool:
+        """The plugin-owned reserved ``manual`` child.
+
+        Its handler closes over this descriptor's packaged skill, so ``manual``
+        never routes through the package's manager and cannot be rebound to
+        other material by anything the manager does.
+        """
+        return ChildTool(
+            MANUAL_ACTION,
+            MANUAL_INPUT_SCHEMA,
+            lambda _input: self.manual_payload(),
+            title=f"{MANUAL_ACTION} input",
+        )
+
+    def validate_packaged_skill(self) -> None:
+        """Raise if the packaged manual is missing, empty, or a foreign skill.
+
+        The loud form of :meth:`load_manual`'s degraded result, for packaging
+        tests and doctor-style checks that want a packaging defect to fail
+        rather than be reported at runtime.
+        """
+        loaded = self.load_manual()
+        if loaded["status"] != "ok":
+            raise BuiltinToolPluginError(
+                f"BuiltinToolPlugin {self.name!r}: {loaded.get('error', 'unusable manual')}"
+            )
+
+    def installed_manual_path(self) -> str:
+        """Agent-relative path the host installs this packaged skill to.
+
+        ``Agent._install_intrinsic_manuals`` copies ``<package>/manual/`` into
+        ``.library/intrinsic/capabilities/<name>/`` on every boot, keyed by the
+        *public* name — which is why a retained implementation directory must
+        declare ``module_name`` instead of renaming this destination.
+        """
+        return f"{INSTALLED_MANUAL_ROOT}/{self.name}/SKILL.md"
+
+    # -- family composition -------------------------------------------------
+
+    def actions(self, declared: Sequence[str]) -> tuple[str, ...]:
+        """Declared actions plus the reserved ``manual``, in that order."""
+        self._check_declared_names(declared)
+        return tuple(declared) + (MANUAL_ACTION,)
+
+    def child_specs(
+        self, declared: Sequence[tuple[str, dict[str, Any]]]
+    ) -> tuple[tuple[str, dict[str, Any]], ...]:
+        """Declared ``(action, input schema)`` specs plus the reserved ``manual``.
+
+        The appended ``manual`` spec is the one shared
+        :data:`~lingtai.tools.tool_family.manual.MANUAL_INPUT_SCHEMA` object, not
+        a copy, so a family that declares this schema and the child that
+        dispatches it cannot drift apart.
+        """
+        self._check_declared_names([name for name, _schema in declared])
+        return tuple(declared) + ((MANUAL_ACTION, MANUAL_INPUT_SCHEMA),)
+
+    def build_family(self, declared: Sequence[ChildTool]) -> ToolFamily:
+        """Compose this plugin's one public family, ``manual`` always appended."""
+        self._check_declared_names([child.name for child in declared])
+        return ToolFamily(self.name, [*declared, self.manual_child()])
+
+    def _check_declared_names(self, declared: Sequence[str] | Any) -> None:
+        names = list(declared)
+        if not names:
+            raise BuiltinToolPluginError(
+                f"BuiltinToolPlugin {self.name!r} must declare at least one action"
+            )
+        if MANUAL_ACTION in names:
+            raise BuiltinToolPluginError(
+                f"BuiltinToolPlugin {self.name!r} must not declare the reserved "
+                f"{MANUAL_ACTION!r} action; it is appended from the packaged "
+                f"{MANUAL_RESOURCE}"
+            )
+        if len(set(names)) != len(names):
+            raise BuiltinToolPluginError(
+                f"BuiltinToolPlugin {self.name!r} declared a duplicate action"
+            )
+
+    # -- shipped capability declaration / mount -----------------------------
+
+    def capability_declaration(self) -> dict[str, Any]:
+        """This package's built-in capability record, in registry-entry shape.
+
+        The same facts ``lingtai.tools.registry`` publishes: the capability name
+        (``BUILTIN_TOOLS`` key), the module it imports (``BUILTIN_TOOLS`` value),
+        and the always-on boot kwargs (``CORE_DEFAULTS`` value, ``{}`` when the
+        capability is opt-in). Returning it here registers and activates
+        nothing: the registry mapping remains the runtime source the host reads
+        and lazily imports, and this descriptor is what that entry must agree
+        with.
+        """
+        return {
+            "name": self.name,
+            "module": self.package,
+            "default_kwargs": dict(self.default_kwargs),
+            "source": BUILTIN_SOURCE,
+            "summary": self.summary,
+            "manual_skill": self.skill_name,
+            "installed_manual_path": self.installed_manual_path(),
+        }
+
+    def tool_registration(
+        self,
+        *,
+        schema: Mapping[str, Any],
+        description: str,
+        handler: Callable[..., Any],
+    ) -> dict[str, Any]:
+        """The ``BaseAgent.add_tool`` keyword arguments for this plugin's one tool.
+
+        Composition only — the package's own ``setup()`` still performs the
+        call, so tool registration stays exactly where the host's capability
+        boot put it. What is registered (public name, glossary package) comes
+        from the descriptor instead of being restated at the call site.
+        """
+        return {
+            "schema": dict(schema),
+            "handler": handler,
+            "description": description,
+            "glossary_package": self.package,
+        }

--- a/src/lingtai/tools/_plugin.py
+++ b/src/lingtai/tools/_plugin.py
@@ -26,21 +26,27 @@ that its own package calls explicitly.
 The one hard promise it enforces is the reserved ``manual`` action
 (``tools/CONTRACT.md`` "Every LingTai-owned family MUST offer a ``manual``
 action"): a package declares only its *own* actions, and this module appends
-``manual`` itself, answered from the package's bundled ``manual/SKILL.md``. A
-package that tries to declare, re-schema, or re-handle ``manual`` raises
+``manual`` itself, answered — like every other LingTai family's ``manual`` —
+from the host-local copy the host installed for *this* agent, through the one
+shared :func:`lingtai.tools._manual.load_installed_manual`. The packaged
+``manual/SKILL.md`` is that copy's source, not the document the agent reads,
+so it is what :meth:`BuiltinToolPlugin.validate_packaged_skill` checks and
+what the host installs — never what the action reports. A package that tries
+to declare, re-schema, or re-handle ``manual`` raises
 :class:`BuiltinToolPluginError` at import time rather than shipping a family
-whose manual is missing or points somewhere other than its packaged skill.
+whose manual is missing or points somewhere other than its own skill.
 
 Deliberate divergence from the curated-MCP twin: that descriptor loads and
 validates its ``SKILL.md`` eagerly at construction and raises on a missing or
 foreign manual. A curated MCP that fails that way loses one subprocess. A
 built-in tool is imported in-process by an agent that may boot it as a core
 default, so an unreadable packaged file must never take agent boot down —
-:meth:`BuiltinToolPlugin.load_manual` therefore reads on demand and *degrades
-truthfully* (``status="degraded"`` plus a naming ``error``, never a foreign
-body), while :meth:`BuiltinToolPlugin.validate_packaged_skill` raises the same
-defect loudly for packaging tests and doctor-style checks. Descriptor-shape
-defects, which need no filesystem, still fail at import.
+:meth:`BuiltinToolPlugin.load_manual` therefore reads the packaged skill on
+demand and *degrades truthfully* (``status="degraded"`` plus a naming
+``error``, never a foreign body), while
+:meth:`BuiltinToolPlugin.validate_packaged_skill` raises the same defect
+loudly for packaging tests and doctor-style checks. Descriptor-shape defects,
+which need no filesystem, still fail at import.
 """
 from __future__ import annotations
 
@@ -51,6 +57,7 @@ from typing import Any, Callable
 
 from lingtai.kernel._frontmatter import split_frontmatter
 
+from ._manual import load_installed_manual
 from .tool_family import RESERVED_MANUAL_NAME, ChildTool, ToolFamily
 from .tool_family.manual import MANUAL_INPUT_SCHEMA
 
@@ -74,8 +81,9 @@ MANUAL_ACTION = RESERVED_MANUAL_NAME
 
 #: The packaged manual resource every built-in tool ships, relative to its own
 #: package root. ``Agent._install_intrinsic_manuals`` copies this ``manual/``
-#: directory verbatim; ``manual`` reads the packaged original, which is the
-#: source of truth for the installed copy.
+#: directory verbatim into :data:`INSTALLED_MANUAL_ROOT`; the packaged original
+#: is the source of truth for that installed copy, and the ``manual`` action
+#: serves the installed copy — the document the agent itself can read.
 MANUAL_RESOURCE = "manual/SKILL.md"
 
 #: Where the host installs that packaged manual inside an agent working dir.
@@ -156,13 +164,15 @@ class BuiltinToolPlugin:
         return resources.files(self.package).joinpath(MANUAL_RESOURCE)
 
     def load_manual(self) -> dict[str, Any]:
-        """Read the packaged skill → the flat installed-manual result shape.
+        """Read and validate the *packaged* skill → the flat loader result shape.
 
-        Returns ``{status, manual, manual_path}`` — the same three keys
-        ``lingtai.tools._manual.load_installed_manual`` returns — plus ``error``
-        when degraded. ``manual`` is the *whole* ``SKILL.md`` text, frontmatter
-        included, because that is the document the skill catalog and the model
-        both read.
+        The packaging-side read: the source ``Agent._install_intrinsic_manuals``
+        copies from, not the host-local document the ``manual`` action serves
+        (:meth:`manual_payload`). Returns ``{status, manual, manual_path}`` —
+        the same three keys ``lingtai.tools._manual.load_installed_manual``
+        returns — plus ``error`` when degraded. ``manual`` is the *whole*
+        ``SKILL.md`` text, frontmatter included, because that is the document
+        the skill catalog and the model both read.
 
         Read on demand rather than cached at construction: a built-in tool is
         imported in-process during agent boot, and a packaging fault must
@@ -193,9 +203,22 @@ class BuiltinToolPlugin:
     def _degraded(path: str, error: str) -> dict[str, Any]:
         return {"status": "degraded", "manual": "", "manual_path": path, "error": error}
 
-    def manual_payload(self) -> dict[str, Any]:
-        """The ``action='manual'`` result: the packaged skill, named by its action."""
-        loaded = self.load_manual()
+    def manual_payload(self, agent: Any) -> dict[str, Any]:
+        """The ``action='manual'`` result: this agent's installed skill, named by its action.
+
+        *agent* is the host this capability is mounted on. The manual reported
+        is the host-local copy at :meth:`installed_manual_path` inside that
+        agent's working dir — the document the agent can actually open, and the
+        one every other LingTai family's ``manual`` reports via the shared
+        ``load_installed_manual``. Reporting the packaged source path instead
+        would hand the model a path outside its own working dir, and one that
+        does not exist at all in an installed distribution.
+
+        A missing installed copy degrades truthfully (the loader's own
+        ``status``/``error``); it is never silently backfilled from the
+        packaged source, because that would hide a failed install.
+        """
+        loaded = load_installed_manual(agent, self.name)
         payload: dict[str, Any] = {
             "status": loaded["status"],
             "action": MANUAL_ACTION,
@@ -206,17 +229,19 @@ class BuiltinToolPlugin:
             payload["error"] = loaded["error"]
         return payload
 
-    def manual_child(self) -> ChildTool:
-        """The plugin-owned reserved ``manual`` child.
+    def manual_child(self, agent: Any) -> ChildTool:
+        """The plugin-owned reserved ``manual`` child, bound to one host.
 
-        Its handler closes over this descriptor's packaged skill, so ``manual``
+        Its handler closes over this descriptor and *agent*, so ``manual``
         never routes through the package's manager and cannot be rebound to
-        other material by anything the manager does.
+        other material by anything the manager does. *agent* may be ``None``
+        for a module-level schema-only family that never dispatches, matching
+        ``tool_family.manual.build_manual_child``'s own contract.
         """
         return ChildTool(
             MANUAL_ACTION,
             MANUAL_INPUT_SCHEMA,
-            lambda _input: self.manual_payload(),
+            lambda _input: self.manual_payload(agent),
             title=f"{MANUAL_ACTION} input",
         )
 
@@ -239,7 +264,8 @@ class BuiltinToolPlugin:
         ``Agent._install_intrinsic_manuals`` copies ``<package>/manual/`` into
         ``.library/intrinsic/capabilities/<name>/`` on every boot, keyed by the
         *public* name — which is why a retained implementation directory must
-        declare ``module_name`` instead of renaming this destination.
+        declare ``module_name`` instead of renaming this destination. This is
+        the manual the ``manual`` action reads and reports.
         """
         return f"{INSTALLED_MANUAL_ROOT}/{self.name}/SKILL.md"
 
@@ -263,10 +289,14 @@ class BuiltinToolPlugin:
         self._check_declared_names([name for name, _schema in declared])
         return tuple(declared) + ((MANUAL_ACTION, MANUAL_INPUT_SCHEMA),)
 
-    def build_family(self, declared: Sequence[ChildTool]) -> ToolFamily:
-        """Compose this plugin's one public family, ``manual`` always appended."""
+    def build_family(self, declared: Sequence[ChildTool], agent: Any) -> ToolFamily:
+        """Compose this plugin's one public family, ``manual`` always appended.
+
+        *agent* is the host whose installed manual the appended child serves;
+        it may be ``None`` for a schema-only family that never dispatches.
+        """
         self._check_declared_names([child.name for child in declared])
-        return ToolFamily(self.name, [*declared, self.manual_child()])
+        return ToolFamily(self.name, [*declared, self.manual_child(agent)])
 
     def _check_declared_names(self, declared: Sequence[str] | Any) -> None:
         names = list(declared)

--- a/src/lingtai/tools/avatar/ANATOMY.md
+++ b/src/lingtai/tools/avatar/ANATOMY.md
@@ -69,7 +69,7 @@ family (`src/lingtai/tools/CONTRACT.md`) whose actions are canonical children:
 |------|------|-------------|
 | `spawn` | `name`, `type`, `comment`, `dry_run`, `confirm` | Spawn a new avatar agent (shallow or deep). `dry_run` previews only; `confirm` acknowledges the mission-quality gate. |
 | `rules` | `rules_content` | Set rules content and distribute via `.rules` signal files to self + all descendants. Karma-gated. |
-| `manual` | *(empty)* | Read-only, **plugin-owned**: `AVATAR_PLUGIN` appends this child and answers it from the packaged `manual/SKILL.md` — the manager holds no binding for it. Returns the exact body plus its host-local `manual_path`. No spawn or rules I/O. |
+| `manual` | *(empty)* | Read-only, **plugin-owned**: `AVATAR_PLUGIN` appends this child and answers it from the agent's installed `.library/intrinsic/capabilities/avatar/SKILL.md` — the manager holds no binding for it. Returns that exact body plus its host-local `manual_path`. No spawn or rules I/O. |
 
 The model-facing root is exactly `action` + `input` + required `reasoning` +
 optional `summarize`, `additionalProperties: false`. Each action owns exactly
@@ -160,16 +160,25 @@ avatar/__init__.py
   (`tests/test_builtin_tool_plugin_package.py`) rather than by importing the
   descriptor into the registry.
 - **Reserved `manual` is plugin-owned:** avatar declares only `spawn` and
-  `rules`; `AVATAR_PLUGIN` appends `manual` and answers it from the packaged
-  skill. Declaring, re-schema'ing, or rebinding it raises
+  `rules`; `AVATAR_PLUGIN` appends `manual` and answers it from the host-local
+  installed skill. Declaring, re-schema'ing, or rebinding it raises
   `BuiltinToolPluginError` at import time, and no `AvatarManager` change can
   drop or replace the document the action serves.
+- **`manual_path` is the agent's own file:** like every other LingTai family's
+  `manual`, the action loads `.library/intrinsic/capabilities/avatar/SKILL.md`
+  from the calling agent's working dir through the one shared
+  `lingtai.tools._manual.load_installed_manual`, so the path handed to the
+  model is one it can open. The packaged `manual/SKILL.md` is that copy's
+  source, not the agent-visible document, and is never reported. An agent with
+  no installed copy degrades truthfully (`status: "degraded"` plus the loader's
+  `error`) rather than being backfilled from the source, which would hide a
+  failed install.
 - **Packaging faults degrade, boot does not:** the packaged skill is read on
   demand, not cached at construction (the deliberate divergence from the
-  curated-MCP twin). A missing, empty, or foreign `manual/SKILL.md` degrades
-  that one action with a truthful `error` and is never served as a body;
-  `AVATAR_PLUGIN.validate_packaged_skill()` raises the same defect loudly for
-  packaging checks. A core-default capability must not fail an agent's import.
+  curated-MCP twin), so a missing, empty, or foreign `manual/SKILL.md` never
+  fails the import of a core-default capability;
+  `AVATAR_PLUGIN.validate_packaged_skill()` raises that packaging defect loudly
+  for packaging checks.
 - **Name validation:** Avatar names must match `^[\w-]+$` (Unicode-aware), max 64 chars, no dots or path separators. The name doubles as the working directory basename.
 - **Path scope:** The avatar's working directory must be a direct sibling of the parent's (same parent directory). Resolved path is checked against the network root to prevent escape.
 - **No identity inheritance:** Avatars get no name (`agent_name` is set to the avatar name), no admin privileges, no comment, no brief, no addons (IMAP/Telegram). The inherited `lingtai` seed is blanked; the first turn still arrives via a separate `.prompt` signal file.
@@ -198,7 +207,8 @@ avatar/__init__.py
 `Agent._install_intrinsic_manuals` copies this package's `manual/` directory
 into `.library/intrinsic/capabilities/avatar/` on every boot — the destination
 `AVATAR_PLUGIN.installed_manual_path()` names. The packaged file stays the
-source of truth: `action="manual"` reads it, never the installed copy.
+source of truth for that copy; `action="manual"` reads and reports the
+installed copy, which is the one the agent itself can open.
 
 Platform process mechanics are in `adapters/avatar_launcher.py` and the
 POSIX reference adapter. Unsupported Windows selection fails loudly; a future

--- a/src/lingtai/tools/avatar/ANATOMY.md
+++ b/src/lingtai/tools/avatar/ANATOMY.md
@@ -5,6 +5,8 @@ related_files:
   - src/lingtai/tools/ANATOMY.md
   - src/lingtai/tools/avatar/BEHAVIORS.md
   - src/lingtai/tools/avatar/__init__.py
+  - src/lingtai/tools/avatar/plugin.py
+  - src/lingtai/tools/_plugin.py
   - src/lingtai/tools/avatar/_launcher.py
   - src/lingtai/tools/avatar/CONTRACT.md
   - src/lingtai/adapters/avatar_launcher.py
@@ -14,6 +16,7 @@ related_files:
   - src/lingtai/tools/tool_family/ANATOMY.md
   - tests/test_avatar_rules.py
   - tests/test_tool_family_avatar_migration.py
+  - tests/test_builtin_tool_plugin_package.py
   - src/lingtai/tools/avatar/glossary-en.md
   - src/lingtai/tools/avatar/glossary-zh.md
   - src/lingtai/tools/avatar/glossary-wen.md
@@ -42,10 +45,20 @@ independent life — its existence does not depend on yours.
 
 ## Components
 
+- `avatar/plugin.py` — the **built-in tool plugin descriptor**. One place that
+  states avatar's capability/tool name, the module the registry imports, the
+  always-on boot kwargs, the packaged `avatar-manual` skill, avatar's own
+  declared actions, and the model-facing root description. `AVATAR_PLUGIN`
+  appends the reserved `manual` action from the packaged skill and refuses any
+  attempt to declare it (`avatar/plugin.py:25-45`).
 - `avatar/__init__.py` — validation, preparation, boot policy, ledger, rules,
   schemas, and setup. The core class is `AvatarManager`.
 - `avatar/_launcher.py` — immutable launch request/receipt and the avatar-local
   opaque-handle Port.
+- `../_plugin.py` — the shared `BuiltinToolPlugin` packaging descriptor avatar
+  is the reference slice for: identity checks, the reserved-`manual` promise,
+  family composition, the capability declaration, and the `add_tool` kwargs.
+  Declarative only — it discovers, imports, spawns, and registers nothing.
 
 ## Public API
 
@@ -56,7 +69,7 @@ family (`src/lingtai/tools/CONTRACT.md`) whose actions are canonical children:
 |------|------|-------------|
 | `spawn` | `name`, `type`, `comment`, `dry_run`, `confirm` | Spawn a new avatar agent (shallow or deep). `dry_run` previews only; `confirm` acknowledges the mission-quality gate. |
 | `rules` | `rules_content` | Set rules content and distribute via `.rules` signal files to self + all descendants. Karma-gated. |
-| `manual` | *(empty)* | Read-only: returns the exact `manual/SKILL.md` body plus its host-local `manual_path`. No spawn or rules I/O. |
+| `manual` | *(empty)* | Read-only, **plugin-owned**: `AVATAR_PLUGIN` appends this child and answers it from the packaged `manual/SKILL.md` — the manager holds no binding for it. Returns the exact body plus its host-local `manual_path`. No spawn or rules I/O. |
 
 The model-facing root is exactly `action` + `input` + required `reasoning` +
 optional `summarize`, `additionalProperties: false`. Each action owns exactly
@@ -85,24 +98,39 @@ unknown-action error string.
 ## Internal Module Layout
 
 ```
+avatar/plugin.py
+  ├── AVATAR_PLUGIN                 — the BuiltinToolPlugin descriptor:
+  │                                    identity, packaged skill, capability
+  │                                    declaration, add_tool kwargs
+  ├── AVATAR_DECLARED_ACTIONS       — avatar's own actions ('manual' absent)
+  ├── AVATAR_ACTIONS                — declared + the appended 'manual'
+  └── AVATAR_DESCRIPTION            — the model-facing root description,
+                                       pointing at the plugin's own skill name
+
 avatar/__init__.py
   ├── _SPAWN/_RULES_INPUT_SCHEMA    — canonical strict per-action inputs
-  │                                    (manual reuses the generic
+  ├── _DECLARED_CHILD_SPECS         — avatar's own (action, schema) pairs
+  ├── _CHILD_SPECS                  — the plugin-composed listing: declared
+  │                                    plus ('manual', the shared
   │                                    tool_family.manual.MANUAL_INPUT_SCHEMA)
-  ├── _CHILD_SPECS                  — the one (action, schema) source both
-  │                                    family listings are built from
-  ├── _build_family() / _FAMILY     — import-time registry validation;
-  │                                    get_schema() composes from _FAMILY
+  ├── _SUPPORTED_ACTIONS_PHRASE     — the pinned unknown-action wording,
+  │                                    rendered from AVATAR_ACTIONS
+  ├── _build_family() / _FAMILY     — AVATAR_PLUGIN.build_family() appends the
+  │                                    plugin-owned manual child; import-time
+  │                                    registry validation; get_schema()
+  │                                    composes from _FAMILY
   ├── AvatarManager.__init__        — parent agent ref + per-instance ToolFamily
   ├── handle()                      — envelope entry: captures root _reasoning,
   │                                    delegates to ToolFamily.handle(), then
   │                                    normalizes ACTION_REQUIRED back to
   │                                    avatar's pinned unknown-action error
-  ├── _dispatch_spawn/_rules/_manual — child handlers; strip nulls, thread
-  │                                    the mission brief to _spawn
+  ├── _dispatch_spawn/_rules        — child handlers; strip nulls, thread
+  │                                    the mission brief to _spawn. There is
+  │                                    no manual dispatcher: the plugin owns it
   ├── _strip_nulls()                — nullable-optional → absent
-  ├── _manual()                     — reads the packaged manual/SKILL.md body
-  │                                    and reports its host-local path
+  ├── _manual()                     — read-only convenience delegate to
+  │                                    AVATAR_PLUGIN.manual_payload(); the
+  │                                    public action does not route here
   │
   │  Spawn pipeline:
   ├── _spawn()                      — validates name, checks liveness, prepares working dir, launches process
@@ -123,6 +151,25 @@ avatar/__init__.py
 
 ## Key Invariants
 
+- **Plugin packaging:** avatar is a built-in tool *plugin package*. `plugin.py`
+  is the single source for its identity, and `AVATAR_PLUGIN.capability_declaration()`
+  must equal the shipped `registry.BUILTIN_TOOLS["avatar"]` /
+  `registry.CORE_DEFAULTS["avatar"]` entries. The registry mapping stays the
+  runtime source the host reads and lazily imports — importing the registry
+  must not import this package, so the agreement is proven by test
+  (`tests/test_builtin_tool_plugin_package.py`) rather than by importing the
+  descriptor into the registry.
+- **Reserved `manual` is plugin-owned:** avatar declares only `spawn` and
+  `rules`; `AVATAR_PLUGIN` appends `manual` and answers it from the packaged
+  skill. Declaring, re-schema'ing, or rebinding it raises
+  `BuiltinToolPluginError` at import time, and no `AvatarManager` change can
+  drop or replace the document the action serves.
+- **Packaging faults degrade, boot does not:** the packaged skill is read on
+  demand, not cached at construction (the deliberate divergence from the
+  curated-MCP twin). A missing, empty, or foreign `manual/SKILL.md` degrades
+  that one action with a truthful `error` and is never served as a body;
+  `AVATAR_PLUGIN.validate_packaged_skill()` raises the same defect loudly for
+  packaging checks. A core-default capability must not fail an agent's import.
 - **Name validation:** Avatar names must match `^[\w-]+$` (Unicode-aware), max 64 chars, no dots or path separators. The name doubles as the working directory basename.
 - **Path scope:** The avatar's working directory must be a direct sibling of the parent's (same parent directory). Resolved path is checked against the network root to prevent escape.
 - **No identity inheritance:** Avatars get no name (`agent_name` is set to the avatar name), no admin privileges, no comment, no brief, no addons (IMAP/Telegram). The inherited `lingtai` seed is blanked; the first turn still arrives via a separate `.prompt` signal file.
@@ -146,7 +193,12 @@ avatar/__init__.py
 
 - **Parent:** `src/lingtai/tools/` (tool package).
 - **Siblings:** `daemon/`, `mcp/`, `knowledge/` (private durable memory), `skills/` (skill catalog), `bash/`.
-- **Kernel hooks:** `setup()` is called during capability initialization; `AvatarManager.handle()` is registered as the single `avatar` tool handler, internally dispatching `spawn`/`rules`/`manual` through its own `tool_family.ToolFamily`. `avatar` is on the kernel's `_LTP_V2_MIGRATED_FAMILIES` allowlist (`src/lingtai/kernel/tool_result_summary.py`), so the root `summarize` boolean it advertises is actually honored by the single central summarizer. The daemon capability blacklists `avatar` to prevent avatar-in-daemon recursion and rules mutation from emanations.
+- **Kernel hooks:** `setup()` is called during capability initialization and performs the one `add_tool` call from `AVATAR_PLUGIN.tool_registration()` (composition only — the host still decides whether setup runs at all); `AvatarManager.handle()` is registered as the single `avatar` tool handler, internally dispatching `spawn`/`rules`/`manual` through its own `tool_family.ToolFamily`. `avatar` is on the kernel's `_LTP_V2_MIGRATED_FAMILIES` allowlist (`src/lingtai/kernel/tool_result_summary.py`), so the root `summarize` boolean it advertises is actually honored by the single central summarizer. The daemon capability blacklists `avatar` to prevent avatar-in-daemon recursion and rules mutation from emanations.
+
+`Agent._install_intrinsic_manuals` copies this package's `manual/` directory
+into `.library/intrinsic/capabilities/avatar/` on every boot — the destination
+`AVATAR_PLUGIN.installed_manual_path()` names. The packaged file stays the
+source of truth: `action="manual"` reads it, never the installed copy.
 
 Platform process mechanics are in `adapters/avatar_launcher.py` and the
 POSIX reference adapter. Unsupported Windows selection fails loudly; a future

--- a/src/lingtai/tools/avatar/CONTRACT.md
+++ b/src/lingtai/tools/avatar/CONTRACT.md
@@ -67,8 +67,10 @@ per-action `input` object, and the model-facing root is exactly `action`,
   one call into the next.
 - The unknown/omitted-`action` error envelope is **preserved exactly** (see
   §Invalid or missing `action`).
-- `manual`'s result gains `manual_path` (the host-local packaged resource
-  path) alongside the unchanged `status`, `action`, and exact `manual` body.
+- `manual`'s result gains `manual_path` (the host-local installed path,
+  `.library/intrinsic/capabilities/avatar/SKILL.md` inside the calling agent's
+  working dir) alongside the unchanged `status`, `action`, and exact `manual`
+  body.
 - `avatar` joins the kernel's `_LTP_V2_MIGRATED_FAMILIES` allowlist so the
   root `summarize` boolean it advertises is honored by the single central
   summarizer rather than silently ignored.
@@ -121,19 +123,20 @@ storage; detached-process launch -> §Cross-platform invariants.
 - `action="rules"` writes a `.rules` signal to the caller and every descendant
   so each agent refreshes its own `system/rules.md`-derived prompt. It carries
   its own admin gate, independent of `spawn` — spawning never requires admin.
-- `action="manual"` is read-only: it returns the exact packaged
-  `src/lingtai/tools/avatar/manual/SKILL.md` body plus its host-local
-  `manual_path`, and performs no filesystem mutation (no spawn, no ledger
-  write, no `.rules` write). The action is **plugin-owned**: `AVATAR_PLUGIN`
+- `action="manual"` is read-only: it returns the exact
+  `.library/intrinsic/capabilities/avatar/SKILL.md` body installed in the
+  calling agent's working dir plus that host-local `manual_path`, and performs
+  no filesystem mutation (no spawn, no ledger write, no `.rules` write). The
+  action is **plugin-owned**: `AVATAR_PLUGIN`
   (`src/lingtai/tools/avatar/plugin.py`) appends the reserved child and answers
-  it straight from the packaged skill, so `AvatarManager` has no `manual`
-  binding to drop or rebind. Avatar's manual is read from the package rather
-  than from the agent's installed `.library` intrinsic catalog, so the plugin
-  owns this loader instead of the shared
-  `load_installed_manual`/`build_manual_child` pair — that builder would
-  report a `.library` path this family never reads. The packaged copy is the
-  source of truth for the installed one: the host copies `manual/` to
-  `.library/intrinsic/capabilities/avatar/` on every boot.
+  it itself, so `AvatarManager` has no `manual` binding to drop or rebind. Like
+  every other LingTai family's `manual`, it reads that installed copy through
+  the one shared `lingtai.tools._manual.load_installed_manual`, so the path the
+  model is handed is one it can open from its own working dir. The packaged
+  `src/lingtai/tools/avatar/manual/SKILL.md` is the *source* of the installed
+  copy — the host copies `manual/` to `.library/intrinsic/capabilities/avatar/`
+  on every boot — and is never what the action reports. A missing installed
+  copy degrades truthfully rather than being backfilled from that source.
 
 **Non-goals:** the parent holds no in-process handle to the avatar — liveness is
 checked purely via the filesystem handshake. The tool does not manage the
@@ -194,7 +197,7 @@ I/O of any kind.
 
 | Input | Optional input | Success output | Error shapes |
 |---|---|---|---|
-| `{}` | — | `{status: "ok", action: "manual", manual: <exact SKILL.md body>, manual_path: <host-local packaged path>}` | `{status: "degraded", action: "manual", manual: "", manual_path: ..., error: "avatar manual missing"}` if the packaged manual file is missing; the same degraded shape with an `error` naming the mismatch if the packaged file is present but is not the declared `avatar-manual` skill (a foreign or empty manual is refused, never served) |
+| `{}` | — | `{status: "ok", action: "manual", manual: <exact installed SKILL.md body>, manual_path: <agent working dir>/.library/intrinsic/capabilities/avatar/SKILL.md}` | `{status: "degraded", action: "manual", manual: "", manual_path: <that same host-local path>, error: "avatar manual missing — initializer may have failed or capability not installed correctly"}` if this agent has no installed copy — the packaged source is never substituted for it. Packaging defects in that source (missing, empty, or a foreign skill) are reported by `AVATAR_PLUGIN.validate_packaged_skill()`, not by this action |
 
 The result is avatar's own canonical shape, returned verbatim — it is never
 nested inside another action's result envelope and never double-wrapped.
@@ -227,8 +230,8 @@ avatar's own declared actions — and `src/lingtai/tools/_plugin.py`
   Agent Plugins v1.0.0 directories.
 - **Packaging faults degrade, they do not crash boot.** Unlike the curated-MCP
   twin, which validates its skill eagerly at construction, avatar reads its
-  packaged skill on demand: an unreadable or foreign manual degrades that one
-  action (above) instead of failing the import of a core-default capability.
+  packaged skill on demand, so an unreadable or foreign packaged manual never
+  fails the import of a core-default capability.
   `AVATAR_PLUGIN.validate_packaged_skill()` raises the same defect loudly for
   packaging tests and doctor-style checks.
 
@@ -334,7 +337,8 @@ live descendant.
 | Rules are distributed recursively to descendants (cycle-safe) | `src/lingtai/tools/avatar/__init__.py` | `tests/test_avatar_rules.py::test_rules_distributes_recursively`, `::test_rules_root_not_duplicated_via_cycle` |
 | Spawning distributes existing rules to the newborn | `src/lingtai/tools/avatar/__init__.py` | `tests/test_avatar_rules.py::test_spawn_distributes_existing_rules`, `::test_spawn_deep_clone_also_gets_rules_signal` |
 | `_prepare_deep` refuses a non-sibling destination | `src/lingtai/tools/avatar/__init__.py` | `tests/test_layers_avatar.py::test_prepare_deep_refuses_non_sibling_dst` |
-| `action="manual"` returns the exact packaged manual body and mutates nothing | `src/lingtai/tools/avatar/__init__.py` | `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_manual_returns_exact_body_and_performs_no_mutation` |
+| `action="manual"` returns the exact manual body and mutates nothing | `src/lingtai/tools/avatar/__init__.py` | `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_manual_returns_exact_body_and_performs_no_mutation` |
+| `action="manual"` reports the agent's host-local installed `manual_path`, never the packaged source path | `src/lingtai/tools/_plugin.py`, `src/lingtai/tools/avatar/__init__.py` | `tests/test_builtin_tool_plugin_package.py::test_manual_reports_the_host_local_install_not_the_packaged_source`, `::test_manual_degrades_truthfully_when_the_host_has_no_installed_copy`; `tests/test_tool_family_avatar_migration.py::TestManualThroughTheEnvelope::test_manual_returns_the_exact_installed_body_and_host_local_path` |
 | Invalid `action` fails deterministically without touching other actions | `src/lingtai/tools/avatar/__init__.py` | `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_invalid_action_fails_deterministically`, `::test_spawn_missing_name_fails_without_affecting_other_actions` |
 | `action` is schema-required (root `required: ["action", "input", "reasoning"]`) and runtime-required — a missing `action` never defaults to `spawn`, `rules`, or `manual`, regardless of which action's fields are present, and mutates nothing | `src/lingtai/tools/avatar/__init__.py` | `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_missing_action_fails_deterministically_regardless_of_payload_shape`; `tests/test_avatar_rules.py::TestAvatarRulesAction::test_explicit_spawn_action_required` |
 | The daemon blacklists the canonical `avatar` name (not the retired two-tool names) | `src/lingtai/tools/daemon/__init__.py` | `tests/test_daemon.py::test_build_tool_surface_blacklist`, `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_daemon_excludes_avatar_from_child_surface` |

--- a/src/lingtai/tools/avatar/CONTRACT.md
+++ b/src/lingtai/tools/avatar/CONTRACT.md
@@ -4,6 +4,8 @@ tool: avatar
 contract_version: 4
 related_files:
   - src/lingtai/tools/avatar/__init__.py
+  - src/lingtai/tools/avatar/plugin.py
+  - src/lingtai/tools/_plugin.py
   - src/lingtai/tools/avatar/_launcher.py
   - src/lingtai/tools/avatar/ANATOMY.md
   - src/lingtai/tools/avatar/manual/SKILL.md
@@ -14,6 +16,7 @@ related_files:
   - src/lingtai/tools/tool_family/CONTRACT.md
   - src/lingtai/kernel/tool_result_summary.py
   - tests/test_tool_family_avatar_migration.py
+  - tests/test_builtin_tool_plugin_package.py
 maintenance: |
   Keep related_files as repo-relative paths to real files. If behavior and this
   contract disagree, the code is the source of truth — fix the contract in the
@@ -121,11 +124,16 @@ storage; detached-process launch -> §Cross-platform invariants.
 - `action="manual"` is read-only: it returns the exact packaged
   `src/lingtai/tools/avatar/manual/SKILL.md` body plus its host-local
   `manual_path`, and performs no filesystem mutation (no spawn, no ledger
-  write, no `.rules` write). Avatar's manual ships inside this package rather
-  than being installed into the agent's `.library` intrinsic catalog, so this
-  action owns its own loader instead of the shared
+  write, no `.rules` write). The action is **plugin-owned**: `AVATAR_PLUGIN`
+  (`src/lingtai/tools/avatar/plugin.py`) appends the reserved child and answers
+  it straight from the packaged skill, so `AvatarManager` has no `manual`
+  binding to drop or rebind. Avatar's manual is read from the package rather
+  than from the agent's installed `.library` intrinsic catalog, so the plugin
+  owns this loader instead of the shared
   `load_installed_manual`/`build_manual_child` pair — that builder would
-  report a `.library` path this family never reads.
+  report a `.library` path this family never reads. The packaged copy is the
+  source of truth for the installed one: the host copies `manual/` to
+  `.library/intrinsic/capabilities/avatar/` on every boot.
 
 **Non-goals:** the parent holds no in-process handle to the avatar — liveness is
 checked purely via the filesystem handshake. The tool does not manage the
@@ -186,10 +194,43 @@ I/O of any kind.
 
 | Input | Optional input | Success output | Error shapes |
 |---|---|---|---|
-| `{}` | — | `{status: "ok", action: "manual", manual: <exact SKILL.md body>, manual_path: <host-local packaged path>}` | `{status: "degraded", action: "manual", manual: "", manual_path: ..., error: "avatar manual missing"}` if the packaged manual file is missing |
+| `{}` | — | `{status: "ok", action: "manual", manual: <exact SKILL.md body>, manual_path: <host-local packaged path>}` | `{status: "degraded", action: "manual", manual: "", manual_path: ..., error: "avatar manual missing"}` if the packaged manual file is missing; the same degraded shape with an `error` naming the mismatch if the packaged file is present but is not the declared `avatar-manual` skill (a foreign or empty manual is refused, never served) |
 
 The result is avatar's own canonical shape, returned verbatim — it is never
 nested inside another action's result envelope and never double-wrapped.
+
+### Packaging: avatar is a built-in tool plugin
+
+`src/lingtai/tools/avatar/` is a plugin-style package. `plugin.py` states the
+capability identity in one place — the public name, the module the registry
+imports, the always-on boot kwargs, the packaged `avatar-manual` skill, and
+avatar's own declared actions — and `src/lingtai/tools/_plugin.py`
+(`BuiltinToolPlugin`, the in-process twin of the curated-MCP
+`lingtai.mcp_servers._plugin`) binds them. The contract this adds:
+
+- **`manual` is reserved and appended, never declared.** Declaring,
+  re-schema'ing, or rebinding `manual` raises `BuiltinToolPluginError` at
+  import time. The appended child's `input` is the one shared
+  `tool_family.manual.MANUAL_INPUT_SCHEMA` object.
+- **The declaration must equal the shipped registry entry.**
+  `AVATAR_PLUGIN.capability_declaration()` states `lingtai.tools.avatar` and
+  `{}`; `registry.BUILTIN_TOOLS["avatar"]` and `registry.CORE_DEFAULTS["avatar"]`
+  remain the runtime source the host reads and lazily imports, and the
+  agreement is proven by test — the registry never imports this descriptor.
+- **The descriptor is declarative, not a runtime.** It discovers nothing,
+  imports nothing by name, spawns nothing, and registers nothing. `setup()`
+  still performs the one `add_tool` call, `registry.setup_capability` still
+  decides whether that happens, `Agent._install_intrinsic_manuals` still
+  performs the `.library` install, and the `rules` karma gate, the launcher
+  Port, the network scope checks, and `delegates/ledger.jsonl` are untouched.
+  It is unrelated to `lingtai.tools.plugin`, the catalog tool for external
+  Agent Plugins v1.0.0 directories.
+- **Packaging faults degrade, they do not crash boot.** Unlike the curated-MCP
+  twin, which validates its skill eagerly at construction, avatar reads its
+  packaged skill on demand: an unreadable or foreign manual degrades that one
+  action (above) instead of failing the import of a core-default capability.
+  `AVATAR_PLUGIN.validate_packaged_skill()` raises the same defect loudly for
+  packaging tests and doctor-style checks.
 
 ### Invalid or missing `action`
 

--- a/src/lingtai/tools/avatar/__init__.py
+++ b/src/lingtai/tools/avatar/__init__.py
@@ -204,21 +204,24 @@ _SUPPORTED_ACTIONS_PHRASE = (
 )
 
 
-def _build_family(handlers: Mapping[str, Any]) -> ToolFamily:
+def _build_family(handlers: Mapping[str, Any], agent: "Agent | None") -> ToolFamily:
     """Build avatar's family, binding each declared action to *handlers[name]*.
 
     Only avatar's own actions are bound here. ``manual`` is appended by
-    ``AVATAR_PLUGIN`` and answered directly from the packaged skill, with or
-    without a manager — it is not in *handlers* and cannot be supplied there.
-    Construction validates the registry, so a duplicate or reserved-name
-    collision raises ``ToolFamilyError``/``BuiltinToolPluginError`` here — at
-    import time for ``_FAMILY`` — rather than shipping silently.
+    ``AVATAR_PLUGIN`` and answered from *agent*'s installed
+    ``.library/intrinsic/capabilities/avatar/SKILL.md``, with or without a
+    manager — it is not in *handlers* and cannot be supplied there. *agent* is
+    ``None`` only for the module-level schema-only family, which never
+    dispatches. Construction validates the registry, so a duplicate or
+    reserved-name collision raises ``ToolFamilyError``/``BuiltinToolPluginError``
+    here — at import time for ``_FAMILY`` — rather than shipping silently.
     """
     return AVATAR_PLUGIN.build_family(
         [
             ChildTool(name, schema, handlers[name], title=f"{name} input")
             for name, schema in _DECLARED_CHILD_SPECS
         ],
+        agent,
     )
 
 
@@ -228,7 +231,7 @@ def _unused(_input: Mapping[str, Any]) -> dict[str, Any]:
 
 # Composes the model-facing schema only; ``AvatarManager`` builds its own
 # per-instance family with real handlers bound to that instance.
-_FAMILY = _build_family({name: _unused for name, _ in _DECLARED_CHILD_SPECS})
+_FAMILY = _build_family({name: _unused for name, _ in _DECLARED_CHILD_SPECS}, None)
 
 
 def get_description(lang: str = "en") -> str:
@@ -258,11 +261,15 @@ class AvatarManager:
         # The spawn mission brief reaches ``_spawn`` out-of-band via
         # ``self._pending_reasoning``, set by ``handle()`` (see ``handle``).
         # ``manual`` is deliberately absent: the plugin appends and answers it
-        # from the packaged skill, so no manager binding exists to rebind.
-        self._family = _build_family({
-            "spawn": self._dispatch_spawn,
-            "rules": self._dispatch_rules,
-        })
+        # from this agent's installed manual, so no manager binding exists to
+        # rebind.
+        self._family = _build_family(
+            {
+                "spawn": self._dispatch_spawn,
+                "rules": self._dispatch_rules,
+            },
+            agent,
+        )
         self._pending_reasoning: str | None = None
 
     # ------------------------------------------------------------------
@@ -315,20 +322,21 @@ class AvatarManager:
         return self._rules(self._strip_nulls(action_input))
 
     def _manual(self) -> dict:
-        """The packaged avatar-manual result — plugin-owned, no mutation.
+        """The installed avatar-manual result — plugin-owned, no mutation.
 
-        Avatar's manual ships inside this package (``manual/SKILL.md``) rather
-        than in the agent's installed ``.library`` catalog, so ``AVATAR_PLUGIN``
-        owns the loader instead of the shared
-        ``load_installed_manual``/``build_manual_child`` pair — that builder
-        would report a ``.library`` path this family never reads.
+        ``Agent._install_intrinsic_manuals`` installs this package's
+        ``manual/SKILL.md`` into the agent's ``.library`` catalog like every
+        other capability's, so ``AVATAR_PLUGIN`` reports that host-local copy
+        through the same shared ``load_installed_manual`` the rest of the
+        families use. The packaged file is that copy's source, not the document
+        this agent reads.
 
         This is a read-only convenience for callers holding a manager; the
         public ``manual`` action does **not** come through here. The family's
         ``manual`` child is the plugin's own, so nothing this manager does can
-        drop or replace the packaged skill it serves.
+        drop or replace the skill it serves.
         """
-        return AVATAR_PLUGIN.manual_payload()
+        return AVATAR_PLUGIN.manual_payload(self._agent)
 
     # ------------------------------------------------------------------
     # Ledger (append-only JSONL log of avatar spawn events)

--- a/src/lingtai/tools/avatar/__init__.py
+++ b/src/lingtai/tools/avatar/__init__.py
@@ -24,6 +24,16 @@ Usage (LTP v2 envelope — one action, one strict child input):
 
 The spawn mission brief is root ``reasoning`` (normalized to ``_reasoning`` by
 ToolExecutor), never an ``input`` property — see ``handle()``.
+
+Packaging: this folder is a built-in tool *plugin package*. ``plugin.py`` states
+avatar's capability identity, its packaged ``manual/SKILL.md`` skill, its own
+declared actions, and the capability declaration the registry must agree with;
+``AVATAR_PLUGIN`` appends the reserved ``manual`` action and answers it straight
+from that packaged skill, so ``manual`` never routes through ``AvatarManager``
+and no manager change can drop or rebind it. Registration, activation,
+privilege, and lifecycle stay exactly where they were: ``setup()`` still
+performs the one ``add_tool`` call, and ``lingtai.tools.registry`` still owns
+capability lookup and boot.
 """
 from __future__ import annotations
 
@@ -32,15 +42,14 @@ import os
 import re
 import shutil
 import time
-from importlib import resources
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Mapping
 
 from lingtai.kernel.agent_presence import observe_alive as _presence_observe_alive
 from lingtai.kernel.i18n import t
 from ..tool_family import ChildTool, ToolFamily
-from ..tool_family.manual import MANUAL_INPUT_SCHEMA
 from ._launcher import AvatarLaunchReceipt, AvatarLaunchRequest, AvatarLauncherPort
+from .plugin import AVATAR_ACTIONS, AVATAR_DESCRIPTION, AVATAR_PLUGIN
 
 
 def _is_alive(working_dir) -> bool:
@@ -168,29 +177,47 @@ _RULES_INPUT_SCHEMA: dict[str, Any] = {
     "additionalProperties": False,
 }
 
-# The one child spec: canonical action name → its own strict input schema, in
-# model-facing enum order. Both the module-level schema-only family and each
-# manager's handler-bound family are built from this single source by
-# ``_build_family`` below, so the two listings cannot drift apart.
-_CHILD_SPECS: tuple[tuple[str, dict[str, Any]], ...] = (
+# Avatar's OWN child specs: canonical action name → its own strict input
+# schema, in model-facing enum order. The reserved ``manual`` action is
+# deliberately absent — ``AVATAR_PLUGIN`` appends it from the packaged
+# ``manual/SKILL.md`` and rejects any attempt to declare it here.
+_DECLARED_CHILD_SPECS: tuple[tuple[str, dict[str, Any]], ...] = (
     ("spawn", _SPAWN_INPUT_SCHEMA),
     ("rules", _RULES_INPUT_SCHEMA),
-    ("manual", MANUAL_INPUT_SCHEMA),
+)
+
+# The complete child spec — declared actions plus the plugin-appended
+# ``manual``, whose input is the one shared ``MANUAL_INPUT_SCHEMA`` object.
+# Both the module-level schema-only family and each manager's handler-bound
+# family are built from this single source by ``_build_family`` below, so the
+# two listings cannot drift apart.
+_CHILD_SPECS: tuple[tuple[str, dict[str, Any]], ...] = AVATAR_PLUGIN.child_specs(
+    _DECLARED_CHILD_SPECS
+)
+
+# Avatar's pinned unknown-action wording, rendered from the plugin's one public
+# action list so the error can never name a set of actions the family does not
+# actually serve. Renders exactly "'spawn', 'rules', or 'manual'".
+_SUPPORTED_ACTIONS_PHRASE = (
+    "".join(f"{action!r}, " for action in AVATAR_ACTIONS[:-1])
+    + f"or {AVATAR_ACTIONS[-1]!r}"
 )
 
 
 def _build_family(handlers: Mapping[str, Any]) -> ToolFamily:
-    """Build avatar's family, binding each spec'd action to *handlers[name]*.
+    """Build avatar's family, binding each declared action to *handlers[name]*.
 
+    Only avatar's own actions are bound here. ``manual`` is appended by
+    ``AVATAR_PLUGIN`` and answered directly from the packaged skill, with or
+    without a manager — it is not in *handlers* and cannot be supplied there.
     Construction validates the registry, so a duplicate or reserved-name
-    collision raises ``ToolFamilyError`` here — at import time for ``_FAMILY``
-    — rather than shipping silently.
+    collision raises ``ToolFamilyError``/``BuiltinToolPluginError`` here — at
+    import time for ``_FAMILY`` — rather than shipping silently.
     """
-    return ToolFamily(
-        "avatar",
+    return AVATAR_PLUGIN.build_family(
         [
             ChildTool(name, schema, handlers[name], title=f"{name} input")
-            for name, schema in _CHILD_SPECS
+            for name, schema in _DECLARED_CHILD_SPECS
         ],
     )
 
@@ -201,21 +228,12 @@ def _unused(_input: Mapping[str, Any]) -> dict[str, Any]:
 
 # Composes the model-facing schema only; ``AvatarManager`` builds its own
 # per-instance family with real handlers bound to that instance.
-_FAMILY = _build_family({name: _unused for name, _ in _CHILD_SPECS})
+_FAMILY = _build_family({name: _unused for name, _ in _DECLARED_CHILD_SPECS})
 
 
 def get_description(lang: str = "en") -> str:
-    return (
-        "Spawn an independent agent (他我), set network rules for descendants, "
-        "or read the avatar manual. Requires an explicit action — no default. "
-        "avatar(action='spawn', input={'name': 'researcher', ...}, "
-        "reasoning='<the avatar's mission>'): inherits init.json, boots on "
-        "default preset; your reasoning becomes the avatar's first prompt. "
-        "avatar(action='rules', input={'rules_content': '...'}, reasoning='...'): "
-        "distribute rules to self + all descendants (requires karma). "
-        "avatar(action='manual', input={}, reasoning='...'): return the "
-        "avatar-manual skill body. See avatar-manual skill for full guidance."
-    )
+    """The model-facing root description, owned by the plugin descriptor."""
+    return AVATAR_DESCRIPTION
 
 
 def get_schema(lang: str = "en") -> dict[str, Any]:
@@ -239,10 +257,11 @@ class AvatarManager:
         self._launcher = launcher
         # The spawn mission brief reaches ``_spawn`` out-of-band via
         # ``self._pending_reasoning``, set by ``handle()`` (see ``handle``).
+        # ``manual`` is deliberately absent: the plugin appends and answers it
+        # from the packaged skill, so no manager binding exists to rebind.
         self._family = _build_family({
             "spawn": self._dispatch_spawn,
             "rules": self._dispatch_rules,
-            "manual": self._dispatch_manual,
         })
         self._pending_reasoning: str | None = None
 
@@ -276,8 +295,8 @@ class AvatarManager:
             action = raw.get("action", "")
             return {
                 "error": (
-                    f"unknown action: {action!r}, only 'spawn', 'rules', or "
-                    f"'manual' is supported"
+                    f"unknown action: {action!r}, only "
+                    f"{_SUPPORTED_ACTIONS_PHRASE} is supported"
                 ),
             }
         return result
@@ -295,35 +314,21 @@ class AvatarManager:
     def _dispatch_rules(self, action_input: Mapping[str, Any]) -> dict:
         return self._rules(self._strip_nulls(action_input))
 
-    def _dispatch_manual(self, _action_input: Mapping[str, Any]) -> dict:
-        return self._manual()
-
     def _manual(self) -> dict:
-        """Return the exact packaged avatar-manual body; performs no mutation.
+        """The packaged avatar-manual result — plugin-owned, no mutation.
 
         Avatar's manual ships inside this package (``manual/SKILL.md``) rather
-        than in the agent's installed ``.library`` catalog, so this action owns
-        its own loader instead of the shared
-        ``load_installed_manual``/``build_manual_child`` pair — reusing that
-        builder here would report a ``.library`` path this family never reads.
+        than in the agent's installed ``.library`` catalog, so ``AVATAR_PLUGIN``
+        owns the loader instead of the shared
+        ``load_installed_manual``/``build_manual_child`` pair — that builder
+        would report a ``.library`` path this family never reads.
+
+        This is a read-only convenience for callers holding a manager; the
+        public ``manual`` action does **not** come through here. The family's
+        ``manual`` child is the plugin's own, so nothing this manager does can
+        drop or replace the packaged skill it serves.
         """
-        resource = resources.files(__package__).joinpath("manual/SKILL.md")
-        try:
-            body = resource.read_text(encoding="utf-8")
-        except (FileNotFoundError, ModuleNotFoundError, AttributeError, OSError):
-            return {
-                "status": "degraded",
-                "action": "manual",
-                "manual": "",
-                "manual_path": str(resource),
-                "error": "avatar manual missing",
-            }
-        return {
-            "status": "ok",
-            "action": "manual",
-            "manual": body,
-            "manual_path": str(resource),
-        }
+        return AVATAR_PLUGIN.manual_payload()
 
     # ------------------------------------------------------------------
     # Ledger (append-only JSONL log of avatar spawn events)
@@ -952,13 +957,21 @@ class AvatarManager:
 
 
 def setup(agent: "Agent", **kwargs) -> AvatarManager:
-    """Set up the avatar capability on an agent."""
+    """Set up the avatar capability on an agent.
+
+    The host still performs mounting: ``registry.setup_capability`` calls this,
+    and this calls ``add_tool`` once. What gets mounted — the public tool name
+    and the glossary package — comes from ``AVATAR_PLUGIN`` rather than being
+    restated here, so the registered tool cannot drift from the descriptor the
+    capability declaration is checked against.
+    """
     mgr = AvatarManager(agent)
     agent.add_tool(
-        "avatar",
-        schema=get_schema(),
-        handler=mgr.handle,
-        description=get_description(),
-        glossary_package=__package__,
+        AVATAR_PLUGIN.name,
+        **AVATAR_PLUGIN.tool_registration(
+            schema=get_schema(),
+            description=get_description(),
+            handler=mgr.handle,
+        ),
     )
     return mgr

--- a/src/lingtai/tools/avatar/plugin.py
+++ b/src/lingtai/tools/avatar/plugin.py
@@ -1,0 +1,61 @@
+"""The Avatar built-in tool plugin descriptor.
+
+One place where this package states who it is: its capability/tool name, the
+module the capability registry imports for it, the always-on boot kwargs the
+registry's ``CORE_DEFAULTS`` carries, the bundled ``manual/SKILL.md`` its
+``manual`` action returns, and the actions it *itself* owns. ``manual`` is
+deliberately absent from :data:`AVATAR_DECLARED_ACTIONS` —
+:class:`~lingtai.tools._plugin.BuiltinToolPlugin` appends the reserved action
+from the packaged skill and rejects any attempt to declare it here.
+
+``__init__.py`` consumes this for the public schema, the family composition, the
+model-facing description, and the one ``add_tool`` registration ``setup()``
+performs. The shipped ``lingtai.tools.registry`` entries for ``avatar`` must
+equal :meth:`~lingtai.tools._plugin.BuiltinToolPlugin.capability_declaration`;
+the registry mapping itself stays the runtime source the host reads and lazily
+imports, so importing the registry never imports this package.
+
+This is a *kernel-shipped built-in* plugin package. It has nothing to do with
+``lingtai.tools.plugin``, the read-only catalog tool for external Agent Plugins
+v1.0.0 directories that ``lingtai.services.plugin_registry`` mounts.
+"""
+from __future__ import annotations
+
+from .._plugin import BuiltinToolPlugin
+
+AVATAR_PLUGIN = BuiltinToolPlugin(
+    name="avatar",
+    package=__package__,
+    summary=(
+        "Spawn independent peer agents (分身) as detached processes and "
+        "distribute rules across the avatar subtree."
+    ),
+    skill_name="avatar-manual",
+    # Avatar boots on every agent with no configuration — the registry's
+    # CORE_DEFAULTS entry this must agree with is the empty mapping.
+    default_kwargs={},
+)
+
+#: Avatar's own public actions, in stable model-facing order. The reserved
+#: ``manual`` action is appended by the plugin, never declared here.
+AVATAR_DECLARED_ACTIONS: tuple[str, ...] = ("spawn", "rules")
+
+#: The complete public action list, declared actions followed by ``manual``.
+AVATAR_ACTIONS: tuple[str, ...] = AVATAR_PLUGIN.actions(AVATAR_DECLARED_ACTIONS)
+
+#: The model-facing root description. Terse by design: the safety contract lives
+#: in the strict per-action ``input`` schemas plus the packaged manual, not in a
+#: long description string. The manual pointer is the plugin's own skill name,
+#: so a renamed skill cannot leave the description advertising a dead pointer.
+AVATAR_DESCRIPTION = (
+    "Spawn an independent agent (他我), set network rules for descendants, "
+    "or read the avatar manual. Requires an explicit action — no default. "
+    "avatar(action='spawn', input={'name': 'researcher', ...}, "
+    "reasoning='<the avatar's mission>'): inherits init.json, boots on "
+    "default preset; your reasoning becomes the avatar's first prompt. "
+    "avatar(action='rules', input={'rules_content': '...'}, reasoning='...'): "
+    "distribute rules to self + all descendants (requires karma). "
+    f"avatar(action='manual', input={{}}, reasoning='...'): return the "
+    f"{AVATAR_PLUGIN.skill_name} skill body. See {AVATAR_PLUGIN.skill_name} "
+    "skill for full guidance."
+)

--- a/src/lingtai/tools/registry.py
+++ b/src/lingtai/tools/registry.py
@@ -108,6 +108,13 @@ BUILTIN_TOOLS: dict[str, str] = {
     # capability is canonically named ``shell`` while its implementation stays
     # in the retained internal package.
     "shell": "lingtai.tools.bash",
+    # ``avatar`` is packaged as a built-in tool plugin: its own
+    # ``lingtai.tools.avatar.plugin`` descriptor states this module path and the
+    # ``CORE_DEFAULTS`` kwargs below, and
+    # ``tests/test_builtin_tool_plugin_package.py`` pins that this shipped
+    # mapping equals ``AVATAR_PLUGIN.capability_declaration()``. This mapping
+    # stays the runtime source — importing it must not import the package, so
+    # the agreement is proven by test, never by importing the descriptor here.
     "avatar": "lingtai.tools.avatar",
     "daemon": "lingtai.tools.daemon",
     "mcp": "lingtai.tools.mcp",
@@ -150,6 +157,7 @@ CORE_DEFAULTS: dict[str, dict] = {
     "knowledge": {},
     "skills": {},
     "shell": {"yolo": True},
+    # Must equal ``AVATAR_PLUGIN.capability_declaration()["default_kwargs"]``.
     "avatar": {},
     "daemon": {},
     "mcp": {},

--- a/tests/test_builtin_tool_plugin_package.py
+++ b/tests/test_builtin_tool_plugin_package.py
@@ -1,0 +1,345 @@
+"""Built-in tool plugin packaging invariants, proven on the Avatar reference slice.
+
+A built-in tool is a plugin-style package: the same folder ships the tool code,
+the bundled ``manual/SKILL.md``, and the capability declaration the tool
+registry publishes. ``lingtai.tools._plugin.BuiltinToolPlugin`` binds those
+three and owns the one promise a package must not be able to break — the
+reserved ``manual`` action, appended from the packaged skill rather than
+declared, schema'd, or handled by the package.
+
+These tests pin the packaging promise, the runtime discovery/mount contract
+around it (registry entry, lazy import, ``.library`` install), and the
+*unchanged* public Avatar surface. No test spawns a live avatar: the launcher
+Port is a double, every agent lives under ``tmp_path``, and the manual action
+touches nothing.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from lingtai.tools import _plugin, registry
+from lingtai.tools import avatar as avatar_tool
+from lingtai.tools._plugin import BuiltinToolPlugin, BuiltinToolPluginError
+from lingtai.tools.avatar import AvatarManager
+from lingtai.tools.avatar.plugin import (
+    AVATAR_ACTIONS,
+    AVATAR_DECLARED_ACTIONS,
+    AVATAR_DESCRIPTION,
+    AVATAR_PLUGIN,
+)
+from lingtai.tools.tool_family import ChildTool
+from lingtai.tools.tool_family.manual import MANUAL_INPUT_SCHEMA
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class _RecordingManager:
+    """Stands in for AvatarManager's handlers; records every action it is handed."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict]] = []
+
+    def handler(self, action: str):
+        def _handle(action_input):
+            self.calls.append((action, dict(action_input)))
+            return {"status": "ok", "action": action}
+
+        return _handle
+
+
+def _recording_family(recorder: _RecordingManager):
+    """Avatar's real family with its declared actions bound to the recorder."""
+    return avatar_tool._build_family(
+        {action: recorder.handler(action) for action in AVATAR_DECLARED_ACTIONS}
+    )
+
+
+def _descriptor_fields(**overrides):
+    fields = {
+        "name": "avatar",
+        "package": "lingtai.tools.avatar",
+        "summary": "s",
+        "skill_name": "avatar-manual",
+    }
+    fields.update(overrides)
+    return fields
+
+
+# ---------------------------------------------------------------------------
+# The package ships its own capability declaration
+# ---------------------------------------------------------------------------
+
+def test_avatar_package_declaration_matches_the_shipped_registry_entries():
+    """The package owns its module path and boot kwargs; the registry publishes exactly them."""
+    declaration = AVATAR_PLUGIN.capability_declaration()
+    assert registry.BUILTIN_TOOLS[declaration["name"]] == declaration["module"]
+    assert registry.CORE_DEFAULTS[declaration["name"]] == declaration["default_kwargs"]
+    assert declaration["source"] == _plugin.BUILTIN_SOURCE
+
+
+def test_declaration_imports_the_declaring_package_and_still_boots_through_the_host():
+    declaration = AVATAR_PLUGIN.capability_declaration()
+    assert declaration["module"] == AVATAR_PLUGIN.package == avatar_tool.__name__
+    # The host's own resolution path — unchanged — still finds this capability.
+    assert registry.canonical_capability_name("avatar") == "avatar"
+    assert "avatar" in registry.get_all_providers()
+    # And the always-on floor materializes exactly the declared kwargs.
+    assert registry.apply_core_defaults({})["avatar"] == declaration["default_kwargs"]
+
+
+def test_registry_lookup_is_unchanged_and_still_the_runtime_source():
+    """The descriptor documents the entry; it does not replace registry lookup.
+
+    Importing the registry must still not import this package — the descriptor
+    lives inside ``lingtai.tools.avatar``, so a registry that consulted it at
+    import time would break the lazy-capability-import discipline the registry
+    docstring promises.
+    """
+    probe = (
+        "import sys, lingtai.tools.registry as r;"
+        "assert 'lingtai.tools.avatar' not in sys.modules, 'registry eagerly imported avatar';"
+        "assert 'lingtai.tools.avatar.plugin' not in sys.modules;"
+        "print(r.BUILTIN_TOOLS['avatar'])"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", probe],
+        cwd=_REPO_ROOT,
+        env={**os.environ, "PYTHONPATH": str(_REPO_ROOT / "src")},
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip() == "lingtai.tools.avatar"
+
+
+# ---------------------------------------------------------------------------
+# `manual` is mandatory, reserved, and sourced from the packaged skill
+# ---------------------------------------------------------------------------
+
+def test_package_does_not_declare_manual_and_the_plugin_appends_it_last():
+    assert _plugin.MANUAL_ACTION not in AVATAR_DECLARED_ACTIONS
+    assert AVATAR_ACTIONS == (*AVATAR_DECLARED_ACTIONS, "manual")
+    assert AVATAR_ACTIONS[-1] == "manual"
+    assert [name for name, _schema in avatar_tool._DECLARED_CHILD_SPECS] == list(
+        AVATAR_DECLARED_ACTIONS
+    )
+
+
+@pytest.mark.parametrize(
+    "compose",
+    [
+        pytest.param(lambda: AVATAR_PLUGIN.actions(["spawn", "manual"]), id="actions"),
+        pytest.param(
+            lambda: AVATAR_PLUGIN.child_specs(
+                [("spawn", {"type": "object"}), ("manual", {"type": "object"})]
+            ),
+            id="specs",
+        ),
+        pytest.param(
+            lambda: AVATAR_PLUGIN.build_family(
+                [
+                    ChildTool("spawn", {"type": "object"}, lambda _i: {}),
+                    ChildTool("manual", {"type": "object"}, lambda _i: {"hijacked": True}),
+                ]
+            ),
+            id="family",
+        ),
+    ],
+)
+def test_a_package_cannot_declare_re_schema_or_rebind_the_reserved_manual(compose):
+    with pytest.raises(BuiltinToolPluginError, match="reserved 'manual'"):
+        compose()
+
+
+def test_composed_family_always_carries_a_manual_child_with_the_shared_strict_input():
+    family = _recording_family(_RecordingManager())
+    assert family.has_manual()
+    assert family.child_names == AVATAR_ACTIONS
+    # The one owned strict-empty schema object, not a restatement of it.
+    assert dict(avatar_tool._CHILD_SPECS)["manual"] is MANUAL_INPUT_SCHEMA
+
+
+def test_manual_answers_from_the_packaged_skill_without_entering_the_manager():
+    recorder = _RecordingManager()
+    family = _recording_family(recorder)
+    result = family.handle({"action": "manual", "input": {}})
+    assert recorder.calls == []
+    assert result == AVATAR_PLUGIN.manual_payload()
+    assert result["status"] == "ok"
+    assert result["action"] == "manual"
+    skill_path = Path(result["manual_path"])
+    assert skill_path.is_absolute() and skill_path.name == "SKILL.md"
+    assert result["manual"] == skill_path.read_text(encoding="utf-8")
+
+
+def test_the_manager_cannot_rebind_the_public_manual_action(tmp_path):
+    """Even a manager that redefines its own manual cannot change the action."""
+
+    class _HijackingManager(AvatarManager):
+        def _manual(self):
+            return {"status": "ok", "action": "manual", "manual": "hijacked"}
+
+    (tmp_path / "parent").mkdir()
+    agent = type("_StubAgent", (), {})()
+    agent._working_dir = tmp_path / "parent"
+    agent._admin = {}
+    agent.agent_name = "parent"
+    agent._venv_path = None
+    manager = _HijackingManager(agent, launcher=object())
+
+    result = manager.handle({"action": "manual", "input": {}})
+    assert result == AVATAR_PLUGIN.manual_payload()
+    assert result["manual"] != "hijacked"
+
+
+def test_manual_payload_is_the_same_document_the_legacy_manager_helper_returns():
+    """Routing manual through the plugin preserves the existing public result."""
+    bare = object.__new__(AvatarManager)
+    assert bare._manual() == AVATAR_PLUGIN.manual_payload()
+
+
+def test_manual_input_stays_strictly_empty_and_the_action_writes_nothing(tmp_path):
+    recorder = _RecordingManager()
+    family = _recording_family(recorder)
+    rejected = family.handle({"action": "manual", "input": {"name": "helper"}})
+    assert rejected["status"] == "failed"
+    assert rejected["error_code"] == "INVALID_ARGUMENT"
+    assert recorder.calls == []
+    # The accepted call is read-only: nothing is created anywhere.
+    before = sorted(p.name for p in tmp_path.iterdir())
+    assert family.handle({"action": "manual", "input": {}})["status"] == "ok"
+    assert sorted(p.name for p in tmp_path.iterdir()) == before
+
+
+# ---------------------------------------------------------------------------
+# The packaged skill is this plugin's owned skill, installed where it says
+# ---------------------------------------------------------------------------
+
+def test_the_packaged_manual_is_the_declared_owned_skill():
+    AVATAR_PLUGIN.validate_packaged_skill()
+    packaged = Path(str(AVATAR_PLUGIN.manual_resource()))
+    assert packaged == _REPO_ROOT / "src/lingtai/tools/avatar/manual/SKILL.md"
+    assert f"name: {AVATAR_PLUGIN.skill_name}" in packaged.read_text(encoding="utf-8")
+
+
+def test_a_foreign_or_missing_packaged_skill_degrades_and_validates_loudly():
+    foreign = BuiltinToolPlugin(**_descriptor_fields(skill_name="somebody-elses-manual"))
+    loaded = foreign.load_manual()
+    assert loaded["status"] == "degraded"
+    # Refused, not served: the body is empty and the error names the mismatch.
+    assert loaded["manual"] == ""
+    assert "expected 'somebody-elses-manual'" in loaded["error"]
+    assert foreign.manual_payload()["action"] == "manual"
+    with pytest.raises(BuiltinToolPluginError, match="declares skill"):
+        foreign.validate_packaged_skill()
+
+
+def test_the_host_installs_the_packaged_skill_where_the_descriptor_says(tmp_path):
+    """``Agent._install_intrinsic_manuals`` is the mount; the descriptor names it."""
+    from lingtai.agent import Agent
+    from tests._service_helpers import make_gemini_mock_service
+
+    agent = Agent(
+        service=make_gemini_mock_service(),
+        agent_name="parent",
+        working_dir=tmp_path / "parent",
+        capabilities=["avatar"],
+    )
+    installed = agent._working_dir / AVATAR_PLUGIN.installed_manual_path()
+    assert installed.is_file()
+    assert installed.read_text(encoding="utf-8") == AVATAR_PLUGIN.manual_payload()["manual"]
+
+
+# ---------------------------------------------------------------------------
+# The public envelope and mount are unchanged by the packaging
+# ---------------------------------------------------------------------------
+
+def test_public_schema_keeps_the_strict_action_family_shape():
+    schema = avatar_tool.get_schema()
+    assert set(schema["properties"]) == {"action", "input", "reasoning", "summarize"}
+    assert schema["required"] == ["action", "input", "reasoning"]
+    assert schema["additionalProperties"] is False
+    assert schema["properties"]["action"]["enum"] == list(AVATAR_ACTIONS)
+    assert len(schema["allOf"]) == len(AVATAR_ACTIONS)
+    branch_titles = [b["title"] for b in schema["properties"]["input"]["oneOf"]]
+    assert branch_titles == [f"{action} input" for action in AVATAR_ACTIONS]
+
+
+def test_unknown_action_error_names_exactly_the_plugin_action_list():
+    bare = object.__new__(AvatarManager)
+    bare._family = avatar_tool._FAMILY
+    bare._pending_reasoning = None
+    assert bare.handle({"action": "bogus", "input": {}}) == {
+        "error": "unknown action: 'bogus', only 'spawn', 'rules', or 'manual' is supported",
+    }
+    assert avatar_tool._SUPPORTED_ACTIONS_PHRASE == "'spawn', 'rules', or 'manual'"
+
+
+def test_declared_actions_still_dispatch_into_their_own_handlers():
+    recorder = _RecordingManager()
+    family = _recording_family(recorder)
+    result = family.handle(
+        {"action": "rules", "input": {"rules_content": "Be concise."}}
+    )
+    assert result == {"status": "ok", "action": "rules"}
+    assert recorder.calls == [("rules", {"rules_content": "Be concise."})]
+
+
+def test_setup_mounts_one_tool_sourced_from_the_plugin_descriptor():
+    from unittest.mock import MagicMock
+
+    agent = MagicMock()
+    avatar_tool.setup(agent)
+    assert agent.add_tool.call_count == 1
+    (name,), kwargs = agent.add_tool.call_args
+    assert name == AVATAR_PLUGIN.name == "avatar"
+    assert kwargs["glossary_package"] == AVATAR_PLUGIN.package
+    assert kwargs["description"] == AVATAR_DESCRIPTION
+    assert kwargs["schema"] == avatar_tool.get_schema()
+    # Composition only: the descriptor hands back kwargs, the package calls.
+    assert set(kwargs) == {"schema", "handler", "description", "glossary_package"}
+
+
+# ---------------------------------------------------------------------------
+# Descriptor defects fail loudly at import time
+# ---------------------------------------------------------------------------
+
+def test_descriptor_rejects_a_package_that_is_not_its_own_module():
+    with pytest.raises(BuiltinToolPluginError, match="must be the 'avatar' module"):
+        BuiltinToolPlugin(**_descriptor_fields(package="lingtai.tools.daemon"))
+
+
+def test_descriptor_rejects_a_package_outside_the_builtin_tool_tree():
+    with pytest.raises(BuiltinToolPluginError, match="must live under 'lingtai.tools.'"):
+        BuiltinToolPlugin(**_descriptor_fields(package="lingtai.mcp_servers.avatar"))
+
+
+def test_descriptor_accepts_a_retained_implementation_directory_alias():
+    """``bash``→``shell`` style renames declare the module, never the destination."""
+    aliased = BuiltinToolPlugin(
+        name="shell",
+        package="lingtai.tools.bash",
+        summary="s",
+        skill_name="shell-manual",
+        module_name="bash",
+    )
+    assert aliased.module == "bash"
+    assert aliased.capability_declaration()["module"] == "lingtai.tools.bash"
+    assert aliased.installed_manual_path() == ".library/intrinsic/capabilities/shell/SKILL.md"
+
+
+@pytest.mark.parametrize("blank_field", ["name", "package", "summary", "skill_name"])
+def test_descriptor_rejects_blank_identity_fields(blank_field):
+    with pytest.raises(BuiltinToolPluginError, match="non-empty string"):
+        BuiltinToolPlugin(**_descriptor_fields(**{blank_field: "  "}))
+
+
+def test_descriptor_rejects_non_mapping_boot_kwargs():
+    with pytest.raises(BuiltinToolPluginError, match="must be a mapping"):
+        BuiltinToolPlugin(**_descriptor_fields(default_kwargs=["yolo"]))

--- a/tests/test_builtin_tool_plugin_package.py
+++ b/tests/test_builtin_tool_plugin_package.py
@@ -9,9 +9,13 @@ declared, schema'd, or handled by the package.
 
 These tests pin the packaging promise, the runtime discovery/mount contract
 around it (registry entry, lazy import, ``.library`` install), and the
-*unchanged* public Avatar surface. No test spawns a live avatar: the launcher
-Port is a double, every agent lives under ``tmp_path``, and the manual action
-touches nothing.
+*unchanged* public Avatar surface. The ``manual`` tests run against a real
+host built by the ``host`` fixture — a real ``Agent`` whose real
+``_install_intrinsic_manuals`` put the skill on disk — because the one thing
+the action must report is the *host-local installed* path, which a hand-built
+stub could only assert against itself. No test spawns a live avatar: the
+launcher Port is a double, every agent lives under ``tmp_path``, and the
+manual action touches nothing.
 """
 from __future__ import annotations
 
@@ -52,11 +56,35 @@ class _RecordingManager:
         return _handle
 
 
-def _recording_family(recorder: _RecordingManager):
+def _recording_family(recorder: _RecordingManager, agent=None):
     """Avatar's real family with its declared actions bound to the recorder."""
     return avatar_tool._build_family(
-        {action: recorder.handler(action) for action in AVATAR_DECLARED_ACTIONS}
+        {action: recorder.handler(action) for action in AVATAR_DECLARED_ACTIONS},
+        agent,
     )
+
+
+@pytest.fixture
+def host(tmp_path):
+    """A real agent host, manuals installed by the real installer.
+
+    ``Agent.__init__`` runs ``_install_intrinsic_manuals``, so the avatar skill
+    is on disk at ``AVATAR_PLUGIN.installed_manual_path()`` exactly as a booted
+    agent sees it. No live avatar is ever spawned: nothing here calls ``spawn``.
+    """
+    from lingtai.agent import Agent
+    from tests._service_helpers import make_gemini_mock_service
+
+    return Agent(
+        service=make_gemini_mock_service(),
+        agent_name="parent",
+        working_dir=tmp_path / "parent",
+        capabilities=["avatar"],
+    )
+
+
+def _installed_manual(agent) -> Path:
+    return agent._working_dir / AVATAR_PLUGIN.installed_manual_path()
 
 
 def _descriptor_fields(**overrides):
@@ -146,7 +174,8 @@ def test_package_does_not_declare_manual_and_the_plugin_appends_it_last():
                 [
                     ChildTool("spawn", {"type": "object"}, lambda _i: {}),
                     ChildTool("manual", {"type": "object"}, lambda _i: {"hijacked": True}),
-                ]
+                ],
+                None,
             ),
             id="family",
         ),
@@ -165,48 +194,81 @@ def test_composed_family_always_carries_a_manual_child_with_the_shared_strict_in
     assert dict(avatar_tool._CHILD_SPECS)["manual"] is MANUAL_INPUT_SCHEMA
 
 
-def test_manual_answers_from_the_packaged_skill_without_entering_the_manager():
+def test_manual_answers_from_the_installed_skill_without_entering_the_manager(host):
     recorder = _RecordingManager()
-    family = _recording_family(recorder)
+    family = _recording_family(recorder, host)
     result = family.handle({"action": "manual", "input": {}})
     assert recorder.calls == []
-    assert result == AVATAR_PLUGIN.manual_payload()
+    assert result == AVATAR_PLUGIN.manual_payload(host)
     assert result["status"] == "ok"
     assert result["action"] == "manual"
     skill_path = Path(result["manual_path"])
-    assert skill_path.is_absolute() and skill_path.name == "SKILL.md"
+    assert skill_path == _installed_manual(host)
     assert result["manual"] == skill_path.read_text(encoding="utf-8")
 
 
-def test_the_manager_cannot_rebind_the_public_manual_action(tmp_path):
+def test_manual_reports_the_host_local_install_not_the_packaged_source(host):
+    """The regression: ``manual_path`` is the agent's own file, never the source tree.
+
+    A real host, a real ``_install_intrinsic_manuals``, and the real
+    ``AvatarManager.handle`` dispatch — the path the model is handed must be
+    openable from inside this agent's working dir.
+    """
+    installed = _installed_manual(host)
+    assert installed.is_file()
+
+    manager = AvatarManager(host, launcher=object())
+    result = manager.handle({"action": "manual", "input": {}})
+
+    assert result["status"] == "ok"
+    assert result["action"] == "manual"
+    assert Path(result["manual_path"]) == installed
+    assert result["manual"] == installed.read_text(encoding="utf-8")
+    # Not the candidate/source copy the host installed *from*.
+    packaged = Path(str(AVATAR_PLUGIN.manual_resource()))
+    assert Path(result["manual_path"]) != packaged
+    assert host._working_dir in Path(result["manual_path"]).parents
+
+
+def test_manual_degrades_truthfully_when_the_host_has_no_installed_copy(host):
+    """A failed install is reported, never backfilled from the packaged source."""
+    installed = _installed_manual(host)
+    installed.unlink()
+
+    result = AvatarManager(host, launcher=object()).handle(
+        {"action": "manual", "input": {}}
+    )
+    assert result["status"] == "degraded"
+    assert result["action"] == "manual"
+    assert result["manual"] == ""
+    assert "avatar manual missing" in result["error"]
+    assert Path(result["manual_path"]) == installed
+
+
+def test_the_manager_cannot_rebind_the_public_manual_action(host):
     """Even a manager that redefines its own manual cannot change the action."""
 
     class _HijackingManager(AvatarManager):
         def _manual(self):
             return {"status": "ok", "action": "manual", "manual": "hijacked"}
 
-    (tmp_path / "parent").mkdir()
-    agent = type("_StubAgent", (), {})()
-    agent._working_dir = tmp_path / "parent"
-    agent._admin = {}
-    agent.agent_name = "parent"
-    agent._venv_path = None
-    manager = _HijackingManager(agent, launcher=object())
+    manager = _HijackingManager(host, launcher=object())
 
     result = manager.handle({"action": "manual", "input": {}})
-    assert result == AVATAR_PLUGIN.manual_payload()
+    assert result == AVATAR_PLUGIN.manual_payload(host)
     assert result["manual"] != "hijacked"
 
 
-def test_manual_payload_is_the_same_document_the_legacy_manager_helper_returns():
+def test_manual_payload_is_the_same_document_the_legacy_manager_helper_returns(host):
     """Routing manual through the plugin preserves the existing public result."""
     bare = object.__new__(AvatarManager)
-    assert bare._manual() == AVATAR_PLUGIN.manual_payload()
+    bare._agent = host
+    assert bare._manual() == AVATAR_PLUGIN.manual_payload(host)
 
 
-def test_manual_input_stays_strictly_empty_and_the_action_writes_nothing(tmp_path):
+def test_manual_input_stays_strictly_empty_and_the_action_writes_nothing(host, tmp_path):
     recorder = _RecordingManager()
-    family = _recording_family(recorder)
+    family = _recording_family(recorder, host)
     rejected = family.handle({"action": "manual", "input": {"name": "helper"}})
     assert rejected["status"] == "failed"
     assert rejected["error_code"] == "INVALID_ARGUMENT"
@@ -235,25 +297,18 @@ def test_a_foreign_or_missing_packaged_skill_degrades_and_validates_loudly():
     # Refused, not served: the body is empty and the error names the mismatch.
     assert loaded["manual"] == ""
     assert "expected 'somebody-elses-manual'" in loaded["error"]
-    assert foreign.manual_payload()["action"] == "manual"
+    assert foreign.load_manual()["manual_path"].endswith("SKILL.md")
     with pytest.raises(BuiltinToolPluginError, match="declares skill"):
         foreign.validate_packaged_skill()
 
 
-def test_the_host_installs_the_packaged_skill_where_the_descriptor_says(tmp_path):
+def test_the_host_installs_the_packaged_skill_where_the_descriptor_says(host):
     """``Agent._install_intrinsic_manuals`` is the mount; the descriptor names it."""
-    from lingtai.agent import Agent
-    from tests._service_helpers import make_gemini_mock_service
-
-    agent = Agent(
-        service=make_gemini_mock_service(),
-        agent_name="parent",
-        working_dir=tmp_path / "parent",
-        capabilities=["avatar"],
-    )
-    installed = agent._working_dir / AVATAR_PLUGIN.installed_manual_path()
+    installed = _installed_manual(host)
     assert installed.is_file()
-    assert installed.read_text(encoding="utf-8") == AVATAR_PLUGIN.manual_payload()["manual"]
+    # Installed verbatim from the packaged source the descriptor points at.
+    packaged = Path(str(AVATAR_PLUGIN.manual_resource()))
+    assert installed.read_text(encoding="utf-8") == packaged.read_text(encoding="utf-8")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tool_family_avatar_migration.py
+++ b/tests/test_tool_family_avatar_migration.py
@@ -573,6 +573,12 @@ class TestManualThroughTheEnvelope:
         assert sorted(p.name for p in network.parent.iterdir()) == before
 
     def test_missing_packaged_manual_degrades_truthfully(self, network, launcher, monkeypatch):
+        # The packaged-skill read moved into the plugin descriptor when avatar
+        # became a built-in tool plugin, so the resource seam patched here is
+        # the plugin's. The dispatch boundary and the degraded result are
+        # unchanged: a missing manual never takes the family down.
+        from lingtai.tools import _plugin as tool_plugin
+
         mgr, _ = _manager(network, launcher)
 
         class _Missing:
@@ -586,10 +592,11 @@ class TestManualThroughTheEnvelope:
                 return "<missing avatar manual>"
 
         monkeypatch.setattr(
-            avatar_tool.resources, "files", lambda _pkg: _Missing(),
+            tool_plugin.resources, "files", lambda _pkg: _Missing(),
         )
         result = mgr.handle({"action": "manual", "input": {}})
         assert result["status"] == "degraded"
+        assert result["action"] == "manual"
         assert result["manual"] == ""
         assert result["error"] == "avatar manual missing"
         assert result["manual_path"] == "<missing avatar manual>"

--- a/tests/test_tool_family_avatar_migration.py
+++ b/tests/test_tool_family_avatar_migration.py
@@ -98,6 +98,21 @@ def _manager(parent_dir: Path, launcher: _FakeLauncher, *, admin: dict | None = 
     return AvatarManager(agent, launcher=launcher), agent
 
 
+def _install_manual(parent_dir: Path) -> Path:
+    """Put avatar's skill where ``Agent._install_intrinsic_manuals`` puts it.
+
+    Same destination, same bytes — the host-local copy ``manual`` reports. The
+    real installer is exercised end to end in
+    ``tests/test_builtin_tool_plugin_package.py``; here the stub agent stands in
+    for the host, so the install is reproduced rather than booted.
+    """
+    packaged = Path(str(avatar_tool.AVATAR_PLUGIN.manual_resource()))
+    installed = parent_dir / avatar_tool.AVATAR_PLUGIN.installed_manual_path()
+    installed.parent.mkdir(parents=True, exist_ok=True)
+    installed.write_text(packaged.read_text(encoding="utf-8"), encoding="utf-8")
+    return installed
+
+
 # ---------------------------------------------------------------------------
 # Schema: root envelope, per-action children, wire correlation
 # ---------------------------------------------------------------------------
@@ -233,6 +248,7 @@ class TestAvatarDispatch:
         assert kwargs["schema"]["required"] == ["action", "input", "reasoning"]
 
     def test_manual_result_is_not_double_wrapped(self, network, launcher):
+        _install_manual(network)
         mgr, _ = _manager(network, launcher)
         result = mgr.handle({"action": "manual", "input": {}})
         # Avatar's own canonical flat result — no generic envelope nested
@@ -547,19 +563,24 @@ class TestRulesThroughTheEnvelope:
 
 
 class TestManualThroughTheEnvelope:
-    def test_manual_returns_the_exact_packaged_body_and_path(self, network, launcher):
+    def test_manual_returns_the_exact_installed_body_and_host_local_path(
+        self, network, launcher
+    ):
+        installed = _install_manual(network)
         mgr, _ = _manager(network, launcher)
         result = mgr.handle({"action": "manual", "input": {}})
 
-        source = (
-            Path(avatar_tool.__file__).resolve().parent / "manual" / "SKILL.md"
-        )
         assert result["status"] == "ok"
         assert result["action"] == "manual"
-        assert result["manual"] == source.read_text(encoding="utf-8")
-        assert Path(result["manual_path"]) == source
+        assert result["manual"] == installed.read_text(encoding="utf-8")
+        assert Path(result["manual_path"]) == installed
+        # Never the candidate/source tree the host installed *from*.
+        assert Path(result["manual_path"]) != (
+            Path(avatar_tool.__file__).resolve().parent / "manual" / "SKILL.md"
+        )
 
     def test_manual_performs_no_spawn_or_rules_io(self, network, launcher):
+        _install_manual(network)
         mgr, _ = _manager(network, launcher, admin={"karma": True})
         before = sorted(p.name for p in network.parent.iterdir())
 
@@ -572,31 +593,18 @@ class TestManualThroughTheEnvelope:
         assert not (network / "logs").exists()
         assert sorted(p.name for p in network.parent.iterdir()) == before
 
-    def test_missing_packaged_manual_degrades_truthfully(self, network, launcher, monkeypatch):
-        # The packaged-skill read moved into the plugin descriptor when avatar
-        # became a built-in tool plugin, so the resource seam patched here is
-        # the plugin's. The dispatch boundary and the degraded result are
-        # unchanged: a missing manual never takes the family down.
-        from lingtai.tools import _plugin as tool_plugin
-
+    def test_missing_installed_manual_degrades_truthfully(self, network, launcher):
+        # This agent never had the manual installed. The dispatch boundary and
+        # the degraded result are unchanged: a missing manual never takes the
+        # family down — and it is never quietly backfilled from the packaged
+        # source, which would hide a failed install.
         mgr, _ = _manager(network, launcher)
 
-        class _Missing:
-            def joinpath(self, _name):
-                return self
-
-            def read_text(self, **_kwargs):
-                raise FileNotFoundError("gone")
-
-            def __str__(self) -> str:
-                return "<missing avatar manual>"
-
-        monkeypatch.setattr(
-            tool_plugin.resources, "files", lambda _pkg: _Missing(),
-        )
         result = mgr.handle({"action": "manual", "input": {}})
         assert result["status"] == "degraded"
         assert result["action"] == "manual"
         assert result["manual"] == ""
-        assert result["error"] == "avatar manual missing"
-        assert result["manual_path"] == "<missing avatar manual>"
+        assert "avatar manual missing" in result["error"]
+        assert Path(result["manual_path"]) == (
+            network / avatar_tool.AVATAR_PLUGIN.installed_manual_path()
+        )


### PR DESCRIPTION
## Summary
- Turns `avatar` into a real Agent Plugin with its package manifest, runtime discovery/mount wiring, and a plugin-owned manual skill.
- Candidate head: `26109df4`; this is one isolated tool PR and remains unmerged for Jason’s decision.

## Validation and review context
- Candidate-focused validation and independent review artifacts were completed locally before this PR.
- Any reviewer findings remain preserved with the candidate; this PR is opened under Jason’s explicit all-tool PR instruction (Telegram 14623).

Telegram: @lingtaidev1bot | Nickname: 知微
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
