### PR TITLE
feat: make daemon a real agent plugin

### DIFF
--- a/src/lingtai/tools/ANATOMY.md
+++ b/src/lingtai/tools/ANATOMY.md
@@ -46,6 +46,7 @@ related_files:
   - ENVIRONMENT_VARIABLES.md
   - src/lingtai/tools/__init__.py
   - src/lingtai/tools/_manual.py
+  - src/lingtai/tools/_plugin.py
   - src/lingtai/tools/email/ANATOMY.md
   - src/lingtai/tools/i18n/__init__.py
   - src/lingtai/tools/i18n/en.json
@@ -158,6 +159,18 @@ capability names and lazy adapters.
   (`src/lingtai/tools/email/ANATOMY.md`).
 - `_manual.py` — bounded installed-manual loader
   (`src/lingtai/tools/_manual.py:1-29`).
+- `_plugin.py` — built-in tool **plugin packaging** descriptor:
+  `BuiltinToolPlugin` binds one package's identity, its bundled `manual/`
+  skill (loaded and name-checked at construction), and the capability record
+  the host registry publishes for it (`capability_declaration()`). It also owns
+  the reserved-action promise: `actions()`, `action_input_schemas()`, and
+  `build_family()` append `manual` from the packaged skill — bound to that
+  skill's mounted destination — and raise `BuiltinToolPluginError` if a package
+  declares, re-schemas, or rebinds it. Declarative only — no discovery,
+  import-by-name, activation, workdir I/O, or config reading; capability
+  lookup/setup stays in `registry.py` and manual mounting stays in
+  `lingtai/agent.py`'s `_install_intrinsic_manuals`. It is the `lingtai.tools`
+  twin of `src/lingtai/mcp_servers/_plugin.py`.
 - `__init__.py` — the package docstring that fixes the flat one-directory-per-tool
   layout and the `lingtai → lingtai.tools → lingtai.kernel` import DAG enforced by
   `tests/test_kernel_isolation.py` (`src/lingtai/tools/__init__.py:1-12`).
@@ -229,3 +242,15 @@ registry, schema, prompt, check-caps, manual, or catalog entries under those old
 public names. The five pre-migration file packages are not among them: they were
 deleted outright into `file/`, so there is no legacy directory, contract,
 glossary, or alias left for that surface.
+
+**Built-in plugin packaging is declarative, not a runtime.** `_plugin.py` adds
+no in-process plugin runtime, no config flag, and no second registry: a
+`BuiltinToolPlugin` is a package-local descriptor its own package imports
+explicitly. `registry.py`'s `BUILTIN_TOOLS`/`CORE_DEFAULTS` remain the tables
+the host reads for capability lookup, `setup_capability` remains the only
+activation path, and `Agent._install_intrinsic_manuals` remains the only thing
+that mounts a `manual/` bundle — the descriptor is what those must agree with,
+proven by test rather than by generating them at import. `daemon/` is the one
+package wired through it today (`src/lingtai/tools/daemon/plugin.py`,
+`tests/test_builtin_tool_plugin_package.py`); every other tool still declares
+these facts inline and is unchanged.

--- a/src/lingtai/tools/_plugin.py
+++ b/src/lingtai/tools/_plugin.py
@@ -1,0 +1,289 @@
+"""Built-in tool plugin packaging: one package owns its manual, actions, and mount record.
+
+A built-in capability tool is not just a module ``registry.BUILTIN_TOOLS``
+happens to name. It is a *plugin-style package*: the same folder ships the
+handler code, the bundled ``manual/`` skill the agent library mounts, and the
+capability record the host publishes for it. This module is the small shared
+piece that binds those three together for one package, so a built-in tool
+cannot drift into declaring its module path in one place, its manual in
+another, and a public action list that silently disagrees with both.
+
+It is the ``lingtai.tools`` twin of ``lingtai.mcp_servers._plugin`` — same
+descriptor shape, same reserved-``manual`` promise — with the one difference
+that matters for a built-in: an MCP package publishes a *launcher* record and
+answers ``manual`` straight from its own wheel, while a built-in tool publishes
+a *capability* record and answers ``manual`` from the copy the initializer
+mounted into the agent's own ``.library``. Both facts are declared here, in one
+place, by the package that owns them.
+
+It deliberately is **not** a plugin runtime. Nothing here discovers packages,
+imports them by name, spawns them, registers them, reads configuration, or
+touches an agent's workdir. Capability activation, kwargs resolution, ordering,
+supervision, and lifecycle all remain the host's: ``lingtai.tools.registry``
+still owns ``BUILTIN_TOOLS``/``CORE_DEFAULTS``/``setup_capability`` and
+``lingtai.agent`` still owns ``_install_intrinsic_manuals``. A
+:class:`BuiltinToolPlugin` is a declarative descriptor plus three composition
+helpers that its own package calls explicitly, and the shipped registry/
+initializer stay the runtime source the host reads — this descriptor is what
+those must agree with, proven by test rather than by generating them at import.
+
+The one hard promise it enforces is the reserved ``manual`` action
+(``tools/CONTRACT.md`` "Every LingTai-owned family MUST offer a ``manual``
+action"): a package declares only its *own* actions, and this module appends
+``manual`` itself, bound to the packaged skill's mounted destination. A package
+that tries to declare, re-schema, or re-handle ``manual`` raises
+:class:`BuiltinToolPluginError` at import time rather than shipping a family
+whose manual is missing or points somewhere other than its own mounted skill.
+"""
+from __future__ import annotations
+
+import copy
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from importlib import resources
+from typing import Any
+
+from lingtai.kernel._frontmatter import split_frontmatter
+
+from .tool_family import RESERVED_MANUAL_NAME, ChildTool, ToolFamily
+from .tool_family.manual import MANUAL_INPUT_SCHEMA, build_manual_child
+
+__all__ = [
+    "BUILTIN_SOURCE",
+    "INTRINSIC_CAPABILITIES_RELPATH",
+    "MANUAL_ACTION",
+    "MANUAL_BUNDLE_DIRNAME",
+    "SKILL_FILENAME",
+    "TOOLS_PACKAGE",
+    "BuiltinToolPlugin",
+    "BuiltinToolPluginError",
+]
+
+#: ``source`` stamped on every built-in capability record — the value that tells
+#: a kernel-shipped capability apart from a ``plugin:<name>``-sourced external
+#: Agent Plugin (``services/plugin_registry.py``) or a curated MCP
+#: (``mcp_servers/_plugin.py``'s ``lingtai-curated``).
+BUILTIN_SOURCE = "lingtai-builtin"
+
+#: The reserved action name. Owned by ``lingtai.tools.tool_family``; re-exported
+#: here so a tool package never spells the literal itself.
+MANUAL_ACTION = RESERVED_MANUAL_NAME
+
+#: The package that owns every built-in tool; every descriptor's ``package``
+#: must live under it.
+TOOLS_PACKAGE = "lingtai.tools"
+
+#: The per-package manual bundle directory ``Agent._install_intrinsic_manuals``
+#: copies verbatim, and the skill file inside it.
+MANUAL_BUNDLE_DIRNAME = "manual"
+SKILL_FILENAME = "SKILL.md"
+
+#: Where that bundle lands inside an agent's working directory. The trailing
+#: path component is the *public* capability name, not the implementation
+#: package — which is why the descriptor carries both.
+INTRINSIC_CAPABILITIES_RELPATH = ".library/intrinsic/capabilities"
+
+
+class BuiltinToolPluginError(ValueError):
+    """Raised for a built-in tool packaging defect (bad descriptor or shape)."""
+
+
+@dataclass(frozen=True)
+class BuiltinToolPlugin:
+    """One built-in tool package's identity, packaged manual, and mount record.
+
+    ``name`` is the public capability name, the registered model-facing tool
+    name, the family name, and the directory the packaged manual is mounted
+    under in an agent's ``.library``. ``package`` is the Python package that
+    ships the handler code and the ``manual/`` bundle, and ``implementation``
+    is that package's last component — the directory
+    ``Agent._install_intrinsic_manuals`` scans. The two are stated separately
+    because the kernel deliberately mounts some packages under a different
+    public name (``bash`` → ``shell``, ``web_search`` → ``web``); a descriptor
+    that collapsed them could not describe those tools at all, and one whose
+    ``implementation`` disagreed with its own ``package`` would advertise a
+    manual source belonging to a different tool.
+
+    The bundled skill is loaded once at construction and its frontmatter
+    ``name`` is checked against ``manual_skill_name``, so a package that
+    renames or loses its manual fails loudly at import instead of serving an
+    empty or foreign ``manual``.
+    """
+
+    name: str
+    package: str
+    implementation: str
+    summary: str
+    manual_skill_name: str
+
+    # Loaded from the package's bundled manual/SKILL.md at construction.
+    # Excluded from init/repr/eq: derived material, not declared identity.
+    _skill_frontmatter: dict[str, str] = field(init=False, repr=False, compare=False)
+    _skill_body: str = field(init=False, repr=False, compare=False)
+    _skill_path: str = field(init=False, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        for attribute in (
+            "name", "package", "implementation", "summary", "manual_skill_name",
+        ):
+            value = getattr(self, attribute)
+            if not isinstance(value, str) or not value.strip():
+                raise BuiltinToolPluginError(
+                    f"BuiltinToolPlugin {attribute!r} must be a non-empty string"
+                )
+        if not self.package.startswith(f"{TOOLS_PACKAGE}."):
+            raise BuiltinToolPluginError(
+                f"BuiltinToolPlugin package {self.package!r} must live under "
+                f"{TOOLS_PACKAGE!r} so the capability registry can import it"
+            )
+        if self.package.rpartition(".")[2] != self.implementation:
+            raise BuiltinToolPluginError(
+                f"BuiltinToolPlugin package {self.package!r} must be the "
+                f"{self.implementation!r} module so its declared manual source "
+                f"is its own bundle"
+            )
+        frontmatter, body, path = self._load_packaged_skill()
+        if frontmatter.get("name") != self.manual_skill_name:
+            raise BuiltinToolPluginError(
+                f"BuiltinToolPlugin {self.name!r} bundled {SKILL_FILENAME} declares "
+                f"name {frontmatter.get('name')!r}, expected {self.manual_skill_name!r}"
+            )
+        if not body.strip():
+            raise BuiltinToolPluginError(
+                f"BuiltinToolPlugin {self.name!r} bundled {SKILL_FILENAME} "
+                f"has an empty body"
+            )
+        object.__setattr__(self, "_skill_frontmatter", frontmatter)
+        object.__setattr__(self, "_skill_body", body)
+        object.__setattr__(self, "_skill_path", path)
+
+    def _load_packaged_skill(self) -> tuple[dict[str, str], str, str]:
+        """Read this package's own ``manual/SKILL.md`` → (frontmatter, body, path)."""
+        try:
+            resource = resources.files(self.package).joinpath(
+                MANUAL_BUNDLE_DIRNAME, SKILL_FILENAME
+            )
+            text = resource.read_text(encoding="utf-8")
+        except (FileNotFoundError, ModuleNotFoundError, OSError) as e:
+            raise BuiltinToolPluginError(
+                f"BuiltinToolPlugin {self.name!r} cannot read its bundled "
+                f"{MANUAL_BUNDLE_DIRNAME}/{SKILL_FILENAME}: {e}"
+            ) from e
+        frontmatter, body = split_frontmatter(text)
+        return frontmatter, body, str(resource)
+
+    # -- packaged skill / mount contract -----------------------------------
+
+    @property
+    def skill_frontmatter(self) -> dict[str, str]:
+        """Parsed packaged ``SKILL.md`` frontmatter (the manual's catalog entry)."""
+        return self._skill_frontmatter
+
+    @property
+    def skill_body(self) -> str:
+        """The packaged ``SKILL.md`` markdown body the initializer mounts."""
+        return self._skill_body
+
+    @property
+    def skill_path(self) -> str:
+        """Absolute resolved path of the packaged ``manual/SKILL.md``."""
+        return self._skill_path
+
+    def packaged_manual_relpath(self) -> str:
+        """Repo-relative source of the manual bundle the initializer copies."""
+        return (
+            f"src/{self.package.replace('.', '/')}/{MANUAL_BUNDLE_DIRNAME}"
+        )
+
+    def mounted_manual_relpath(self) -> str:
+        """Workdir-relative destination the mounted manual is read back from.
+
+        The exact path ``tools/_manual.load_installed_manual`` composes for
+        this plugin's :attr:`name`, and therefore the path ``action='manual'``
+        reports to the model.
+        """
+        return f"{INTRINSIC_CAPABILITIES_RELPATH}/{self.name}/{SKILL_FILENAME}"
+
+    # -- family composition -------------------------------------------------
+
+    def manual_input_schema(self) -> dict[str, Any]:
+        """A fresh copy of the one shared strict-empty ``manual`` input schema."""
+        # Deep copy for the same reason ``build_manual_child`` does it: a shallow
+        # one would share the nested ``properties`` map across every family.
+        return copy.deepcopy(MANUAL_INPUT_SCHEMA)
+
+    def manual_child(self, agent: Any) -> ChildTool:
+        """The plugin-owned reserved ``manual`` child.
+
+        Bound to this descriptor's :attr:`name` — the mounted destination of
+        its own packaged bundle — so ``manual`` never routes through the
+        package's business manager and cannot be rebound to another tool's
+        skill. ``agent`` may be ``None`` for a schema-only family, exactly as
+        it may be for :func:`~lingtai.tools.tool_family.manual.build_manual_child`;
+        such a family never dispatches.
+        """
+        return build_manual_child(agent, self.name)
+
+    def actions(self, declared: Sequence[str]) -> tuple[str, ...]:
+        """Declared actions plus the reserved ``manual``, in that order."""
+        self._check_declared_names(declared)
+        return tuple(declared) + (MANUAL_ACTION,)
+
+    def action_input_schemas(
+        self, declared: Sequence[tuple[str, Mapping[str, Any]]]
+    ) -> tuple[tuple[str, dict[str, Any]], ...]:
+        """Declared ``input`` schemas plus the reserved ``manual`` schema, in order.
+
+        Ordered pairs rather than a mapping because this sequence *is* the
+        model-facing enum order and the ``input`` branch order of the composed
+        schema, not an incidental lookup table.
+        """
+        self._check_declared_names([action for action, _ in declared])
+        return (
+            *((action, dict(schema)) for action, schema in declared),
+            (MANUAL_ACTION, self.manual_input_schema()),
+        )
+
+    def build_family(self, declared: Sequence[ChildTool], agent: Any) -> ToolFamily:
+        """Compose this plugin's one public family, manual always appended."""
+        self._check_declared_names([child.name for child in declared])
+        return ToolFamily(self.name, [*declared, self.manual_child(agent)])
+
+    def _check_declared_names(self, declared: Sequence[str]) -> None:
+        names = list(declared)
+        if not names:
+            raise BuiltinToolPluginError(
+                f"BuiltinToolPlugin {self.name!r} must declare at least one action"
+            )
+        if MANUAL_ACTION in names:
+            raise BuiltinToolPluginError(
+                f"BuiltinToolPlugin {self.name!r} must not declare the reserved "
+                f"{MANUAL_ACTION!r} action; it is appended from the packaged "
+                f"{MANUAL_BUNDLE_DIRNAME}/{SKILL_FILENAME}"
+            )
+        if len(set(names)) != len(names):
+            raise BuiltinToolPluginError(
+                f"BuiltinToolPlugin {self.name!r} declared a duplicate action"
+            )
+
+    # -- shipped capability declaration -------------------------------------
+
+    def capability_declaration(self) -> dict[str, Any]:
+        """This package's built-in capability record, in host-registry shape.
+
+        ``module`` is exactly what ``registry.BUILTIN_TOOLS[name]`` must hold
+        (the path ``setup_capability`` imports), and ``manual_source`` /
+        ``manual_mount`` are exactly the copy ``Agent._install_intrinsic_manuals``
+        performs for this package. Returning them here registers and mounts
+        nothing: the shipped registry and initializer remain the runtime source
+        the host reads, and this descriptor is what they must agree with.
+        """
+        return {
+            "name": self.name,
+            "summary": self.summary,
+            "module": self.package,
+            "source": BUILTIN_SOURCE,
+            "manual_skill": self.manual_skill_name,
+            "manual_source": self.packaged_manual_relpath(),
+            "manual_mount": self.mounted_manual_relpath(),
+        }

--- a/src/lingtai/tools/daemon/ANATOMY.md
+++ b/src/lingtai/tools/daemon/ANATOMY.md
@@ -5,6 +5,8 @@ related_files:
   - src/lingtai/tools/daemon/CONTRACT.md
   - src/lingtai/tools/daemon/__init__.py
   - src/lingtai/tools/daemon/_tool_family.py
+  - src/lingtai/tools/daemon/plugin.py
+  - src/lingtai/tools/_plugin.py
   - src/lingtai/tools/daemon/system_prompt.py
   - src/lingtai/tools/tool_family/ANATOMY.md
   - src/lingtai/tools/tool_family/__init__.py
@@ -35,6 +37,7 @@ related_files:
   - tests/test_daemon_attention_delay.py
   - tests/test_daemon_central_manager.py
   - tests/test_tool_family_daemon_migration.py
+  - tests/test_builtin_tool_plugin_package.py
   - tests/test_daemon_empty_parity.py
   - tests/test_apriori_summary_executor.py
   - tests/test_daemon_run_dir.py
@@ -169,6 +172,16 @@ remains deferred until ConPTY has its own accepted adapter. `ClaudeInteractiveBr
 - `adapters/posix/daemon_execution_child_entrypoint.py` — fresh-interpreter execution boundary launched by the supervisor before its watcher. It registers exact execution PID/PGID/start identity and composes the existing production host; it does not duplicate backend parsers. `daemon_resume_owner_entrypoint.py` provides the bounded detached owner for one terminal supported-CLI resume generation. Durable `resume-claims/` records enforce one writer, and `followups/` plus `daemon.json` expose follow-up truth to `daemon(check)`.
 - `adapters/posix/process_identity.py` — shared POSIX process-incarnation helper. Linux identities combine boot ID and `/proc/<pid>/stat` start ticks; Darwin/BSD identities use bounded `ps` start time plus PPID. It returns `None` when observation is unavailable, and all ownership-sensitive signal paths refuse unknown or mismatched identities.
 - `daemon/runtime.py` — stateless daemon backend runtime primitives shared by the LingTai in-process loop and transitional CLI runners. Port-owned Codex, Cursor, OpenCode-family, Qwen, and Kimi runners use the daemon-local process Port for stderr draining and stdout iteration; only ask workers use a local deadline, while initial streams remain watchdog-owned. The historical private names remain for unmigrated paths and compatibility tests.
+- `daemon/plugin.py` — Daemon's **plugin descriptor**, the reference slice for
+  `src/lingtai/tools/_plugin.py`. `DAEMON_PLUGIN` states the public capability
+  name, the module the capability registry imports, the packaged `manual/`
+  bundle and the `daemon-manual` skill it declares;
+  `DAEMON_DECLARED_ACTIONS` lists Daemon's own five actions with `manual`
+  deliberately absent, and `DAEMON_ACTIONS` is the plugin-composed public list.
+  `_tool_family.py` builds the schema/dispatch from it and `__init__.py`
+  registers the public tool under its name. Packaging only: no manager
+  construction, backend routing, supervision, lifecycle, config, or auth
+  decision lives here.
 - `daemon/CONTRACT.md` — maintained daemon contract for the public tool surface, selected skills catalog/path semantics, MCP registration redaction/native mounting, `daemon_common` checkpoint/inbox delivery and completion enforcement, backend implementation status, run artifacts, review triggers, and the acceptance gate for new backend or contract-impacting changes.
 
 - `daemon/interactive_terminal/` — capability-local immutable command/exit values and the
@@ -210,8 +223,10 @@ remains deferred until ConPTY has its own accepted adapter. `ClaudeInteractiveBr
 
 `daemon` is one model-facing tool carrying the LTP v2 action-separated envelope
 (`action`, `input`, required `reasoning`, optional `summarize`) composed by
-`_tool_family.py` from six internal `ChildTool`s. The children consume no extra
-model tool slot. Each action's own strict `input` fields are listed in
+`_tool_family.py` from six internal `ChildTool`s — Daemon's own five, declared
+in `plugin.py`, plus the reserved `manual` that `BuiltinToolPlugin` appends from
+the packaged skill and no package may declare, re-schema, or rebind. The
+children consume no extra model tool slot. Each action's own strict `input` fields are listed in
 `CONTRACT.md` §Tool Surface; `list`/`check`/`manual` are read-only and
 `emanate`/`ask`/`reclaim` are the side-effectful three.
 

--- a/src/lingtai/tools/daemon/CONTRACT.md
+++ b/src/lingtai/tools/daemon/CONTRACT.md
@@ -8,12 +8,15 @@ description: >
   terminal notifications, and compaction boundaries.
 status: active
 contract_version: 10
-last_changed_at: "2026-08-18"
+last_changed_at: "2026-08-22"
 related_files:
   - src/lingtai/tools/daemon/ANATOMY.md
   - src/lingtai/tools/daemon/BEHAVIORS.md
   - src/lingtai/tools/daemon/__init__.py
   - src/lingtai/tools/daemon/_tool_family.py
+  - src/lingtai/tools/daemon/plugin.py
+  - src/lingtai/tools/_plugin.py
+  - tests/test_builtin_tool_plugin_package.py
   - src/lingtai/tools/daemon/system_prompt.py
   - src/lingtai/tools/tool_family/CONTRACT.md
   - src/lingtai/tools/tool_family/__init__.py
@@ -63,6 +66,8 @@ related_files:
 review_triggers:
   - src/lingtai/tools/daemon/__init__.py
   - src/lingtai/tools/daemon/_tool_family.py
+  - src/lingtai/tools/daemon/plugin.py
+  - src/lingtai/tools/_plugin.py
   - src/lingtai/tools/daemon/system_prompt.py
   - src/lingtai/kernel/meta_block.py
   - src/lingtai/services/mcp.py
@@ -205,17 +210,34 @@ The former flat root `summary` boolean is replaced by the canonical root
 rather than silently ignored, and the legacy `summary` spelling remains
 accepted there for historical/pending calls.
 
+`plugin.py` owns this package's plugin identity: the public capability name,
+the module the capability registry imports, the packaged `manual/` bundle and
+the `daemon-manual` skill it declares, and Daemon's own five declared actions.
 `_tool_family.py` owns the child registry, the composed schema, and the
 `DaemonFamilyDispatcher` that translates one envelope call into
-`DaemonManager.handle`'s unchanged legacy flat shape. `DaemonManager` remains
+`DaemonManager.handle`'s unchanged legacy flat shape; it composes both through
+the descriptor, so the public tool name and the appended reserved `manual` are
+the plugin's, not literals restated per call site. `DaemonManager` remains
 the untouched engine: batch emanation, backend routing, run directories, the
 detached supervisor, `daemon_common` completion signaling, cancellation,
 timeouts, terminal notifications, and result/error persistence are unchanged by
-the migration. `DaemonManager.handle`'s own `action="manual"` branch is retained
-as that internal flat shape only; the registered model-facing `manual` is the
-shared reserved `build_manual_child(agent, "daemon")` child, returning the
-canonical `content[0].text` / `structuredContent.manual_path` result verbatim
-with no double wrap, and reaching no engine method.
+the migration and by the packaging. `DaemonManager.handle`'s own
+`action="manual"` branch is retained as that internal flat shape only; the
+registered model-facing `manual` is the plugin-owned reserved child
+(`DAEMON_PLUGIN.manual_child(agent)`), bound to this package's own mounted
+skill, returning the canonical `content[0].text` /
+`structuredContent.manual_path` result verbatim with no double wrap, and
+reaching no engine method. A package that declares, re-schemas, or rebinds
+`manual` raises `BuiltinToolPluginError` at import.
+
+Packaging is declarative. `registry.BUILTIN_TOOLS`/`CORE_DEFAULTS` remain the
+tables the host reads, `setup_capability` remains the only activation path, and
+`Agent._install_intrinsic_manuals` remains the only thing that mounts the
+`manual/` bundle. `DAEMON_PLUGIN.capability_declaration()` states the record
+those must agree with — `module` equal to `BUILTIN_TOOLS["daemon"]` and
+`manual_mount` equal to `.library/intrinsic/capabilities/daemon/SKILL.md` — and
+`tests/test_builtin_tool_plugin_package.py` proves the agreement rather than
+generating either at import.
 
 `list`, `check`, and `manual` are read-only. `emanate`, `ask`, and `reclaim`
 are the three side-effectful actions.

--- a/src/lingtai/tools/daemon/__init__.py
+++ b/src/lingtai/tools/daemon/__init__.py
@@ -60,6 +60,7 @@ from ._tool_family import (
     DaemonFamilyDispatcher,
     build_schema as _family_build_schema,
 )
+from .plugin import DAEMON_PLUGIN
 from lingtai.adapters.posix.process_identity import (
     process_identity,
     process_identity_matches,
@@ -1864,7 +1865,11 @@ class DaemonManager:
     def handle(self, args: dict) -> dict:
         action = args.get("action")
         if action == "manual":
-            return load_installed_manual(self._agent, "daemon")
+            # Retained legacy flat branch (never the registered model-facing
+            # path — the family's plugin-owned ``manual`` child is). It reads
+            # the same mounted skill the descriptor declares, so the two
+            # spellings cannot point at different documents.
+            return load_installed_manual(self._agent, DAEMON_PLUGIN.name)
         backend = _normalize_backend(args.get("backend", "lingtai"))
         if action == "emanate":
             return self._handle_emanate(
@@ -9708,6 +9713,9 @@ def setup(agent: "Agent",
     # engine's legacy flat ``handle``. Still exactly one registered public
     # tool named ``daemon`` — the six children consume no extra tool slot.
     dispatcher = DaemonFamilyDispatcher(mgr, agent, list(_BACKEND_SCHEMA_ENUM))
-    agent.add_tool("daemon", schema=schema, handler=dispatcher.handle,
+    # The registered public name is the plugin descriptor's (``plugin.py``) —
+    # the same name the capability registry keys this package under and the
+    # same directory its packaged manual is mounted at.
+    agent.add_tool(DAEMON_PLUGIN.name, schema=schema, handler=dispatcher.handle,
                    description=get_description(), glossary_package=__package__)
     return mgr

--- a/src/lingtai/tools/daemon/_tool_family.py
+++ b/src/lingtai/tools/daemon/_tool_family.py
@@ -34,12 +34,14 @@ one registered public tool.
 
 Two behaviors deliberately do NOT move here:
 
-* ``manual`` is served by the shared ``build_manual_child(agent, "daemon")``
-  reserved child, which reads the same installed
-  ``.library/intrinsic/capabilities/daemon/SKILL.md`` body/path the
+* ``manual`` is served by the plugin-owned reserved child
+  (``DAEMON_PLUGIN.manual_child(agent)``, ``plugin.py``), which reads the same
+  installed ``.library/intrinsic/capabilities/daemon/SKILL.md`` body/path the
   pre-migration ``DaemonManager.handle({"action": "manual"})`` branch read via
-  ``load_installed_manual``. It returns the canonical
-  ``content``/``structuredContent`` shape and performs no daemon operation.
+  ``load_installed_manual`` — that mount is the descriptor's own
+  ``manual_mount``, so the child cannot point at another tool's skill. It
+  returns the canonical ``content``/``structuredContent`` shape and performs no
+  daemon operation.
 * The legacy flat root ``summary`` boolean is replaced by the canonical root
   ``summarize`` control, which ``ToolFamily.build_schema`` advertises and
   ``ToolFamily.handle`` strips before any child handler runs. ``daemon`` joins
@@ -52,8 +54,8 @@ from __future__ import annotations
 
 from typing import Any, Mapping
 
-from ..tool_family import ChildTool, ToolFamily
-from ..tool_family.manual import MANUAL_INPUT_SCHEMA, build_manual_child
+from ..tool_family import ChildTool
+from .plugin import DAEMON_ACTIONS, DAEMON_DECLARED_ACTIONS, DAEMON_PLUGIN
 
 # Re-exported engine constants the child schemas pin. Imported lazily inside
 # ``_emanate_input_schema`` would hide them from readers; a module-level import
@@ -64,15 +66,12 @@ DEFAULT_MAX_TURNS = 5000
 CHECK_LAST_MAX = 1000
 LIST_DEFAULT_LAST = 1000
 
-#: The canonical action order, model-facing enum order, and dispatch order.
-DAEMON_ACTIONS: tuple[str, ...] = (
-    "emanate",
-    "list",
-    "ask",
-    "check",
-    "reclaim",
-    "manual",
-)
+# The canonical action order, model-facing enum order, and dispatch order is
+# the plugin descriptor's (``plugin.py``): Daemon's own five declared actions
+# followed by the reserved ``manual`` the plugin appends from the packaged
+# skill. It is imported above and re-exported under its historical name, so
+# every existing importer of ``_tool_family.DAEMON_ACTIONS`` keeps working
+# while there is exactly one list.
 
 
 def _backend_option_env_schema() -> dict[str, Any]:
@@ -343,12 +342,14 @@ RECLAIM_INPUT_SCHEMA: dict[str, Any] = {
 }
 
 
-def _child_specs(backend_enum: list[str]) -> tuple[tuple[str, dict[str, Any]], ...]:
-    """The one child registry source: canonical action name → strict input schema.
+def _declared_child_specs(
+    backend_enum: list[str],
+) -> tuple[tuple[str, dict[str, Any]], ...]:
+    """Daemon's *own* five children: canonical action name → strict input schema.
 
-    Both the module-level schema-only family and each dispatcher's
-    handler-bound family are built from this single source, so the composed
-    schema and the dispatch registry cannot drift apart.
+    The reserved ``manual`` is deliberately absent — the plugin appends it, and
+    :meth:`BuiltinToolPlugin.action_input_schemas` rejects a package that tries
+    to declare or re-schema it here.
     """
     return (
         ("emanate", _emanate_input_schema(backend_enum)),
@@ -356,8 +357,27 @@ def _child_specs(backend_enum: list[str]) -> tuple[tuple[str, dict[str, Any]], .
         ("ask", ASK_INPUT_SCHEMA),
         ("check", CHECK_INPUT_SCHEMA),
         ("reclaim", RECLAIM_INPUT_SCHEMA),
-        ("manual", MANUAL_INPUT_SCHEMA),
     )
+
+
+def _child_specs(backend_enum: list[str]) -> tuple[tuple[str, dict[str, Any]], ...]:
+    """The one child registry source: canonical action name → strict input schema.
+
+    Daemon's declared children plus the plugin-appended ``manual`` schema, in
+    the descriptor's order. Both the module-level schema-only family and each
+    dispatcher's handler-bound family are built from this single source, so the
+    composed schema and the dispatch registry cannot drift apart — and neither
+    can spell the reserved action itself.
+    """
+    return DAEMON_PLUGIN.action_input_schemas(_declared_child_specs(backend_enum))
+
+
+# The declared child registry and the descriptor's declared action list are the
+# same names in the same order. An action added to one without the other is a
+# packaging defect, caught here at import rather than as a silently missing
+# branch in the composed schema. The backend enum is irrelevant to the names,
+# so the cheapest possible one is used.
+assert tuple(name for name, _ in _declared_child_specs([])) == DAEMON_DECLARED_ACTIONS
 
 
 def build_schema(backend_enum: list[str], lang: str = "en") -> dict[str, Any]:
@@ -366,7 +386,9 @@ def build_schema(backend_enum: list[str], lang: str = "en") -> dict[str, Any]:
     Generated purely from the child registry by the generic ``ToolFamily``
     infra (root ``allOf`` correlation plus ``input.oneOf`` disclosure) — this
     is the schema registered for the public ``daemon`` tool, and the only one
-    the package defines. Constructing the family here is also the registry's
+    the package defines. The family is composed through the plugin descriptor,
+    so the public tool name is the descriptor's and ``manual`` is appended
+    rather than declared; constructing it here is also the registry's
     duplicate/reserved-``manual``-collision check.
     """
     _ = lang  # The daemon tool surface is canonical English.
@@ -374,12 +396,14 @@ def build_schema(backend_enum: list[str], lang: str = "en") -> dict[str, Any]:
     def _unused(_input: Mapping[str, Any]) -> dict[str, Any]:
         raise AssertionError("the schema-only ToolFamily never dispatches")
 
-    family = ToolFamily(
-        "daemon",
+    family = DAEMON_PLUGIN.build_family(
         [
             ChildTool(name, schema, _unused, title=f"{name} input")
-            for name, schema in _child_specs(backend_enum)
+            for name, schema in _declared_child_specs(backend_enum)
         ],
+        # No agent exists at module import; the schema-only family never
+        # dispatches, so its manual child never reads a workdir.
+        None,
     )
     return family.build_schema()
 
@@ -397,8 +421,9 @@ class DaemonFamilyDispatcher:
     process interaction, notification, and error string stays exactly what the
     engine already produces.
 
-    ``manual`` is registered directly, unwrapped, from ``build_manual_child``
-    — the shared reserved-name contract every LingTai family uses — so
+    ``manual`` is appended directly, unwrapped, by the plugin descriptor
+    (``DAEMON_PLUGIN.manual_child``) — the shared reserved-name contract every
+    LingTai family uses, bound to this package's own mounted skill — so
     ``ToolFamily.handle()`` returns its canonical
     ``content``/``structuredContent`` result verbatim with no double wrap. It
     is the family's sole manual surface and reaches no engine method, so
@@ -409,17 +434,16 @@ class DaemonFamilyDispatcher:
 
     def __init__(self, manager: Any, agent: Any, backend_enum: list[str]) -> None:
         self._manager = manager
-        specs = dict(_child_specs(backend_enum))
-        self._family = ToolFamily(
-            "daemon",
+        specs = dict(_declared_child_specs(backend_enum))
+        self._family = DAEMON_PLUGIN.build_family(
             [
                 ChildTool("emanate", specs["emanate"], self._dispatch_emanate, title="emanate input"),
                 ChildTool("list", specs["list"], self._dispatch_list, title="list input"),
                 ChildTool("ask", specs["ask"], self._dispatch_ask, title="ask input"),
                 ChildTool("check", specs["check"], self._dispatch_check, title="check input"),
                 ChildTool("reclaim", specs["reclaim"], self._dispatch_reclaim, title="reclaim input"),
-                build_manual_child(agent, "daemon"),
             ],
+            agent,
         )
 
     @staticmethod
@@ -474,6 +498,8 @@ class DaemonFamilyDispatcher:
         result = self._family.handle(args)
         if result.get("error_code") == "ACTION_REQUIRED":
             result["message"] = (
-                "action must be one of emanate, list, ask, check, reclaim, or manual"
+                "action must be one of "
+                + ", ".join(DAEMON_ACTIONS[:-1])
+                + f", or {DAEMON_ACTIONS[-1]}"
             )
         return result

--- a/src/lingtai/tools/daemon/plugin.py
+++ b/src/lingtai/tools/daemon/plugin.py
@@ -1,0 +1,54 @@
+"""The Daemon built-in tool plugin descriptor.
+
+One place where this package states who it is: its public capability name, the
+module the capability registry imports for it, the packaged ``manual/`` bundle
+the initializer mounts, the skill that bundle declares, and the actions it
+*itself* owns. ``manual`` is deliberately absent from
+:data:`DAEMON_DECLARED_ACTIONS` —
+:class:`~lingtai.tools._plugin.BuiltinToolPlugin` appends the reserved action,
+bound to this package's own mounted skill, and rejects any attempt to declare
+it here.
+
+``_tool_family.py`` consumes this for the public action order, the composed
+schema, and the dispatch registry; ``__init__.py`` for the registered public
+tool name. The shipped ``registry.BUILTIN_TOOLS`` entry must equal this
+descriptor's :meth:`~lingtai.tools._plugin.BuiltinToolPlugin.capability_declaration`
+``module``, and the initializer's mount must equal its ``manual_mount``; the
+registry and the initializer themselves stay the runtime source the host reads.
+
+Nothing about the daemon *engine* lives here. Manager construction, backend
+routing, run directories, the detached supervisor, completion signalling,
+cancellation, timeouts, notifications, config resolution, and every auth or
+credential boundary stay exactly where they were — this descriptor is
+declarative packaging only.
+"""
+from __future__ import annotations
+
+from .._plugin import BuiltinToolPlugin
+
+DAEMON_PLUGIN = BuiltinToolPlugin(
+    name="daemon",
+    package=__package__,
+    implementation="daemon",
+    summary=(
+        "Daemon (神識) — delegate work to ephemeral subagents for context "
+        "isolation, with supervised lifecycle and exactly-once terminal "
+        "notification."
+    ),
+    manual_skill_name="daemon-manual",
+)
+
+#: Daemon's own public actions, in stable model-facing order. The reserved
+#: ``manual`` action is appended by the plugin, never declared here.
+DAEMON_DECLARED_ACTIONS: tuple[str, ...] = (
+    "emanate",
+    "list",
+    "ask",
+    "check",
+    "reclaim",
+)
+
+#: The complete public action list, declared actions followed by ``manual``.
+#: This is the model-facing ``action`` enum order, the ``input`` branch order,
+#: and the dispatch order — one list, three roles.
+DAEMON_ACTIONS: tuple[str, ...] = DAEMON_PLUGIN.actions(DAEMON_DECLARED_ACTIONS)

--- a/tests/test_builtin_tool_plugin_package.py
+++ b/tests/test_builtin_tool_plugin_package.py
@@ -1,0 +1,308 @@
+"""Built-in tool plugin packaging invariants, proven on the Daemon reference slice.
+
+A built-in capability tool is a plugin-style package: the same folder ships the
+handler code, the bundled ``manual/`` skill the initializer mounts into the
+agent's own ``.library``, and the capability record the host registry publishes.
+``lingtai.tools._plugin.BuiltinToolPlugin`` binds those three and owns the one
+promise a package must not be able to break — the reserved ``manual`` action,
+appended from the packaged skill rather than declared by the package.
+
+These tests pin the packaging promise, the runtime discovery/mount contract the
+descriptor states, and the *unchanged* public Daemon surface around it. They
+start no emanation, spawn no process, and write no run directory: every daemon
+action here either stops at the family's dispatch boundary or lands on a
+recording stand-in for ``DaemonManager``.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests._daemon_helpers import make_daemon_agent
+from lingtai.tools import _plugin
+from lingtai.tools._plugin import BuiltinToolPlugin, BuiltinToolPluginError
+from lingtai.tools import daemon as daemon_pkg
+from lingtai.tools.daemon import _tool_family
+from lingtai.tools.daemon.plugin import (
+    DAEMON_ACTIONS,
+    DAEMON_DECLARED_ACTIONS,
+    DAEMON_PLUGIN,
+)
+from lingtai.tools.registry import BUILTIN_TOOLS, CORE_DEFAULTS, setup_capability
+from lingtai.tools.tool_family import ChildTool
+from lingtai.tools.tool_family.manual import MANUAL_INPUT_SCHEMA
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+_VALID_FIELDS = {
+    "name": "daemon",
+    "package": "lingtai.tools.daemon",
+    "implementation": "daemon",
+    "summary": "s",
+    "manual_skill_name": "daemon-manual",
+}
+
+
+class _RecordingManager:
+    """Stands in for ``DaemonManager``; records every flat action it is handed."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def handle(self, args: dict) -> dict:
+        self.calls.append(dict(args))
+        return {"status": "ok", "action": args.get("action")}
+
+
+def _dispatcher(tmp_path: Path) -> tuple[_tool_family.DaemonFamilyDispatcher, _RecordingManager]:
+    agent = MagicMock()
+    agent._working_dir = tmp_path
+    manager = _RecordingManager()
+    return (
+        _tool_family.DaemonFamilyDispatcher(
+            manager, agent, list(daemon_pkg._BACKEND_SCHEMA_ENUM)
+        ),
+        manager,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The package ships its own capability declaration
+# ---------------------------------------------------------------------------
+
+def test_daemon_package_declaration_matches_the_shipped_capability_registry():
+    """The package owns its module path; BUILTIN_TOOLS publishes exactly it."""
+    declaration = DAEMON_PLUGIN.capability_declaration()
+    assert BUILTIN_TOOLS[declaration["name"]] == declaration["module"]
+    assert declaration["module"] == "lingtai.tools.daemon"
+    assert declaration["source"] == _plugin.BUILTIN_SOURCE
+    # Daemon is part of the always-on floor; the descriptor names the same key.
+    assert declaration["name"] in CORE_DEFAULTS
+
+
+def test_registry_loading_is_unchanged_and_still_the_runtime_source(tmp_path):
+    """The descriptor documents the record; it does not replace capability setup."""
+    agent = MagicMock()
+    agent._working_dir = tmp_path
+    manager = setup_capability(agent, DAEMON_PLUGIN.name)
+    assert isinstance(manager, daemon_pkg.DaemonManager)
+    registered = agent.add_tool.call_args
+    assert registered.args[0] == DAEMON_PLUGIN.name == "daemon"
+    assert registered.kwargs["schema"]["properties"]["action"]["enum"] == list(
+        DAEMON_ACTIONS
+    )
+
+
+def test_the_descriptor_is_declarative_and_imports_no_runtime(tmp_path):
+    """``_plugin`` is packaging, not a plugin runtime: it discovers nothing.
+
+    Importing it must not drag in the daemon engine, the agent, or the
+    capability registry — the same import discipline ``lingtai.tools`` owes
+    the kernel. A descriptor that imported what it describes would be a
+    discovery mechanism in disguise.
+    """
+    probe = (
+        "import sys; import lingtai.tools._plugin as p; "
+        "print(','.join(sorted(m for m in "
+        "('lingtai.agent', 'lingtai.tools.daemon', 'lingtai.tools.registry') "
+        "if m in sys.modules)))"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", probe],
+        cwd=_REPO_ROOT,
+        env={"PYTHONPATH": str(_REPO_ROOT / "src"), "PATH": "/usr/bin:/bin"},
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert completed.stdout.strip() == ""
+
+
+# ---------------------------------------------------------------------------
+# Runtime discovery/mount contract: the packaged bundle and where it lands
+# ---------------------------------------------------------------------------
+
+def test_declared_manual_source_is_the_packages_own_bundle():
+    source = _REPO_ROOT / DAEMON_PLUGIN.capability_declaration()["manual_source"]
+    assert source.is_dir()
+    skill = source / _plugin.SKILL_FILENAME
+    assert skill.is_file()
+    assert Path(DAEMON_PLUGIN.skill_path).resolve() == skill.resolve()
+    assert DAEMON_PLUGIN.skill_frontmatter["name"] == "daemon-manual"
+
+
+def test_the_initializer_mounts_the_packaged_bundle_at_the_declared_mount(tmp_path):
+    """The real ``Agent`` install puts this package's skill exactly where the
+    descriptor says the ``manual`` action will read it back from."""
+    agent = make_daemon_agent(tmp_path, working_dir_name="mount-agent")
+    mounted = agent._working_dir / DAEMON_PLUGIN.mounted_manual_relpath()
+    assert mounted.is_file()
+    assert mounted.read_text(encoding="utf-8") == (
+        Path(DAEMON_PLUGIN.skill_path).read_text(encoding="utf-8")
+    )
+    assert DAEMON_PLUGIN.skill_body in mounted.read_text(encoding="utf-8")
+
+
+def test_manual_answers_from_the_mounted_skill_without_entering_the_manager(tmp_path):
+    agent = make_daemon_agent(tmp_path, working_dir_name="manual-agent")
+    manager = _RecordingManager()
+    dispatcher = _tool_family.DaemonFamilyDispatcher(
+        manager, agent, list(daemon_pkg._BACKEND_SCHEMA_ENUM)
+    )
+    result = dispatcher.handle(
+        {"action": "manual", "input": {}, "reasoning": "read the manual"}
+    )
+    assert manager.calls == []
+    assert result["status"] == "ok"
+    mounted = agent._working_dir / DAEMON_PLUGIN.mounted_manual_relpath()
+    assert result["structuredContent"] == {"manual_path": str(mounted)}
+    assert result["content"][0]["text"] == mounted.read_text(encoding="utf-8")
+    assert DAEMON_PLUGIN.skill_body in result["content"][0]["text"]
+
+
+# ---------------------------------------------------------------------------
+# `manual` is mandatory, reserved, and owned by the plugin
+# ---------------------------------------------------------------------------
+
+def test_package_does_not_declare_manual_and_the_plugin_appends_it_last():
+    assert _plugin.MANUAL_ACTION not in DAEMON_DECLARED_ACTIONS
+    assert DAEMON_ACTIONS == (*DAEMON_DECLARED_ACTIONS, "manual")
+    assert DAEMON_ACTIONS[-1] == "manual"
+    # The package's own child registry stops at its five declared actions.
+    assert tuple(name for name, _ in _tool_family._declared_child_specs([])) == (
+        DAEMON_DECLARED_ACTIONS
+    )
+
+
+@pytest.mark.parametrize(
+    "compose",
+    [
+        pytest.param(lambda: DAEMON_PLUGIN.actions(["check", "manual"]), id="actions"),
+        pytest.param(
+            lambda: DAEMON_PLUGIN.action_input_schemas(
+                (("check", {}), ("manual", {}))
+            ),
+            id="schemas",
+        ),
+        pytest.param(
+            lambda: DAEMON_PLUGIN.build_family(
+                [
+                    ChildTool("check", {"type": "object"}, lambda _i: {}),
+                    ChildTool("manual", {"type": "object"}, lambda _i: {"hijacked": True}),
+                ],
+                None,
+            ),
+            id="family",
+        ),
+    ],
+)
+def test_a_package_cannot_declare_re_schema_or_rebind_the_reserved_manual(compose):
+    with pytest.raises(BuiltinToolPluginError, match="reserved 'manual'"):
+        compose()
+
+
+def test_a_package_must_declare_at_least_one_action_of_its_own():
+    with pytest.raises(BuiltinToolPluginError, match="at least one action"):
+        DAEMON_PLUGIN.actions([])
+
+
+def test_composed_family_always_carries_a_manual_child_with_a_strict_empty_input(tmp_path):
+    dispatcher, _ = _dispatcher(tmp_path)
+    family = dispatcher._family
+    assert family.child_names == DAEMON_ACTIONS
+    assert dict(_tool_family._child_specs([]))["manual"] == MANUAL_INPUT_SCHEMA
+    # A fresh copy per family: one tool's manual child cannot edit another's.
+    assert DAEMON_PLUGIN.manual_input_schema() is not MANUAL_INPUT_SCHEMA
+    assert DAEMON_PLUGIN.manual_input_schema() == MANUAL_INPUT_SCHEMA
+
+
+def test_manual_lives_in_the_same_strict_root_as_every_other_action(tmp_path):
+    """Plugin ownership does not buy ``manual`` a laxer envelope."""
+    schema = daemon_pkg.get_schema()
+    assert "manual" in schema["properties"]["action"]["enum"]
+    assert schema["required"] == ["action", "input", "reasoning"]
+
+    dispatcher, manager = _dispatcher(tmp_path)
+    rejected = dispatcher.handle(
+        {"action": "manual", "input": {"topic": "check"}, "reasoning": "x"}
+    )
+    assert rejected["status"] == "failed"
+    assert manager.calls == []
+
+
+# ---------------------------------------------------------------------------
+# The public envelope shape is unchanged by the packaging
+# ---------------------------------------------------------------------------
+
+def test_public_schema_keeps_the_strict_action_family_shape():
+    schema = daemon_pkg.get_schema()
+    assert set(schema["properties"]) == {"action", "input", "reasoning", "summarize"}
+    assert schema["required"] == ["action", "input", "reasoning"]
+    assert schema["additionalProperties"] is False
+    assert schema["properties"]["action"]["enum"] == list(DAEMON_ACTIONS)
+    assert len(schema["allOf"]) == len(DAEMON_ACTIONS)
+    branch_titles = [b["title"] for b in schema["properties"]["input"]["oneOf"]]
+    assert branch_titles == [f"{action} input" for action in DAEMON_ACTIONS]
+
+
+def test_declared_actions_still_dispatch_flat_into_the_engine(tmp_path):
+    dispatcher, manager = _dispatcher(tmp_path)
+    result = dispatcher.handle(
+        {
+            "action": "check",
+            "input": {"id": "em-1", "last": None, "truncate": None},
+            "reasoning": "probe",
+        }
+    )
+    assert result["status"] == "ok"
+    assert manager.calls == [{"action": "check", "id": "em-1"}]
+
+
+def test_unknown_action_message_is_generated_from_the_declared_action_list(tmp_path):
+    dispatcher, manager = _dispatcher(tmp_path)
+    rejected = dispatcher.handle({"input": {}, "reasoning": "no action"})
+    assert rejected["error_code"] == "ACTION_REQUIRED"
+    assert rejected["message"] == (
+        "action must be one of emanate, list, ask, check, reclaim, or manual"
+    )
+    assert manager.calls == []
+
+
+# ---------------------------------------------------------------------------
+# Descriptor defects fail loudly at import time
+# ---------------------------------------------------------------------------
+
+def test_descriptor_rejects_a_package_outside_the_tools_namespace():
+    with pytest.raises(BuiltinToolPluginError, match="must live under"):
+        BuiltinToolPlugin(**{**_VALID_FIELDS, "package": "lingtai.mcp_servers.telegram"})
+
+
+def test_descriptor_rejects_a_package_that_is_not_its_own_implementation():
+    with pytest.raises(BuiltinToolPluginError, match="must be the 'daemon' module"):
+        BuiltinToolPlugin(**{**_VALID_FIELDS, "package": "lingtai.tools.avatar"})
+
+
+def test_descriptor_rejects_a_manual_that_is_not_the_packaged_skill():
+    with pytest.raises(BuiltinToolPluginError, match="declares name"):
+        BuiltinToolPlugin(**{**_VALID_FIELDS, "manual_skill_name": "somebody-elses-manual"})
+
+
+def test_descriptor_rejects_a_package_with_no_bundled_manual():
+    with pytest.raises(BuiltinToolPluginError, match="cannot read its bundled"):
+        BuiltinToolPlugin(
+            name="file",
+            package="lingtai.tools.file",
+            implementation="file",
+            summary="s",
+            manual_skill_name="file-manual",
+        )
+
+
+@pytest.mark.parametrize("blank_field", sorted(_VALID_FIELDS))
+def test_descriptor_rejects_blank_identity_fields(blank_field):
+    with pytest.raises(BuiltinToolPluginError, match="non-empty string"):
+        BuiltinToolPlugin(**{**_VALID_FIELDS, blank_field: "  "})


### PR DESCRIPTION
## Summary
- Turns `daemon` into a real Agent Plugin with its package manifest, runtime discovery/mount wiring, and a plugin-owned manual skill.
- Candidate head: `55d3831e`; this is one isolated tool PR and remains unmerged for Jason’s decision.

## Validation and review context
- Candidate-focused validation and independent review artifacts were completed locally before this PR.
- Any reviewer findings remain preserved with the candidate; this PR is opened under Jason’s explicit all-tool PR instruction (Telegram 14623).

Telegram: @lingtaidev1bot | Nickname: 知微
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
