### PR TITLE
docs(tools): define Tool-to-MCP Plugin Contract

### DIFF
--- a/BEHAVIORS.md
+++ b/BEHAVIORS.md
@@ -8,6 +8,7 @@ related_files:
   - dev-guide-skill/SKILL.md
   - tests/CONTRACT.md
   - src/lingtai/kernel/BEHAVIORS.md
+  - src/lingtai/tools/BEHAVIORS.md
   - src/lingtai/tools/system/BEHAVIORS.md
   - src/lingtai/tools/context/BEHAVIORS.md
   - src/lingtai/tools/daemon/BEHAVIORS.md

--- a/src/lingtai/tools/ANATOMY.md
+++ b/src/lingtai/tools/ANATOMY.md
@@ -41,6 +41,9 @@ related_files:
   - src/lingtai/tools/bash/CONTRACT.md
   - src/lingtai/tools/bash/_tool_family.py
   - src/lingtai/adapters/browser_transport.py
+  - src/lingtai/mcp_servers/_plugin.py
+  - src/lingtai/services/plugin_registry.py
+  - src/lingtai/kernel/base_agent/tools.py
   - src/lingtai/tools/registry.py
   - src/lingtai/tools/glossary_validator.py
   - ENVIRONMENT_VARIABLES.md
@@ -62,6 +65,11 @@ maintenance: |
   future family migration may adopt, not a second registry. context is its
   thirteenth consumer and the fifth migrated intrinsic. Update
   structural claims with code and keep reciprocal graph edges valid.
+  The curated-MCP packaging, Agent Plugins, and host tool-registration entries
+  in related_files are navigation to the precedent the paired Contract's
+  `### Tool-to-MCP Plugin Contract` names as a future migration target; they are
+  not a claim that any family here is wrapped today, and the normative rules
+  stay in the Contract.
   Capability mentions in any document require explicit bidirectional
   related_files mapping to the implementing code (see root ## Maintenance).
 ---
@@ -75,7 +83,12 @@ capability names and lazy adapters.
 
 - `CONTRACT.md` — the LingTai Tool Protocol (LTP): the future canonical
   model-facing tool call contract, the two-level family/action settings
-  addressing and ownership rules, and the explicit per-tool migration boundary.
+  addressing and ownership rules, the explicit per-tool migration boundary, and
+  `### Tool-to-MCP Plugin Contract`, the additive future target for wrapping
+  each first-party family in an MCP-style plugin package that owns its manual.
+- `BEHAVIORS.md` — the paired LABT file: LP001 guards the closed LTP envelope,
+  LP002 guards the Tool-to-MCP Plugin Contract's status, graph, and
+  current-evidence claims.
 - `registry.py` — intrinsic mapping, public `BUILTIN_TOOLS`, input aliases,
   defaults, normalization, setup, and check-caps metadata
   (`src/lingtai/tools/registry.py:39-344`).
@@ -203,13 +216,30 @@ the artifact writer entirely within `lingtai.tools`. It writes only
 `taskcard/status` and `taskcard/taskcard.md`; consumer-specific reading,
 polling, and projection stay outside this package.
 
+The route the paired Contract's `### Tool-to-MCP Plugin Contract` targets is
+not wired here today. These are the roles it separates, and the nearest
+existing precedent for each. `registry.py` is the current first-party
+composition point — it imports no `lingtai.mcp_servers` packaging, so no family
+here is wrapped.
+`src/lingtai/mcp_servers/_plugin.py` is the existing *packaging* precedent:
+one curated package binding its server, bundled `SKILL.md`, declaration, and
+reserved `manual` child, and it is explicitly not a plugin runtime.
+`src/lingtai/services/plugin_registry.py` is the existing *declaration and
+boot-registration* precedent for external Agent Plugins, with activation kept
+separate (the rendering tool is `src/lingtai/tools/plugin/ANATOMY.md`).
+`src/lingtai/kernel/base_agent/tools.py` is the *host* mount point whose
+`_add_tool` replaces a schema of the same name, which is why the Contract
+records live tool-name collision policy as an open decision rather than a
+promise. Read the Contract for the rules; this file only names the route.
+
 ## Composition
 
 The parent [`src/lingtai/ANATOMY.md`](../ANATOMY.md) owns Agent composition.
 The paired tools Contract owns LTP: the future canonical `action` / `input` /
 `reasoning` / `summarize` public call shape, family/action settings ownership,
-and the migration boundary. Read it there; this Anatomy does not restate those
-promises. The web Contract specializes
+the migration boundary, and the Tool-to-MCP Plugin Contract. Read it there;
+this Anatomy does not restate those promises, and `BEHAVIORS.md` LP002 owns
+their verification. The web Contract specializes
 that promise for the first real implementation; its Anatomy and the internal
 browser Anatomy provide progressive disclosure. Other tool packages retain their
 existing public shapes until explicitly migrated.

--- a/src/lingtai/tools/ANATOMY.md
+++ b/src/lingtai/tools/ANATOMY.md
@@ -42,6 +42,8 @@ related_files:
   - src/lingtai/tools/bash/_tool_family.py
   - src/lingtai/adapters/browser_transport.py
   - src/lingtai/mcp_servers/_plugin.py
+  - src/lingtai/mcp_servers/telegram/plugin.py
+  - src/lingtai/mcp_catalog.json
   - src/lingtai/services/plugin_registry.py
   - src/lingtai/kernel/base_agent/tools.py
   - src/lingtai/tools/registry.py
@@ -65,10 +67,13 @@ maintenance: |
   future family migration may adopt, not a second registry. context is its
   thirteenth consumer and the fifth migrated intrinsic. Update
   structural claims with code and keep reciprocal graph edges valid.
-  The curated-MCP packaging, Agent Plugins, and host tool-registration entries
-  in related_files are navigation to the precedent the paired Contract's
-  `### Tool-to-MCP Plugin Contract` names as a future migration target; they are
-  not a claim that any family here is wrapped today, and the normative rules
+  The curated-MCP packaging, catalog, Agent Plugins, and host tool-registration
+  entries in related_files are navigation for the paired Contract's
+  `### Tool-to-MCP Plugin Contract`: the curated descriptor/catalog route is the
+  form that Contract selects, and the Agent Plugins entry is the excluded
+  external standard kept only as the registration-versus-activation precedent.
+  They are not a claim that any family here is wrapped today, and the normative
+  rules — including the selected form and the governed-surface classification —
   stay in the Contract.
   Capability mentions in any document require explicit bidirectional
   related_files mapping to the implementing code (see root ## Maintenance).
@@ -85,9 +90,11 @@ capability names and lazy adapters.
   model-facing tool call contract, the two-level family/action settings
   addressing and ownership rules, the explicit per-tool migration boundary, and
   `### Tool-to-MCP Plugin Contract`, the additive future target for wrapping
-  each first-party family in an MCP-style plugin package that owns its manual.
+  each first-party family in the selected curated-descriptor MCP plugin package
+  form that owns its manual.
 - `BEHAVIORS.md` — the paired LABT file: LP001 guards the closed LTP envelope,
-  LP002 guards the Tool-to-MCP Plugin Contract's status, graph, and
+  LP002 guards the Tool-to-MCP Plugin Contract's status, its two-class governed
+  surface, its single selected wrapper form, the document graph, and the
   current-evidence claims.
 - `registry.py` — intrinsic mapping, public `BUILTIN_TOOLS`, input aliases,
   defaults, normalization, setup, and check-caps metadata
@@ -217,16 +224,22 @@ the artifact writer entirely within `lingtai.tools`. It writes only
 polling, and projection stay outside this package.
 
 The route the paired Contract's `### Tool-to-MCP Plugin Contract` targets is
-not wired here today. These are the roles it separates, and the nearest
-existing precedent for each. `registry.py` is the current first-party
-composition point — it imports no `lingtai.mcp_servers` packaging, so no family
-here is wrapped.
-`src/lingtai/mcp_servers/_plugin.py` is the existing *packaging* precedent:
-one curated package binding its server, bundled `SKILL.md`, declaration, and
-reserved `manual` child, and it is explicitly not a plugin runtime.
-`src/lingtai/services/plugin_registry.py` is the existing *declaration and
-boot-registration* precedent for external Agent Plugins, with activation kept
-separate (the rendering tool is `src/lingtai/tools/plugin/ANATOMY.md`).
+not wired here today. These are the roles it separates, and where each one
+already lives. `registry.py` is the current first-party composition point — it
+imports no `lingtai.mcp_servers` packaging, so no family *in this package* is
+wrapped; the Contract's governed surface is wider than this directory and also
+classifies the kernel-shipped MCP families under `src/lingtai/mcp_servers/`.
+`src/lingtai/mcp_servers/_plugin.py` is the *selected* wrapper form, not merely
+one precedent among several: one curated package binding its server, bundled
+`SKILL.md`, declaration, and reserved `manual` child, and it is explicitly not
+a plugin runtime. `src/lingtai/mcp_servers/telegram/plugin.py` is its reference
+descriptor slice and `src/lingtai/mcp_catalog.json` the shipped catalog record
+each descriptor must agree with.
+`src/lingtai/services/plugin_registry.py` is the external Agent Plugins v1.0.0
+*declaration and boot-registration* path, with activation kept separate (the
+rendering tool is `src/lingtai/tools/plugin/ANATOMY.md`). The Contract excludes
+that standard from conversion; it is navigation to the precedent for
+registration versus activation, not an alternative wrapper form.
 `src/lingtai/kernel/base_agent/tools.py` is the *host* mount point whose
 `_add_tool` replaces a schema of the same name, which is why the Contract
 records live tool-name collision policy as an open decision rather than a

--- a/src/lingtai/tools/BEHAVIORS.md
+++ b/src/lingtai/tools/BEHAVIORS.md
@@ -12,6 +12,8 @@ related_files:
   - src/lingtai/tools/registry.py
   - src/lingtai/tools/plugin/CONTRACT.md
   - src/lingtai/mcp_servers/_plugin.py
+  - src/lingtai/mcp_servers/telegram/plugin.py
+  - src/lingtai/mcp_catalog.json
   - src/lingtai/services/plugin_registry.py
   - src/lingtai/kernel/base_agent/tools.py
   - scripts/check_docs_governance.py
@@ -21,11 +23,16 @@ maintenance: |
   reciprocal with CONTRACT.md and ANATOMY.md (tridirectional loop): when an LTP
   envelope or settings rule changes, update the guarding LABT here in the same
   change. LP002 guards the additive `### Tool-to-MCP Plugin Contract` section:
-  it verifies only what is true today (the section's status wording, the
-  document graph, and the cited current evidence). When a family actually
-  recuts onto a plugin wrapper, replace LP002's "no family is wrapped" evidence
-  with that family's own proof in the same change rather than leaving a stale
-  pass.
+  it verifies only what is true today (the section's scope-qualified status
+  wording, its two-class governed surface, its single selected wrapper form,
+  the document graph, and the cited current evidence). Its steps inspect the
+  full governed boundary — the registry surface *and* the kernel-shipped MCP
+  packages — so a registry-only grep is never treated as proof about every
+  family. Keep every command copy-paste executable (one line, or a fenced block
+  with explicit `\` continuations). When a family actually recuts onto a plugin
+  wrapper, or when authoring-time line numbers drift, replace the affected
+  evidence with that family's own proof in the same change rather than leaving
+  a stale pass.
 ---
 # LingTai Tool Protocol (LTP) Behavior Tests
 
@@ -60,113 +67,207 @@ Pass when the suite passes and the closed-envelope observation holds for a real 
 
 - **id**: LP002
 - **title**: the Tool-to-MCP Plugin Contract is a documented migration target, not a shipped wrapper
-- **guards**: `lingtai-tool-protocol` § Tool-to-MCP Plugin Contract
-  (`CONTRACT.md` `### Tool-to-MCP Plugin Contract`)
+- **guards**: `lingtai-tool-protocol` §
+  [Tool-to-MCP Plugin Contract](CONTRACT.md#tool-to-mcp-plugin-contract)
 - **runner**: any LingTai agent with `shell` and `file` access to a clean
   checkout of the `lingtai-kernel` repository
 - **prerequisites**: a clean checkout of the repository; a working repository
   virtual environment at `.venv/` (`uv venv --python 3.11 && uv pip install -e
   . pytest`, per `AGENTS.md`). Run every command below from the repository root
-  (`git rev-parse --show-toplevel`). No network, no agent runtime, and no MCP
-  server is needed: this task inspects documents and source text only.
+  (`git rev-parse --show-toplevel`). Every command block is copy-paste
+  executable as written. No network, no agent runtime, and no MCP server is
+  needed: this task inspects documents and source text only.
 - **estimate**: ≈ 15 minutes
 
 ### Steps
 
 1. Read `src/lingtai/tools/CONTRACT.md`, section `### Tool-to-MCP Plugin
    Contract` (it sits under `## Contract rules`, between `### Non-goals` and
-   `### Relationship to current runtime`). Confirm its opening **Status**
-   paragraph says the section is a migration target, that no LingTai-owned
-   family ships as an MCP plugin today, and that the families listed under
-   `### Relationship to current runtime` are LTP *envelope* migrations rather
-   than plugin wrappers or a compatible universal runtime.
-2. Check that every use of the phrase is a negation, not a claim:
-   `grep -n "MCP plugin" src/lingtai/tools/CONTRACT.md`. Expect exactly two
-   matches, both inside that section (at authoring time, lines 277 and 430),
-   one saying no family ships as an MCP plugin today and one listing
-   "any first-party built-in family shipping as an MCP plugin" under
-   *not evidenced*.
-3. Prove no first-party family is wrapped today:
-   `grep -n "lingtai.mcp_servers\|CuratedMcpPlugin" src/lingtai/tools/registry.py`.
+   `### Relationship to current runtime`; at authoring time lines 277-507).
+   Confirm its opening **Status** paragraph says the section is a migration
+   target that converts nothing; that its negative claim is **scope-qualified**
+   — no family registered through `src/lingtai/tools/registry.py` ships as an
+   MCP plugin package today; that the kernel-shipped curated MCP families are
+   named as the current first-party precedent for the selected form, with that
+   stated as packaging evidence only rather than conformance; and that the
+   families listed under `### Relationship to current runtime` are LTP
+   *envelope* migrations rather than plugin wrappers or a compatible universal
+   runtime.
+2. Prove the old unqualified global negative is gone and that every surviving
+   use of the phrase is scope-qualified:
+
+   ```bash
+   grep -n "No LingTai-owned family ships as an MCP plugin" src/lingtai/tools/CONTRACT.md
+   grep -n "MCP plugin" src/lingtai/tools/CONTRACT.md
+   ```
+
+   The first command must print nothing and exit 1. The second must print
+   exactly two matches, both inside this section: at authoring time line 303,
+   inside the **Registry families** bullet whose own first line names
+   `src/lingtai/tools/registry.py`, and line 501, which names that path on the
+   matched line itself. Neither may be a bare global negative.
+3. Confirm the section classifies the **whole** first-party boundary, not just
+   the registry, and that exactly one wrapper form is selected:
+
+   ```bash
+   grep -n "Registry families\|Kernel-shipped MCP families" src/lingtai/tools/CONTRACT.md
+   grep -n "Selected wrapper form" src/lingtai/tools/CONTRACT.md
+   grep -n "separate standard, excluded" src/lingtai/tools/CONTRACT.md
+   grep -n "plugin-admission engine" src/lingtai/tools/CONTRACT.md
+   ```
+
+   Expect: two governed-surface class bullets (authoring lines 300 and 305);
+   two `Selected wrapper form` references (the normative paragraph at 327 and
+   the back-reference at 497); exactly one `separate standard, excluded` line
+   (349) putting external Agent Plugins v1.0.0 and raw third-party MCP schemas
+   outside this conversion contract; and exactly two `plugin-admission engine`
+   lines (353 and 476) disclaiming a generic manifest compiler or admission
+   engine. Read the `**Selected wrapper form.**` paragraph and confirm the
+   selected form is the `lingtai.mcp_servers._plugin.CuratedMcpPlugin`
+   descriptor plus the curated catalog/package route.
+4. Inspect the **registry class** of the governed surface — no family there is
+   wrapped today:
+
+   ```bash
+   grep -n "lingtai\.mcp_servers\|CuratedMcpPlugin" src/lingtai/tools/registry.py
+   ```
+
    Expect no output and shell exit status 1.
-4. Prove the packaging precedent the section cites exists and is not a runtime:
-   `grep -n "plugin runtime" src/lingtai/mcp_servers/_plugin.py` (expect
-   exactly one match, at authoring time line 11, reading "It deliberately is
-   **not** a plugin runtime.") and
-   `grep -n "must not declare the reserved" src/lingtai/mcp_servers/_plugin.py`
-   (expect exactly one match, at authoring time line 201, raising
-   `CuratedMcpPluginError`).
-5. Prove the live-collision clause is still an open decision rather than a
+5. Inspect the **kernel-shipped MCP class** of the governed surface. A
+   registry-only grep proves nothing about these families, so check them
+   directly:
+
+   ```bash
+   grep -rln "CuratedMcpPlugin" src/lingtai/mcp_servers/*/plugin.py | sort
+   grep -c "lingtai-curated" src/lingtai/mcp_catalog.json
+   grep -rn "CuratedMcpPlugin" src/lingtai/mcp_servers/daemon_common src/lingtai/mcp_servers/daemon_email
+   ```
+
+   Expect exactly these six descriptor paths — `cloud_mail`, `feishu`, `imap`,
+   `telegram`, `wechat`, `whatsapp` under `src/lingtai/mcp_servers/<name>/plugin.py`
+   — then `6` curated catalog records, then no output and exit status 1 for the
+   built-in daemon families. That is exactly the split the Contract's
+   `**Governed surface.**` bullets state: the six curated families already ship
+   in the selected form, the built-in daemon families are in the governed class
+   without a descriptor, and neither fact is a conformance claim.
+6. Prove the packaging precedent the section selects exists and is not a
+   runtime:
+
+   ```bash
+   grep -n "plugin runtime" src/lingtai/mcp_servers/_plugin.py
+   grep -n "must not declare the reserved" src/lingtai/mcp_servers/_plugin.py
+   ```
+
+   Expect exactly one match each: at authoring time line 11, reading "It
+   deliberately is **not** a plugin runtime.", and line 201, raising
+   `CuratedMcpPluginError`.
+7. Prove the live-collision clause is still an open decision rather than a
    shipped promise:
-   `grep -n "Remove any existing schema with same name" src/lingtai/kernel/base_agent/tools.py`.
+
+   ```bash
+   grep -n "Remove any existing schema with same name" src/lingtai/kernel/base_agent/tools.py
+   ```
+
    Expect exactly one match (at authoring time line 162) inside `_add_tool`,
    immediately followed by a line rebuilding `agent._tool_schemas` with
    `s.name != name` — i.e. last registration replaces an existing tool of the
    same name. Confirm the contract records this as current behavior and an
    implementation target, and does **not** claim reject-before-mount,
    namespacing, or any deterministic precedence already holds.
-6. Prove the tridirectional graph edges exist exactly once each:
-   `grep -c "src/lingtai/tools/BEHAVIORS.md" BEHAVIORS.md
-   src/lingtai/tools/CONTRACT.md src/lingtai/tools/ANATOMY.md` (expect `1` for
-   each of the three files) and
-   `grep -n "behavior-lp002" src/lingtai/tools/CONTRACT.md` (expect exactly one
+8. Prove the tridirectional graph edges exist exactly once each:
+
+   ```bash
+   grep -c "src/lingtai/tools/BEHAVIORS.md" BEHAVIORS.md src/lingtai/tools/CONTRACT.md src/lingtai/tools/ANATOMY.md
+   grep -n "behavior-lp002" src/lingtai/tools/CONTRACT.md
+   grep -n "^  \[Tool-to-MCP Plugin Contract\](CONTRACT\.md#tool-to-mcp-plugin-contract)$" src/lingtai/tools/BEHAVIORS.md
+   ```
+
+   Expect `1` for each of the three files; exactly one
    `Guarded by: [LP002](BEHAVIORS.md#behavior-lp002)` line directly under the
-   section heading).
-7. Run the governed-graph validation with the repository venv:
-   `.venv/bin/python -m pytest -q
-   tests/test_architecture_documents.py::test_root_architecture_documents_are_reciprocal_and_well_formed
-   tests/test_architecture_documents.py::test_governed_child_contracts_have_reciprocal_anatomy_pairs
-   tests/test_architecture_documents.py::test_governed_cross_document_links_are_reciprocal`.
-   Expect `3 passed`.
-8. Run the documentation governance checker:
-   `.venv/bin/python scripts/check_docs_governance.py --check`. At authoring
-   time it exits 1 with exactly five violations, none of them under
-   `src/lingtai/tools/`: `IMPLEMENTATION_REPORT.md` (no frontmatter),
-   `src/lingtai/kernel/llm/ANATOMY.md` (duplicate `related_files` entries), and
-   `src/lingtai/mcp_servers/feishu/reference/{capability-matrix,diagnostics,setup}.md`
-   (no frontmatter). These are pre-existing defects owned elsewhere. Any
-   violation naming a path under `src/lingtai/tools/` — or the root
-   `BEHAVIORS.md` — is a failure of this task, not a pre-existing one. The same
-   `src/lingtai/kernel/llm/ANATOMY.md` duplicate is also why
-   `tests/test_architecture_documents.py::test_every_tracked_file_climbs_the_anatomy_graph`
-   fails at authoring time; treat a `src/lingtai/tools/` path in that failure
-   as a failure of this task.
+   section heading; and exactly one anchored reverse clause link — the
+   continuation line of this LABT's own `guards` annotation (authoring time
+   line 71) — satisfying root `BEHAVIORS.md`'s "`guards` annotation + relative
+   link back" rule. The anchor pattern deliberately excludes this step's own
+   indented command text.
+9. Run the governed-graph validation with the repository venv:
+
+   ```bash
+   .venv/bin/python -m pytest -q \
+     tests/test_architecture_documents.py::test_root_architecture_documents_are_reciprocal_and_well_formed \
+     tests/test_architecture_documents.py::test_governed_child_contracts_have_reciprocal_anatomy_pairs \
+     tests/test_architecture_documents.py::test_governed_cross_document_links_are_reciprocal
+   ```
+
+   Expect `3 passed`. This covers only those three node IDs; the fourth test in
+   that file is checked in step 10.
+10. Run the documentation governance checker:
+
+    ```bash
+    .venv/bin/python scripts/check_docs_governance.py --check
+    ```
+
+    At authoring time it exits 1 with exactly five violations, none of them
+    under `src/lingtai/tools/`: `IMPLEMENTATION_REPORT.md` (no frontmatter),
+    `src/lingtai/kernel/llm/ANATOMY.md` (duplicate `related_files` entries), and
+    `src/lingtai/mcp_servers/feishu/reference/{capability-matrix,diagnostics,setup}.md`
+    (no frontmatter). These are pre-existing defects owned elsewhere. Any
+    violation naming a path under `src/lingtai/tools/` — or the root
+    `BEHAVIORS.md` — is a failure of this task, not a pre-existing one. The same
+    `src/lingtai/kernel/llm/ANATOMY.md` duplicate is also why
+    `tests/test_architecture_documents.py::test_every_tracked_file_climbs_the_anatomy_graph`
+    fails at authoring time; treat a `src/lingtai/tools/` path in that failure
+    as a failure of this task.
 
 ### Expected evidence
 
 - [ ] Step 1: the section exists in `src/lingtai/tools/CONTRACT.md` and opens
       with a Status paragraph declaring it a migration target that converts
-      nothing and claims no shipped wrapper.
-- [ ] Steps 1-2: the section names its governed surface as first-party
-      LingTai-owned families and explicitly excludes external/third-party MCP
-      schemas and legacy MCP transport/catalog paths from conversion; both
-      "MCP plugin" occurrences are negations.
-- [ ] Step 3: `src/lingtai/tools/registry.py` contains no `lingtai.mcp_servers`
+      nothing, whose negative claim is qualified to the
+      `src/lingtai/tools/registry.py` surface.
+- [ ] Step 2: no unqualified "No LingTai-owned family ships as an MCP plugin"
+      sentence survives (exit 1), and both remaining `MCP plugin` matches are
+      registry-scoped.
+- [ ] Step 3: the governed surface names both classes — registry families and
+      kernel-shipped MCP families — and exactly one wrapper form is selected,
+      with external Agent Plugins v1.0.0 and raw third-party MCP schemas
+      excluded and no manifest compiler or admission engine introduced.
+- [ ] Step 4: `src/lingtai/tools/registry.py` contains no `lingtai.mcp_servers`
       import and no `CuratedMcpPlugin` reference (grep exit status 1).
-- [ ] Step 4: `src/lingtai/mcp_servers/_plugin.py` states it is not a plugin
+- [ ] Step 5: exactly six curated `plugin.py` descriptors and six
+      `lingtai-curated` catalog records exist, and the built-in daemon MCP
+      families carry no descriptor (grep exit status 1) — matching the
+      Contract's two-class governed-surface statement.
+- [ ] Step 6: `src/lingtai/mcp_servers/_plugin.py` states it is not a plugin
       runtime and refuses a package that declares the reserved `manual` action.
-- [ ] Step 5: `_add_tool` in `src/lingtai/kernel/base_agent/tools.py` replaces a
+- [ ] Step 7: `_add_tool` in `src/lingtai/kernel/base_agent/tools.py` replaces a
       same-named schema, and the contract's identifier clause presents the live
       collision policy as an explicit open maintainer decision.
-- [ ] Step 6: root `BEHAVIORS.md`, the tools Contract, and the tools Anatomy
-      each reference `src/lingtai/tools/BEHAVIORS.md` exactly once, and the
-      contract section carries exactly one `LP002` guard link.
-- [ ] Step 7: the three reciprocity/pairing tests report `3 passed`.
-- [ ] Step 8: the governance checker reports no violation under
+- [ ] Step 8: root `BEHAVIORS.md`, the tools Contract, and the tools Anatomy
+      each reference `src/lingtai/tools/BEHAVIORS.md` exactly once; the contract
+      section carries exactly one `LP002` guard link; and this LABT carries
+      exactly one relative link back to the guarded clause.
+- [ ] Step 9: the three named reciprocity/pairing node IDs report `3 passed`.
+- [ ] Step 10: the governance checker reports no violation under
       `src/lingtai/tools/` or in the root `BEHAVIORS.md`.
 
 ### Pass / Fail
 
 Pass when every box above is observed. **Fail loudly** — do not soften the
 report — if the contract section asserts that any LingTai tool family already
-ships as an MCP plugin wrapper, that a wrapper runtime, universal compiler, or
-conformance suite exists, that live model-facing tool-name collisions are
-already fail-closed, or that external/third-party MCP schemas and legacy
-transport paths have been converted; if step 3 finds plugin packaging wired
-into `src/lingtai/tools/registry.py` while the contract still says no family is
-wrapped; if any graph edge in step 6 is missing or duplicated; or if steps 7-8
-report a failure naming a path under `src/lingtai/tools/` or the root
-`BEHAVIORS.md`. Record the evidence trail, including the exact grep output and
-test summary lines, in the task report. This task performs no writes: creating
-a plugin package, editing a contract to make an assertion pass, or running the
-code/package test suites to imply a wrapper works are forbidden side effects.
+ships as a *conforming* MCP plugin wrapper under this section, if it makes an
+unqualified global claim that no LingTai-owned family is packaged as an MCP
+plugin, if it leaves the first-party wrapper form unselected or admits more
+than one form, if it claims a wrapper runtime, universal compiler, manifest
+compiler, admission engine, or conformance suite exists, if it claims live
+model-facing tool-name collisions are already fail-closed, or if it claims
+external/third-party MCP schemas and legacy transport paths have been
+converted; if step 4 finds plugin packaging wired into
+`src/lingtai/tools/registry.py` while the contract still says no registry
+family is wrapped; if step 5's curated/daemon split disagrees with the
+Contract's governed-surface bullets; if any graph edge in step 8 is missing or
+duplicated; or if steps 9-10 report a failure naming a path under
+`src/lingtai/tools/` or the root `BEHAVIORS.md`. Record the evidence trail,
+including the exact grep output and test summary lines, in the task report.
+This task performs no writes: creating a plugin package, editing a contract to
+make an assertion pass, or running the code/package test suites to imply a
+wrapper works are forbidden side effects.

--- a/src/lingtai/tools/BEHAVIORS.md
+++ b/src/lingtai/tools/BEHAVIORS.md
@@ -9,11 +9,23 @@ related_files:
   - src/lingtai/tools/ANATOMY.md
   - src/lingtai/tools/_catalog.py
   - src/lingtai/tools/_manual.py
+  - src/lingtai/tools/registry.py
+  - src/lingtai/tools/plugin/CONTRACT.md
+  - src/lingtai/mcp_servers/_plugin.py
+  - src/lingtai/services/plugin_registry.py
+  - src/lingtai/kernel/base_agent/tools.py
+  - scripts/check_docs_governance.py
+  - tests/test_architecture_documents.py
 maintenance: |
   Created during the every-contract-needs-behaviors sweep. Keep this file
   reciprocal with CONTRACT.md and ANATOMY.md (tridirectional loop): when an LTP
   envelope or settings rule changes, update the guarding LABT here in the same
-  change.
+  change. LP002 guards the additive `### Tool-to-MCP Plugin Contract` section:
+  it verifies only what is true today (the section's status wording, the
+  document graph, and the cited current evidence). When a family actually
+  recuts onto a plugin wrapper, replace LP002's "no family is wrapped" evidence
+  with that family's own proof in the same change rather than leaving a stale
+  pass.
 ---
 # LingTai Tool Protocol (LTP) Behavior Tests
 
@@ -43,3 +55,118 @@ repo root with the project's Python.
 
 ### Pass / Fail
 Pass when the suite passes and the closed-envelope observation holds for a real migrated family. Fail on an extra root property, on `reasoning`/`summarize` leaking into `input`, or on a summary replacing the recorded raw output; record the evidence trail in the task report.
+
+## Behavior LP002 — the Tool-to-MCP Plugin Contract is a documented migration target, not a shipped wrapper
+
+- **id**: LP002
+- **title**: the Tool-to-MCP Plugin Contract is a documented migration target, not a shipped wrapper
+- **guards**: `lingtai-tool-protocol` § Tool-to-MCP Plugin Contract
+  (`CONTRACT.md` `### Tool-to-MCP Plugin Contract`)
+- **runner**: any LingTai agent with `shell` and `file` access to a clean
+  checkout of the `lingtai-kernel` repository
+- **prerequisites**: a clean checkout of the repository; a working repository
+  virtual environment at `.venv/` (`uv venv --python 3.11 && uv pip install -e
+  . pytest`, per `AGENTS.md`). Run every command below from the repository root
+  (`git rev-parse --show-toplevel`). No network, no agent runtime, and no MCP
+  server is needed: this task inspects documents and source text only.
+- **estimate**: ≈ 15 minutes
+
+### Steps
+
+1. Read `src/lingtai/tools/CONTRACT.md`, section `### Tool-to-MCP Plugin
+   Contract` (it sits under `## Contract rules`, between `### Non-goals` and
+   `### Relationship to current runtime`). Confirm its opening **Status**
+   paragraph says the section is a migration target, that no LingTai-owned
+   family ships as an MCP plugin today, and that the families listed under
+   `### Relationship to current runtime` are LTP *envelope* migrations rather
+   than plugin wrappers or a compatible universal runtime.
+2. Check that every use of the phrase is a negation, not a claim:
+   `grep -n "MCP plugin" src/lingtai/tools/CONTRACT.md`. Expect exactly two
+   matches, both inside that section (at authoring time, lines 277 and 430),
+   one saying no family ships as an MCP plugin today and one listing
+   "any first-party built-in family shipping as an MCP plugin" under
+   *not evidenced*.
+3. Prove no first-party family is wrapped today:
+   `grep -n "lingtai.mcp_servers\|CuratedMcpPlugin" src/lingtai/tools/registry.py`.
+   Expect no output and shell exit status 1.
+4. Prove the packaging precedent the section cites exists and is not a runtime:
+   `grep -n "plugin runtime" src/lingtai/mcp_servers/_plugin.py` (expect
+   exactly one match, at authoring time line 11, reading "It deliberately is
+   **not** a plugin runtime.") and
+   `grep -n "must not declare the reserved" src/lingtai/mcp_servers/_plugin.py`
+   (expect exactly one match, at authoring time line 201, raising
+   `CuratedMcpPluginError`).
+5. Prove the live-collision clause is still an open decision rather than a
+   shipped promise:
+   `grep -n "Remove any existing schema with same name" src/lingtai/kernel/base_agent/tools.py`.
+   Expect exactly one match (at authoring time line 162) inside `_add_tool`,
+   immediately followed by a line rebuilding `agent._tool_schemas` with
+   `s.name != name` — i.e. last registration replaces an existing tool of the
+   same name. Confirm the contract records this as current behavior and an
+   implementation target, and does **not** claim reject-before-mount,
+   namespacing, or any deterministic precedence already holds.
+6. Prove the tridirectional graph edges exist exactly once each:
+   `grep -c "src/lingtai/tools/BEHAVIORS.md" BEHAVIORS.md
+   src/lingtai/tools/CONTRACT.md src/lingtai/tools/ANATOMY.md` (expect `1` for
+   each of the three files) and
+   `grep -n "behavior-lp002" src/lingtai/tools/CONTRACT.md` (expect exactly one
+   `Guarded by: [LP002](BEHAVIORS.md#behavior-lp002)` line directly under the
+   section heading).
+7. Run the governed-graph validation with the repository venv:
+   `.venv/bin/python -m pytest -q
+   tests/test_architecture_documents.py::test_root_architecture_documents_are_reciprocal_and_well_formed
+   tests/test_architecture_documents.py::test_governed_child_contracts_have_reciprocal_anatomy_pairs
+   tests/test_architecture_documents.py::test_governed_cross_document_links_are_reciprocal`.
+   Expect `3 passed`.
+8. Run the documentation governance checker:
+   `.venv/bin/python scripts/check_docs_governance.py --check`. At authoring
+   time it exits 1 with exactly five violations, none of them under
+   `src/lingtai/tools/`: `IMPLEMENTATION_REPORT.md` (no frontmatter),
+   `src/lingtai/kernel/llm/ANATOMY.md` (duplicate `related_files` entries), and
+   `src/lingtai/mcp_servers/feishu/reference/{capability-matrix,diagnostics,setup}.md`
+   (no frontmatter). These are pre-existing defects owned elsewhere. Any
+   violation naming a path under `src/lingtai/tools/` — or the root
+   `BEHAVIORS.md` — is a failure of this task, not a pre-existing one. The same
+   `src/lingtai/kernel/llm/ANATOMY.md` duplicate is also why
+   `tests/test_architecture_documents.py::test_every_tracked_file_climbs_the_anatomy_graph`
+   fails at authoring time; treat a `src/lingtai/tools/` path in that failure
+   as a failure of this task.
+
+### Expected evidence
+
+- [ ] Step 1: the section exists in `src/lingtai/tools/CONTRACT.md` and opens
+      with a Status paragraph declaring it a migration target that converts
+      nothing and claims no shipped wrapper.
+- [ ] Steps 1-2: the section names its governed surface as first-party
+      LingTai-owned families and explicitly excludes external/third-party MCP
+      schemas and legacy MCP transport/catalog paths from conversion; both
+      "MCP plugin" occurrences are negations.
+- [ ] Step 3: `src/lingtai/tools/registry.py` contains no `lingtai.mcp_servers`
+      import and no `CuratedMcpPlugin` reference (grep exit status 1).
+- [ ] Step 4: `src/lingtai/mcp_servers/_plugin.py` states it is not a plugin
+      runtime and refuses a package that declares the reserved `manual` action.
+- [ ] Step 5: `_add_tool` in `src/lingtai/kernel/base_agent/tools.py` replaces a
+      same-named schema, and the contract's identifier clause presents the live
+      collision policy as an explicit open maintainer decision.
+- [ ] Step 6: root `BEHAVIORS.md`, the tools Contract, and the tools Anatomy
+      each reference `src/lingtai/tools/BEHAVIORS.md` exactly once, and the
+      contract section carries exactly one `LP002` guard link.
+- [ ] Step 7: the three reciprocity/pairing tests report `3 passed`.
+- [ ] Step 8: the governance checker reports no violation under
+      `src/lingtai/tools/` or in the root `BEHAVIORS.md`.
+
+### Pass / Fail
+
+Pass when every box above is observed. **Fail loudly** — do not soften the
+report — if the contract section asserts that any LingTai tool family already
+ships as an MCP plugin wrapper, that a wrapper runtime, universal compiler, or
+conformance suite exists, that live model-facing tool-name collisions are
+already fail-closed, or that external/third-party MCP schemas and legacy
+transport paths have been converted; if step 3 finds plugin packaging wired
+into `src/lingtai/tools/registry.py` while the contract still says no family is
+wrapped; if any graph edge in step 6 is missing or duplicated; or if steps 7-8
+report a failure naming a path under `src/lingtai/tools/` or the root
+`BEHAVIORS.md`. Record the evidence trail, including the exact grep output and
+test summary lines, in the task report. This task performs no writes: creating
+a plugin package, editing a contract to make an assertion pass, or running the
+code/package test suites to imply a wrapper works are forbidden side effects.

--- a/src/lingtai/tools/CONTRACT.md
+++ b/src/lingtai/tools/CONTRACT.md
@@ -4,6 +4,7 @@ contract_version: 2
 root_contract: CONTRACT.md
 related_files:
   - src/lingtai/tools/ANATOMY.md
+  - src/lingtai/tools/BEHAVIORS.md
   - src/lingtai/tools/registry.py
   - src/lingtai/kernel/base_agent/tools.py
   - src/lingtai/kernel/tool_executor.py
@@ -32,6 +33,9 @@ related_files:
   - src/lingtai/tools/pad/CONTRACT.md
   - src/lingtai/tools/lingtai/CONTRACT.md
   - src/lingtai/tools/psyche/CONTRACT.md
+  - src/lingtai/tools/plugin/CONTRACT.md
+  - src/lingtai/mcp_servers/_plugin.py
+  - src/lingtai/services/plugin_registry.py
   - tests/test_browser_capability.py
   - tests/test_wire_tool_description.py
 maintenance: |
@@ -41,7 +45,11 @@ maintenance: |
   each migrated family, the `_LTP_V2_MIGRATED_FAMILIES` allowlist, and this
   contract together when the canonical call boundary changes. LTP alignment is documentary — this pair is the source of
   truth, not a central validator. Migrate one real family at a time; do not
-  claim legacy tools already conform.
+  claim legacy tools already conform. `### Tool-to-MCP Plugin Contract` is an
+  additive, not-yet-implemented migration target guarded by LP002 in the paired
+  BEHAVIORS.md: keep its status paragraph, its open collision decision, and its
+  current-evidence list honest, and update it, the paired ANATOMY.md, and
+  BEHAVIORS.md together when a family actually recuts onto a plugin wrapper.
 ---
 # LingTai Tool Protocol (LTP)
 
@@ -258,6 +266,170 @@ The `input.summary` non-goal bans one thing: carrying the result-summarization
 *control* below root. It does not reserve the word `summary`, and it does not ban
 an unrelated domain field that happens to be named `summary` — see
 `### Envelope`.
+
+### Tool-to-MCP Plugin Contract
+Guarded by: [LP002](BEHAVIORS.md#behavior-lp002)
+
+**Status.** This is a shared **migration target**, not shipped state. It fixes
+the activation, dispatch, manual, host, identifier, and migration vocabulary
+that later per-family recuts MUST share, so those recuts do not each invent
+their own. It converts nothing by itself. No LingTai-owned family ships as an
+MCP plugin today, and nothing here says the families listed under
+`### Relationship to current runtime` have become a compatible universal
+runtime — those are LTP *envelope* migrations, and a plugin wrapper is a
+separate, later, per-family change with its own evidence.
+
+**Governed surface.** First-party LingTai-owned model-facing tool families: the
+intrinsics and built-in capability rows registered through
+`src/lingtai/tools/registry.py` and governed by this contract. `mcp` and
+`plugin` are first-party families and are in scope *as families*; the external
+records they render are not. Externally supplied MCP schemas — third-party
+servers reached through `mcp_registry.jsonl`, external Agent Plugins
+directories — and legacy MCP transport and catalog paths are **not** converted
+by this contract. Their wire shape stays theirs, and adopting any individual
+one of them is separate, explicitly authorized, later work.
+
+**One family, one wrapper, retained form.** The unit of migration is one
+current model-facing family becoming one MCP-style plugin package that *wraps*
+it.
+
+- The wrapper MUST preserve that family's public tool name, action inventory
+  and spelling, per-action strict `input` schemas, the closed root
+  (`action`, `input`, `reasoning`, `summarize`), result shapes, error
+  vocabulary, authorization gates, side effects, and public manual result
+  shape. It is an adapter, not a rename, flattening, aggregation, split, or new
+  public capability.
+- A wrapper MAY translate at its own private boundary — the division `shell`
+  already uses to keep `ShellManager`'s flat call shape and `daemon` to keep
+  `DaemonManager`'s — but public semantics MUST survive unchanged.
+- Adopting this section makes no family a plugin. Blanket conformance claims
+  are prohibited: a family is a plugin only once its own vertical PR lands.
+
+**Authority: manager, wrapper, host stay separate.**
+
+- The original family or domain **manager** remains the sole semantic authority
+  for business actions, validation, state, side effects, and family errors.
+- The **wrapper** owns only MCP adaptation and its packaged manual. It MUST NOT
+  become a second tool registry, a hidden configuration owner, an alternate
+  execution path, or a place domain decisions migrate into.
+- The **host** owns discovery, registration, activation, process and connection
+  lifecycle, mounting, audit, and the live model-facing namespace. A wrapper
+  MUST NOT self-register, self-spawn a host route, or leave a live-looking
+  route behind after close.
+
+**The package owns the manual and its submanuals.** Per root Design principles
+3 and 4, the manual travels with the capability:
+
+- One package ships the server entry point, the declarative launch/identity
+  record, the public action descriptor, the bundled `SKILL.md`, and every
+  submanual, reference, or asset that skill routes to. Package identity,
+  registered server name, launcher, action list, and manual MUST agree and MUST
+  fail loudly at construction or import when they do not.
+- Submanuals stay progressive-disclosure skill files referenced by the parent
+  `SKILL.md`. They MUST NOT be inlined into schemas or copied into a second
+  host-side catalog.
+- Packaging does not remove the Contract→manual and Anatomy→manual edges; both
+  owner twins still carry them.
+
+**Reserved `manual`.** The reserved-action rule under
+`### Dispatch and actions` is unchanged and binds wrappers. An operational
+action MUST NOT declare, schema, or handle `manual`; the wrapper appends
+exactly one strict-empty `manual` child sourced from its own packaged skill,
+and a duplicate or reserved-name collision fails at construction, before any
+server is advertised. Where a family's current public manual result differs
+from the canonical child result, the wrapper MUST preserve the current family
+shape through an explicit presentation adapter applied after canonical
+dispatch, rather than double-wrapping it or silently changing what the model
+sees.
+
+**Registration is not activation.** Declaration or boot registration validates
+a plugin and MAY compose its validated skills and register its MCP declaration;
+it MUST NOT start a server. Starting a registered server requires explicit host
+activation. Discovery is read-only: a directory found on a skills search path
+MUST NEVER be silently mounted or executed.
+
+**One host lifecycle owner.** The host starts the selected transport client,
+injects only bounded host metadata and only where the wire permits, mounts the
+server's advertised schema unmodified, tracks client-to-tool ownership, retries
+only through the documented refresh path, and on retry, refresh, or stop closes
+clients and removes stale metadata so no false-live route survives. The host
+MUST NOT widen an existing tool's public schema in order to transport plugin
+metadata.
+
+**Strict dispatch boundary.** Envelope mapping happens only at the wrapper's
+adapter boundary. A strict LTP wrapper receives and restores root `reasoning`;
+a flat third-party MCP schema does not, and MUST NOT have it injected. The host
+forwards only schema-permitted arguments. Malformed envelopes and wrong-branch
+keys are rejected *before* the manager performs any I/O, exactly as
+`### Dispatch and actions` already requires.
+
+**Identifiers, provenance, and collisions — an explicit open decision.**
+
+- Three identifier scopes stay separate: plugin package name, registered server
+  record name, and model-facing tool family name. Server records retain source
+  provenance, and a registry conflict MUST NOT overwrite a record the plugin
+  does not own; a same-plugin change converges by replacing only the
+  plugin-owned record.
+- **The live model-facing tool namespace has no fail-closed collision policy
+  today.** Every advertised MCP tool name is registered, and
+  `lingtai.kernel.base_agent.tools._add_tool` replaces an existing schema of
+  the same name, so current behavior is last-registration-wins with the
+  collision recorded after mounting rather than refused before it. This section
+  records that as the current fact and as an implementation target. It does
+  **not** claim a fail-closed policy exists. Choosing the target — reject
+  before mount, namespacing, or a stated deterministic precedence — is an
+  explicit maintainer decision that MUST be made and written here before the
+  first wrapper is mounted, and no clause above may be read as pre-empting it.
+
+**Observable failures.** An invalid manifest or unsupported version rejects the
+whole plugin. An invalid or path-escaping skill or server component is skipped
+with a bounded, source-attributed reason instead of failing the agent. A
+malformed call or envelope is rejected before manager I/O. A missing packaged
+manual degrades honestly and says so rather than fabricating content. A launch
+or transport failure is observable and retries only through the lifecycle
+policy above. Business-tool errors stay exactly as the family already returns
+them: a wrapper MUST NOT rewrite a domain error as a plugin error, and no
+failure path may leak secrets or resolved configuration.
+
+**Compatibility.** Existing declaration surfaces are unchanged — the canonical
+spelling and its read-compatible alias both keep working, and current init and
+registry files are not rewritten. Legacy tool names, inputs, actions, manual
+paths and results, direct external MCP schemas, and existing tool lifecycle
+semantics MUST NOT be silently altered. Migration is additive at the packaging
+and host boundaries only; a wire or schema change requires that family's own
+explicitly authorized PR.
+
+**Vertical migration.** Each family recuts vertically in its own later PR:
+wrapper and server, declaration, host wiring, package data, its local
+Contract/Anatomy/Behaviors and manual, and the evidence that migration's
+reviewer asks for. Until then the family's runtime and schema are unchanged,
+exactly as `### Scope` already requires for LTP itself.
+
+**Non-goals of this section.** It introduces none of the following, and a later
+migration MUST NOT add one merely to satisfy this file: a generic wrapper
+runtime or shared base class; a universal MCP server compiler; a universal
+validator or conformance suite; an implemented collision mechanism; automatic
+discovery, activation, install, or uninstall; a registry rewrite; a provider
+protocol rewrite; or conversion of arbitrary third-party MCP schemas. It does
+not state that registration launches a server, and it changes no wire, schema,
+or runtime behavior by itself.
+
+**Current evidence versus migration target.** Cited here as precedent, not as
+conformance:
+
+- Curated MCP packages already realize this packaging unit for *curated
+  servers*: `src/lingtai/mcp_servers/_plugin.py` binds one package's server,
+  bundled `SKILL.md`, declaration, and reserved `manual` child, and refuses a
+  package that declares `manual` itself. Its own docstring states it is
+  deliberately not a plugin runtime.
+- External Agent Plugins v1.0.0 already separate declaration from activation
+  (`src/lingtai/services/plugin_registry.py`, and
+  `src/lingtai/tools/plugin/CONTRACT.md` for the tool that renders the result).
+
+Not evidenced, and therefore stated above only as a target: any first-party
+built-in family shipping as an MCP plugin (`src/lingtai/tools/registry.py`
+imports no plugin packaging); wrapper-level retention proven across every
+family; and fail-closed live tool-name collision behavior.
 
 ### Relationship to current runtime
 

--- a/src/lingtai/tools/CONTRACT.md
+++ b/src/lingtai/tools/CONTRACT.md
@@ -35,6 +35,8 @@ related_files:
   - src/lingtai/tools/psyche/CONTRACT.md
   - src/lingtai/tools/plugin/CONTRACT.md
   - src/lingtai/mcp_servers/_plugin.py
+  - src/lingtai/mcp_servers/telegram/plugin.py
+  - src/lingtai/mcp_catalog.json
   - src/lingtai/services/plugin_registry.py
   - tests/test_browser_capability.py
   - tests/test_wire_tool_description.py
@@ -47,9 +49,14 @@ maintenance: |
   truth, not a central validator. Migrate one real family at a time; do not
   claim legacy tools already conform. `### Tool-to-MCP Plugin Contract` is an
   additive, not-yet-implemented migration target guarded by LP002 in the paired
-  BEHAVIORS.md: keep its status paragraph, its open collision decision, and its
+  BEHAVIORS.md: keep its status paragraph, its governed-surface classification,
+  its selected wrapper form, its open collision decision, and its
   current-evidence list honest, and update it, the paired ANATOMY.md, and
   BEHAVIORS.md together when a family actually recuts onto a plugin wrapper.
+  The selected form is the `CuratedMcpPlugin` descriptor plus the curated
+  catalog/package route; changing that choice is a normative change, so move
+  `src/lingtai/mcp_servers/_plugin.py`, `telegram/plugin.py`, and
+  `src/lingtai/mcp_catalog.json` in related_files with it.
 ---
 # LingTai Tool Protocol (LTP)
 
@@ -273,25 +280,83 @@ Guarded by: [LP002](BEHAVIORS.md#behavior-lp002)
 **Status.** This is a shared **migration target**, not shipped state. It fixes
 the activation, dispatch, manual, host, identifier, and migration vocabulary
 that later per-family recuts MUST share, so those recuts do not each invent
-their own. It converts nothing by itself. No LingTai-owned family ships as an
-MCP plugin today, and nothing here says the families listed under
+their own. It converts nothing by itself.
+
+No family registered through `src/lingtai/tools/registry.py` ships as an MCP
+plugin package today. The kernel-shipped curated MCP families under
+`src/lingtai/mcp_servers/` do already ship in the plugin-style package form
+this section selects below, and they are the current first-party precedent for
+it — but that is evidence about *packaging* only. It is not a claim that those
+families already satisfy every clause of this section, and no clause here may
+be read as certifying them. Nothing here says the families listed under
 `### Relationship to current runtime` have become a compatible universal
-runtime — those are LTP *envelope* migrations, and a plugin wrapper is a
+runtime either — those are LTP *envelope* migrations, and a plugin wrapper is a
 separate, later, per-family change with its own evidence.
 
-**Governed surface.** First-party LingTai-owned model-facing tool families: the
-intrinsics and built-in capability rows registered through
-`src/lingtai/tools/registry.py` and governed by this contract. `mcp` and
-`plugin` are first-party families and are in scope *as families*; the external
-records they render are not. Externally supplied MCP schemas — third-party
-servers reached through `mcp_registry.jsonl`, external Agent Plugins
-directories — and legacy MCP transport and catalog paths are **not** converted
-by this contract. Their wire shape stays theirs, and adopting any individual
-one of them is separate, explicitly authorized, later work.
+**Governed surface.** Every LingTai-owned first-party model-facing tool family
+shipped in this distribution. That is two classes today, and both are inside
+this contract's classification:
+
+- **Registry families** — the intrinsics and built-in capability rows
+  registered through `src/lingtai/tools/registry.py`. `mcp` and `plugin` are
+  first-party families and are in scope *as families*; the external records
+  they render are not. No family in this class is wrapped as an MCP plugin
+  package today, so each one is a future migration unit.
+- **Kernel-shipped MCP families** — the model-facing families this
+  distribution ships as MCP server packages under `src/lingtai/mcp_servers/`.
+  The curated catalog families (`imap`, `telegram`, `feishu`, `wechat`,
+  `whatsapp`, `cloud_mail`) each own a `CuratedMcpPlugin` descriptor and a
+  matching `src/lingtai/mcp_catalog.json` record, and are therefore the current
+  first-party precedent for the form selected below, not a separate standard
+  and not exempt from this section. The built-in daemon MCP families
+  (`lingtai.mcp_servers.daemon_common`, `lingtai.mcp_servers.daemon_email`) are
+  also in this class but carry no descriptor and no packaged `SKILL.md` today,
+  so adopting the selected form is future work for them.
+
+Classification is not conformance. A family in either class conforms to a
+clause of this section only with its own evidence for that clause; this
+contract makes no blanket conformance claim for the curated families or for
+anything else.
+
+Externally supplied MCP schemas — third-party servers reached through
+`mcp_registry.jsonl`, external Agent Plugins directories — and legacy MCP
+transport and catalog paths are **not** converted by this contract. Their wire
+shape stays theirs, and adopting any individual one of them is separate,
+explicitly authorized, later work.
+
+**Selected wrapper form.** There is exactly **one** in-distribution form a
+LingTai-owned wrapper may take, and it is the form the curated packages already
+use: the `lingtai.mcp_servers._plugin.CuratedMcpPlugin` descriptor plus the
+curated catalog/package route. A first-party wrapper MUST:
+
+- live as a Python package inside this distribution under
+  `src/lingtai/mcp_servers/<family>/`, shipping its server module, its stdio
+  `__main__.py` entry point, and its bundled `SKILL.md`;
+- own exactly one `CuratedMcpPlugin` descriptor
+  (`src/lingtai/mcp_servers/_plugin.py`) naming the registry/family name, the
+  Python package, the server name, the summary, the homepage, and the packaged
+  skill name, with its own actions declared beside that descriptor and `manual`
+  never declared there;
+- express the "declarative launch/identity record" required below as that
+  descriptor's catalog-record shape (`CuratedMcpPlugin.mcp_declaration()`), and
+  — for a family published through the curated catalog — keep the shipped
+  `src/lingtai/mcp_catalog.json` entry equal to it. That equality is what makes
+  the identity/action/manual agreement objectively checkable rather than a
+  matter of taste.
+
+External **Agent Plugins v1.0.0** filesystem packages (`plugin.json`,
+`skills/`, `mcp.json`; `src/lingtai/services/plugin_registry.py`) and raw
+third-party MCP schemas are a **separate standard, excluded** from this
+conversion contract: no first-party family may be recut into them under this
+section, and they are cited below only as the precedent for
+`**Registration is not activation**`. Selecting one form is the point — this
+section introduces no generic manifest compiler, no plugin-admission engine,
+and no multi-form compatibility layer, and defines no implementation or wire
+behavior for the selected form beyond the documentary requirements above.
 
 **One family, one wrapper, retained form.** The unit of migration is one
-current model-facing family becoming one MCP-style plugin package that *wraps*
-it.
+current model-facing family becoming one plugin package, in the selected form
+above, that *wraps* it.
 
 - The wrapper MUST preserve that family's public tool name, action inventory
   and spelling, per-action strict `input` schemas, the closed root
@@ -407,29 +472,38 @@ exactly as `### Scope` already requires for LTP itself.
 
 **Non-goals of this section.** It introduces none of the following, and a later
 migration MUST NOT add one merely to satisfy this file: a generic wrapper
-runtime or shared base class; a universal MCP server compiler; a universal
-validator or conformance suite; an implemented collision mechanism; automatic
-discovery, activation, install, or uninstall; a registry rewrite; a provider
-protocol rewrite; or conversion of arbitrary third-party MCP schemas. It does
-not state that registration launches a server, and it changes no wire, schema,
-or runtime behavior by itself.
+runtime or shared base class; a universal MCP server compiler; a generic
+manifest compiler or plugin-admission engine; a multi-form manifest
+compatibility layer; a universal validator or conformance suite; an implemented
+collision mechanism; automatic discovery, activation, install, or uninstall; a
+registry rewrite; a provider protocol rewrite; or conversion of arbitrary
+third-party MCP schemas. It does not state that registration launches a server,
+and it changes no wire, schema, or runtime behavior by itself.
 
 **Current evidence versus migration target.** Cited here as precedent, not as
 conformance:
 
-- Curated MCP packages already realize this packaging unit for *curated
-  servers*: `src/lingtai/mcp_servers/_plugin.py` binds one package's server,
-  bundled `SKILL.md`, declaration, and reserved `manual` child, and refuses a
-  package that declares `manual` itself. Its own docstring states it is
-  deliberately not a plugin runtime.
+- The selected form already ships, for the curated MCP families only:
+  `src/lingtai/mcp_servers/_plugin.py` binds one package's server, bundled
+  `SKILL.md`, declaration, and reserved `manual` child, and refuses a package
+  that declares `manual` itself; `src/lingtai/mcp_servers/telegram/plugin.py`
+  is the reference descriptor slice; `src/lingtai/mcp_catalog.json` carries the
+  matching record for each of the six curated families. Its own docstring
+  states it is deliberately not a plugin runtime. This is packaging evidence
+  about those six families — nothing more.
 - External Agent Plugins v1.0.0 already separate declaration from activation
   (`src/lingtai/services/plugin_registry.py`, and
   `src/lingtai/tools/plugin/CONTRACT.md` for the tool that renders the result).
+  That standard is excluded from conversion by `**Selected wrapper form**`; it
+  is cited only for the registration-versus-activation rule.
 
-Not evidenced, and therefore stated above only as a target: any first-party
-built-in family shipping as an MCP plugin (`src/lingtai/tools/registry.py`
-imports no plugin packaging); wrapper-level retention proven across every
-family; and fail-closed live tool-name collision behavior.
+Not evidenced, and therefore stated above only as a target: any family
+registered through `src/lingtai/tools/registry.py` shipping as an MCP plugin
+package (`registry.py` imports no plugin packaging); a `CuratedMcpPlugin`
+descriptor or packaged `SKILL.md` for the built-in daemon MCP families; the
+retention, dispatch, host-lifecycle, and manual clauses above proven for any
+family, curated ones included; and fail-closed live tool-name collision
+behavior.
 
 ### Relationship to current runtime
 


### PR DESCRIPTION
## Summary
- Establish the shared Tool-to-MCP Plugin Contract as the migration target for every LingTai-owned first-party model-facing tool family.
- Classify both `lingtai.tools.registry` families and kernel-shipped MCP families; preserve the distinction between current curated packaging precedent and future clause-by-clause conformance.
- Select the in-distribution curated `CuratedMcpPlugin` descriptor plus catalog/package route as the one first-party wrapper form; keep external Agent Plugins v1.0.0 and raw third-party MCP schemas outside this conversion.
- Add an executable LP002 proof path and the missing Behaviors-to-Contract guard link.

## Validation
- `git diff --check` — pass.
- Independent repair review — **APPROVE**: `reports/tool-protocol-contract-repair-independent-review-20260822.md`.
- `.venv/bin/python -m pytest -q tests/test_architecture_documents.py` — `1 failed, 3 passed`; the only failure is the pre-existing duplicate `related_files` entry in `src/lingtai/kernel/llm/ANATOMY.md`.
- `python scripts/check_docs_governance.py --check` — five known baseline violations, none under `src/lingtai/tools/`.
- `.venv/bin/python -m pytest -q tests/test_docs_governance.py` — `2 failed, 68 passed`; the same five docs-baseline violations plus pre-existing notification-header hash drift.

## Scope
Documentation-only: the tools Contract/Anatomy/Behaviors graph and root Behaviors index. No runtime, registry, packaging, config, auth, or live-service behavior changes. No merge is implied.

Telegram: @lingtaidev1bot | Nickname: 知微
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai