### PR TITLE
fix(notification): remove global store lock convoy

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -26,6 +26,10 @@ include NOTICE
 include README.md
 include src/lingtai/init.jsonc
 
+# Standalone intrinsic skill bundles are runtime package data (including nested
+# system-manual scripts/references); source releases must carry the same tree.
+graft src/lingtai/intrinsic_skills
+
 # Include packaged prompt resources and the runtime guidance Markdown catalog in
 # sdists. pyproject.toml owns wheel package-data globs; keep this connected so
 # source releases carry the same prompt corpus. The `*.yaml` line carries the

--- a/src/lingtai/adapters/notification_store_lock.py
+++ b/src/lingtai/adapters/notification_store_lock.py
@@ -1,26 +1,61 @@
-"""Platform selector for Notification Store mutation serialization."""
+"""Platform selection and same-process Store resource serialization."""
 
 from __future__ import annotations
 
+import contextlib
 import os
+import threading
+from contextlib import ExitStack
+from pathlib import Path
+from typing import Iterable
 
 from lingtai.kernel.notification_store._mutation_lock import (
     NotificationMutationLockPort,
+    notification_mutation_lock_path,
 )
+
+_PROCESS_LOCKS_GUARD = threading.Lock()
+_PROCESS_LOCKS: dict[str, threading.RLock] = {}
+
+
+def _same_process_lock(notification_dir: Path, scope: str) -> threading.RLock:
+    """Return the process-wide guard for one native resource-lock path.
+
+    POSIX `flock` ownership is per open file description, so independently
+    constructed Store adapters in one process still need this guard.  It is
+    keyed by the canonical lock path, not by a Store instance.
+    """
+    key = str(notification_mutation_lock_path(notification_dir, scope).resolve(strict=False))
+    with _PROCESS_LOCKS_GUARD:
+        return _PROCESS_LOCKS.setdefault(key, threading.RLock())
+
+
+@contextlib.contextmanager
+def exclusive_notification_mutation(
+    mutation_lock: NotificationMutationLockPort,
+    notification_dir: Path,
+    scopes: str | Iterable[str],
+):
+    """Hold deduplicated resource locks in deterministic order."""
+    requested = [scopes] if isinstance(scopes, str) else list(scopes)
+    ordered = sorted(set(requested))
+    if not ordered:
+        raise ValueError("at least one notification mutation lock scope is required")
+    with ExitStack() as stack:
+        for scope in ordered:
+            stack.enter_context(_same_process_lock(notification_dir, scope))
+            stack.enter_context(mutation_lock.exclusive(notification_dir, scope))
+        yield
 
 
 def select_notification_store_lock() -> NotificationMutationLockPort:
     """Return the native cross-process lock for this platform."""
     if os.name == "posix":
-        from .posix.notification_store_lock import (
-            PosixNotificationStoreLockAdapter,
-        )
+        from .posix.notification_store_lock import PosixNotificationStoreLockAdapter
 
         return PosixNotificationStoreLockAdapter()
     if os.name == "nt":
-        from .windows.notification_store_lock import (
-            WindowsNotificationStoreLockAdapter,
-        )
+        from .windows.notification_store_lock import WindowsNotificationStoreLockAdapter
 
         return WindowsNotificationStoreLockAdapter()
     raise NotImplementedError(

--- a/src/lingtai/adapters/posix/notification_store.py
+++ b/src/lingtai/adapters/posix/notification_store.py
@@ -1,6 +1,8 @@
-"""POSIX adapter for ``.notification/<channel>.json`` mirrors.
+"""Filesystem Notification Store adapter over the established JSON layout.
 
-It provides atomic file replacement and Store-owned mutation serialization.
+Ordinary JSON channel mutations are serialized only with their own resource.
+Daemon aggregate administration is separately linearized by its durable control
+record; ordinary per-run appends never rebuild the aggregate report.
 """
 
 from __future__ import annotations
@@ -10,11 +12,14 @@ import contextlib
 import hashlib
 import json
 import re
-import threading
+from collections import Counter
 from pathlib import Path
 
-from lingtai.adapters.notification_store_lock import select_notification_store_lock
-from lingtai.kernel._fsutil import atomic_write_json
+from lingtai.adapters.notification_store_lock import (
+    exclusive_notification_mutation,
+    select_notification_store_lock,
+)
+from lingtai.kernel._fsutil import atomic_write_json, atomic_write_text
 from lingtai.kernel.notification_store import (
     AllowPredicate,
     CompareUpdateResult,
@@ -31,6 +36,9 @@ from lingtai.kernel.notification_store import (
 )
 from lingtai.kernel.notification_store._mutation_lock import (
     NotificationMutationLockPort,
+    channel_mutation_scope,
+    daemon_run_mutation_scope,
+    resource_mutation_scope,
 )
 
 _LARGE_RESULT_ACK_FILE = "large_result_acks.json"
@@ -39,26 +47,47 @@ _DOT_NOTIFICATION = ".notification"
 _DAEMON_CHANNEL = "daemon"
 _DAEMON_DIR = "daemon"
 _DAEMON_AGGREGATE_FILENAME = "daemon.json"
+_DAEMON_TOMBSTONE_FILENAME = ".tombstone"
+_DAEMON_CONTROL_VERSION = 1
+_DAEMON_CONTROL_SCOPE = resource_mutation_scope("daemon-control")
+_ACK_SCOPE = resource_mutation_scope("ack-refs")
+_HOOK_SCOPE = resource_mutation_scope("hook-registry")
 _DAEMON_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
 
 
+class DaemonControlError(RuntimeError):
+    """A corrupt daemon tombstone/control record that must be repaired loudly."""
+
+
 def _notification_dir(workdir: Path) -> Path:
-    """Return the canonical ``.notification/`` directory for a workdir."""
     return workdir / _DOT_NOTIFICATION
 
 
 def _channel_path(workdir: Path, channel: str) -> Path:
-    """Return the canonical path for one non-daemon channel mirror file."""
     return _notification_dir(workdir) / f"{channel}.json"
 
 
 def _daemon_dir(workdir: Path) -> Path:
-    """Return the directory containing daemon mini-channel files."""
     return _notification_dir(workdir) / _DAEMON_DIR
 
 
+def _daemon_control_path(workdir: Path) -> Path:
+    return _daemon_dir(workdir) / _DAEMON_TOMBSTONE_FILENAME
+
+
+def _daemon_report_path(workdir: Path) -> Path:
+    return _notification_dir(workdir) / _DAEMON_AGGREGATE_FILENAME
+
+
+def _ack_path(workdir: Path) -> Path:
+    return _notification_dir(workdir) / _LARGE_RESULT_ACK_FILE
+
+
+def _hook_registry_path(workdir: Path) -> Path:
+    return _notification_dir(workdir) / _HOOK_REGISTRY_FILE
+
+
 def _validate_daemon_id(daemon_id: str) -> str:
-    """Validate a daemon id before using it as a mini-channel filename."""
     if not isinstance(daemon_id, str) or _DAEMON_ID_RE.fullmatch(daemon_id) is None:
         raise ValueError("daemon_id must match ^[A-Za-z0-9][A-Za-z0-9_.-]*$")
     if ".." in daemon_id:
@@ -66,31 +95,20 @@ def _validate_daemon_id(daemon_id: str) -> str:
     return daemon_id
 
 
-def _daemon_report_path(workdir: Path) -> Path:
-    """Return the non-event aggregate report path."""
-    return _notification_dir(workdir) / _DAEMON_AGGREGATE_FILENAME
-
-
 def _daemon_path(workdir: Path, daemon_id: str) -> Path:
     return _daemon_dir(workdir) / f"{_validate_daemon_id(daemon_id)}.json"
 
 
 def _daemon_id_from_payload(payload: object) -> str | None:
-    """Extract the owning daemon id carried by a typed channel mutation.
-
-    Every daemon event write must carry its run id.  An absent marker is not a
-    compatibility request for the root report: callers must fail closed rather
-    than create a competing event source.
-    """
-    if isinstance(payload, dict):
-        direct = payload.get("daemon_id")
-        if isinstance(direct, str) and direct:
-            return _validate_daemon_id(direct)
-        data = payload.get("data")
-        if isinstance(data, dict):
-            direct = data.get("daemon_id")
-            if isinstance(direct, str) and direct:
-                return _validate_daemon_id(direct)
+    if not isinstance(payload, dict):
+        return None
+    direct = payload.get("daemon_id")
+    if isinstance(direct, str) and direct:
+        return _validate_daemon_id(direct)
+    data = payload.get("data")
+    direct = data.get("daemon_id") if isinstance(data, dict) else None
+    if isinstance(direct, str) and direct:
+        return _validate_daemon_id(direct)
     return None
 
 
@@ -104,25 +122,6 @@ def _daemon_files(workdir: Path) -> list[Path]:
     )
 
 
-def _daemon_records(workdir: Path) -> list[Path]:
-    """Return only canonical per-daemon event files in deterministic order."""
-    return _daemon_files(workdir)
-
-
-def _read_daemon_payloads(workdir: Path) -> list[tuple[Path, bytes, dict]]:
-    """Read valid canonical mini-channel files in deterministic order."""
-    payloads: list[tuple[Path, bytes, dict]] = []
-    for path in _daemon_records(workdir):
-        try:
-            raw = path.read_bytes()
-            payload = json.loads(raw)
-        except (OSError, json.JSONDecodeError):
-            continue
-        if isinstance(payload, dict):
-            payloads.append((path, raw, payload))
-    return payloads
-
-
 def _daemon_events(payload: object) -> list[dict]:
     if not isinstance(payload, dict):
         return []
@@ -131,78 +130,249 @@ def _daemon_events(payload: object) -> list[dict]:
     return [event for event in events if isinstance(event, dict)] if isinstance(events, list) else []
 
 
-def _configured_daemon_alarm_threshold(workdir: Path) -> int | None:
-    """Read the optional daemon attention threshold for aggregate projection."""
+def _event_tombstone_key(event: dict) -> str:
+    event_id = event.get("event_id")
+    if isinstance(event_id, str) and event_id:
+        return "event:" + event_id
+    idempotency_key = event.get("idempotency_key")
+    if isinstance(idempotency_key, str) and idempotency_key:
+        return "idempotency:" + idempotency_key
+    material = json.dumps(event, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return "sha256:" + hashlib.sha256(material).hexdigest()
+
+
+def _valid_batch_state(value: object) -> dict:
+    if not isinstance(value, dict):
+        raise DaemonControlError("invalid daemon notification tombstone batch state")
+    count = value.get("count")
+    alarm_fired = value.get("alarm_fired")
+    if isinstance(count, bool) or not isinstance(count, int) or count < 0:
+        raise DaemonControlError("invalid daemon notification tombstone batch count")
+    if not isinstance(alarm_fired, bool):
+        raise DaemonControlError("invalid daemon notification tombstone alarm state")
+    return {"count": count, "alarm_fired": alarm_fired}
+
+
+def _empty_daemon_control() -> dict:
+    return {
+        "version": _DAEMON_CONTROL_VERSION,
+        "epoch": 0,
+        "cleared": {},
+        "batch_state": {"count": 0, "alarm_fired": False},
+        "pending": None,
+    }
+
+
+def _read_daemon_control(workdir: Path) -> dict:
+    """Read and validate aggregate authority without ever hiding corruption."""
+    path = _daemon_control_path(workdir)
     try:
-        config = json.loads((workdir / "notification.json").read_text(encoding="utf-8"))
-        value = config["channels"][_DAEMON_CHANNEL]["alarm_threshold"]
-    except (KeyError, OSError, TypeError, ValueError, json.JSONDecodeError):
+        value = json.loads(path.read_bytes())
+    except FileNotFoundError:
+        return _empty_daemon_control()
+    except (OSError, json.JSONDecodeError) as exc:
+        raise DaemonControlError("daemon notification tombstone is unreadable or invalid") from exc
+    if not isinstance(value, dict) or value.get("version") != _DAEMON_CONTROL_VERSION:
+        raise DaemonControlError("invalid daemon notification tombstone version")
+    epoch = value.get("epoch")
+    cleared = value.get("cleared")
+    if isinstance(epoch, bool) or not isinstance(epoch, int) or epoch < 0:
+        raise DaemonControlError("invalid daemon notification tombstone epoch")
+    if not isinstance(cleared, dict):
+        raise DaemonControlError("invalid daemon notification tombstone entries")
+    normalized: dict[str, dict] = {}
+    for filename, entry in cleared.items():
+        if not isinstance(filename, str) or not isinstance(entry, dict):
+            raise DaemonControlError("invalid daemon notification tombstone entry")
+        if not filename.endswith(".json"):
+            raise DaemonControlError("invalid daemon notification tombstone entry")
+        try:
+            _validate_daemon_id(filename[:-5])
+        except ValueError as exc:
+            raise DaemonControlError("invalid daemon notification tombstone entry") from exc
+        raw_sha256 = entry.get("raw_sha256")
+        event_keys = entry.get("event_keys")
+        if (
+            not isinstance(raw_sha256, str)
+            or len(raw_sha256) != 64
+            or not isinstance(event_keys, list)
+            or any(not isinstance(key, str) for key in event_keys)
+        ):
+            raise DaemonControlError("invalid daemon notification tombstone entry")
+        normalized[filename] = {"raw_sha256": raw_sha256, "event_keys": list(event_keys)}
+    pending = value.get("pending")
+    normalized_pending = None
+    if pending is not None:
+        if not isinstance(pending, dict):
+            raise DaemonControlError("invalid daemon notification tombstone pending append")
+        daemon_id = pending.get("daemon_id")
+        event_id = pending.get("event_id")
+        if not isinstance(event_id, str) or not event_id:
+            raise DaemonControlError("invalid daemon notification tombstone pending event")
+        try:
+            normalized_daemon_id = _validate_daemon_id(daemon_id)
+        except ValueError as exc:
+            raise DaemonControlError("invalid daemon notification tombstone pending daemon") from exc
+        normalized_pending = {
+            "daemon_id": normalized_daemon_id,
+            "event_id": event_id,
+            "prior_batch_state": _valid_batch_state(pending.get("prior_batch_state")),
+            "batch_state": _valid_batch_state(pending.get("batch_state")),
+        }
+    return {
+        "version": _DAEMON_CONTROL_VERSION,
+        "epoch": epoch,
+        "cleared": normalized,
+        "batch_state": _valid_batch_state(value.get("batch_state")),
+        "pending": normalized_pending,
+    }
+
+
+def _write_daemon_control(workdir: Path, control: dict, *, fsync: bool = False) -> None:
+    path = _daemon_control_path(workdir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    atomic_write_json(path, control, ensure_ascii=False, indent=None, fsync=fsync)
+
+
+def _pending_is_visible(workdir: Path, pending: dict) -> bool:
+    try:
+        raw = _daemon_path(workdir, pending["daemon_id"]).read_bytes()
+        payload = json.loads(raw)
+    except (OSError, ValueError, json.JSONDecodeError):
+        return False
+    return any(event.get("event_id") == pending["event_id"] for event in _daemon_events(payload))
+
+
+def _effective_batch_state(workdir: Path, control: dict) -> dict:
+    pending = control.get("pending")
+    if isinstance(pending, dict):
+        return dict(pending["batch_state"] if _pending_is_visible(workdir, pending) else pending["prior_batch_state"])
+    return dict(control["batch_state"])
+
+
+def _logical_daemon_record(path: Path, physical_raw: bytes, control: dict) -> tuple[Path, bytes, dict | None, bytes] | None:
+    """Apply a committed aggregate tombstone to a physical mini-file."""
+    entry = control["cleared"].get(path.name)
+    if not isinstance(entry, dict) or hashlib.sha256(physical_raw).hexdigest() != entry["raw_sha256"]:
+        try:
+            parsed = json.loads(physical_raw)
+        except json.JSONDecodeError:
+            return (path, physical_raw, None, physical_raw)
+        return (path, physical_raw, parsed if isinstance(parsed, dict) else None, physical_raw)
+    try:
+        payload = json.loads(physical_raw)
+    except json.JSONDecodeError:
+        return (path, physical_raw, None, physical_raw)
+    if not isinstance(payload, dict):
+        return (path, physical_raw, None, physical_raw)
+    remaining = Counter(entry["event_keys"])
+    kept: list[dict] = []
+    removed = False
+    for event in _daemon_events(payload):
+        key = _event_tombstone_key(event)
+        if remaining[key] > 0:
+            remaining[key] -= 1
+            removed = True
+        else:
+            kept.append(event)
+    if not removed:
+        return (path, physical_raw, payload, physical_raw)
+    if not kept:
         return None
-    return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else None
+    updated = dict(payload)
+    data = payload.get("data")
+    updated_data = dict(data) if isinstance(data, dict) else {}
+    updated_data["events"] = kept
+    updated["data"] = updated_data
+    updated["header"] = f"{len(kept)} daemon notification{'s' if len(kept) != 1 else ''}"
+    raw = json.dumps(updated, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    return (path, raw, updated, physical_raw)
 
 
-def _aggregate_daemon_payload(workdir: Path) -> dict | None:
-    """Build the parent-visible event aggregate from canonical mini-files."""
-    records = _read_daemon_payloads(workdir)
-    if not records:
+def _read_daemon_records(workdir: Path, control: dict | None = None) -> list[tuple[Path, bytes, dict | None, bytes]]:
+    control = _read_daemon_control(workdir) if control is None else control
+    records: list[tuple[Path, bytes, dict | None, bytes]] = []
+    for path in _daemon_files(workdir):
+        try:
+            raw = path.read_bytes()
+        except OSError:
+            continue
+        logical = _logical_daemon_record(path, raw, control)
+        if logical is not None:
+            records.append(logical)
+    return records
+
+
+def _aggregate_daemon_payload(workdir: Path, records: list[tuple[Path, bytes, dict | None, bytes]], control: dict) -> dict | None:
+    valid = [(path, payload) for path, _raw, payload, _physical in records if isinstance(payload, dict)]
+    if not valid:
         return None
     events: list[dict] = []
-    template = records[0][2]
-    alarm_fired = False
-    for _, _, payload in records:
+    template = valid[0][1]
+    for _path, payload in valid:
         events.extend(_daemon_events(payload))
-        data = payload.get("data")
-        state = data.get(_DAEMON_CHANNEL) if isinstance(data, dict) else None
-        alarm_fired = alarm_fired or (
-            isinstance(state, dict) and state.get("alarm_fired") is True
-        )
-    # Preserve append order within each mini-file while giving independent
-    # daemon files a deterministic order for snapshots and CAS tokens.
-    data = {"events": events}
-    threshold = _configured_daemon_alarm_threshold(workdir)
-    data[_DAEMON_CHANNEL] = {
-        "count": len(events),
-        "alarm_fired": alarm_fired or (
-            threshold is not None and len(events) > threshold
-        ),
-    }
+    # The control record only transports Core-computed batch state.  It never
+    # reads notification.json or makes an alarm decision.
+    data = {"events": events, _DAEMON_CHANNEL: _effective_batch_state(workdir, control)}
     aggregate = dict(template)
     aggregate["header"] = f"{len(events)} daemon notification{'s' if len(events) != 1 else ''}"
     aggregate["data"] = data
     return aggregate
 
 
-def _daemon_fingerprint(workdir: Path) -> tuple[str, int, str] | None:
-    """Return one synthetic version covering every canonical mini-file byte."""
-    records: list[tuple[str, bytes]] = []
-    for path in _daemon_records(workdir):
-        try:
-            records.append(("mini/" + path.name, path.read_bytes()))
-        except OSError:
-            continue
+def _daemon_fingerprint(records: list[tuple[Path, bytes, dict | None, bytes]]) -> tuple[str, int, str] | None:
     if not records:
         return None
     material = b"".join(
-        name.encode("utf-8") + b"\\0" + str(len(raw)).encode("ascii") + b"\\0" + raw
-        for name, raw in records
+        ("mini/" + path.name).encode("utf-8") + b"\0" + str(len(raw)).encode("ascii") + b"\0" + raw
+        for path, raw, _payload, _physical in records
     )
     return (_DAEMON_AGGREGATE_FILENAME, len(material), hashlib.sha256(material).hexdigest())
 
 
-def _daemon_report_payload(workdir: Path) -> dict:
-    """Build the root report from mini-file stats, never from root events."""
-    records = _read_daemon_payloads(workdir)
+def _daemon_control_error_payload() -> dict:
+    """Return bounded, content-free daemon visibility when control is broken."""
+    return {
+        "header": "Daemon notification control error; run lingtai-doctor",
+        "icon": "⚠️",
+        "priority": "high",
+        "data": {
+            "events": [],
+            _DAEMON_CHANNEL: {"count": 0, "alarm_fired": True},
+            "error": {
+                "code": "daemon_control_error",
+                "action": "run lingtai-doctor",
+            },
+        },
+    }
+
+
+def _daemon_control_error_fingerprint() -> tuple[str, int, str]:
+    raw = json.dumps(
+        _daemon_control_error_payload(),
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return (_DAEMON_AGGREGATE_FILENAME, len(raw), hashlib.sha256(raw).hexdigest())
+
+
+def _daemon_report_payload(workdir: Path, records: list[tuple[Path, bytes, dict | None, bytes]]) -> dict:
+    """Build a non-authoritative compatibility report from a captured aggregate."""
     runs: list[dict] = []
     total_events = 0
     active_runs = 0
     terminal_runs = 0
     terminal_states = {"done", "failed", "cancelled", "timeout"}
-    for path, _, payload in records:
-        data = payload.get("data")
+    for path, _raw, payload, _physical in records:
+        if not isinstance(payload, dict):
+            continue
         events = _daemon_events(payload)
+        data = payload.get("data")
         state = payload.get("state")
         if not isinstance(state, str) and isinstance(data, dict):
-            state = data.get("state") or data.get("run_state")
+            candidate = data.get("state") or data.get("run_state")
+            state = candidate if isinstance(candidate, str) else None
         if not isinstance(state, str) and events:
             candidate = events[-1].get("status")
             state = candidate if isinstance(candidate, str) else None
@@ -215,27 +385,10 @@ def _daemon_report_payload(workdir: Path) -> dict:
         if state:
             run["state"] = state
         runs.append(run)
-    report = {
-        "kind": "daemon_report",
-        "version": 1,
-        "stats": {
-            "run_count": len(runs),
-            "event_count": total_events,
-            "active_run_count": active_runs,
-            "terminal_run_count": terminal_runs,
-        },
-        "runs": runs,
-    }
-    report_path = _daemon_report_path(workdir)
+    report = {"kind": "daemon_report", "version": 1, "derived": True, "stats": {"run_count": len(runs), "event_count": total_events, "active_run_count": active_runs, "terminal_run_count": terminal_runs}, "runs": runs}
     try:
-        raw = report_path.read_bytes()
-    except FileNotFoundError:
-        return report
-    except OSError:
-        return report
-    try:
-        previous = json.loads(raw)
-    except json.JSONDecodeError:
+        previous = json.loads(_daemon_report_path(workdir).read_bytes())
+    except (OSError, json.JSONDecodeError):
         previous = None
     if isinstance(previous, dict) and previous.get("kind") == "daemon_report":
         migration = previous.get("migration")
@@ -243,113 +396,96 @@ def _daemon_report_payload(workdir: Path) -> dict:
             report["migration"] = migration
     elif previous is not None:
         report["migration"] = {"legacy_root": previous}
-    else:
-        report["migration"] = {
-            "legacy_root_raw_base64": base64.b64encode(raw).decode("ascii")
-        }
     return report
 
 
-def _write_daemon_report(workdir: Path) -> None:
-    """Persist the root aggregate report after a mini-file mutation."""
-    report_path = _daemon_report_path(workdir)
-    report_path.parent.mkdir(parents=True, exist_ok=True)
-    atomic_write_json(
-        report_path, _daemon_report_payload(workdir), ensure_ascii=False, indent=None
-    )
-
-
-def _ack_path(workdir: Path) -> Path:
-    return _notification_dir(workdir) / _LARGE_RESULT_ACK_FILE
-
-
-def _hook_registry_path(workdir: Path) -> Path:
-    return _notification_dir(workdir) / _HOOK_REGISTRY_FILE
+def _write_daemon_report(workdir: Path, records: list[tuple[Path, bytes, dict | None, bytes]]) -> None:
+    path = _daemon_report_path(workdir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    atomic_write_json(path, _daemon_report_payload(workdir, records), ensure_ascii=False, indent=None)
 
 
 def _version_entry(path: Path, raw: bytes) -> list:
-    """Build one fingerprint entry from bytes already read successfully."""
     return [path.name, len(raw), hashlib.sha256(raw).hexdigest()]
 
 
 def _safe_version(entry: list | tuple | None) -> list | None:
-    """Return a JSON/log-safe fingerprint representation."""
-    if entry is None:
-        return None
-    return list(entry)
+    return list(entry) if entry is not None else None
 
 
 class PosixNotificationStoreAdapter(NotificationStorePort):
-    """Filesystem implementation of the Core-owned Store Port.
+    """Production filesystem adapter retaining the established JSON protocol."""
 
-    One composed instance owns serialization; Core supplies channel policy.
-    """
-
-    def __init__(
-        self,
-        workdir: Path,
-        mutation_lock: NotificationMutationLockPort | None = None,
-    ):
+    def __init__(self, workdir: Path, mutation_lock: NotificationMutationLockPort | None = None):
         self._workdir = Path(workdir)
-        self._lock = threading.Lock()
         self._mutation_lock = mutation_lock or select_notification_store_lock()
 
     @contextlib.contextmanager
-    def _exclusive_mutation(self):
-        # The thread lock prevents same-process lock re-entry while the native
-        # lock serializes independently composed producer/supervisor processes.
-        with self._lock:
-            with self._mutation_lock.exclusive(_notification_dir(self._workdir)):
-                yield
+    def _exclusive_mutation(self, scopes: str | list[str]):
+        with exclusive_notification_mutation(self._mutation_lock, _notification_dir(self._workdir), scopes):
+            yield
 
     def snapshot(self, allow_channel: AllowPredicate) -> dict[str, object]:
         notif_dir = _notification_dir(self._workdir)
         if not notif_dir.is_dir():
             return {}
         out: dict[str, object] = {}
-        # Daemon is the one aggregate model-visible channel whose storage is a
-        # directory of independent mini-channels. The sibling daemon.json is a
-        # report only and is deliberately never read here.
         if allow_channel(_DAEMON_CHANNEL):
-            aggregate = _aggregate_daemon_payload(self._workdir)
+            try:
+                control = _read_daemon_control(self._workdir)
+                aggregate = _aggregate_daemon_payload(
+                    self._workdir,
+                    _read_daemon_records(self._workdir, control),
+                    control,
+                )
+            except DaemonControlError:
+                # The control record is daemon-only authority. A bad record is
+                # loud to the agent but cannot turn every other channel into an
+                # indefinitely unstable coherent read.
+                aggregate = _daemon_control_error_payload()
             if aggregate is not None:
                 out[_DAEMON_CHANNEL] = aggregate
-        for f in sorted(notif_dir.glob("*.json")):
-            if f.name in {_LARGE_RESULT_ACK_FILE, _HOOK_REGISTRY_FILE, _DAEMON_AGGREGATE_FILENAME}:
+        for path in sorted(notif_dir.glob("*.json")):
+            if path.name in {_LARGE_RESULT_ACK_FILE, _HOOK_REGISTRY_FILE, _DAEMON_AGGREGATE_FILENAME}:
                 continue
-            if not allow_channel(f.stem):
+            if not allow_channel(path.stem):
                 continue
             try:
-                out[f.stem] = json.loads(f.read_bytes())
+                out[path.stem] = json.loads(path.read_bytes())
             except (json.JSONDecodeError, OSError):
                 continue
         return out
 
-
-    def fingerprint(
-        self, allow_channel: AllowPredicate
-    ) -> tuple[tuple[str, int, str], ...]:
+    def fingerprint(self, allow_channel: AllowPredicate) -> tuple[tuple[str, int, str], ...]:
         notif_dir = _notification_dir(self._workdir)
         if not notif_dir.is_dir():
             return ()
         entries: list[tuple[str, int, str]] = []
-        daemon_entry = _daemon_fingerprint(self._workdir) if allow_channel(_DAEMON_CHANNEL) else None
-        if daemon_entry is not None:
-            entries.append(daemon_entry)
-        for f in notif_dir.iterdir():
-            if not (f.is_file() and f.suffix == ".json"):
+        if allow_channel(_DAEMON_CHANNEL):
+            try:
+                control = _read_daemon_control(self._workdir)
+                daemon_entry = _daemon_fingerprint(
+                    _read_daemon_records(self._workdir, control)
+                )
+            except DaemonControlError:
+                # Use the exact synthetic projection's bytes so the coherent
+                # snapshot/fingerprint bookends describe the same loud state.
+                daemon_entry = _daemon_control_error_fingerprint()
+            if daemon_entry is not None:
+                entries.append(daemon_entry)
+        for path in notif_dir.iterdir():
+            if not (path.is_file() and path.suffix == ".json"):
                 continue
-            if f.name in {_LARGE_RESULT_ACK_FILE, _HOOK_REGISTRY_FILE, _DAEMON_AGGREGATE_FILENAME}:
+            if path.name in {_LARGE_RESULT_ACK_FILE, _HOOK_REGISTRY_FILE, _DAEMON_AGGREGATE_FILENAME}:
                 continue
-            if not allow_channel(f.stem):
+            if not allow_channel(path.stem):
                 continue
             try:
-                data = f.read_bytes()
+                raw = path.read_bytes()
             except OSError:
                 continue
-            entries.append((f.name, len(data), hashlib.sha256(data).hexdigest()))
+            entries.append((path.name, len(raw), hashlib.sha256(raw).hexdigest()))
         return tuple(sorted(entries))
-
 
     def publish(self, channel: str, payload: dict) -> None:
         if channel == _DAEMON_CHANNEL:
@@ -357,338 +493,377 @@ class PosixNotificationStoreAdapter(NotificationStorePort):
             if daemon_id is None:
                 raise ValueError("daemon event publish requires a daemon_id")
             target = _daemon_path(self._workdir, daemon_id)
+            scopes = [daemon_run_mutation_scope(daemon_id), _DAEMON_CONTROL_SCOPE]
         else:
             target = _channel_path(self._workdir, channel)
-        with self._exclusive_mutation():
+            scopes = channel_mutation_scope(channel)
+        with self._exclusive_mutation(scopes):
+            if channel == _DAEMON_CHANNEL:
+                # Daemon mini-file writes must not proceed around unreadable
+                # aggregate authority. Read paths contain this only for
+                # delivery; mutation paths remain fail closed.
+                _read_daemon_control(self._workdir)
             target.parent.mkdir(parents=True, exist_ok=True)
             atomic_write_json(target, payload, ensure_ascii=False, indent=None)
-            if channel == _DAEMON_CHANNEL:
-                _write_daemon_report(self._workdir)
-
 
     def clear(self, channel: str) -> bool:
-        with self._exclusive_mutation():
-            targets = _daemon_records(self._workdir) if channel == _DAEMON_CHANNEL else [_channel_path(self._workdir, channel)]
-            existed = False
-            for target in targets:
-                try:
-                    target.unlink()
-                    existed = True
-                except FileNotFoundError:
-                    continue
-            if channel == _DAEMON_CHANNEL and existed:
-                _write_daemon_report(self._workdir)
-            return existed
-
-
-    def _compare_update_daemon_aggregate(
-        self,
-        expected_version: ExpectedVersion,
-        pure_core_mutator: PureCoreMutator,
-    ) -> CompareUpdateResult:
-        """Apply daemon policy through the existing typed channel family.
-
-        Core mutators see the aggregate projection.  An append carries its run
-        id in ``data.daemon_id``; this adapter-only routing detail lets the
-        existing ``compare_update_channel`` Port operation disaggregate the new
-        event into one mini-file without exposing a ninth Core operation.  A
-        removal instead identifies removed event ids and unlinks only the
-        corresponding mini-file.
-        """
-        current_payload = _aggregate_daemon_payload(self._workdir) or {}
-        current_entry = _daemon_fingerprint(self._workdir)
-        current_version = list(current_entry) if current_entry is not None else None
-        if expected_version is not UNCONDITIONAL and _safe_version(expected_version) != current_version:
-            return _conflict_result(
-                expected_version=expected_version,
-                current_version=current_version,
-            )
-
-        new_payload, new_changed, policy_value = pure_core_mutator(dict(current_payload))
-        if not new_changed:
-            return _applied_result(
-                changed=False,
-                cleared=False,
-                value=policy_value,
-                current_version=current_version,
-                previous_version=current_version,
-            )
-        previous_version = current_version
-
-        if new_payload is None:
-            changed = False
-            for target in _daemon_records(self._workdir):
-                try:
-                    target.unlink()
-                    changed = True
-                except FileNotFoundError:
-                    continue
-            if changed:
-                _write_daemon_report(self._workdir)
-            new_entry = _daemon_fingerprint(self._workdir)
-            return _applied_result(
-                changed=changed,
-                cleared=new_entry is None,
-                value=policy_value,
-                current_version=list(new_entry) if new_entry is not None else None,
-                previous_version=previous_version,
-            )
-
-        current_events = _daemon_events(current_payload)
-        new_events = _daemon_events(new_payload)
-        current_ids = {
-            event.get("event_id") for event in current_events if event.get("event_id")
-        }
-        new_ids = {
-            event.get("event_id") for event in new_events if event.get("event_id")
-        }
-        removed_ids = current_ids - new_ids
-        # Compare event records as a multiset for compatibility with older
-        # mini-file entries, while using event ids whenever present for
-        # unambiguous run-file routing.
-        remaining_new_events = list(new_events)
-        removed_events: list[dict] = []
-        for event in current_events:
-            try:
-                remaining_new_events.remove(event)
-            except ValueError:
-                removed_events.append(event)
-        removed_without_id = [event for event in removed_events if not event.get("event_id")]
-
-        def _is_removed(event: dict) -> bool:
-            event_id = event.get("event_id")
-            return bool(
-                (event_id and event_id in removed_ids)
-                or (not event_id and event in removed_without_id)
-            )
-
-        daemon_id = _daemon_id_from_payload(new_payload)
-        changed = False
-
-        if daemon_id is not None:
-            added_events = [
-                event for event in new_events
-                if event.get("event_id") and event.get("event_id") not in current_ids
-            ]
-            if added_events:
-                target = _daemon_path(self._workdir, daemon_id)
-                target_payload: dict = {}
-                try:
-                    parsed = json.loads(target.read_bytes())
-                    if isinstance(parsed, dict):
-                        target_payload = parsed
-                except (FileNotFoundError, OSError, json.JSONDecodeError):
-                    target_payload = {}
-                target_events = _daemon_events(target_payload) + added_events
-                target_data = dict(new_payload.get("data", {}))
-                target_data["events"] = target_events
-                target_data["daemon_id"] = daemon_id
-                target_payload = dict(new_payload)
-                target_payload["data"] = target_data
-                target_payload["header"] = (
-                    f"{len(target_events)} daemon notification"
-                    f"{'s' if len(target_events) != 1 else ''}"
-                )
-                target.parent.mkdir(parents=True, exist_ok=True)
-                atomic_write_json(target, target_payload, ensure_ascii=False, indent=None)
-                changed = True
-        elif removed_events:
-            for path, _, payload in _read_daemon_payloads(self._workdir):
-                events = _daemon_events(payload)
-                if not any(_is_removed(event) for event in events):
-                    continue
-                # A daemon event/ref dismissal owns the entire run file; never
-                # unlink a different or newer run's mini-channel.
-                try:
-                    path.unlink()
-                    changed = True
-                except FileNotFoundError:
-                    pass
-
-        elif new_changed:
-            # An event mutation without a run marker has no canonical target.
-            # Never fall back to the root report as an event store.
-            raise ValueError("daemon event mutation requires a daemon_id")
-
-        if changed:
-            _write_daemon_report(self._workdir)
-
-        # A daemon aggregate is never blindly rewritten: only an identified
-        # append or an event/ref removal may change physical storage.
-        new_entry = _daemon_fingerprint(self._workdir)
-        return _applied_result(
-            changed=changed,
-            cleared=new_entry is None,
-            value=policy_value,
-            current_version=list(new_entry) if new_entry is not None else None,
-            previous_version=previous_version,
-        )
-
-
-    def compare_update_channel(
-        self,
-        channel: str,
-        expected_version: ExpectedVersion,
-        pure_core_mutator: PureCoreMutator,
-    ) -> CompareUpdateResult:
         if channel == _DAEMON_CHANNEL:
-            with self._exclusive_mutation():
-                return self._compare_update_daemon_aggregate(
-                    expected_version, pure_core_mutator
-                )
+            return self._clear_daemon_aggregate()
         target = _channel_path(self._workdir, channel)
-
-        with self._exclusive_mutation():
-            current_payload: dict = {}
-            current_version: list | None = None
+        with self._exclusive_mutation(channel_mutation_scope(channel)):
             try:
-                raw_bytes = target.read_bytes()
+                target.unlink()
+                return True
             except FileNotFoundError:
-                raw_bytes = None
-            if raw_bytes is not None:
-                current_version = _version_entry(target, raw_bytes)
-                try:
-                    parsed = json.loads(raw_bytes)
-                    current_payload = parsed if isinstance(parsed, dict) else {}
-                except json.JSONDecodeError:
-                    current_payload = {}
+                return False
 
-            if expected_version is not UNCONDITIONAL:
-                if expected_version is None:
-                    if current_version is not None:
-                        return _conflict_result(
-                            expected_version=expected_version,
-                            current_version=_safe_version(current_version),
-                        )
-                else:
-                    expected_list = _safe_version(expected_version)
-                    current_list = _safe_version(current_version)
-                    if current_list != expected_list:
-                        return _conflict_result(
-                            expected_version=expected_list,
-                            current_version=current_list,
-                        )
+    def _normalise_pending_for_writer(self, control: dict) -> dict:
+        """Resolve a prior append receipt under a writer lock; readers never do this."""
+        if control.get("pending") is None:
+            return control
+        normalized = dict(control)
+        normalized["batch_state"] = _effective_batch_state(self._workdir, control)
+        normalized["pending"] = None
+        _write_daemon_control(self._workdir, normalized)
+        return normalized
 
-            new_payload, new_changed, policy_value = pure_core_mutator(
-                dict(current_payload) if isinstance(current_payload, dict) else {}
-            )
+    @staticmethod
+    def _overlay_batch_state(payload: dict, batch_state: dict) -> dict:
+        current = dict(payload)
+        data = payload.get("data")
+        updated = dict(data) if isinstance(data, dict) else {}
+        updated[_DAEMON_CHANNEL] = dict(batch_state)
+        current["data"] = updated
+        return current
 
-            if not new_changed:
-                return _applied_result(
-                    changed=False,
-                    cleared=False,
-                    value=policy_value,
-                    current_version=_safe_version(current_version),
-                    previous_version=_safe_version(current_version),
-                )
-
+    def _compare_update_daemon_owner(self, owner: str, expected_version: ExpectedVersion, pure_core_mutator: PureCoreMutator) -> CompareUpdateResult:
+        if expected_version is not UNCONDITIONAL:
+            raise ValueError("daemon owner-scoped mutation requires UNCONDITIONAL")
+        daemon_id = _validate_daemon_id(owner)
+        target = _daemon_path(self._workdir, daemon_id)
+        scopes = [daemon_run_mutation_scope(daemon_id), _DAEMON_CONTROL_SCOPE]
+        with self._exclusive_mutation(scopes):
+            control = self._normalise_pending_for_writer(_read_daemon_control(self._workdir))
+            try:
+                physical_raw = target.read_bytes()
+            except FileNotFoundError:
+                logical = None
+            else:
+                logical = _logical_daemon_record(target, physical_raw, control)
+            current_payload = logical[2] if logical is not None and isinstance(logical[2], dict) else {}
+            current_version = _version_entry(target, logical[1]) if logical is not None else None
+            prior_batch = _effective_batch_state(self._workdir, control)
+            new_payload, requested_change, value = pure_core_mutator(self._overlay_batch_state(current_payload, prior_batch))
+            if not requested_change:
+                return _applied_result(changed=False, cleared=False, value=value, current_version=_safe_version(current_version), previous_version=_safe_version(current_version))
             previous_version = _safe_version(current_version)
-
             if new_payload is None:
                 try:
                     target.unlink()
-                    did_clear = True
+                    changed = True
                 except FileNotFoundError:
-                    did_clear = False
-                return _applied_result(
-                    changed=did_clear,
-                    cleared=did_clear,
-                    value=policy_value,
-                    current_version=None,
-                    previous_version=previous_version,
+                    changed = False
+                return _applied_result(changed=changed, cleared=changed, value=value, current_version=None, previous_version=previous_version)
+            routed_owner = _daemon_id_from_payload(new_payload)
+            if routed_owner != daemon_id:
+                raise ValueError("daemon mutation owner does not match payload daemon_id")
+            data = new_payload.get("data") if isinstance(new_payload, dict) else None
+            next_batch = _valid_batch_state(data.get(_DAEMON_CHANNEL) if isinstance(data, dict) else None)
+            event_id = value if isinstance(value, str) and value else None
+            if event_id is None:
+                raise ValueError("daemon owner mutation requires a stable event id policy value")
+            pending = {"daemon_id": daemon_id, "event_id": event_id, "prior_batch_state": prior_batch, "batch_state": next_batch}
+            pending_control = dict(control)
+            pending_control["pending"] = pending
+            _write_daemon_control(self._workdir, pending_control)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            atomic_write_json(target, new_payload, ensure_ascii=False, indent=None)
+            committed = dict(pending_control)
+            committed["batch_state"] = next_batch
+            committed["pending"] = None
+            _write_daemon_control(self._workdir, committed)
+            raw = target.read_bytes()
+            return _applied_result(changed=True, cleared=False, value=value, current_version=_safe_version(_version_entry(target, raw)), previous_version=previous_version)
+
+    @staticmethod
+    def _extend_control(
+        control: dict,
+        removed: list[tuple[Path, bytes, dict | None, bytes]],
+        wanted: Counter[str],
+        reset_batch: bool,
+    ) -> dict:
+        cleared = {
+            name: {
+                "raw_sha256": entry["raw_sha256"],
+                "event_keys": list(entry["event_keys"]),
+            }
+            for name, entry in control["cleared"].items()
+        }
+        for path, _raw, payload, physical_raw in removed:
+            keys: list[str] = []
+            if isinstance(payload, dict):
+                for event in _daemon_events(payload):
+                    key = _event_tombstone_key(event)
+                    if wanted[key] > 0:
+                        wanted[key] -= 1
+                        keys.append(key)
+            if keys:
+                cleared[path.name] = {
+                    "raw_sha256": hashlib.sha256(physical_raw).hexdigest(),
+                    "event_keys": keys,
+                }
+        return {
+            "version": _DAEMON_CONTROL_VERSION,
+            "epoch": control["epoch"] + 1,
+            "cleared": cleared,
+            "batch_state": (
+                {"count": 0, "alarm_fired": False}
+                if reset_batch
+                else dict(control["batch_state"])
+            ),
+            "pending": None,
+        }
+
+    def _compact_daemon_tombstone(self) -> None:
+        """Physically compact only after the durable visibility cut is committed.
+
+        Each file is re-read under its run plus control scopes.  Do not nest a
+        second native flock for the control path: independent file descriptions
+        can deadlock against this process's first exclusive flock on POSIX.
+        """
+        with self._exclusive_mutation(_DAEMON_CONTROL_SCOPE):
+            names = tuple(sorted(_read_daemon_control(self._workdir)["cleared"]))
+        for filename in names:
+            if not filename.endswith(".json"):
+                continue
+            daemon_id = filename[:-5]
+            try:
+                _validate_daemon_id(daemon_id)
+            except ValueError:
+                continue
+            target = _daemon_path(self._workdir, daemon_id)
+            with self._exclusive_mutation([daemon_run_mutation_scope(daemon_id), _DAEMON_CONTROL_SCOPE]):
+                control = _read_daemon_control(self._workdir)
+                if filename not in control["cleared"]:
+                    continue
+                try:
+                    physical_raw = target.read_bytes()
+                except FileNotFoundError:
+                    physical_raw = None
+                if physical_raw is None:
+                    logical = None
+                else:
+                    logical = _logical_daemon_record(target, physical_raw, control)
+                compacted = dict(control)
+                cleared = dict(control["cleared"])
+                if logical is None:
+                    try:
+                        target.unlink()
+                    except FileNotFoundError:
+                        pass
+                    cleared.pop(filename, None)
+                elif logical[1] != physical_raw and isinstance(logical[2], dict):
+                    atomic_write_text(target, logical[1].decode("utf-8"), encoding="utf-8")
+                    cleared.pop(filename, None)
+                else:
+                    # A SHA mismatch or a tombstone whose keys no longer apply
+                    # is inert because its logical bytes equal the physical
+                    # bytes. Drop it now so every heartbeat does not keep
+                    # parsing an unbounded historical entry.
+                    cleared.pop(filename, None)
+                compacted["cleared"] = cleared
+                _write_daemon_control(self._workdir, compacted)
+
+    def _commit_daemon_removal(
+        self,
+        control: dict,
+        removed: list[tuple[Path, bytes, dict | None, bytes]],
+        wanted: Counter[str],
+        reset_batch: bool,
+    ) -> None:
+        # This is the durable aggregate visibility cut. Keep hot append
+        # receipts non-fsync; only a committed clear/dismiss pays this cost.
+        _write_daemon_control(
+            self._workdir,
+            self._extend_control(control, removed, wanted, reset_batch),
+            fsync=True,
+        )
+
+    def _clear_daemon_aggregate(self) -> bool:
+        with self._exclusive_mutation(_DAEMON_CONTROL_SCOPE):
+            control = self._normalise_pending_for_writer(_read_daemon_control(self._workdir))
+            records = _read_daemon_records(self._workdir, control)
+            if not records:
+                return False
+            self._commit_daemon_removal(
+                control,
+                records,
+                Counter(
+                    _event_tombstone_key(event)
+                    for _path, _raw, payload, _physical in records
+                    if isinstance(payload, dict)
+                    for event in _daemon_events(payload)
+                ),
+                reset_batch=True,
+            )
+        try:
+            self._compact_daemon_tombstone()
+        except (DaemonControlError, OSError):
+            # The visibility cut is already committed. Leave physical cleanup
+            # retryable rather than turning a successful clear into a false
+            # failure/retry ambiguity.
+            pass
+        return True
+
+    def _compare_update_daemon_aggregate(self, expected_version: ExpectedVersion, pure_core_mutator: PureCoreMutator) -> CompareUpdateResult:
+        compact = False
+        with self._exclusive_mutation(_DAEMON_CONTROL_SCOPE):
+            control = self._normalise_pending_for_writer(_read_daemon_control(self._workdir))
+            records = _read_daemon_records(self._workdir, control)
+            current_payload = _aggregate_daemon_payload(self._workdir, records, control) or {}
+            current_entry = _daemon_fingerprint(records)
+            current_version = _safe_version(current_entry)
+            if expected_version is not UNCONDITIONAL and _safe_version(expected_version) != current_version:
+                return _conflict_result(expected_version=expected_version, current_version=current_version)
+            new_payload, requested_change, value = pure_core_mutator(dict(current_payload))
+            if not requested_change:
+                return _applied_result(changed=False, cleared=False, value=value, current_version=current_version, previous_version=current_version)
+            if new_payload is None:
+                removed = records
+                wanted = Counter(
+                    _event_tombstone_key(event)
+                    for _path, _raw, payload, _physical in records
+                    if isinstance(payload, dict)
+                    for event in _daemon_events(payload)
                 )
+                reset_batch = True
+            else:
+                current_events = _daemon_events(current_payload)
+                next_events = _daemon_events(new_payload)
+                remaining = list(next_events)
+                removed_events: list[dict] = []
+                for event in current_events:
+                    try:
+                        remaining.remove(event)
+                    except ValueError:
+                        removed_events.append(event)
+                if not removed_events:
+                    raise ValueError("daemon aggregate mutation must clear or remove events")
+                wanted = Counter(_event_tombstone_key(event) for event in removed_events)
+                removed = []
+                for record in records:
+                    payload = record[2]
+                    if isinstance(payload, dict) and any(wanted[_event_tombstone_key(event)] > 0 for event in _daemon_events(payload)):
+                        removed.append(record)
+                reset_batch = False
+            changed = bool(removed)
+            if changed:
+                self._commit_daemon_removal(control, removed, wanted, reset_batch)
+                compact = True
+            # Return the logical post-cut version; compaction must not alter it.
+            next_control = _read_daemon_control(self._workdir)
+            next_entry = _daemon_fingerprint(_read_daemon_records(self._workdir, next_control))
+            result = _applied_result(changed=changed, cleared=next_entry is None, value=value, current_version=_safe_version(next_entry), previous_version=current_version)
+        if compact:
+            try:
+                self._compact_daemon_tombstone()
+            except (DaemonControlError, OSError):
+                # The logical removal and returned version were committed under
+                # daemon control. Compaction remains best effort after that cut.
+                pass
+        return result
 
-            notif_dir = _notification_dir(self._workdir)
-            notif_dir.mkdir(exist_ok=True)
-            atomic_write_json(
-                target, new_payload, ensure_ascii=False, indent=None
-            )
-
-            new_raw = target.read_bytes()
-            new_version = _version_entry(target, new_raw)
-            return _applied_result(
-                changed=True,
-                cleared=False,
-                value=policy_value,
-                current_version=_safe_version(new_version),
-                previous_version=previous_version,
-            )
-
+    def compare_update_channel(self, channel: str, expected_version: ExpectedVersion, pure_core_mutator: PureCoreMutator, *, owner: str | None = None) -> CompareUpdateResult:
+        if channel == _DAEMON_CHANNEL:
+            if owner is not None:
+                return self._compare_update_daemon_owner(owner, expected_version, pure_core_mutator)
+            return self._compare_update_daemon_aggregate(expected_version, pure_core_mutator)
+        if owner is not None:
+            raise ValueError("notification mutation owner is only valid for daemon")
+        target = _channel_path(self._workdir, channel)
+        with self._exclusive_mutation(channel_mutation_scope(channel)):
+            current_payload: dict = {}
+            current_version: list | None = None
+            try:
+                raw = target.read_bytes()
+            except FileNotFoundError:
+                raw = None
+            if raw is not None:
+                current_version = _version_entry(target, raw)
+                try:
+                    parsed = json.loads(raw)
+                    current_payload = parsed if isinstance(parsed, dict) else {}
+                except json.JSONDecodeError:
+                    current_payload = {}
+            if expected_version is not UNCONDITIONAL and _safe_version(expected_version) != _safe_version(current_version):
+                return _conflict_result(expected_version=expected_version, current_version=_safe_version(current_version))
+            new_payload, requested_change, value = pure_core_mutator(dict(current_payload))
+            if not requested_change:
+                return _applied_result(changed=False, cleared=False, value=value, current_version=_safe_version(current_version), previous_version=_safe_version(current_version))
+            previous_version = _safe_version(current_version)
+            if new_payload is None:
+                try:
+                    target.unlink()
+                    cleared = True
+                except FileNotFoundError:
+                    cleared = False
+                return _applied_result(changed=cleared, cleared=cleared, value=value, current_version=None, previous_version=previous_version)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            atomic_write_json(target, new_payload, ensure_ascii=False, indent=None)
+            raw = target.read_bytes()
+            return _applied_result(changed=True, cleared=False, value=value, current_version=_safe_version(_version_entry(target, raw)), previous_version=previous_version)
 
     def load_ack_refs(self) -> set[str]:
-        ack_path = _ack_path(self._workdir)
         try:
-            data = json.loads(ack_path.read_text(encoding="utf-8"))
-            if isinstance(data, list):
-                return {r for r in data if isinstance(r, str)}
+            data = json.loads(_ack_path(self._workdir).read_text(encoding="utf-8"))
+            return {value for value in data if isinstance(value, str)} if isinstance(data, list) else set()
         except (json.JSONDecodeError, OSError):
-            pass
-        return set()
+            return set()
 
-    def update_ack_refs(
-        self, pure_core_set_mutator: PureAckMutator
-    ) -> UpdateAckRefsResult:
-        ack_path = _ack_path(self._workdir)
-        with self._exclusive_mutation():
-            current = self.load_ack_refs()
-            refs, requested_change, value = pure_core_set_mutator(set(current))
+    def update_ack_refs(self, pure_core_set_mutator: PureAckMutator) -> UpdateAckRefsResult:
+        path = _ack_path(self._workdir)
+        with self._exclusive_mutation(_ACK_SCOPE):
+            refs, requested_change, value = pure_core_set_mutator(self.load_ack_refs())
             if not requested_change:
-                return UpdateAckRefsResult(changed=False, value=value)
+                return UpdateAckRefsResult(False, value)
             if not refs:
                 try:
-                    ack_path.unlink()
+                    path.unlink()
                     changed = True
                 except OSError:
                     changed = False
-                return UpdateAckRefsResult(changed=changed, value=value)
-            ack_path.parent.mkdir(exist_ok=True)
-            atomic_write_json(
-                ack_path, sorted(refs), ensure_ascii=False, indent=None
-            )
-            return UpdateAckRefsResult(changed=True, value=value)
+                return UpdateAckRefsResult(changed, value)
+            path.parent.mkdir(exist_ok=True)
+            atomic_write_json(path, sorted(refs), ensure_ascii=False, indent=None)
+            return UpdateAckRefsResult(True, value)
 
     def load_hook_manifests(self) -> list[dict]:
-        """Return the persisted hook manifests, or ``[]`` when the registry
-        is absent. A corrupt (invalid JSON) or unreadable registry raises so
-        the tool layer can surface a structured ``hook_registry_load_failed``
-        error instead of masquerading as "nothing registered"."""
-        registry_path = _hook_registry_path(self._workdir)
         try:
-            data = json.loads(registry_path.read_text(encoding="utf-8"))
+            data = json.loads(_hook_registry_path(self._workdir).read_text(encoding="utf-8"))
         except FileNotFoundError:
             return []
-        if isinstance(data, list):
-            return [m for m in data if isinstance(m, dict)]
-        return []
+        return [item for item in data if isinstance(item, dict)] if isinstance(data, list) else []
 
     def stat_hook_registry(self) -> tuple[int, int] | None:
-        registry_path = _hook_registry_path(self._workdir)
         try:
-            st = registry_path.stat()
-            return (st.st_mtime_ns, st.st_size)
+            stat = _hook_registry_path(self._workdir).stat()
+            return stat.st_mtime_ns, stat.st_size
         except OSError:
             return None
 
-    def update_hook_manifests(
-        self, pure_core_manifest_mutator: PureHookManifestMutator
-    ) -> UpdateHookManifestsResult:
-        registry_path = _hook_registry_path(self._workdir)
-        with self._exclusive_mutation():
-            current = self.load_hook_manifests()
-            manifests, requested_change, value = pure_core_manifest_mutator(
-                list(current)
-            )
+    def update_hook_manifests(self, pure_core_manifest_mutator: PureHookManifestMutator) -> UpdateHookManifestsResult:
+        path = _hook_registry_path(self._workdir)
+        with self._exclusive_mutation(_HOOK_SCOPE):
+            manifests, requested_change, value = pure_core_manifest_mutator(self.load_hook_manifests())
             if not requested_change:
-                return UpdateHookManifestsResult(changed=False, value=value)
+                return UpdateHookManifestsResult(False, value)
             if not manifests:
                 try:
-                    registry_path.unlink()
+                    path.unlink()
                     changed = True
                 except OSError:
                     changed = False
-                return UpdateHookManifestsResult(changed=changed, value=value)
-            registry_path.parent.mkdir(exist_ok=True)
-            atomic_write_json(
-                registry_path, manifests, ensure_ascii=False, indent=None
-            )
-            return UpdateHookManifestsResult(changed=True, value=value)
+                return UpdateHookManifestsResult(changed, value)
+            path.parent.mkdir(exist_ok=True)
+            atomic_write_json(path, manifests, ensure_ascii=False, indent=None)
+            return UpdateHookManifestsResult(True, value)

--- a/src/lingtai/adapters/posix/notification_store_lock.py
+++ b/src/lingtai/adapters/posix/notification_store_lock.py
@@ -1,4 +1,4 @@
-"""POSIX cross-process mutation lock for the Notification Store."""
+"""POSIX resource locks with a one-release legacy `.store.lock` bridge."""
 
 from __future__ import annotations
 
@@ -6,24 +6,42 @@ import contextlib
 import fcntl
 from pathlib import Path
 
-_LOCK_FILE = ".store.lock"
+from lingtai.kernel.notification_store._mutation_lock import notification_mutation_lock_path
+
+_LEGACY_LOCK_FILE = ".store.lock"
 
 
 class PosixNotificationStoreLockAdapter:
-    """Advisory ``flock`` held for one complete Store mutation."""
+    """Scope-local exclusive flock plus shared lock against legacy writers.
+
+    The shared legacy acquisition is intentionally retained for exactly one
+    compatibility release: an old global exclusive holder excludes every new
+    mutation, while two new unrelated resource mutations still share it.
+    """
 
     @contextlib.contextmanager
-    def exclusive(self, notification_dir: Path):
+    def exclusive(self, notification_dir: Path, scope: str):
         notification_dir.mkdir(parents=True, exist_ok=True)
-        handle = open(notification_dir / _LOCK_FILE, "a+b")
-        locked = False
+        legacy_handle = open(notification_dir / _LEGACY_LOCK_FILE, "a+b")
+        scoped_path = notification_mutation_lock_path(notification_dir, scope)
+        scoped_path.parent.mkdir(parents=True, exist_ok=True)
+        scoped_handle = open(scoped_path, "a+b")
+        legacy_locked = False
+        scoped_locked = False
         try:
-            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
-            locked = True
+            fcntl.flock(legacy_handle.fileno(), fcntl.LOCK_SH)
+            legacy_locked = True
+            fcntl.flock(scoped_handle.fileno(), fcntl.LOCK_EX)
+            scoped_locked = True
             yield
         finally:
             try:
-                if locked:
-                    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+                if scoped_locked:
+                    fcntl.flock(scoped_handle.fileno(), fcntl.LOCK_UN)
             finally:
-                handle.close()
+                try:
+                    if legacy_locked:
+                        fcntl.flock(legacy_handle.fileno(), fcntl.LOCK_UN)
+                finally:
+                    scoped_handle.close()
+                    legacy_handle.close()

--- a/src/lingtai/adapters/windows/notification_store_lock.py
+++ b/src/lingtai/adapters/windows/notification_store_lock.py
@@ -1,4 +1,4 @@
-"""Windows cross-process mutation lock for the Notification Store."""
+"""Windows resource locks for the Notification Store."""
 
 from __future__ import annotations
 
@@ -6,20 +6,29 @@ import contextlib
 import time
 from pathlib import Path
 
-_LOCK_FILE = ".store.lock"
+from lingtai.kernel.notification_store._mutation_lock import notification_mutation_lock_path
 
 
 class WindowsNotificationStoreLockAdapter:
-    """Byte-range lock held for one complete Store mutation."""
+    """Byte-range lock held for one scoped Store mutation.
+
+    Windows `msvcrt.locking` cannot express the POSIX bridge's shared lock.
+    Upgrades therefore require a documented quiesced cutover: do not run an old
+    `.store.lock` writer concurrently with this adapter.  The adapter does not
+    pretend that an exclusive legacy lock would preserve scoped concurrency.
+    """
+
+    requires_quiesced_legacy_cutover = True
 
     @contextlib.contextmanager
-    def exclusive(self, notification_dir: Path):
+    def exclusive(self, notification_dir: Path, scope: str):
         if __import__("os").name != "nt":
             raise OSError("Windows notification Store lock requires Windows")
         import msvcrt
 
-        notification_dir.mkdir(parents=True, exist_ok=True)
-        handle = open(notification_dir / _LOCK_FILE, "a+b")
+        lock_path = notification_mutation_lock_path(notification_dir, scope)
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        handle = open(lock_path, "a+b")
         locked = False
         try:
             if handle.seek(0, 2) == 0:
@@ -32,10 +41,7 @@ class WindowsNotificationStoreLockAdapter:
                     locked = True
                     break
                 except OSError as exc:
-                    if getattr(exc, "winerror", None) != 33 and exc.errno not in {
-                        13,
-                        36,
-                    }:
+                    if getattr(exc, "winerror", None) != 33 and exc.errno not in {13, 36}:
                         raise
                     time.sleep(0.01)
             yield

--- a/src/lingtai/intrinsic_skills/lingtai-doctor/scripts/doctor.py
+++ b/src/lingtai/intrinsic_skills/lingtai-doctor/scripts/doctor.py
@@ -14,6 +14,7 @@ import ntpath
 import os
 import platform
 import posixpath
+import re
 import shutil
 import subprocess
 import sys
@@ -484,6 +485,73 @@ def collect_process(report: Report) -> None:
         sec.add("WARN", "no lingtai process found", "No `lingtai-agent run <agent-dir>` or `python -m lingtai run <agent-dir>` process was found. A fresh heartbeat would make this inconsistent.")
 
 
+def _daemon_tombstone_health(path: Path) -> tuple[bool, dict[str, Any]]:
+    """Validate only bounded daemon-control structure, never event bodies."""
+    try:
+        raw = path.read_bytes()
+    except OSError as exc:
+        return False, {"error": type(exc).__name__}
+    if len(raw) > 65536:
+        return False, {"error": "oversize", "byte_size": len(raw)}
+    try:
+        value = json.loads(raw)
+        if not isinstance(value, dict) or value.get("version") != 1:
+            raise ValueError("version")
+        epoch = value.get("epoch")
+        cleared = value.get("cleared")
+        batch = value.get("batch_state")
+        if isinstance(epoch, bool) or not isinstance(epoch, int) or epoch < 0:
+            raise ValueError("epoch")
+        if not isinstance(cleared, dict):
+            raise ValueError("cleared")
+
+        daemon_id_re = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
+
+        def valid_daemon_id(candidate: object) -> bool:
+            return isinstance(candidate, str) and daemon_id_re.fullmatch(candidate) is not None
+
+        def validate_batch(candidate: object) -> None:
+            if not isinstance(candidate, dict):
+                raise ValueError("batch_state")
+            count = candidate.get("count")
+            if (
+                isinstance(count, bool)
+                or not isinstance(count, int)
+                or count < 0
+                or not isinstance(candidate.get("alarm_fired"), bool)
+            ):
+                raise ValueError("batch_state")
+
+        for filename, entry in cleared.items():
+            if (
+                not isinstance(filename, str)
+                or not filename.endswith(".json")
+                or not valid_daemon_id(filename[:-5])
+                or not isinstance(entry, dict)
+                or not isinstance(entry.get("raw_sha256"), str)
+                or len(entry["raw_sha256"]) != 64
+                or not isinstance(entry.get("event_keys"), list)
+                or any(not isinstance(key, str) for key in entry["event_keys"])
+            ):
+                raise ValueError("cleared")
+
+        validate_batch(batch)
+        pending = value.get("pending")
+        if pending is not None:
+            if (
+                not isinstance(pending, dict)
+                or not valid_daemon_id(pending.get("daemon_id"))
+                or not isinstance(pending.get("event_id"), str)
+                or not pending["event_id"]
+            ):
+                raise ValueError("pending")
+            validate_batch(pending.get("prior_batch_state"))
+            validate_batch(pending.get("batch_state"))
+    except (ValueError, TypeError, json.JSONDecodeError) as exc:
+        return False, {"error": type(exc).__name__}
+    return True, {"epoch": epoch, "cleared_entry_count": len(cleared), "byte_size": len(raw)}
+
+
 def collect_notifications_logs_mail(report: Report) -> None:
     sec = report.section("notifications/logs/mail")
     notif_dir = report.agent_dir / ".notification"
@@ -495,6 +563,18 @@ def collect_notifications_logs_mail(report: Report) -> None:
                 info["channel"] = path.name
                 entries.append(info)
         sec.add("OK", "notification directory scanned", f"Found {len(entries)} notification file(s).", notifications=entries)
+        tombstone = notif_dir / "daemon" / ".tombstone"
+        if tombstone.exists():
+            valid, detail = _daemon_tombstone_health(tombstone)
+            if valid:
+                sec.add("OK", "daemon notification tombstone valid", "Daemon aggregate control state is structurally valid.", daemon_tombstone=detail)
+            else:
+                sec.add(
+                    "WARN",
+                    "daemon notification tombstone invalid",
+                    "Daemon notifications fail loud until an operator explicitly repairs or quarantines .notification/daemon/.tombstone; doctor never repairs it automatically.",
+                    daemon_tombstone=detail,
+                )
     else:
         sec.add("OK", "notification directory absent", "No .notification directory is present.")
 

--- a/src/lingtai/intrinsic_skills/system-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/SKILL.md
@@ -4,14 +4,15 @@ description: >
   Second-layer router for LingTai's progressive-disclosure operating manuals.
   Read this when resident substrate/procedures are too compact and you need the
   right lower reference; route from the table, then open that node.
-version: 1.12.0
-last_changed_at: "2026-08-09T00:00:00Z"
+version: 1.13.0
+last_changed_at: "2026-08-24T02:20:00Z"
 tags: [lingtai, agent, runtime, procedures, substrate, system, lifecycle, memory, communication, skills, molt, summarize, nudge, updates, runtime-checks, refresh, preset, llm, adapters, codex, websocket]
 related_files:
 - src/lingtai/prompts/substrate/substrate.md
 - src/lingtai/prompts/procedures/procedures.md
 - src/lingtai/kernel/nudge/ANATOMY.md
 - src/lingtai/intrinsic_skills/system-manual/reference/llm-adapters/SKILL.md
+- src/lingtai/intrinsic_skills/system-manual/reference/external-attach-diagnostic/SKILL.md
 - src/lingtai/llm/_register.py
 - src/lingtai/llm/openai/adapter.py
 maintenance: |
@@ -104,6 +105,13 @@ The router table is the routing authority; this list is the inventory.
     Built-in LLM adapters: named adapter inventory, per-provider
     configuration/dispatch, the Codex REST vs WebSocket transport opt-in and
     its environment variables, and provider special behaviors.
+- name: external-attach-diagnostic
+  location: reference/external-attach-diagnostic/SKILL.md
+  description: |
+    Guarded macOS-only external attach: exact agent-dir/PID incarnation
+    verification, bounded `/usr/bin/sample` stacks, content-free runtime facts,
+    and an exceptional controlled external `mcp.*` burst that does not exercise
+    Store locking.
 ```
 
 ## Router table
@@ -123,6 +131,7 @@ The router table is the routing authority; this list is the inventory.
 | Goal notifications; `.notification/goal.json`; active goal source of truth; goal `instructions`; idle goal reminder; cancel/complete goal | `reference/goal-manual/SKILL.md` |
 | Change an agent workdir basename/address; POSIX suspend → no-replace rename → resume; preserve `agent_id` and true name | `reference/how-to-change-name/SKILL.md` |
 | LLM adapters; named adapter inventory; provider configuration; Codex REST vs WebSocket transport; `LINGTAI_CODEX_TRANSPORT` / `LINGTAI_CODEX_WS` opt-in; provider special behaviors | `reference/llm-adapters/SKILL.md` |
+| Authorized external attach; macOS `/usr/bin/sample`; exact PID/agent-dir incarnation verification; bounded content-free stacks; guarded controlled external `mcp.*` burst; diagnostic privacy | `reference/external-attach-diagnostic/SKILL.md` |
 | Molt mechanics, pad tending, session journals, post-wipe recovery | `context-manual` |
 | Soul tool; soul flow opt-in (`LINGTAI_SOUL_FLOW_ENABLED`); disabled-flow behavior; `delay_seconds` as cadence-not-off-switch; inquiry/config/voice/dismiss; privacy/cost rationale | `soul-manual` |
 | Authoring/publishing skills or changing skill catalog behavior | `skills-manual` |

--- a/src/lingtai/intrinsic_skills/system-manual/reference/external-attach-diagnostic/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/external-attach-diagnostic/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: external-attach-diagnostic
+description: >
+  Guarded macOS-only external attach diagnostic: verifies a live LingTai PID and
+  incarnation against an exact agent directory, captures bounded /usr/bin/sample
+  stacks plus content-free runtime facts, and optionally performs one controlled
+  external mcp.* burst without exercising NotificationStore locking.
+version: 1.0.0
+last_changed_at: "2026-08-24T02:20:00Z"
+tags: [lingtai, diagnostic, external, attach, sample, stack, pid, privacy, notification]
+related_files:
+- src/lingtai/intrinsic_skills/system-manual/reference/external-attach-diagnostic/scripts/external_attach_diagnostic.py
+- src/lingtai/adapters/posix/process_identity.py
+- src/lingtai/adapters/posix/process_scan.py
+- src/lingtai/kernel/process_match.py
+- src/lingtai/kernel/runtime_identity.py
+maintenance: |
+  Keep host support, process-incarnation checks, data-minimization boundaries, and
+  controlled-burst semantics synchronized with the named runtime helpers.
+---
+
+# External Attach Diagnostic
+
+Use this **only for an authorized, live macOS incident investigation** when an
+external observer needs bounded process stacks. It is a reusable script, not an
+in-process debug mode and not a timing profiler: its samples are **stacks, not
+semantic stage timings**.
+
+The script is at `scripts/external_attach_diagnostic.py`. Run it from a Python
+environment that can import the target LingTai runtime. It requires exact
+`--agent-dir` and `--pid`, plus an **absent** absolute `--artifact-dir`:
+
+```bash
+python3 scripts/external_attach_diagnostic.py \
+  --agent-dir /absolute/path/to/agent \
+  --pid 12345 \
+  --artifact-dir /absolute/empty-parent/attach-20260824
+```
+
+## Preconditions and refusal rules
+
+1. It is macOS-only and requires executable `/usr/bin/sample`. Unsupported
+   host/tool failure happens **before** it creates the artifact directory or
+   mutates the agent directory.
+2. `--agent-dir` and the artifact parent must be canonical absolute directories;
+   the artifact target itself must not exist. The script creates only that new
+   evidence directory (mode `0700`).
+3. The supplied PID is verified through the existing process-table adapter and
+   canonical `match_agent_run`, then bound to a stable existing
+   `process_identity` before and after each capture. It never trusts PID alone
+   or a command substring.
+4. Default mode is observational with respect to the agent: it writes only the
+   requested evidence directory and **refuses any notification mutation** unless
+   the explicit controlled-burst flag is present.
+
+Artifacts contain bounded `/usr/bin/sample` stack files and an `evidence.json`
+record with a hashed start-identity token, kernel identity, heartbeat age, and
+safe file counts. They do **not** read or record prompt, notification, tool, or
+secret bodies. Stack capture does not infer semantic stages or timings.
+
+Optional related PIDs are operator-supplied only and must each have a stable
+incarnation identity:
+
+```bash
+python3 scripts/external_attach_diagnostic.py \
+  --agent-dir /absolute/path/to/agent --pid 12345 \
+  --related-pid 12361 --related-pid 12372 \
+  --sample-seconds 3 --artifact-dir /absolute/empty-parent/attach-20260824
+```
+
+`--sample-seconds` is bounded to 1–10 seconds; at most eight related PIDs are
+accepted. The script suppresses `/usr/bin/sample` stdout/stderr from the
+artifact record and stores only stack outputs.
+
+## Controlled external producer burst (exceptional)
+
+This is a **separate, explicitly opt-in** simulation of an external producer;
+it does not call the Store and therefore does **not** exercise Store locking.
+After all read-only preflight and stack capture succeeds, it atomically creates
+exactly one unique, content-free file:
+
+```bash
+python3 scripts/external_attach_diagnostic.py \
+  --agent-dir /absolute/path/to/agent --pid 12345 \
+  --artifact-dir /absolute/empty-parent/attach-control \
+  --controlled-burst --burst-run-id incident-20260824-a
+```
+
+The target is exactly
+`.notification/mcp.external-attach-diagnostic.<run-id>.json`. Its exclusive
+creation refuses an existing target rather than overwriting or merging any
+notification. The payload is only a control marker/run ID; it contains no
+prompt, notification, or tool body. The script never creates `.notification/`
+for this purpose: a canonical existing directory is required.
+
+If cleanup is authorized after observing the burst, use the same exact run ID:
+
+```bash
+python3 scripts/external_attach_diagnostic.py \
+  --agent-dir /absolute/path/to/agent --pid 12345 \
+  --artifact-dir /absolute/empty-parent/attach-cleanup \
+  --cleanup-controlled-burst --burst-run-id incident-20260824-a
+```
+
+Cleanup is deliberately narrow: it revalidates the exact filename and its own
+content-free marker before deleting it. It cannot enumerate, clear, or touch
+any other notification file, and it refuses an absent, malformed, altered, or
+foreign target.
+
+## Limits
+
+- No in-process debug mode, cache, notification cap, database, refresh, restart,
+  or daemon-manager operation is involved.
+- It cannot establish causality from stacks. Preserve external timing/incident
+  context separately if authorized.
+- A changed PID incarnation during preflight or sampling makes the invocation
+  fail rather than attributing output to a recycled PID.
+- Do not use this script as a notification Store concurrency test. The focused
+  cross-process Store tests own real native lock-path coverage.

--- a/src/lingtai/intrinsic_skills/system-manual/reference/external-attach-diagnostic/scripts/external_attach_diagnostic.py
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/external-attach-diagnostic/scripts/external_attach_diagnostic.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+"""Guarded macOS-only external stack capture for one live LingTai agent.
+
+This is deliberately an *external producer* diagnostic. It does not import or
+exercise NotificationStore locking. Its only optional agent mutation is one
+unique, content-free ``mcp.*`` file created after read-only preflight passes.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+from lingtai.adapters.posix.git_cli import PosixGitCliAdapter
+from lingtai.adapters.posix.process_identity import process_identity, process_identity_matches
+from lingtai.adapters.posix.process_scan import PosixAgentProcessScanAdapter
+from lingtai.kernel.process_match import match_agent_run
+from lingtai.kernel.runtime_identity import _source_root, runtime_identity
+
+SAMPLE_TOOL = Path("/usr/bin/sample")
+_MAX_SAMPLE_SECONDS = 10
+_MAX_RELATED_PIDS = 8
+_RUN_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$")
+_BURST_PREFIX = "mcp.external-attach-diagnostic."
+_BURST_SUFFIX = ".json"
+
+
+class DiagnosticError(RuntimeError):
+    """A refused or failed diagnostic operation with a safe reason."""
+
+
+@dataclass(frozen=True)
+class ObservedProcess:
+    pid: int
+    start_identity: str
+    run_form: str | None
+
+
+def _parse_pid(value: str) -> int:
+    try:
+        pid = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("PID must be a positive integer") from exc
+    if pid <= 0:
+        raise argparse.ArgumentTypeError("PID must be a positive integer")
+    return pid
+
+
+def _canonical_existing_directory(value: str | Path, *, label: str) -> Path:
+    path = Path(value)
+    if not path.is_absolute() or path.is_symlink() or not path.is_dir():
+        raise DiagnosticError(f"{label} must be an existing canonical absolute directory")
+    if path != path.resolve():
+        raise DiagnosticError(f"{label} must not use a symlink or non-canonical path")
+    return path
+
+
+def _new_artifact_directory(value: str | Path) -> Path:
+    path = Path(value)
+    if not path.is_absolute() or path.exists() or path.is_symlink():
+        raise DiagnosticError("--artifact-dir must be an absent canonical absolute directory")
+    parent = path.parent
+    if not parent.is_dir() or parent.is_symlink() or parent != parent.resolve():
+        raise DiagnosticError("--artifact-dir parent must be an existing canonical absolute directory")
+    return path
+
+
+def _require_supported_host_and_tool() -> None:
+    """Fail before any artifact or agent-directory mutation on unsupported hosts."""
+    if sys.platform != "darwin":
+        raise DiagnosticError("external attach diagnostic is supported only on macOS (/usr/bin/sample)")
+    if not SAMPLE_TOOL.is_file() or not os.access(SAMPLE_TOOL, os.X_OK):
+        raise DiagnosticError("macOS /usr/bin/sample is unavailable; no artifacts were created")
+
+
+def _find_target_run(agent_dir: Path, pid: int) -> str:
+    """Bind a PID to one exact workdir through canonical runtime policy."""
+    for observed_pid, command in PosixAgentProcessScanAdapter().iter_process_commands():
+        if observed_pid == pid:
+            form = match_agent_run(command, str(agent_dir))
+            if form is not None:
+                return form
+            break
+    raise DiagnosticError("--pid is not a live LingTai run for --agent-dir")
+
+
+def _observe_target(agent_dir: Path, pid: int) -> ObservedProcess:
+    """Capture a PID incarnation before and after canonical ownership matching."""
+    start_identity = process_identity(pid)
+    if not start_identity:
+        raise DiagnosticError("cannot obtain a stable process-incarnation identity for --pid")
+    run_form = _find_target_run(agent_dir, pid)
+    if not process_identity_matches(pid, start_identity):
+        raise DiagnosticError("--pid changed incarnation during ownership verification")
+    return ObservedProcess(pid=pid, start_identity=start_identity, run_form=run_form)
+
+
+def _observe_related(pids: Iterable[int]) -> list[ObservedProcess]:
+    observed: list[ObservedProcess] = []
+    for pid in pids:
+        identity = process_identity(pid)
+        if not identity or not process_identity_matches(pid, identity):
+            raise DiagnosticError(f"cannot obtain a stable process-incarnation identity for related PID {pid}")
+        observed.append(ObservedProcess(pid=pid, start_identity=identity, run_form=None))
+    return observed
+
+
+def _identity_digest(identity: str) -> str:
+    """Do not place raw OS incarnation tokens in external evidence."""
+    return hashlib.sha256(identity.encode("utf-8")).hexdigest()[:16]
+
+
+def _heartbeat_age_seconds(agent_dir: Path) -> float | None:
+    try:
+        return round(max(0.0, time.time() - (agent_dir / ".agent.heartbeat").stat().st_mtime), 3)
+    except OSError:
+        return None
+
+
+def _safe_counts(agent_dir: Path) -> dict[str, int]:
+    """Count only names; never parse notification, prompt, tool, or secret bodies."""
+    notification_dir = agent_dir / ".notification"
+    if not notification_dir.is_dir():
+        return {"notification_json_files": 0, "mcp_notification_files": 0, "daemon_mini_files": 0}
+    try:
+        children = list(notification_dir.iterdir())
+    except OSError:
+        return {"notification_json_files": 0, "mcp_notification_files": 0, "daemon_mini_files": 0}
+    json_names = [path.name for path in children if path.is_file() and path.suffix == ".json"]
+    daemon_dir = notification_dir / "daemon"
+    try:
+        daemon_mini_files = sum(1 for path in daemon_dir.iterdir() if path.is_file() and path.suffix == ".json")
+    except OSError:
+        daemon_mini_files = 0
+    return {
+        "notification_json_files": len(json_names),
+        "mcp_notification_files": sum(name.startswith("mcp.") for name in json_names),
+        "daemon_mini_files": daemon_mini_files,
+    }
+
+
+def _kernel_identity(agent_dir: Path) -> dict[str, object]:
+    """Use the imported kernel checkout identity, never the enclosing agent repo."""
+    del agent_dir  # Process binding owns this path; kernel identity owns its source root.
+    try:
+        module_path = Path(runtime_identity.__code__.co_filename).resolve()
+        raw = runtime_identity(PosixGitCliAdapter(_source_root(module_path)))
+    except Exception:
+        return {"status": "unavailable"}
+    allowed = ("version", "stamp", "mode", "source", "installed_version", "git_commit", "git_dirty")
+    return {key: raw[key] for key in allowed if isinstance(raw.get(key), (str, bool))}
+
+
+def _burst_path(agent_dir: Path, run_id: str) -> Path:
+    return agent_dir / ".notification" / f"{_BURST_PREFIX}{run_id}{_BURST_SUFFIX}"
+
+
+def _validate_run_id(run_id: str | None) -> str:
+    if not isinstance(run_id, str) or _RUN_ID_RE.fullmatch(run_id) is None:
+        raise DiagnosticError("--burst-run-id must be 1-64 ASCII letters/digits/_/- and start alphanumeric")
+    return run_id
+
+
+def _is_exact_controlled_burst(payload: object, run_id: str) -> bool:
+    data = payload.get("data") if isinstance(payload, dict) else None
+    return bool(
+        isinstance(data, dict)
+        and data.get("kind") == "external_attach_controlled_burst"
+        and data.get("diagnostic_run_id") == run_id
+        and data.get("content_free") is True
+    )
+
+
+def _validate_burst_plan(agent_dir: Path, *, run_id: str, cleanup: bool) -> Path:
+    notification_dir = agent_dir / ".notification"
+    if not notification_dir.is_dir() or notification_dir.is_symlink():
+        raise DiagnosticError("agent has no canonical .notification directory; refusing controlled burst")
+    target = _burst_path(agent_dir, run_id)
+    if cleanup:
+        if not target.is_file() or target.is_symlink():
+            raise DiagnosticError("exact controlled-burst target is absent; refusing cleanup")
+        try:
+            payload = json.loads(target.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            raise DiagnosticError("exact controlled-burst target is unreadable; refusing cleanup") from exc
+        if not _is_exact_controlled_burst(payload, run_id):
+            raise DiagnosticError("target is not this exact controlled burst; refusing cleanup")
+    elif target.exists() or target.is_symlink():
+        raise DiagnosticError("exact controlled-burst target already exists; refusing overwrite")
+    return target
+
+
+def _write_exclusive(path: Path, content: bytes) -> None:
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    with os.fdopen(fd, "wb") as stream:
+        stream.write(content)
+        stream.flush()
+        os.fsync(stream.fileno())
+
+
+def _capture_stack(observed: ObservedProcess, output: Path, seconds: int) -> None:
+    """Capture only a bounded process stack, never a semantic stage-timing trace."""
+    try:
+        result = subprocess.run(
+            [str(SAMPLE_TOOL), str(observed.pid), str(seconds), "-file", str(output)],
+            stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            check=False, timeout=float(seconds) + 8.0,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise DiagnosticError(f"/usr/bin/sample failed for PID {observed.pid}; no diagnostic interpretation was made") from exc
+    if result.returncode != 0 or not output.is_file():
+        raise DiagnosticError(f"/usr/bin/sample failed for PID {observed.pid}; no diagnostic interpretation was made")
+    if not process_identity_matches(observed.pid, observed.start_identity):
+        raise DiagnosticError(f"PID {observed.pid} changed incarnation during stack capture")
+
+
+def _create_controlled_burst(target: Path, run_id: str) -> None:
+    payload = {
+        "header": "External diagnostic controlled burst",
+        "icon": "🔬",
+        "priority": "normal",
+        "published_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "instructions": "External diagnostic control marker; no prompt, notification, or tool body was captured.",
+        "data": {"kind": "external_attach_controlled_burst", "diagnostic_run_id": run_id, "content_free": True},
+    }
+    _write_exclusive(target, (json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n").encode("utf-8"))
+
+
+def _remove_exact_controlled_burst(target: Path, run_id: str) -> None:
+    """Only remove the exact-run-id control file validated in preflight."""
+    try:
+        payload = json.loads(target.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise DiagnosticError("exact controlled-burst target changed; refusing cleanup") from exc
+    if not _is_exact_controlled_burst(payload, run_id):
+        raise DiagnosticError("exact controlled-burst target changed; refusing cleanup")
+    try:
+        target.unlink()
+    except FileNotFoundError as exc:
+        raise DiagnosticError("exact controlled-burst target disappeared; no cleanup performed") from exc
+
+
+def _evidence(*, target: ObservedProcess, related: list[ObservedProcess], agent_dir: Path, burst_target: Path | None, controlled_burst: bool, cleanup: bool) -> dict[str, object]:
+    return {
+        "schema": "lingtai.external_attach_diagnostic.v1",
+        "captured_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "interpretation": "Stacks only; not semantic stage timings.",
+        "privacy": "No prompt, notification, tool, or secret bodies were read into this evidence.",
+        "target": {"pid": target.pid, "run_form": target.run_form, "start_identity_sha256_16": _identity_digest(target.start_identity)},
+        "related_pids": [{"pid": item.pid, "start_identity_sha256_16": _identity_digest(item.start_identity)} for item in related],
+        "heartbeat_age_seconds": _heartbeat_age_seconds(agent_dir),
+        "safe_counts": _safe_counts(agent_dir),
+        "kernel_identity": _kernel_identity(agent_dir),
+        "controlled_burst": {"requested": controlled_burst, "cleanup_requested": cleanup, "target_filename": burst_target.name if burst_target is not None else None, "store_locking_exercised": False},
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Guarded macOS external attach diagnostic; captures stacks, not semantic timings.")
+    parser.add_argument("--agent-dir", required=True, help="Canonical absolute LingTai agent working directory")
+    parser.add_argument("--pid", required=True, type=_parse_pid, help="PID of that live LingTai agent run")
+    parser.add_argument("--artifact-dir", required=True, help="Absent canonical absolute directory for content-free evidence")
+    parser.add_argument("--related-pid", action="append", default=[], type=_parse_pid, help="Optional related PID to sample (repeatable; max 8)")
+    parser.add_argument("--sample-seconds", default=3, type=int, help="Per-PID /usr/bin/sample duration (1-10; default 3)")
+    parser.add_argument("--controlled-burst", action="store_true", help="Explicitly atomically create one content-free mcp.* control file")
+    parser.add_argument("--cleanup-controlled-burst", action="store_true", help="Explicitly remove only this script's exact-run-id control file")
+    parser.add_argument("--burst-run-id", help="Required with either controlled-burst option; exact identity of one control file")
+    return parser
+
+
+def run(args: argparse.Namespace) -> dict[str, object]:
+    _require_supported_host_and_tool()
+    if not 1 <= args.sample_seconds <= _MAX_SAMPLE_SECONDS:
+        raise DiagnosticError("--sample-seconds must be between 1 and 10")
+    if len(args.related_pid) > _MAX_RELATED_PIDS:
+        raise DiagnosticError("at most 8 --related-pid values are allowed")
+    if args.controlled_burst and args.cleanup_controlled_burst:
+        raise DiagnosticError("--controlled-burst and --cleanup-controlled-burst are mutually exclusive")
+    if (args.controlled_burst or args.cleanup_controlled_burst) and not args.burst_run_id:
+        raise DiagnosticError("--burst-run-id is required for controlled-burst creation or cleanup")
+    if args.burst_run_id and not (args.controlled_burst or args.cleanup_controlled_burst):
+        raise DiagnosticError("--burst-run-id requires a controlled-burst option")
+
+    agent_dir = _canonical_existing_directory(args.agent_dir, label="--agent-dir")
+    artifact_dir = _new_artifact_directory(args.artifact_dir)
+    target = _observe_target(agent_dir, args.pid)
+    related = _observe_related(args.related_pid)
+    burst_target = None
+    run_id = None
+    if args.controlled_burst or args.cleanup_controlled_burst:
+        run_id = _validate_run_id(args.burst_run_id)
+        burst_target = _validate_burst_plan(agent_dir, run_id=run_id, cleanup=args.cleanup_controlled_burst)
+
+    # All preflight above is read-only. This is the first filesystem write.
+    artifact_dir.mkdir(mode=0o700)
+    _capture_stack(target, artifact_dir / f"pid-{target.pid}.stack.txt", args.sample_seconds)
+    for item in related:
+        _capture_stack(item, artifact_dir / f"related-pid-{item.pid}.stack.txt", args.sample_seconds)
+    if not process_identity_matches(target.pid, target.start_identity):
+        raise DiagnosticError("--pid changed incarnation before final diagnostic record")
+    if args.controlled_burst:
+        assert burst_target is not None and run_id is not None
+        _create_controlled_burst(burst_target, run_id)
+    elif args.cleanup_controlled_burst:
+        assert burst_target is not None and run_id is not None
+        _remove_exact_controlled_burst(burst_target, run_id)
+
+    record = _evidence(target=target, related=related, agent_dir=agent_dir, burst_target=burst_target, controlled_burst=args.controlled_burst, cleanup=args.cleanup_controlled_burst)
+    _write_exclusive(artifact_dir / "evidence.json", (json.dumps(record, sort_keys=True, indent=2) + "\n").encode("utf-8"))
+    return record
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        record = run(args)
+    except DiagnosticError as exc:
+        print(f"refused: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps({"status": "ok", "artifact_dir": args.artifact_dir, "target_pid": record["target"]["pid"]}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/lingtai/kernel/base_agent/messaging.py
+++ b/src/lingtai/kernel/base_agent/messaging.py
@@ -215,7 +215,12 @@ def _enqueue_system_notification(
     # production adapter recognizes the daemon payload's run-id marker and
     # writes the corresponding mini-channel; Core never probes an adapter-only
     # capability.
-    result = store.compare_update_channel(channel, UNCONDITIONAL, _mutator)
+    result = store.compare_update_channel(
+        channel,
+        UNCONDITIONAL,
+        _mutator,
+        owner=ref_id if channel == DAEMON_CHANNEL else None,
+    )
     applied_event_id = result.value if isinstance(result.value, str) else ""
     if not applied_event_id:
         return ""

--- a/src/lingtai/kernel/notification_store/ANATOMY.md
+++ b/src/lingtai/kernel/notification_store/ANATOMY.md
@@ -15,6 +15,7 @@ related_files:
   - src/lingtai/cli.py
   - src/lingtai/mcp_servers/telegram/server.py
   - src/lingtai/tools/daemon/supervisor_runtime.py
+  - src/lingtai/kernel/refresh_watcher/watcher_program.py
   - tests/test_notification_store.py
 maintenance: |
   Keep related_files repo-relative, duplicate-free, and linked to real files.
@@ -49,17 +50,23 @@ The Notification Store is the Core-owned persistence boundary for current
 - `CompareUpdateResult`, `UpdateAckRefsResult`, and `UpdateHookManifestsResult`
   carry typed operational and policy evidence
   (`src/lingtai/kernel/notification_store/__init__.py:66-90`).
-- `NotificationMutationLockPort` is the Store-private cross-process transaction
-  seam (`src/lingtai/kernel/notification_store/_mutation_lock.py:1-13`). Its
-  platform selector composes native POSIX and Windows implementations
-  (`src/lingtai/adapters/notification_store_lock.py:1-28`).
+- `NotificationMutationLockPort` is the Store-private resource transaction
+  seam (`src/lingtai/kernel/notification_store/_mutation_lock.py`). Its scope
+  helpers map channel, daemon-run, daemon-control, ack, hook, and delay
+  resources to bounded sanitized-plus-SHA-256 filenames under `.locks/`.
+  `exclusive_notification_mutation` adds a process-wide RLock by canonical path
+  before the selected native lock, closing `flock`'s same-process/open-file
+  gap (`src/lingtai/adapters/notification_store_lock.py`).
 - `PosixNotificationStoreAdapter` maps the Port onto the established
-  `.notification/` layout and owns both in-process and native cross-process
-  mutation serialization (`src/lingtai/adapters/posix/notification_store.py:69-314`).
-  Non-daemon channels remain root mirrors; daemon writes use locked
-  `.notification/daemon/<daemon-id>.json` mini-channels, while snapshot and
-  fingerprint compose a single aggregate view over those files. The sibling
-  `.notification/daemon.json` is a derived run/state report, not an event file.
+  `.notification/` layout and owns resource-scoped serialization
+  (`src/lingtai/adapters/posix/notification_store.py`). Non-daemon channels
+  remain root mirrors; daemon writes use locked
+  `.notification/daemon/<daemon-id>.json` mini-channels plus durable
+  `.notification/daemon/.tombstone` control state. Owner append holds its run
+  plus control scope but does not scan an aggregate or rebuild a report;
+  snapshot/fingerprint derive the aggregate only for their read. The sibling
+  `.notification/daemon.json` is a non-authoritative compatibility report, not
+  an event file.
 - Notification Core owns channel policy, atomic acknowledgement union/purge, and
   current-payload dismiss decisions (`src/lingtai/kernel/notifications.py:122-219`,
   `src/lingtai/kernel/notifications.py:704-788`,
@@ -87,30 +94,42 @@ and outer roots inject the Store Port.
 ## State
 
 Persistent protocol state is the existing `.notification/<channel>.json` for
-all non-daemon channels, the derived daemon report
-`.notification/daemon.json`, independent daemon mini-channels
-`.notification/daemon/<daemon-id>.json`, and the aggregate model-visible daemon
-projection, the acknowledgement registry `.notification/large_result_acks.json`,
-and the hook-manifest registry `.notification/hooks.json` (a single non-channel file,
-invisible to snapshot/fingerprint; its `(st_mtime_ns, st_size)` stat is the
-cheap staleness fingerprint Core consults for out-of-band re-seed). The
-Store-owned non-channel stems (`hooks`, `large_result_acks`) are never channels:
-adapters skip them in snapshot/fingerprint and Core validation rejects them as
-hook channels. The daemon aggregate fingerprint changes for mini-file additions,
-removals, and same-file appends; the root report never participates in that
-fingerprint. Channel/event/ref dismissals use the aggregate CAS before deleting
-mini-files. The adapter holds its workdir, an
-in-process mutex, and a platform-selected mutation lock. Native adapters lock
-`.notification/.store.lock` using `flock` on POSIX or byte 0 on Windows
-(`src/lingtai/adapters/posix/notification_store_lock.py:1-29`,
-`src/lingtai/adapters/windows/notification_store_lock.py:1-48`). The refresh
-watcher's generated terminal publisher takes the same sidecar flock before
-merging its `refresh_failed_permanent` event into `system.json`
-(`src/lingtai/kernel/refresh_watcher/watcher_program.py`), with a bounded
-fail-open timeout so the alert is never dropped by a wedged holder. Lock-file
-existence is not authority; OS lock ownership serializes complete mutation
-transactions and releases on process death. Core retains delivered fingerprints
-and policy state on the agent, not in the adapter.
+all non-daemon channels; independent daemon mini-channels
+`.notification/daemon/<daemon-id>.json`; durable daemon control/tombstones at
+`.notification/daemon/.tombstone`; the non-authoritative compatibility report
+`.notification/daemon.json`; the acknowledgement registry
+`.notification/large_result_acks.json`; and the hook-manifest registry
+`.notification/hooks.json` (a single non-channel file, invisible to
+snapshot/fingerprint; its `(st_mtime_ns, st_size)` stat is the cheap staleness
+fingerprint Core consults for out-of-band re-seed). The control record contains
+aggregate visibility cuts, batch/alarm state, and a process-crash-safe pending
+append receipt so a crash between receipt and mini-file/write compaction has a
+deterministic logical projection. Committed clear/dismiss cuts fsync before
+compaction. It is validated on every daemon aggregate read; corruption becomes
+a bounded high-priority daemon control-error projection rather than an empty
+channel or an outage of unrelated channels, while daemon mutation paths refuse.
+The Store-owned
+non-channel stems (`hooks`, `large_result_acks`) are never channels: adapters
+skip them in snapshot/fingerprint and Core validation rejects them as hook
+channels. The daemon aggregate fingerprint changes for logical mini-file
+additions, removals, and same-file appends; the root report never participates
+in that fingerprint. Channel/event/ref dismissals use aggregate CAS, tombstone
+only selected event keys, commit a visibility cut, and only then compact
+mini-files best effort.
+
+The adapter holds its workdir, a process-wide per-canonical-lock-path RLock,
+and a platform-selected native resource lock. POSIX takes shared
+`.notification/.store.lock` for one release with exclusive scoped
+`.notification/.locks/<bounded-label>-<sha20>.lock`; legacy writers remain
+exclusive on `.store.lock`. Windows uses only scoped byte-range locks and
+requires quiesced old-writer cutover. Neither live lock filename is deleted.
+The refresh watcher's generated terminal publisher computes the same `system`
+scope filename and uses POSIX shared legacy + scoped exclusive locking before
+merging `refresh_failed_permanent` into `system.json`, with bounded fail-open
+behavior so a wedged holder does not drop the alert. Lock-file existence is not
+authority; OS lock ownership serializes complete resource transactions and
+releases on process death. Core retains delivered fingerprints and policy state
+on the agent, not in the adapter.
 
 ## Notes
 

--- a/src/lingtai/kernel/notification_store/CONTRACT.md
+++ b/src/lingtai/kernel/notification_store/CONTRACT.md
@@ -1,10 +1,11 @@
 ---
 name: notification-store
-contract_version: 3
+contract_version: 4
 root_contract: CONTRACT.md
 related_files:
   - src/lingtai/kernel/notification_store/ANATOMY.md
   - src/lingtai/kernel/base_agent/CONTRACT.md
+  - src/lingtai/kernel/refresh_watcher/CONTRACT.md
   - src/lingtai/kernel/notification_store/__init__.py
   - src/lingtai/kernel/notification_store/_mutation_lock.py
   - src/lingtai/adapters/notification_store_lock.py
@@ -18,6 +19,7 @@ related_files:
   - src/lingtai/mcp_servers/telegram/manager.py
   - src/lingtai/mcp_servers/telegram/server.py
   - src/lingtai/tools/daemon/supervisor_runtime.py
+  - src/lingtai/kernel/refresh_watcher/watcher_program.py
   - tests/_notification_store_helpers.py
   - tests/test_notification_store.py
 maintenance: |
@@ -55,14 +57,25 @@ channel is the sole exception: producers persist independent mini-channels at
 one aggregate `daemon` channel. The sibling `.notification/daemon.json` is a
 report containing only mini-file-derived run/state statistics; it is not a
 channel event source. Non-force dismiss conflicts remain stale refusals, and
-event/ref daemon dismissal deletes the matching mini-file only. A daemon channel
+event/ref daemon dismissal removes only matching event keys from a mini-file,
+deleting that mini-file only when no sibling events remain. A daemon channel
 dismissal must compare the delivered aggregate version before unlinking any
 mini-file, so a mini-file arriving after delivery is preserved. Existing root
 event facts may be retained only under report migration metadata and MUST NOT
 be delivered. Daemon append routing uses the existing typed channel mutator
-payload and does not add a Store operation. They MUST NOT add a nullable/no-op
-Store, Path-or-Port overload, locator, hidden Core construction, ninth operation
-family, or caller-held transaction lock.
+payload and does not add a Store operation. The optional `owner` argument on
+`compare_update_channel` is daemon-only: it routes one unconditional append to
+one mini-file and is not a general resource key. The
+`.notification/daemon/.tombstone` control record linearizes aggregate
+clear/dismiss/CAS and records process-crash-safe append pending state; committed
+clear/dismiss visibility cuts are fsync-durable. It is Store state, never an
+agent-visible channel. A malformed or unreadable control record MUST remain fail-closed on daemon
+writes/mutations. Snapshot and fingerprint instead expose one bounded,
+content-free high-priority daemon control-error payload directing the agent to
+`lingtai-doctor`, while all unrelated channels remain deliverable.
+They MUST NOT add a nullable/no-op Store, Path-or-Port overload, locator, hidden
+Core construction, ninth operation family, generic event database, or
+caller-held transaction lock.
 
 ## Port
 
@@ -89,39 +102,56 @@ fingerprint tuple means the exact delivered version. Channel mutators return
 
 ## Adapters
 
-`PosixNotificationStoreAdapter` is the production filesystem adapter. Each
-instance owns an in-process mutex and composes the selected native
-`NotificationMutationLockPort`; together they serialize channel, acknowledgement,
-and hook-manifest mutations across threads and independently composed processes.
-The selector provides `flock` on POSIX and byte-range locking on Windows. Agent,
-CLI, daemon supervisor, and Telegram server composition roots construct the Store
+`PosixNotificationStoreAdapter` is the production filesystem adapter. The
+Store-private lock vocabulary maps canonical channel, acknowledgement, hook,
+delay, daemon-run, and daemon-control resources to bounded sanitized-plus-hash
+filenames under `.notification/.locks/`. A process-wide RLock keyed by that
+canonical path closes `flock`'s same-process/open-description gap; native locks
+then serialize only that resource across independently composed processes.
+The POSIX selector takes an exclusive scoped `flock` plus a **shared** legacy
+`.store.lock` bridge for one compatibility release. Windows uses scoped
+byte-range locks but cannot express that shared bridge: old global writers and
+new scoped writers require a documented quiesced cutover, not false parity.
+Lock files are never deleted as part of normal Store operation. Agent, CLI,
+daemon supervisor, and Telegram server composition roots construct the Store
 adapter. External LICC/direct `mcp.*` producers keep the same filesystem path and
 envelope. The POSIX adapter stores daemon events in per-id mini-files under
-`.notification/daemon/`; its aggregate snapshot and synthetic aggregate
-fingerprint cover only those mini-files, including additions, removals, and
-appends. It writes the sibling `.notification/daemon.json` as a derived report
-of run/state statistics; the report is excluded from snapshot, fingerprint, and
-dismissal, and old root facts are migration metadata only.
+`.notification/daemon/`; ordinary owner append does not scan the aggregate or
+rebuild a report. Snapshot/fingerprint derive an aggregate only on read; the
+sibling `.notification/daemon.json` is a non-authoritative compatibility report,
+excluded from snapshot, fingerprint, dismissal, and the heartbeat hot path.
 
 ## Contract rules
 
-- Snapshot and fingerprint skip missing, malformed, or unreadable entries and
-  apply the live Core allow-predicate; fingerprints are sorted SHA-256 entries of
-  filename, byte size, and bytes, not mtime. For daemon, the single aggregate
-  fingerprint is derived from every nested mini-file's name and bytes, so a
-  mini-file addition, removal, or same-file append changes the aggregate version;
-  `.notification/daemon.json` never changes it. New per-run appends carry their
-  daemon id in the pure payload marker consumed by the adapter; the marker is
-  not included in the aggregate projection.
+- Snapshot and fingerprint are read-only: they take no native mutation lock,
+  write no daemon report, and skip missing, malformed, or unreadable ordinary
+  entries while applying the live Core allow-predicate. Fingerprints are sorted
+  SHA-256 entries of filename, byte size, and bytes, not mtime. For daemon, the
+  single aggregate fingerprint is derived from every logical nested mini-file's
+  name and bytes, so a mini-file addition, removal, or same-file append changes
+  the aggregate version; `.notification/daemon.json` never changes it. An
+  unreadable/corrupt daemon control/tombstone is exceptional Store authority:
+  daemon mutation paths raise `DaemonControlError` with no payload-body echo,
+  while snapshot/fingerprint substitute the same bounded content-free,
+  high-priority daemon control-error projection and continue unrelated channels.
+  It is never treated as an empty aggregate. New per-run appends carry their daemon id in
+  the pure payload marker consumed by the adapter; the marker is not included in
+  the aggregate projection.
 - Publish is atomic sibling-temp replacement. Publish and clear hold the Store's
   in-process and cross-process mutation locks. Clear returns `False` only for
   absence; other clear and write errors propagate unless a Core best-effort
   wrapper explicitly preserves legacy suppression.
-- Compare-update reads payload and version under the same whole-transaction
-  cross-process Store serialization. Only
-  `FileNotFoundError` is absence; every other read error propagates. Readable
-  malformed/non-dict JSON retains its version and presents `{}` to Core, so it
-  cannot satisfy expected absence.
+- Compare-update reads payload and version under the same complete-transaction
+  **resource** serialization. Ordinary channel/ack/hook/delay resources do not
+  block unrelated resources. The daemon owner hot path holds only its run scope
+  plus daemon-control scope; it appends one mini-file with a durable pending
+  receipt, then commits batch state without scanning the aggregate or rebuilding
+  the report. Aggregate clear/dismiss/CAS is linearized under daemon-control;
+  it commits a durable tombstone visibility cut before best-effort physical
+  compaction, so a crash after the cut cannot resurrect cleared events. Only
+  `FileNotFoundError` is absence; every other ordinary read error propagates.
+  Readable malformed/non-dict JSON retains its version and presents `{}` to
+  Core, so it cannot satisfy expected absence.
 - A compare conflict does not call the mutator and carries no policy value. A
   matched guard runs the mutator once. `changed=False` performs no write;
   `payload=None` clears; a dict publishes atomically. Operational result fields
@@ -161,14 +191,21 @@ dismissal, and old root facts are migration metadata only.
 - Core acknowledgement union and purge MUST use family 7, never split family 6
   read from a later write. System, nudge, Telegram, and daemon-terminal mutations
   decide from the current payload inside compare-update; daemon event/ref removal
-  removes the matching mini-file rather than rewriting another daemon's file.
+  tombstones only matching event keys, preserves same-run siblings, and never
+  rewrites another daemon's file.
   Force uses
   `UNCONDITIONAL`, while non-force dismiss uses the delivered fingerprint entry
   including explicit absence.
-- `.notification/.store.lock` is coordination metadata, not notification state or
-  authority. POSIX and Windows adapters MUST use native OS locks whose ownership,
-  not file existence, defines exclusion and whose release follows process death.
-  Snapshot and fingerprint continue to expose only allowed JSON channel files.
+- `.notification/.store.lock` is compatibility coordination metadata, not
+  notification state or authority. POSIX scoped writers acquire it shared for one
+  release while legacy writers retain their old exclusive whole-store lock; this
+  prevents mixed-version lost updates without reintroducing new-to-new global
+  serialization. Windows cannot provide shared byte-range parity and therefore
+  requires a quiesced legacy-writer cutover. Scoped `.locks/*.lock` files and
+  legacy `.store.lock` files are never deleted by live Store code. Native lock
+  ownership, not file existence, defines exclusion and release follows process
+  death. Snapshot and fingerprint continue to expose only allowed JSON channel
+  files.
 
 ## Contract tests
 
@@ -176,13 +213,36 @@ Shared conformance covers the eight-family surface, expected absence versus
 unconditional updates, malformed/unreadable/error behavior, typed policy values,
 atomic same-process and spawned-process channel updates, atomic acknowledgement
 union/purge, atomic hook-manifest append/clear, required injection, outer
-composition, stale dismiss refusal,
-unrelated-event survival,
-daemon mini-channel isolation/append, aggregate fingerprint changes, targeted
-mini-file deletion, and late-file stale-CAS preservation, nudge updates, and
-Telegram current-mirror clearing. Production adapter tests
-must use only an explicitly authorized persistent scratch path when deletion is
-separately authorized.
+composition, stale dismiss refusal, unrelated-event survival, daemon mini-channel
+isolation/append, aggregate fingerprint changes, targeted mini-file deletion,
+late-file stale-CAS preservation, nudge updates, and Telegram current-mirror
+clearing. Production evidence additionally uses real native cross-process lock
+paths: an unrelated `email` reader/writer proceeds while a `system` or daemon
+scope is held; forty same-run publishers preserve idempotency/no loss;
+clear/dismiss overlap, crash-after-tombstone-before-compaction, corrupt
+control-record failure, no-delay zero-native-lock heartbeat, snapshot no-write,
+and POSIX legacy bridge behavior are covered. Windows certification either proves
+its scoped native locks or explicitly asserts the quiesced legacy-cutover gate.
+Production adapter tests must use only an explicitly authorized persistent
+scratch path when deletion is separately authorized.
+
+## Migration and rollback
+
+This release keeps the old POSIX `.store.lock` file as a one-release shared-lock
+bridge: an old exclusive writer and a new scoped writer exclude each other, while
+two new unrelated resources do not serialize. The scoped `.locks/` files are
+coordination metadata and remain harmless across a normal code rollback; no live
+code deletes either kind of lock file. Windows upgrades must quiesce all legacy
+writers before selecting the scoped adapter.
+
+Daemon aggregate authority adds `.notification/daemon/.tombstone`. New readers
+validate it: a corrupt control record becomes a bounded daemon-only error
+projection pointing to `lingtai-doctor`, while daemon mutations still refuse.
+A rollback after aggregate clear/dismiss
+has committed a tombstone visibility cut is **not** an automatic compatibility
+operation: quiesce writers, inspect/repair or explicitly migrate that control
+state, then select the legacy reader. A legacy reader cannot be allowed to
+reinterpret a tombstoned-but-not-yet-compacted mini-file as a resurrected event.
 
 ## Maintenance
 

--- a/src/lingtai/kernel/notification_store/__init__.py
+++ b/src/lingtai/kernel/notification_store/__init__.py
@@ -187,13 +187,17 @@ class NotificationStorePort(ABC):
         channel: str,
         expected_version: ExpectedVersion,
         pure_core_mutator: PureCoreMutator,
+        *,
+        owner: str | None = None,
     ) -> CompareUpdateResult:
         """Guard and atomically apply one pure current-payload mutation.
 
         ``UNCONDITIONAL`` always runs; ``None`` expects absence; a fingerprint
         tuple expects that delivered version. A conflict never calls the
         mutator. Otherwise its payload/change/value triple is committed and
-        returned as typed operational and policy evidence.
+        returned as typed operational and policy evidence. ``owner`` is only
+        valid for daemon's existing channel family: it names the run whose
+        mini-file is appended without exposing a separate Store operation.
         """
         ...
 

--- a/src/lingtai/kernel/notification_store/_mutation_lock.py
+++ b/src/lingtai/kernel/notification_store/_mutation_lock.py
@@ -1,13 +1,56 @@
-"""Cross-process mutation lock Port for the Notification Store."""
+"""Store-private resource-scoped cross-process lock vocabulary.
+
+Lock scope names never become notification state.  They are mapped to bounded,
+collision-resistant paths solely by the filesystem adapters.
+"""
 
 from __future__ import annotations
 
+import hashlib
+import re
 from contextlib import AbstractContextManager
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import Protocol
+
+_LOCK_DIRECTORY = ".locks"
+_SAFE_SCOPE_RE = re.compile(r"[^A-Za-z0-9_.-]+")
+_SCOPE_LABEL_MAX = 48
+
+
+def channel_mutation_scope(channel: str) -> str:
+    """Return the Store-private serialization scope for a channel mirror."""
+    if not isinstance(channel, str) or not channel:
+        raise ValueError("notification channel lock scope requires a non-empty channel")
+    return f"channel:{channel}"
+
+
+def daemon_run_mutation_scope(daemon_id: str) -> str:
+    """Return the Store-private serialization scope for one daemon mini-file."""
+    if not isinstance(daemon_id, str) or not daemon_id:
+        raise ValueError("daemon run lock scope requires a non-empty daemon id")
+    return f"daemon-run:{daemon_id}"
+
+
+def resource_mutation_scope(resource: str) -> str:
+    """Return the Store-private serialization scope for a non-channel resource."""
+    if not isinstance(resource, str) or not resource:
+        raise ValueError("notification resource lock scope requires a non-empty name")
+    return f"resource:{resource}"
+
+
+def notification_mutation_lock_path(notification_dir: Path, scope: str) -> Path:
+    """Map one logical scope to a bounded, collision-resistant lock filename."""
+    if not isinstance(scope, str) or not scope:
+        raise ValueError("notification mutation lock scope must be a non-empty string")
+    label = _SAFE_SCOPE_RE.sub("-", scope).strip("-._")[:_SCOPE_LABEL_MAX] or "scope"
+    digest = hashlib.sha256(scope.encode("utf-8")).hexdigest()[:20]
+    base = notification_dir if isinstance(notification_dir, PurePath) else Path(notification_dir)
+    return base / _LOCK_DIRECTORY / f"{label}-{digest}.lock"
 
 
 class NotificationMutationLockPort(Protocol):
-    """Serialize Store mutations across independently composed processes."""
+    """Serialize one Store resource across independently composed processes."""
 
-    def exclusive(self, notification_dir: Path) -> AbstractContextManager[None]: ...
+    def exclusive(
+        self, notification_dir: Path, scope: str
+    ) -> AbstractContextManager[None]: ...

--- a/src/lingtai/kernel/notifications.py
+++ b/src/lingtai/kernel/notifications.py
@@ -264,19 +264,28 @@ def _delay_thread_lock(workdir: str) -> threading.RLock:
 
 @contextmanager
 def _delay_transaction(workdir: str):
-    """Serialize private delay state with the Store's native mutation lock.
+    """Serialize only delay state and its alarm mirror, never all notifications.
 
     This deliberately performs the tiny delay/alarm transaction directly rather
-    than adding a ninth Store Port family: the target and alarm files remain
-    ordinary Store-compatible channel mirrors, while the private dotfile stays
-    outside the Store's public channel surface.  We never call a Store mutation
-    while holding this lock, avoiding a reversed in-process lock order.
+    than adding a ninth Store Port family.  Callers must capture Store read facts
+    before entering: no snapshot/fingerprint may run under these native scopes.
     """
-    from lingtai.adapters.notification_store_lock import select_notification_store_lock
+    from lingtai.adapters.notification_store_lock import (
+        exclusive_notification_mutation,
+        select_notification_store_lock,
+    )
+    from lingtai.kernel.notification_store._mutation_lock import (
+        channel_mutation_scope,
+        resource_mutation_scope,
+    )
 
     notification_dir, _, _ = _delay_paths(workdir)
     with _delay_thread_lock(workdir):
-        with select_notification_store_lock().exclusive(notification_dir):
+        with exclusive_notification_mutation(
+            select_notification_store_lock(),
+            notification_dir,
+            [resource_mutation_scope("delay-state"), channel_mutation_scope(DELAY_ALARM_CHANNEL)],
+        ):
             yield
 
 
@@ -334,15 +343,14 @@ def _active_delay_state(state: object, *, now: float | None = None) -> dict[str,
     return state
 
 
-def _read_target_stats_locked(
+def _read_target_stats(
     workdir: str, channel: str, store: NotificationStorePort
 ) -> dict[str, Any]:
     """Read conservative target facts through the injected Store Port.
 
-    The delay transaction already holds the native Store lock.  Snapshot and
-    fingerprint therefore describe the same target without Core constructing a
-    concrete filesystem adapter; daemon stats use the aggregate projection and
-    its synthetic raw version exactly like ordinary delivery/CAS.
+    This intentionally runs before a delay transaction. The later transaction
+    revalidates delay identity/state; a racing producer only makes `changed`
+    fail visible and never puts a Store read below delay native scopes.
     """
     try:
         allow = lambda name: name == channel
@@ -442,6 +450,33 @@ def reconcile_notification_delay(
     key = _delay_workdir_key(workdir)
     if key is None:
         return False
+    # The heartbeat calls this path every tick. Read the private state first and
+    # acquire *zero* native locks when there is no due transaction to repair.
+    _, observed_state_path, _ = _delay_paths(key)
+    observed = _read_delay_state_locked(observed_state_path)
+    if not isinstance(observed, dict):
+        return False
+    observed_status = observed.get("status")
+    if observed_status in {"published", "cancelled"}:
+        return False
+    observed_request_id = observed.get("request_id")
+    if expected_request_id is not None and observed_request_id != expected_request_id:
+        return False
+    observed_current: dict[str, Any] | None = None
+    if observed_status == "active":
+        observed_target = observed.get("target")
+        observed_deadline = observed.get("deadline_epoch")
+        if (
+            not isinstance(observed_target, str)
+            or observed_target == DELAY_ALARM_CHANNEL
+            or isinstance(observed_deadline, bool)
+            or not isinstance(observed_deadline, (int, float))
+            or observed_deadline > time.time()
+        ):
+            return False
+        observed_current = _read_target_stats(key, observed_target, store)
+    elif observed_status != "expiring":
+        return False
     try:
         with _delay_transaction(key):
             _, state_path, alarm_path = _delay_paths(key)
@@ -475,7 +510,15 @@ def reconcile_notification_delay(
                     or deadline > now
                 ):
                     return False
-                current = _read_target_stats_locked(key, target, store)
+                # Reuse a pre-lock stat only for the exact state/request that
+                # produced it. A replacement delay may keep the same expiry
+                # window while changing target or request id; never describe
+                # that other delay's channel as this completion's current data.
+                current = (
+                    observed_current
+                    if target == observed_target and request_id == observed_request_id
+                    else {"present": None}
+                )
                 initial = state.get("initial")
                 completion = {
                     "request_id": request_id,
@@ -635,6 +678,9 @@ def delay_notification_channel(agent, channel: str, seconds: int) -> dict[str, A
     # first recovery call, and overwriting an overdue active record would lose
     # the alarm it owes.
     reconcile_notification_delay(workdir, store)
+    # Capture target facts before taking delay scopes. The transaction below
+    # validates the delay state again; this observation is informational only.
+    initial_target_stats = _read_target_stats(workdir, channel, store) if seconds else None
     for _ in range(2):
         overdue_request_id = None
         try:
@@ -689,7 +735,7 @@ def delay_notification_channel(agent, channel: str, seconds: int) -> dict[str, A
                             "started_at": _delay_iso(now),
                             "deadline_epoch": now + seconds,
                             "deadline_at": _delay_iso(now + seconds),
-                            "initial": _read_target_stats_locked(workdir, channel, store),
+                            "initial": initial_target_stats or {"present": None},
                         }
                         _write_delay_state_locked(state_path, state)
                         result = {

--- a/src/lingtai/kernel/refresh_watcher/ANATOMY.md
+++ b/src/lingtai/kernel/refresh_watcher/ANATOMY.md
@@ -6,6 +6,9 @@ related_files:
   - src/lingtai/kernel/refresh_watcher/watcher_program.py
   - src/lingtai/kernel/refresh_watcher/MANUAL.md
   - src/lingtai/kernel/process_match.py
+  - src/lingtai/kernel/notification_store/CONTRACT.md
+  - src/lingtai/kernel/notification_store/_mutation_lock.py
+  - src/lingtai/adapters/notification_store_lock.py
   - src/lingtai/kernel/ANATOMY.md
   - src/lingtai/adapters/refresh_watcher.py
   - src/lingtai/adapters/posix/ANATOMY.md
@@ -54,11 +57,13 @@ walkthrough.
 - `render_watcher_script(request)` renders the ACK/lock, heartbeat, retry,
   matcher, redaction, and alert policy and calls only an injected
   `PROCESS_MECHANISM` global for process operations
-  (`src/lingtai/kernel/refresh_watcher/watcher_program.py:69-571`). Its
-  wall-clock policy lives in module-top constants — `MAX_ATTEMPTS`,
+  (`src/lingtai/kernel/refresh_watcher/watcher_program.py`). Its terminal
+  system publisher independently derives the Store's canonical
+  `channel:system` scoped-lock filename, takes the POSIX shared legacy bridge
+  plus exclusive scoped lock, and never removes lock files. Its wall-clock
+  policy lives in module-top constants — `MAX_ATTEMPTS`,
   `HEALTH_CHECK_WAIT`, `HEALTH_CHECK_BUDGET`, `WATCHER_POLL_INTERVAL`,
-  `DUPLICATE_EXIT_WAIT` — that the renderer embeds as plain assignments
-  (`src/lingtai/kernel/refresh_watcher/watcher_program.py:24-40`).
+  `DUPLICATE_EXIT_WAIT` — that the renderer embeds as plain assignments.
 - `select_refresh_watcher` is the fail-loud outer selector
   (`src/lingtai/adapters/refresh_watcher.py:14-35`).
 
@@ -101,8 +106,10 @@ The Core Port and value objects own no runtime process state. The generated
 policy owns only transient retry/failure metadata and the existing filesystem
 artifacts/events. The platform process adapters own no long-lived supervisor; each
 creates observations/handles for one policy run and writes replacement stderr
-through the requested log path. The outer adapter owns only its detached
-entrypoint handoff.
+through the requested log path. The terminal publisher creates only the existing
+`.notification/.store.lock` compatibility file and the canonical scoped
+`.notification/.locks/channel-system-<sha20>.lock` as lock metadata; it deletes
+neither. The outer adapter owns only its detached entrypoint handoff.
 
 ## Notes
 

--- a/src/lingtai/kernel/refresh_watcher/CONTRACT.md
+++ b/src/lingtai/kernel/refresh_watcher/CONTRACT.md
@@ -1,6 +1,6 @@
 ---
 name: refresh-watcher
-contract_version: 3
+contract_version: 4
 root_contract: CONTRACT.md
 related_files:
   - src/lingtai/kernel/refresh_watcher/ANATOMY.md
@@ -10,6 +10,9 @@ related_files:
   - src/lingtai/kernel/refresh_watcher/watcher_program.py
   - src/lingtai/kernel/refresh_watcher/MANUAL.md
   - src/lingtai/kernel/process_match.py
+  - src/lingtai/kernel/notification_store/CONTRACT.md
+  - src/lingtai/kernel/notification_store/_mutation_lock.py
+  - src/lingtai/adapters/notification_store_lock.py
   - src/lingtai/adapters/refresh_watcher.py
   - src/lingtai/adapters/posix/refresh_watcher.py
   - src/lingtai/adapters/posix/refresh_watcher_process.py
@@ -59,7 +62,12 @@ event policy.
 The generated program is still rendered by
 `watcher_program.render_watcher_script(request)` and still crosses the existing
 compact `encode_request`/`decode_request` wire via each platform's `-m`
-entrypoint.
+entrypoint. Its terminal `system.json` publisher independently mirrors the
+Store's canonical `channel:system` path mapping: on POSIX it takes the same
+shared one-release `.store.lock` bridge and exclusive scoped lock before merging
+an event. It must remain a narrow external filesystem producer, not import or
+construct the Store; Windows keeps its existing fail-open publisher and is
+covered by the Store's explicit quiesced legacy-cutover gate.
 The generated policy receives a second, watcher-local
 `RefreshWatcherProcessPort` through the entrypoint's `PROCESS_MECHANISM` global.
 That narrow Port performs no policy: it supplies only observation, process
@@ -244,6 +252,13 @@ same matcher import and not embed a second matcher implementation.
    marker authoritative in both directions without mutating the parent.
 10. The existing request serialization validation rejects invalid JSON, missing
     or extra fields, and wrong field shapes with `ValueError`.
+11. The generated POSIX terminal publisher computes the exact bounded
+    `channel:system` Store lock filename (sanitized scope label plus SHA-256
+    prefix), acquires shared legacy `.store.lock` then exclusive scoped lock in
+    that order, and releases both without deleting either lock file. It has a
+    bounded fail-open timeout so permanent-refresh visibility is not silently
+    lost to a wedged holder. This is canonical behavior sharing, not a second
+    Store implementation; it must stay byte-compatible with the Store mapping.
 
 ## Contract tests
 
@@ -255,7 +270,9 @@ rendered Core policy with a small fake process mechanism and asserts policy
 selection of observation, liveness, launch, graceful stop, and forced stop
 without source-keyword scanning. The real POSIX `-m` smoke remains the evidence
 that the POSIX entrypoint composes the production process adapter.
-`tests/test_refresh_watcher_windows.py` pins the Windows side: exact detached
+`tests/test_perform_refresh_handshake.py` also renders the POSIX terminal
+publisher and pins its canonical `system` scoped filename plus shared legacy
+bridge behavior against the Store mapping. `tests/test_refresh_watcher_windows.py` pins the Windows side: exact detached
 spawn shape (Windows entrypoint module, creation flags, env-overwrite policy in
 both directions), entrypoint composition of the workdir-bound Windows process
 mechanism, the `.suspend` graceful-stop channel, CIM observation shapes with

--- a/src/lingtai/kernel/refresh_watcher/watcher_program.py
+++ b/src/lingtai/kernel/refresh_watcher/watcher_program.py
@@ -18,6 +18,12 @@ policy.
 from __future__ import annotations
 
 import json
+from pathlib import Path
+
+from lingtai.kernel.notification_store._mutation_lock import (
+    channel_mutation_scope,
+    notification_mutation_lock_path,
+)
 
 from . import RefreshWatcherRequest
 
@@ -84,6 +90,10 @@ def render_watcher_script(request: RefreshWatcherRequest) -> str:
     agent_name = request.agent_name
     address = request.address
     identity_fields = _decode_identity_fields(request.identity_fields_json)
+    scoped_system_lock_name = notification_mutation_lock_path(
+        Path(working_dir_str) / ".notification",
+        channel_mutation_scope("system"),
+    ).name
 
     return (
         "import time, os, sys, json\n"
@@ -97,7 +107,6 @@ def render_watcher_script(request: RefreshWatcherRequest) -> str:
         # src/lingtai/adapters/posix/notification_store_lock.py), and the
         # watcher must participate in that lock or its terminal alert can be
         # silently lost against a concurrent agent merge (issue #742).
-        "_NOTIFICATION_LOCK_FILE = '.store.lock'\n"
         "_NOTIFICATION_LOCK_TIMEOUT = 5.0\n"
         "def _process_mechanism():\n"
         "    try:\n"
@@ -236,39 +245,57 @@ def render_watcher_script(request: RefreshWatcherRequest) -> str:
         "    return meta\n"
         "def _acquire_system_notification_lock():\n"
         "    notif_dir = os.path.join(wd, '.notification')\n"
+        "    scope = 'channel:system'\n"
+        f"    scoped_name = {scoped_system_lock_name!r}\n"
         "    try:\n"
-        "        os.makedirs(notif_dir, exist_ok=True)\n"
+        "        os.makedirs(os.path.join(notif_dir, '.locks'), exist_ok=True)\n"
         "    except OSError:\n"
         "        pass\n"
         "    if _fcntl is None:\n"
-        "        log('refresh_failed_permanent_lock_unavailable', reason='no_fcntl')\n"
+        "        # Native Windows has no POSIX shared-lock bridge. Its upgrade is\n"
+        "        # intentionally quiesced; preserve the existing fail-open alert.\n"
+        "        log('refresh_failed_permanent_lock_unavailable', reason='windows_quiesced_cutover')\n"
         "        return None\n"
+        "    legacy_fd = None\n"
         "    try:\n"
-        "        fd = open(os.path.join(notif_dir, _NOTIFICATION_LOCK_FILE), 'a+b')\n"
+        "        legacy_fd = open(os.path.join(notif_dir, '.store.lock'), 'a+b')\n"
+        "        scoped_fd = open(os.path.join(notif_dir, '.locks', scoped_name), 'a+b')\n"
         "    except OSError as exc:\n"
+        "        if legacy_fd is not None:\n"
+        "            legacy_fd.close()\n"
         "        log('refresh_failed_permanent_lock_unavailable', reason='open_failed',\n"
         "            error=_bounded(str(exc), 200))\n"
         "        return None\n"
         "    deadline = time.time() + _NOTIFICATION_LOCK_TIMEOUT\n"
         "    while True:\n"
         "        try:\n"
-        "            _fcntl.flock(fd.fileno(), _fcntl.LOCK_EX | _fcntl.LOCK_NB)\n"
-        "            return fd\n"
+        "            _fcntl.flock(legacy_fd.fileno(), _fcntl.LOCK_SH | _fcntl.LOCK_NB)\n"
+        "            _fcntl.flock(scoped_fd.fileno(), _fcntl.LOCK_EX | _fcntl.LOCK_NB)\n"
+        "            return (legacy_fd, scoped_fd)\n"
         "        except OSError:\n"
+        "            try:\n"
+        "                _fcntl.flock(scoped_fd.fileno(), _fcntl.LOCK_UN)\n"
+        "                _fcntl.flock(legacy_fd.fileno(), _fcntl.LOCK_UN)\n"
+        "            except OSError:\n"
+        "                pass\n"
         "            if time.time() >= deadline:\n"
+        "                legacy_fd.close()\n"
+        "                scoped_fd.close()\n"
         "                log('refresh_failed_permanent_lock_timeout')\n"
-        "                return fd\n"
+        "                return None\n"
         "            time.sleep(0.1)\n"
-        "def _release_system_notification_lock(fd):\n"
-        "    if fd is None:\n"
+        "def _release_system_notification_lock(handles):\n"
+        "    if handles is None:\n"
         "        return\n"
+        "    legacy_fd, scoped_fd = handles\n"
         "    try:\n"
-        "        if _fcntl is not None:\n"
-        "            _fcntl.flock(fd.fileno(), _fcntl.LOCK_UN)\n"
+        "        _fcntl.flock(scoped_fd.fileno(), _fcntl.LOCK_UN)\n"
+        "        _fcntl.flock(legacy_fd.fileno(), _fcntl.LOCK_UN)\n"
         "    except OSError:\n"
         "        pass\n"
         "    finally:\n"
-        "        fd.close()\n"
+        "        scoped_fd.close()\n"
+        "        legacy_fd.close()\n"
         "def _append_system_notification(meta):\n"
         "    fd = _acquire_system_notification_lock()\n"
         "    try:\n"

--- a/src/lingtai/tools/daemon/ANATOMY.md
+++ b/src/lingtai/tools/daemon/ANATOMY.md
@@ -15,6 +15,8 @@ related_files:
   - src/lingtai/kernel/meta_block.py
   - src/lingtai/kernel/llm/base.py
   - src/lingtai/kernel/base_agent/ANATOMY.md
+  - src/lingtai/kernel/notification_store/CONTRACT.md
+  - src/lingtai/adapters/posix/notification_store.py
   - src/lingtai/kernel/tool_executor.py
   - src/lingtai/kernel/tool_result_summary.py
   - src/lingtai/services/mcp.py
@@ -134,10 +136,14 @@ MiMo's hard-failure-on-compact-error divergence from Codex's non-fatal
 policy. Results are persisted in per-run daemon folders; **every** terminal outcome
 (done / failed / cancelled / timeout) is surfaced as a compact event in
 `.notification/daemon/<daemon-id>.json` — never as ordinary parent request text.
-The sibling `.notification/daemon.json` is a derived report of mini-file run/state
-statistics, excluded from delivery, fingerprinting, and dismissal; any retained
-legacy-root facts live only under report migration metadata. Same-run checkpoint,
-terminal, and follow-up events append without a fixed retention cap;
+The typed Store's daemon-only owner mutation is the append hot path: it takes the
+run/control scopes and does not scan the aggregate or rebuild a report. Durable
+`.notification/daemon/.tombstone` state serializes aggregate clear/dismiss/CAS
+and commits logical removal before later best-effort compaction. The sibling
+`.notification/daemon.json` is a non-authoritative derived report of mini-file
+run/state statistics, excluded from delivery, fingerprinting, and dismissal; any
+retained legacy-root facts live only under report migration metadata. Same-run
+checkpoint, terminal, and follow-up events append without a fixed retention cap;
 `daemon.json.terminal_notified` is written only after publication succeeds (or an
 idempotent retry observes the same published event), so a parent that dispatched
 a daemon can safely go idle and be woken when the run ends, without polling.
@@ -278,7 +284,7 @@ daemon/__init__.py
   ├── _handle_ask_opencode()        — OpenCode-family follow-up via `opencode run --session <opencode_session_id> --format json <message>` by default; callers such as oh-my-pi can pass `build_resume_cmd` to customize the resume argv (`omp --mode json --approval-mode yolo --session <oh_my_pi_session_id> <message>`). Symmetric with claude-code / codex ask: spawns, dispatches to `_ask_pool`, returns immediately. Returns a clear error if the backend-specific session id has not been captured yet.
   ├── _run_ask_opencode_stream()    — background worker for the opencode ask. Same defensive JSON-line parse as `_run_opencode_emanation`; clears `ask_in_flight` on exit; terminal-shaped events override intermediate text
   ├── _register_cli_proc()/_unregister_cli_proc()/_kill_cli_group()/_drain_all_cli_procs() — legacy direct-Popen CLI tracking predating the detached supervisor. `_register_cli_proc` (the only writer into `_cli_procs`/`_cli_proc_groups`) has no production caller left — every CLI backend now runs under its own detached supervisor, which owns exact-child ownership and deadline enforcement directly (`kernel/daemon_supervisor/CONTRACT.md`). `_drain_all_cli_procs` remains reachable from the live `_shutdown_runtime_resources` funnel (`_handle_reclaim`, agent stop, refresh) and always drains an empty list in production; it is kept as defensive teardown for any future non-detached direct-Popen caller, not removed as dead code.
-  └── _publish_daemon_notification() — publishes one compact event to the typed Store's `.notification/daemon/<daemon-id>.json` mini-channel (id, terminal status, task summary, run dir, result/error path, bounded preview) and stamps the channel's `data.daemon` batch state; terminal callers pass a stable idempotency key. Every event is typed by `kind` (`daemon/__init__.py:4845`), which defaults to `daemon_terminal`; a follow-up (`ask`) result reuses this same publisher with `kind="daemon_followup"` (`daemon/__init__.py:4954`), and the detached supervisor's equivalent takes the same argument (`daemon/supervisor_runtime.py:496`), so the parent's summary never reads a still-running run as terminal (`_is_terminal_daemon_event`, `kernel/base_agent/__init__.py:99`). The root `.notification/daemon.json` is only a derived run/state report and never enters the aggregate projection. Called directly by parent-process code paths (e.g. `_publish_followup_if_live`) that still run in this process; the detached supervisor's own terminal path uses its own equivalent in `supervisor_runtime.py`, not this method (`daemon/__init__.py:3762`)
+  └── _publish_daemon_notification() — publishes one compact event to the typed Store's `.notification/daemon/<daemon-id>.json` mini-channel (id, terminal status, task summary, run dir, result/error path, bounded preview) and stamps the channel's `data.daemon` batch state; terminal callers pass a stable idempotency key. Every event is typed by `kind` (`daemon/__init__.py:4845`), which defaults to `daemon_terminal`; a follow-up (`ask`) result reuses this same publisher with `kind="daemon_followup"` (`daemon/__init__.py:4954`), and the detached supervisor's equivalent takes the same argument (`daemon/supervisor_runtime.py:496`), so the parent's summary never reads a still-running run as terminal (`_is_terminal_daemon_event`, `kernel/base_agent/__init__.py:99`). The Store routes the mutation with the daemon-only owner/run hot path, records batch state through durable tombstone control, and does not rebuild the root report on append. The root `.notification/daemon.json` is only a derived run/state report and never enters the aggregate projection. Called directly by parent-process code paths (e.g. `_publish_followup_if_live`) that still run in this process; the detached supervisor's own terminal path uses its own equivalent in `supervisor_runtime.py`, not this method (`daemon/__init__.py:3762`)
 
 daemon/run_dir.py
   ├── DaemonRunDir.__init__         — creates folder on disk, writes versioned daemon.json (data_version + call_parameters) + .prompt

--- a/src/lingtai/tools/daemon/CONTRACT.md
+++ b/src/lingtai/tools/daemon/CONTRACT.md
@@ -7,8 +7,8 @@ description: >
   daemon_common completion signaling, support-status honesty, run artifacts,
   terminal notifications, and compaction boundaries.
 status: active
-contract_version: 11
-last_changed_at: "2026-08-23"
+contract_version: 12
+last_changed_at: "2026-08-24"
 related_files:
   - src/lingtai/tools/daemon/ANATOMY.md
   - src/lingtai/tools/daemon/BEHAVIORS.md
@@ -27,6 +27,8 @@ related_files:
   - src/lingtai/services/mcp.py
   - src/lingtai/kernel/llm/base.py
   - src/lingtai/kernel/base_agent/ANATOMY.md
+  - src/lingtai/kernel/notification_store/CONTRACT.md
+  - src/lingtai/adapters/posix/notification_store.py
   - src/lingtai/llm/service.py
   - src/lingtai/llm/interface_converters.py
   - src/lingtai/tools/daemon/process_port.py
@@ -492,10 +494,17 @@ surface through the per-run mini-channel
 `.notification/daemon/<daemon-id>.json`, rather than ordinary parent request
 text. `daemon` is a built-in notification channel; both the in-process manager
 and detached supervisor use the typed `NotificationStorePort.compare_update_channel`
-operation, and the production adapter routes each run id to its own file. The
-sibling `.notification/daemon.json` is a derived report containing only
-mini-file run/state statistics; it is excluded from aggregate snapshot,
-fingerprint, and dismissal. Existing root event facts may be retained only as
+operation, and the production adapter routes each run id through the narrow
+Daemon-only `owner` hot path to its own file. That append is unconditional and
+idempotent under its run/control resources; it does not scan the aggregate or
+rebuild the sibling report. The Store's durable
+`.notification/daemon/.tombstone` control record is the aggregate-clear,
+dismiss, and CAS linearization authority: it commits a visibility cut before
+best-effort mini-file compaction, so a crash cannot resurrect a cleared event.
+A corrupt control record fails loudly into Store/doctor repair visibility rather
+than blacking out daemon notices. The sibling `.notification/daemon.json` is a
+derived report containing only mini-file run/state statistics; it is excluded
+from aggregate snapshot, fingerprint, and dismissal. Existing root event facts may be retained only as
 report migration metadata and are never re-delivered; new event writes always
 route to the run's mini-file and never fall back to the root. The run directory
 may write a temporary `daemon.json.terminal_notification_claim` before publication to

--- a/src/lingtai/tools/daemon/supervisor_runtime.py
+++ b/src/lingtai/tools/daemon/supervisor_runtime.py
@@ -614,8 +614,22 @@ def _publish_daemon_notification(
         return payload, True, event_id
 
     try:
-        result = store.compare_update_channel(DAEMON_CHANNEL, UNCONDITIONAL, _mutator)
-    except Exception:
+        result = store.compare_update_channel(
+            DAEMON_CHANNEL, UNCONDITIONAL, _mutator, owner=em_id
+        )
+    except Exception as exc:
+        # The terminal receipt remains retryable, but never make a Store/control
+        # or Core-mutator contract violation look like a quiet failed enqueue.
+        # The parent-visible durable run state records bounded typed evidence.
+        try:
+            run_dir.append_event(
+                "daemon_notification_error",
+                kind="daemon_notification_error",
+                error_type=type(exc).__name__,
+                retryable=True,
+            )
+        except Exception:
+            pass
         return False
     applied_event_id = result.value if isinstance(result.value, str) else ""
     return bool(applied_event_id)

--- a/tests/_notification_store_helpers.py
+++ b/tests/_notification_store_helpers.py
@@ -89,7 +89,11 @@ class FakeNotificationStore(NotificationStorePort):
         channel: str,
         expected_version: ExpectedVersion,
         pure_core_mutator: PureCoreMutator,
+        *,
+        owner: str | None = None,
     ) -> CompareUpdateResult:
+        if owner is not None and channel != "daemon":
+            raise ValueError("notification mutation owner is only valid for daemon")
         with self._lock:
             present = channel in self._channels
             current_payload = copy.deepcopy(self._channels.get(channel, {}))

--- a/tests/test_daemon_detached_supervisor.py
+++ b/tests/test_daemon_detached_supervisor.py
@@ -140,6 +140,31 @@ def _spawn_lingtai_supervisor(run_dir: DaemonRunDir, *, task="say hi", timeout_s
     return proc
 
 
+def test_supervisor_terminal_store_error_records_typed_retryable_evidence(tmp_path, monkeypatch):
+    from lingtai.tools.daemon import supervisor_runtime
+
+    run_dir = _make_run_dir(tmp_path)
+    manifest = {"parent_working_dir": str(run_dir.path.parent.parent)}
+
+    def fail_control(*_args, **_kwargs):
+        raise ValueError("daemon caller payload violated Store contract")
+
+    monkeypatch.setattr(PosixNotificationStoreAdapter, "compare_update_channel", fail_control)
+    published = supervisor_runtime._publish_daemon_notification(
+        run_dir,
+        manifest,
+        status="done",
+        state={"state": "done"},
+        idempotency_key="daemon-terminal:em-test",
+    )
+
+    assert published is False
+    event = json.loads(run_dir.events_path.read_text(encoding="utf-8").splitlines()[-1])
+    assert (event["event"], event["kind"], event["error_type"], event["retryable"]) == (
+        "daemon_notification_error", "daemon_notification_error", "ValueError", True
+    )
+
+
 def test_posix_adapter_spawns_real_detached_process(tmp_path):
     """The production Port/adapter actually launches a real OS process."""
     run_dir = _make_run_dir(tmp_path, task="say hi", timeout_s=30.0)

--- a/tests/test_daemon_notification_channel.py
+++ b/tests/test_daemon_notification_channel.py
@@ -135,11 +135,10 @@ def test_root_report_is_not_a_daemon_event_source(tmp_path):
 
     snapshot = snapshot_notifications(agent._working_dir)[DAEMON_CHANNEL]
     assert [event["ref_id"] for event in snapshot["data"]["events"]] == ["new-run"]
-    report = json.loads(root_path.read_text(encoding="utf-8"))
-    assert report["kind"] == "daemon_report"
-    assert report["stats"]["run_count"] == 1
-    assert report["stats"]["event_count"] == 1
-    assert report["migration"]["legacy_root"]["data"]["events"][0]["ref_id"] == "legacy-run"
+    # The compatibility report is non-authoritative and deliberately not
+    # rebuilt on the per-run append hot path. A pre-existing legacy report is
+    # ignored for delivery rather than rewritten by a reader or every writer.
+    assert json.loads(root_path.read_text(encoding="utf-8")) == legacy
     assert (agent._working_dir / ".notification" / "daemon" / "new-run.json").is_file()
 
 
@@ -163,7 +162,9 @@ def test_root_report_cannot_reinject_legacy_events_after_mini_dismissal(tmp_path
 
     assert result["status"] == "ok" and result["removed"] == 1
     assert DAEMON_CHANNEL not in snapshot_notifications(agent._working_dir)
-    assert json.loads(root_path.read_text(encoding="utf-8"))["stats"]["run_count"] == 0
+    # A stale legacy report cannot reinject events and is not rewritten by the
+    # aggregate dismiss path merely to make its statistics look current.
+    assert json.loads(root_path.read_text(encoding="utf-8"))["data"]["events"][0]["ref_id"] == "legacy-run"
 
 
 def test_daemon_publish_without_id_never_falls_back_to_root_report(tmp_path):
@@ -919,14 +920,10 @@ def test_daemon_ids_use_independent_mini_channels_and_aggregate_without_overwrit
     assert {path.name for path in mini_dir.glob("*.json")} == {"em-1.json", "em-2.json"}
     events = snapshot_notifications(agent._working_dir)[DAEMON_CHANNEL]["data"]["events"]
     assert {event["ref_id"] for event in events} == {"em-1", "em-2"}
-    report = json.loads(
-        (agent._working_dir / ".notification" / "daemon.json").read_text(
-            encoding="utf-8"
-        )
-    )
-    assert report["kind"] == "daemon_report"
-    assert report["stats"]["run_count"] == 2
-    assert report["stats"]["event_count"] == 2
+    # Owner appends do not scan/rebuild a root aggregate report. Snapshot is
+    # the authoritative derived daemon view; the compatibility report may be
+    # absent or stale until a rare aggregate-administration compaction.
+    assert not (agent._working_dir / ".notification" / "daemon.json").exists()
 
 
 def test_same_daemon_checkpoint_and_terminal_append_to_one_mini_file(tmp_path):
@@ -997,6 +994,95 @@ def test_daemon_event_or_ref_dismiss_deletes_only_matching_mini_file(tmp_path):
     assert not (mini_dir / "em-remove.json").exists()
     assert (mini_dir / "em-keep.json").exists()
     assert first
+
+
+@pytest.mark.parametrize("same_run", (True, False), ids=("same-run-sibling", "other-run"))
+def test_targeted_daemon_event_dismiss_preserves_only_the_selected_event(
+    tmp_path, monkeypatch, same_run
+):
+    from lingtai.kernel.meta_block import _commit_notification_fp
+    from lingtai.kernel.notifications import dismiss_channel
+
+    agent = make_daemon_agent(tmp_path)
+    removed_event_id = _publish(agent, "em-target")
+    if same_run:
+        surviving_event_id = agent._enqueue_system_notification(
+            source="daemon", ref_id="em-target", body="same run sibling",
+            idempotency_key="daemon-checkpoint:em-target:sibling",
+            skip_if_idempotency_key_exists=True, channel=DAEMON_CHANNEL,
+        )
+    else:
+        surviving_event_id = _publish(agent, "em-other")
+    _commit_notification_fp(agent)
+    store = agent._notification_store
+    fingerprints = {}
+    if same_run:
+        original_compact = store._compact_daemon_tombstone
+
+        def compact_with_fingerprint_guard():
+            fingerprints["before"] = store.fingerprint(lambda channel: channel == DAEMON_CHANNEL)
+            original_compact()
+            fingerprints["after"] = store.fingerprint(lambda channel: channel == DAEMON_CHANNEL)
+
+        monkeypatch.setattr(store, "_compact_daemon_tombstone", compact_with_fingerprint_guard)
+    result = dismiss_channel(
+        agent, DAEMON_CHANNEL, invoked_by="notification", event_id=removed_event_id
+    )
+
+    assert result["status"] == "ok" and result["removed"] == 1
+    mini_dir = agent._working_dir / ".notification" / "daemon"
+    if same_run:
+        mini = mini_dir / "em-target.json"
+        assert mini.exists()
+        events = json.loads(mini.read_text(encoding="utf-8"))["data"]["events"]
+        assert [event["event_id"] for event in events] == [surviving_event_id]
+        assert fingerprints["before"] == fingerprints["after"]
+    else:
+        assert not (mini_dir / "em-target.json").exists()
+        assert (mini_dir / "em-other.json").exists()
+        events = snapshot_notifications(agent._working_dir)[DAEMON_CHANNEL]["data"]["events"]
+        assert [event["event_id"] for event in events] == [surviving_event_id]
+
+
+def test_daemon_clear_and_targeted_dismiss_overlap_cannot_resurrect_events(tmp_path):
+    from lingtai.kernel.meta_block import _commit_notification_fp
+    from lingtai.kernel.notifications import dismiss_channel
+
+    agent = make_daemon_agent(tmp_path)
+    event_id = _publish(agent, "em-overlap")
+    _publish(agent, "em-other")
+    _commit_notification_fp(agent)
+    barrier = threading.Barrier(3)
+    clear_results = []
+    dismiss_results = []
+
+    def clear() -> None:
+        barrier.wait()
+        clear_results.append(agent._notification_store.clear(DAEMON_CHANNEL))
+
+    def dismiss() -> None:
+        barrier.wait()
+        dismiss_results.append(
+            dismiss_channel(
+                agent,
+                DAEMON_CHANNEL,
+                invoked_by="notification",
+                force=True,
+                event_id=event_id,
+            )
+        )
+
+    clear_thread = threading.Thread(target=clear)
+    dismiss_thread = threading.Thread(target=dismiss)
+    clear_thread.start()
+    dismiss_thread.start()
+    barrier.wait()
+    clear_thread.join(timeout=10)
+    dismiss_thread.join(timeout=10)
+    assert not clear_thread.is_alive() and not dismiss_thread.is_alive()
+    assert clear_results == [True]
+    assert dismiss_results[0]["status"] == "ok"
+    assert DAEMON_CHANNEL not in snapshot_notifications(agent._working_dir)
 
 
 def test_daemon_channel_dismiss_refuses_to_delete_late_mini_file(tmp_path):

--- a/tests/test_external_attach_diagnostic.py
+++ b/tests/test_external_attach_diagnostic.py
@@ -1,0 +1,184 @@
+"""Safety and usage tests for the bundled external attach diagnostic."""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+SCRIPT = (
+    Path(__file__).parents[1]
+    / "src/lingtai/intrinsic_skills/system-manual/reference/external-attach-diagnostic"
+    / "scripts/external_attach_diagnostic.py"
+)
+spec = importlib.util.spec_from_file_location("external_attach_diagnostic", SCRIPT)
+external_attach_diagnostic = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = external_attach_diagnostic
+assert spec.loader is not None
+spec.loader.exec_module(external_attach_diagnostic)
+
+
+def _agent(tmp_path: Path) -> Path:
+    agent = tmp_path / "agent"
+    agent.mkdir()
+    (agent / ".notification").mkdir()
+    (agent / ".agent.heartbeat").write_text("ok", encoding="utf-8")
+    return agent
+
+
+def _allow_fake_macos_sample(monkeypatch, tmp_path: Path) -> None:
+    sample = tmp_path / "sample"
+    sample.write_text("tool", encoding="utf-8")
+    sample.chmod(0o755)
+    monkeypatch.setattr(external_attach_diagnostic.sys, "platform", "darwin")
+    monkeypatch.setattr(external_attach_diagnostic, "SAMPLE_TOOL", sample)
+    monkeypatch.setattr(external_attach_diagnostic, "process_identity", lambda pid: f"darwin:{pid}:1")
+    monkeypatch.setattr(external_attach_diagnostic, "process_identity_matches", lambda pid, identity: identity == f"darwin:{pid}:1")
+    monkeypatch.setattr(external_attach_diagnostic, "_find_target_run", lambda agent_dir, pid: "module")
+    monkeypatch.setattr(external_attach_diagnostic, "_kernel_identity", lambda agent_dir: {"version": "test-kernel"})
+
+    def fake_sample(argv, **kwargs):
+        assert argv[:4] == [str(sample), str(int(argv[1])), str(int(argv[2])), "-file"]
+        Path(argv[4]).write_text("stack frame only\n", encoding="utf-8")
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(external_attach_diagnostic.subprocess, "run", fake_sample)
+
+
+def test_kernel_identity_uses_imported_runtime_source_not_agent_repo(tmp_path: Path, monkeypatch):
+    agent = _agent(tmp_path)
+    kernel_source = tmp_path / "kernel-source"
+    observed: dict[str, Path] = {}
+
+    class RevisionPort:
+        def __init__(self, directory: Path):
+            observed["directory"] = Path(directory)
+
+    monkeypatch.setattr(external_attach_diagnostic, "PosixGitCliAdapter", RevisionPort)
+    monkeypatch.setattr(external_attach_diagnostic, "_source_root", lambda _module_path: kernel_source)
+    monkeypatch.setattr(
+        external_attach_diagnostic,
+        "runtime_identity",
+        lambda _port: {"version": "test", "git_commit": "bf344c9f", "git_dirty": False},
+    )
+
+    identity = external_attach_diagnostic._kernel_identity(agent)
+
+    assert observed["directory"] == kernel_source
+    assert observed["directory"] != agent
+    assert identity == {"version": "test", "git_commit": "bf344c9f", "git_dirty": False}
+
+
+@pytest.mark.parametrize(
+    ("identity_matches", "error"),
+    ((True, None), (False, "changed incarnation")),
+    ids=("canonical-agent-match", "incarnation-changed"),
+)
+def test_target_binding_requires_canonical_live_agent_and_stable_incarnation(
+    tmp_path: Path, monkeypatch, identity_matches: bool, error: str | None
+):
+    agent = _agent(tmp_path)
+
+    class Scan:
+        def iter_process_commands(self):
+            yield 4242, f"/usr/bin/python3 -m lingtai run {agent}"
+
+    monkeypatch.setattr(external_attach_diagnostic, "PosixAgentProcessScanAdapter", Scan)
+    monkeypatch.setattr(external_attach_diagnostic, "process_identity", lambda _pid: "incarnation-a")
+    monkeypatch.setattr(
+        external_attach_diagnostic,
+        "process_identity_matches",
+        lambda _pid, identity: identity_matches and identity == "incarnation-a",
+    )
+    if error:
+        with pytest.raises(external_attach_diagnostic.DiagnosticError, match=error):
+            external_attach_diagnostic._observe_target(agent, 4242)
+        return
+
+    observed = external_attach_diagnostic._observe_target(agent, 4242)
+    assert (observed.run_form, observed.start_identity) == ("module", "incarnation-a")
+    with pytest.raises(external_attach_diagnostic.DiagnosticError, match="not a live LingTai run"):
+        external_attach_diagnostic._observe_target(tmp_path / "different-agent", 4242)
+
+
+def _arguments(agent: Path, artifact: Path, *extra: str) -> list[str]:
+    return ["--agent-dir", str(agent), "--pid", "4242", "--artifact-dir", str(artifact), *extra]
+
+
+def test_unsupported_host_refuses_before_artifact_directory_side_effect(tmp_path: Path, monkeypatch):
+    agent = _agent(tmp_path)
+    artifact = tmp_path / "must-not-exist"
+    monkeypatch.setattr(external_attach_diagnostic.sys, "platform", "linux")
+
+    assert external_attach_diagnostic.main(_arguments(agent, artifact)) == 1
+    assert not artifact.exists()
+
+
+def test_default_capture_is_content_free_agent_read_only_and_labels_stacks(tmp_path: Path, monkeypatch):
+    agent = _agent(tmp_path)
+    # These deliberately sensitive-looking bodies must never be parsed/copied.
+    (agent / ".notification" / "system.json").write_text('{"body":"do-not-copy-abc123"}', encoding="utf-8")
+    (agent / "system").mkdir()
+    (agent / "system" / "prompt.md").write_text("do-not-copy-prompt-xyz", encoding="utf-8")
+    _allow_fake_macos_sample(monkeypatch, tmp_path)
+    artifact = tmp_path / "capture"
+
+    assert external_attach_diagnostic.main(_arguments(agent, artifact, "--related-pid", "4243")) == 0
+    evidence_text = (artifact / "evidence.json").read_text(encoding="utf-8")
+    evidence = json.loads(evidence_text)
+    assert (artifact / "pid-4242.stack.txt").read_text(encoding="utf-8") == "stack frame only\n"
+    assert (artifact / "related-pid-4243.stack.txt").is_file()
+    assert evidence["interpretation"] == "Stacks only; not semantic stage timings."
+    assert evidence["safe_counts"]["notification_json_files"] == 1
+    assert evidence["controlled_burst"] == {
+        "requested": False,
+        "cleanup_requested": False,
+        "target_filename": None,
+        "store_locking_exercised": False,
+    }
+    assert "darwin:4242:1" not in evidence_text
+    assert "do-not-copy-abc123" not in evidence_text
+    assert "do-not-copy-prompt-xyz" not in evidence_text
+    assert not list((agent / ".notification").glob("mcp.external-attach-diagnostic.*.json"))
+
+
+@pytest.mark.parametrize("target_exists", (False, True), ids=("claim-and-cleanup", "existing-target-refuses"))
+def test_controlled_burst_claim_is_exclusive_and_cleanup_is_exact_run_id_only(
+    tmp_path: Path, monkeypatch, target_exists: bool
+):
+    agent = _agent(tmp_path)
+    _allow_fake_macos_sample(monkeypatch, tmp_path)
+    unrelated = agent / ".notification" / "mcp.unrelated.json"
+    unrelated.write_text("keep", encoding="utf-8")
+    run_id = "existing-a" if target_exists else "incident-20260824-a"
+    target = agent / ".notification" / f"mcp.external-attach-diagnostic.{run_id}.json"
+    if target_exists:
+        target.write_text("foreign-content", encoding="utf-8")
+
+    artifact = tmp_path / ("must-not-exist" if target_exists else "capture-create")
+    result = external_attach_diagnostic.main(
+        _arguments(agent, artifact, "--controlled-burst", "--burst-run-id", run_id)
+    )
+    if target_exists:
+        assert result == 1
+        assert target.read_text(encoding="utf-8") == "foreign-content"
+        assert not artifact.exists()
+        return
+
+    assert result == 0
+    payload = json.loads(target.read_text(encoding="utf-8"))
+    assert payload["data"] == {
+        "kind": "external_attach_controlled_burst",
+        "diagnostic_run_id": run_id,
+        "content_free": True,
+    }
+    assert unrelated.read_text(encoding="utf-8") == "keep"
+    assert external_attach_diagnostic.main(
+        _arguments(agent, tmp_path / "capture-clean", "--cleanup-controlled-burst", "--burst-run-id", run_id)
+    ) == 0
+    assert not target.exists()
+    assert unrelated.read_text(encoding="utf-8") == "keep"

--- a/tests/test_lingtai_doctor.py
+++ b/tests/test_lingtai_doctor.py
@@ -22,6 +22,13 @@ def load_doctor_module():
     return module
 
 
+def _valid_tombstone(*, cleared=None, pending=None) -> dict:
+    return {
+        "version": 1, "epoch": 0, "cleared": cleared or {},
+        "batch_state": {"count": 0, "alarm_fired": False}, "pending": pending,
+    }
+
+
 def test_lingtai_doctor_self_test_passes():
     proc = subprocess.run(
         [sys.executable, str(DOCTOR), "--self-test"],
@@ -153,6 +160,41 @@ def test_lingtai_doctor_skill_doc_lists_every_probed_addon():
 
     for name in doctor.ADDON_MODULES:
         assert f"`{name}`" in probe_text, f"SKILL.md omits probed addon {name}"
+
+
+def test_lingtai_doctor_reports_invalid_daemon_tombstone_without_contents(tmp_path):
+    doctor = load_doctor_module()
+    path = tmp_path / ".notification" / "daemon" / ".tombstone"
+    path.parent.mkdir(parents=True)
+    path.write_text('{"secret":"never-report-me"}', encoding="utf-8")
+
+    valid, detail = doctor._daemon_tombstone_health(path)
+
+    assert valid is False
+    assert detail == {"error": "ValueError"}
+    assert "never-report-me" not in repr(detail)
+
+
+def test_lingtai_doctor_rejects_store_fatal_daemon_tombstones(tmp_path):
+    doctor = load_doctor_module()
+    path = tmp_path / ".notification" / "daemon" / ".tombstone"
+    path.parent.mkdir(parents=True)
+    cases = (
+        _valid_tombstone(cleared={
+            "bad.txt": {"raw_sha256": "0" * 64, "event_keys": []}
+        }),
+        _valid_tombstone(pending={
+            "daemon_id": "!!bad", "event_id": "event-1",
+            "prior_batch_state": {"count": 0, "alarm_fired": False},
+            "batch_state": {"count": 1, "alarm_fired": False},
+        }),
+    )
+
+    for value in cases:
+        path.write_text(json.dumps(value), encoding="utf-8")
+        valid, detail = doctor._daemon_tombstone_health(path)
+        assert valid is False
+        assert detail == {"error": "ValueError"}
 
 
 def test_lingtai_doctor_type_hints_resolve():

--- a/tests/test_notification_delay_alarm.py
+++ b/tests/test_notification_delay_alarm.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -59,6 +60,15 @@ def _expire_state(agent: _DelayAgent) -> None:
     state_path.write_text(json.dumps(state), encoding="utf-8")
 
 
+def _expired_delay(tmp_path: Path, channel="email", payload=None) -> _DelayAgent:
+    agent = _DelayAgent(tmp_path)
+    if payload is not None:
+        publish_test_payload(tmp_path, channel, payload)
+    assert _call(agent, channel, 30)["status"] == "ok"
+    _expire_state(agent)
+    return agent
+
+
 def test_delay_schema_and_allowlist_expose_alarm_but_forbid_target(tmp_path: Path, monkeypatch) -> None:
     agent = _DelayAgent(tmp_path)
     monkeypatch.delenv("LINGTAI_NOTIFICATION_DELAY_MAX_SECONDS", raising=False)
@@ -109,6 +119,27 @@ def test_invalid_delay_cap_falls_back_to_600_and_logs(tmp_path: Path, monkeypatc
     fallback_logs = [event for event in agent._logs if event[0] == "notification_delay_max_seconds_invalid"]
     assert fallback_logs
     assert fallback_logs[-1][1]["fallback_seconds"] == 600
+
+
+def test_no_state_and_future_delay_heartbeat_take_zero_native_locks(tmp_path: Path, monkeypatch) -> None:
+    import lingtai.kernel.notifications as notifications
+
+    agent = _DelayAgent(tmp_path)
+    calls = []
+
+    def no_native_lock(_workdir):
+        calls.append(_workdir)
+        raise AssertionError("heartbeat should not acquire native delay locks")
+
+    monkeypatch.setattr(notifications, "_delay_transaction", no_native_lock)
+    assert reconcile_notification_delay(tmp_path, agent._notification_store) is False
+    assert calls == []
+
+    monkeypatch.undo()
+    assert _call(agent, "email", 30)["status"] == "ok"
+    monkeypatch.setattr(notifications, "_delay_transaction", no_native_lock)
+    assert reconcile_notification_delay(tmp_path, agent._notification_store) is False
+    assert calls == []
 
 
 def test_delay_hides_only_target_from_coherent_and_voluntary_check_reads(tmp_path: Path) -> None:
@@ -190,14 +221,32 @@ def test_expiry_reexposes_unchanged_target_and_writes_one_conservative_alarm(tmp
     assert "not asserted total" in data["current"]["retained_event_count_scope"]
 
 
+def test_expiry_does_not_reuse_prelock_stats_after_delay_identity_replacement(tmp_path: Path, monkeypatch) -> None:
+    import lingtai.kernel.notifications as notifications
+
+    agent = _expired_delay(tmp_path, payload={"data": {"count": 7}})
+
+    @contextmanager
+    def replace_delay_identity(workdir):
+        state_path = Path(workdir) / ".notification" / ".delay_state.json"
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        state["target"] = "soul"
+        state["request_id"] = "replacement-request"
+        state_path.write_text(json.dumps(state), encoding="utf-8")
+        yield
+
+    monkeypatch.setattr(notifications, "_delay_transaction", replace_delay_identity)
+    assert reconcile_notification_delay(tmp_path, agent._notification_store) is True
+
+    alarm = snapshot_notifications(tmp_path)[DELAY_ALARM_CHANNEL]["data"]["delay_alarm"]
+    assert alarm["target"] == "soul"
+    assert alarm["current"] == {"present": None}
+
+
 def test_expiry_marks_changed_without_claiming_capped_event_total(tmp_path: Path) -> None:
-    agent = _DelayAgent(tmp_path)
-    publish_test_payload(
-        tmp_path,
-        "daemon",
-        {"data": {"daemon_id": "delay-test", "events": [{"event_id": "old"}]}},
+    agent = _expired_delay(
+        tmp_path, "daemon", {"data": {"daemon_id": "delay-test", "events": [{"event_id": "old"}]}}
     )
-    assert _call(agent, "daemon", 30)["status"] == "ok"
     publish_test_payload(
         tmp_path,
         "daemon",
@@ -208,8 +257,6 @@ def test_expiry_marks_changed_without_claiming_capped_event_total(tmp_path: Path
             }
         },
     )
-    _expire_state(agent)
-
     assert reconcile_notification_delay(tmp_path, agent._notification_store) is True
     alarm = snapshot_notifications(tmp_path)[DELAY_ALARM_CHANNEL]["data"]["delay_alarm"]
     assert alarm["changed"] is True
@@ -227,10 +274,7 @@ def test_delay_core_rejects_mismatched_early_cancel(tmp_path: Path) -> None:
 
 
 def test_replacement_recovers_an_overdue_alarm_before_overwriting_state(tmp_path: Path) -> None:
-    agent = _DelayAgent(tmp_path)
-    publish_test_payload(tmp_path, "email", {"data": {"count": 1}})
-    assert _call(agent, "email", 30)["status"] == "ok"
-    _expire_state(agent)
+    agent = _expired_delay(tmp_path, payload={"data": {"count": 1}})
 
     replacement = _call(agent, "soul", 30)
     assert replacement["status"] == "ok"
@@ -242,7 +286,6 @@ def test_replacement_recovers_an_overdue_alarm_before_overwriting_state(tmp_path
 
 
 def test_process_timer_prompts_expiry_recovery(monkeypatch, tmp_path: Path) -> None:
-    """The durable heartbeat path is backed by a prompt process-timer callback."""
     import lingtai.kernel.notifications as notifications
 
     fired = []
@@ -263,11 +306,8 @@ def test_process_timer_prompts_expiry_recovery(monkeypatch, tmp_path: Path) -> N
             self.cancelled = True
 
     monkeypatch.setattr(notifications.threading, "Timer", _Timer)
-    agent = _DelayAgent(tmp_path)
-    publish_test_payload(tmp_path, "email", {"data": {"count": 1}})
-    assert _call(agent, "email", 30)["status"] == "ok"
+    agent = _expired_delay(tmp_path, payload={"data": {"count": 1}})
     assert len(fired) == 1
-    _expire_state(agent)
 
     fired[0].callback(*fired[0].args)
     alarm = snapshot_notifications(tmp_path)[DELAY_ALARM_CHANNEL]
@@ -278,9 +318,7 @@ def test_process_timer_prompts_expiry_recovery(monkeypatch, tmp_path: Path) -> N
 def test_concurrent_expiry_recovery_claims_one_alarm_publication(tmp_path: Path) -> None:
     from concurrent.futures import ThreadPoolExecutor
 
-    agent = _DelayAgent(tmp_path)
-    assert _call(agent, "email", 30)["status"] == "ok"
-    _expire_state(agent)
+    agent = _expired_delay(tmp_path)
 
     with ThreadPoolExecutor(max_workers=6) as pool:
         results = list(pool.map(lambda _: reconcile_notification_delay(tmp_path, agent._notification_store), range(6)))

--- a/tests/test_notification_store.py
+++ b/tests/test_notification_store.py
@@ -21,7 +21,7 @@ from typing import Any
 
 import pytest
 
-from lingtai.adapters.posix.notification_store import PosixNotificationStoreAdapter
+from lingtai.adapters.posix.notification_store import DaemonControlError, PosixNotificationStoreAdapter
 from lingtai.kernel.base_agent.messaging import _enqueue_system_notification
 from lingtai.kernel.notification_store import (
     CompareUpdateResult,
@@ -52,6 +52,24 @@ def _posix_store(workdir: Path) -> PosixNotificationStoreAdapter:
     return PosixNotificationStoreAdapter(workdir)
 
 
+def _daemon_payload(daemon_id: str, *event_ids: str, count: int | None = None) -> dict:
+    data = {"daemon_id": daemon_id, "events": [{"event_id": event_id} for event_id in event_ids]}
+    if count is not None:
+        data["daemon"] = {"count": count, "alarm_fired": False}
+    return {"data": data}
+
+
+def _publish_daemon(store, daemon_id: str, *event_ids: str) -> None:
+    store.publish("daemon", _daemon_payload(daemon_id, *event_ids))
+
+
+def _tombstone_control(*, cleared=None, pending=None) -> dict:
+    return {
+        "version": 1, "epoch": 0, "cleared": cleared or {},
+        "batch_state": {"count": 0, "alarm_fired": False}, "pending": pending,
+    }
+
+
 def _process_increment_channel(workdir: str, barrier) -> None:
     store = PosixNotificationStoreAdapter(Path(workdir))
     barrier.wait(timeout=30)
@@ -65,6 +83,49 @@ def _process_increment_channel(workdir: str, barrier) -> None:
     result = store.compare_update_channel("system", UNCONDITIONAL, increment)
     if not result.applied:
         raise RuntimeError(f"channel increment was not applied: {result!r}")
+
+
+def _process_hold_native_scope(workdir: str, scope: str, ready, release) -> None:
+    from lingtai.adapters.posix.notification_store_lock import PosixNotificationStoreLockAdapter
+
+    with PosixNotificationStoreLockAdapter().exclusive(Path(workdir) / ".notification", scope):
+        ready.set()
+        if not release.wait(timeout=30):
+            raise RuntimeError("scope holder release timed out")
+
+
+def _process_write_and_read_email(workdir: str, result_queue, ready=None) -> None:
+    store = PosixNotificationStoreAdapter(Path(workdir))
+    if ready is not None:
+        ready.set()
+    result = store.compare_update_channel(
+        "email", UNCONDITIONAL, lambda current: ({**current, "committed": True}, True, None)
+    )
+    result_queue.put((result.applied, store.snapshot(_allow_all).get("email")))
+
+
+def _process_owner_daemon_append(workdir: str, daemon_id: str, barrier) -> None:
+    store = PosixNotificationStoreAdapter(Path(workdir))
+    barrier.wait(timeout=60)
+
+    def append(current: dict):
+        data = current.get("data") if isinstance(current.get("data"), dict) else {}
+        events = list(data.get("events", []))
+        event_id = f"evt-{daemon_id}"
+        if any(event.get("idempotency_key") == daemon_id for event in events if isinstance(event, dict)):
+            return current, False, event_id
+        events.append({"event_id": event_id, "idempotency_key": daemon_id, "ref_id": daemon_id})
+        batch = data.get("daemon") if isinstance(data.get("daemon"), dict) else {}
+        count = int(batch.get("count", 0)) + 1
+        return (
+            {"data": {"events": events, "daemon": {"count": count, "alarm_fired": False}, "daemon_id": daemon_id}},
+            True,
+            event_id,
+        )
+
+    result = store.compare_update_channel("daemon", UNCONDITIONAL, append, owner=daemon_id)
+    if not result.applied:
+        raise RuntimeError(f"daemon append was not applied: {result!r}")
 
 
 @pytest.fixture(params=("fake", "posix"))
@@ -479,9 +540,13 @@ class TestAtomicCoreRedCounterexamples:
         monkeypatch.setattr(lock_module.fcntl, "flock", fail_acquire)
         lock = lock_module.PosixNotificationStoreLockAdapter()
         with pytest.raises(OSError, match="acquisition failed"):
-            with lock.exclusive(tmp_path):
+            with lock.exclusive(tmp_path, "channel:email"):
                 pytest.fail("mutation body ran without the process lock")
-        assert calls == [lock_module.fcntl.LOCK_EX]
+        assert calls == [
+            lock_module.fcntl.LOCK_SH,
+            lock_module.fcntl.LOCK_EX,
+            lock_module.fcntl.LOCK_UN,
+        ]
 
     def test_windows_lock_preserves_acquisition_error(self, tmp_path, monkeypatch):
         from lingtai.adapters.windows.notification_store_lock import (
@@ -502,9 +567,24 @@ class TestAtomicCoreRedCounterexamples:
 
         lock = WindowsNotificationStoreLockAdapter()
         with pytest.raises(OSError, match="acquisition failed"):
-            with lock.exclusive(tmp_path):
+            with lock.exclusive(tmp_path, "channel:email"):
                 pytest.fail("mutation body ran without the process lock")
         assert calls == [fake_msvcrt.LK_NBLCK]
+
+    def test_windows_lock_declares_quiesced_legacy_cutover(self):
+        from lingtai.adapters.windows.notification_store_lock import (
+            WindowsNotificationStoreLockAdapter,
+        )
+
+        assert WindowsNotificationStoreLockAdapter.requires_quiesced_legacy_cutover is True
+
+    def test_fake_store_rejects_non_daemon_owner_like_production(self):
+        store = FakeNotificationStore()
+
+        with pytest.raises(ValueError, match="only valid for daemon"):
+            store.compare_update_channel(
+                "email", UNCONDITIONAL, lambda current: (current, False, None), owner="em-a"
+            )
 
     def test_concurrent_ack_unions_use_atomic_family_seven(self, tmp_path):
         store = _posix_store(tmp_path / "ack-unions")
@@ -712,6 +792,245 @@ class TestAtomicCoreRedCounterexamples:
         assert nudges[0]["kind"] == "after-dismiss"
         assert nudges[0]["policy"]["enabled"] == "on"
         assert nudges[0]["policy"]["repeat_after_dismiss"] == "24h"
+
+
+class TestScopedNativeLockIsolation:
+    @pytest.mark.skipif(os.name != "posix", reason="requires POSIX native flock")
+    @pytest.mark.parametrize("scope", ("channel:system", "daemon-run:em-held"))
+    def test_real_held_scope_does_not_block_unrelated_email_process(self, tmp_path, scope):
+        workdir = tmp_path / "native-isolation"
+        workdir.mkdir()
+        context = multiprocessing.get_context("spawn")
+        ready = context.Event()
+        release = context.Event()
+        results = context.Queue()
+        holder = context.Process(
+            target=_process_hold_native_scope,
+            args=(str(workdir), scope, ready, release),
+        )
+        holder.start()
+        assert ready.wait(timeout=15), "native scope holder did not acquire"
+        writer = context.Process(
+            target=_process_write_and_read_email, args=(str(workdir), results)
+        )
+        writer.start()
+        try:
+            applied, payload = results.get(timeout=8)
+            assert applied is True
+            assert payload == {"committed": True}
+            assert writer.is_alive() or writer.exitcode == 0
+        finally:
+            release.set()
+            writer.join(timeout=15)
+            holder.join(timeout=15)
+        assert writer.exitcode == 0
+        assert holder.exitcode == 0
+
+    @pytest.mark.skipif(os.name != "posix", reason="requires POSIX native flock")
+    def test_posix_bridge_waits_for_old_global_writer(self, tmp_path):
+        import fcntl
+
+        workdir = tmp_path / "legacy-bridge"
+        notification_dir = workdir / ".notification"
+        notification_dir.mkdir(parents=True)
+        legacy = open(notification_dir / ".store.lock", "a+b")
+        fcntl.flock(legacy.fileno(), fcntl.LOCK_EX)
+        context = multiprocessing.get_context("spawn")
+        results = context.Queue()
+        ready = context.Event()
+        writer = context.Process(
+            target=_process_write_and_read_email, args=(str(workdir), results, ready)
+        )
+        writer.start()
+        try:
+            import queue
+
+            assert ready.wait(timeout=15), "writer did not reach compare-update"
+            with pytest.raises(queue.Empty):
+                results.get(timeout=0.35)
+        finally:
+            fcntl.flock(legacy.fileno(), fcntl.LOCK_UN)
+            legacy.close()
+        applied, payload = results.get(timeout=10)
+        writer.join(timeout=15)
+        assert writer.exitcode == 0
+        assert applied is True and payload == {"committed": True}
+
+    def test_forty_owner_publishers_preserve_every_run_without_aggregate_rebuild(self, tmp_path):
+        workdir = tmp_path / "forty-daemon-publishers"
+        workdir.mkdir()
+        context = multiprocessing.get_context("spawn")
+        barrier = context.Barrier(41)
+        processes = [
+            context.Process(
+                target=_process_owner_daemon_append,
+                args=(str(workdir), f"em-{index}", barrier),
+            )
+            for index in range(40)
+        ]
+        for process in processes:
+            process.start()
+        barrier.wait(timeout=60)
+        for process in processes:
+            process.join(timeout=60)
+        assert [process.exitcode for process in processes] == [0] * 40
+        payload = PosixNotificationStoreAdapter(workdir).snapshot(_allow_all)["daemon"]
+        events = payload["data"]["events"]
+        assert {event["ref_id"] for event in events} == {f"em-{index}" for index in range(40)}
+        assert payload["data"]["daemon"]["count"] == 40
+        assert not (workdir / ".notification" / "daemon.json").exists()
+
+    def test_snapshot_never_creates_or_rebuilds_daemon_report(self, tmp_path):
+        store = _posix_store(tmp_path / "snapshot-no-write")
+        _publish_daemon(store, "em-a", "one")
+        report = tmp_path / "snapshot-no-write" / ".notification" / "daemon.json"
+        before = {path: path.read_bytes() for path in (tmp_path / "snapshot-no-write" / ".notification").rglob("*") if path.is_file()}
+        assert store.snapshot(_allow_all)["daemon"]["data"]["events"] == [{"event_id": "one"}]
+        after = {path: path.read_bytes() for path in (tmp_path / "snapshot-no-write" / ".notification").rglob("*") if path.is_file()}
+        assert after == before
+        assert not report.exists()
+
+    @pytest.mark.parametrize(
+        "corrupt_control",
+        (
+            "{not-json",
+            json.dumps(_tombstone_control(cleared={
+                "unrecognized.txt": {"raw_sha256": "0" * 64, "event_keys": []}
+            })),
+            json.dumps(_tombstone_control(pending={
+                "daemon_id": "!!bad", "event_id": "event-1",
+                "prior_batch_state": {"count": 0, "alarm_fired": False},
+                "batch_state": {"count": 1, "alarm_fired": False},
+            })),
+        ),
+    )
+    def test_corrupt_or_unrecognized_daemon_tombstone_is_loud_but_keeps_other_channels_deliverable(self, tmp_path, corrupt_control):
+        from lingtai.adapters.posix.notification_store import DaemonControlError
+
+        workdir = tmp_path / "corrupt-tombstone"
+        store = _posix_store(workdir)
+        _publish_daemon(store, "em-a", "one")
+        store.publish("email", {"header": "email remains deliverable"})
+        store.publish("system", {"header": "system remains deliverable"})
+        control = workdir / ".notification" / "daemon" / ".tombstone"
+        control.write_text(corrupt_control, encoding="utf-8")
+
+        snapshot = store.snapshot(_allow_all)
+        assert snapshot["email"]["header"] == "email remains deliverable"
+        assert snapshot["system"]["header"] == "system remains deliverable"
+        daemon_error = snapshot["daemon"]
+        assert daemon_error["priority"] == "high"
+        assert daemon_error["header"] == "Daemon notification control error; run lingtai-doctor"
+        assert daemon_error["data"]["error"] == {
+            "code": "daemon_control_error",
+            "action": "run lingtai-doctor",
+        }
+        raw = json.dumps(daemon_error, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+        daemon_entry = next(entry for entry in store.fingerprint(_allow_all) if entry[0] == "daemon.json")
+        assert daemon_entry == ("daemon.json", len(raw), __import__("hashlib").sha256(raw).hexdigest())
+        assert (control.parent / "em-a.json").is_file(), "read containment must not erase live state"
+
+        with pytest.raises(DaemonControlError, match="tombstone"):
+            store.publish("daemon", _daemon_payload("em-a"))
+        with pytest.raises(DaemonControlError, match="tombstone"):
+            store.compare_update_channel(
+                "daemon", UNCONDITIONAL, lambda current: (current, False, None), owner="em-a"
+            )
+        with pytest.raises(DaemonControlError, match="tombstone"):
+            store.clear("daemon")
+
+    def test_only_committed_daemon_removal_cut_fsyncs_control(self, tmp_path, monkeypatch):
+        import lingtai.adapters.posix.notification_store as store_module
+
+        control_fsyncs = []
+        original_write = store_module.atomic_write_json
+
+        def record_control_fsync(path, value, **kwargs):
+            if path.name == ".tombstone":
+                control_fsyncs.append(kwargs.get("fsync", False))
+            return original_write(path, value, **kwargs)
+
+        monkeypatch.setattr(store_module, "atomic_write_json", record_control_fsync)
+        store = _posix_store(tmp_path / "durable-removal-cut")
+        store.compare_update_channel(
+            "daemon",
+            UNCONDITIONAL,
+            lambda _current: (_daemon_payload("em-a", "one", count=1), True, "one"),
+            owner="em-a",
+        )
+        assert control_fsyncs == [False, False], "hot append receipts remain non-fsync"
+        assert store.clear("daemon") is True
+        assert control_fsyncs[2] is True, "committed clear visibility cut is durable"
+
+    @pytest.mark.parametrize(
+        ("failure", "recompact"),
+        ((OSError, True), (DaemonControlError, False)),
+        ids=("crash-before-compaction", "post-cut-control-error"),
+    )
+    def test_committed_clear_stays_unambiguous_after_compaction_failure(
+        self, tmp_path, monkeypatch, failure, recompact
+    ):
+        store = _posix_store(tmp_path / "compaction-failure")
+        _publish_daemon(store, "em-a", "one")
+        monkeypatch.setattr(
+            store, "_compact_daemon_tombstone",
+            lambda: (_ for _ in ()).throw(failure("simulated compaction failure")),
+        )
+        result = store.compare_update_channel("daemon", UNCONDITIONAL, lambda _current: (None, True, "clear"))
+        assert result.applied and result.cleared
+        assert store.snapshot(_allow_all).get("daemon") is None
+        if recompact:
+            mini = tmp_path / "compaction-failure" / ".notification" / "daemon" / "em-a.json"
+            assert mini.is_file(), "physical body remains across crash before compaction"
+            monkeypatch.undo()
+            store._compact_daemon_tombstone()
+            assert not mini.exists()
+
+    def test_stale_tombstone_entry_is_compacted_after_replacement_without_heartbeat_leak(self, tmp_path, monkeypatch):
+        workdir = tmp_path / "stale-tombstone"
+        store = _posix_store(workdir)
+        _publish_daemon(store, "em-a", "old")
+        monkeypatch.setattr(
+            store,
+            "_compact_daemon_tombstone",
+            lambda: (_ for _ in ()).throw(OSError("simulated crash")),
+        )
+        assert store.clear("daemon") is True
+        monkeypatch.undo()
+        replacement = _daemon_payload("em-a", "new")
+        store.publish("daemon", replacement)
+        store._compact_daemon_tombstone()
+        control = json.loads((workdir / ".notification" / "daemon" / ".tombstone").read_text(encoding="utf-8"))
+        assert control["cleared"] == {}
+        first = store.snapshot(_allow_all)
+        first_fingerprint = store.fingerprint(_allow_all)
+        second = store.snapshot(_allow_all)
+        second_fingerprint = store.fingerprint(_allow_all)
+        assert first == second
+        assert first_fingerprint == second_fingerprint
+        assert first["daemon"]["data"]["events"] == [{"event_id": "new"}]
+
+    def test_inert_tombstone_with_no_matching_key_is_compacted(self, tmp_path):
+        workdir = tmp_path / "inert-tombstone"
+        store = _posix_store(workdir)
+        _publish_daemon(store, "em-a", "live")
+        mini = workdir / ".notification" / "daemon" / "em-a.json"
+        raw = mini.read_bytes()
+        control_path = workdir / ".notification" / "daemon" / ".tombstone"
+        control_path.write_text(
+            json.dumps(_tombstone_control(cleared={
+                "em-a.json": {
+                    "raw_sha256": __import__("hashlib").sha256(raw).hexdigest(),
+                    "event_keys": ["event:already-gone"],
+                }
+            })),
+            encoding="utf-8",
+        )
+        store._compact_daemon_tombstone()
+        control = json.loads(control_path.read_text(encoding="utf-8"))
+        assert control["cleared"] == {}
+        assert mini.read_bytes() == raw
+        assert store.snapshot(_allow_all)["daemon"]["data"]["events"] == [{"event_id": "live"}]
 
 
 class TestCompositionAndProvenance:

--- a/tests/test_perform_refresh_handshake.py
+++ b/tests/test_perform_refresh_handshake.py
@@ -1218,10 +1218,10 @@ def test_refresh_watcher_cleanup_then_success_does_not_write_failure_alert(tmp_p
 # Cross-process system.json merge serialization (issue #742)
 #
 # The watcher publishes its terminal alert by merging into the same
-# .notification/system.json that the in-agent Notification Store mutates
-# under an advisory flock on .notification/.store.lock. The generated
-# `_append_system_notification` must take that same lock so a concurrent
-# agent merge is not silently overwritten (lost update) — and vice versa.
+# .notification/system.json that the in-agent Notification Store mutates under
+# canonical `channel:system` scope. The generated publisher independently takes
+# that scoped lock and the shared one-release `.store.lock` bridge, so an old
+# global holder or concurrent system merge cannot silently lose an update.
 # ---------------------------------------------------------------------------
 
 
@@ -1298,10 +1298,25 @@ def _seed_system_event(wd: Path) -> None:
     )
 
 
+def test_refresh_watcher_system_lock_filename_is_pinned_to_store_mapping(tmp_path):
+    from lingtai.kernel.notification_store._mutation_lock import (
+        channel_mutation_scope,
+        notification_mutation_lock_path,
+    )
+
+    agent = _make_agent_with_launch_cmd(tmp_path)
+    script = _capture_watcher_script(agent)
+    expected = notification_mutation_lock_path(
+        agent._working_dir / ".notification",
+        channel_mutation_scope("system"),
+    ).name
+
+    assert f"scoped_name = {expected!r}" in script
+
+
 def test_refresh_watcher_system_notification_append_serializes_with_store_lock(tmp_path):
-    """#742 regression: the generated `_append_system_notification` must block
-    on the same `.notification/.store.lock` flock the Notification Store holds,
-    so a concurrent in-agent merge is not overwritten (lost update)."""
+    """Legacy bridge regression: an old exclusive `.store.lock` holder blocks
+    the generated publisher, preventing a mixed-version lost system update."""
     import fcntl as _fcntl
     import time as _time
 

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -335,8 +335,14 @@ def test_skills_setup_hard_copies_standalone_intrinsic_skills(tmp_path):
         assert "name: runtime-update-checks" in system_manual_body
         assert "name: refresh-precheck" in system_manual_body
         assert "name: trajectory-mining" in system_manual_body
+        assert "name: external-attach-diagnostic" in system_manual_body
+        assert "reference/external-attach-diagnostic/SKILL.md" in system_manual_body
         assert "Nested reference catalog" in system_manual_body
         assert "location: reference/notification-manual/SKILL.md" not in system_manual_body
+        external_attach = workdir / ".library" / "intrinsic" / "capabilities" / "system-manual"
+        external_attach = external_attach / "reference" / "external-attach-diagnostic"
+        assert (external_attach / "SKILL.md").is_file()
+        assert (external_attach / "scripts" / "external_attach_diagnostic.py").is_file()
 
         notification_manual_md = (
             workdir

--- a/tests/test_tools_package_data.py
+++ b/tests/test_tools_package_data.py
@@ -85,6 +85,10 @@ _NOTIFICATION_MANUAL_FILES = (
     "lingtai/intrinsic_skills/notification-manual/reference/channel-model/SKILL.md",
     "lingtai/intrinsic_skills/notification-manual/reference/dismissal-safety/SKILL.md",
 )
+_SYSTEM_MANUAL_EXTERNAL_ATTACH_FILES = (
+    "lingtai/intrinsic_skills/system-manual/reference/external-attach-diagnostic/SKILL.md",
+    "lingtai/intrinsic_skills/system-manual/reference/external-attach-diagnostic/scripts/external_attach_diagnostic.py",
+)
 
 # The three per-tool glossary languages that each package must ship.
 _WEB_SEARCH_MANUAL_FILES = (
@@ -158,12 +162,14 @@ def _build_wheel(dest: Path) -> Path:
 
 
 def _logical(path: str) -> str:
-    """Return an archive entry rooted at the canonical ``lingtai/tools`` path.
+    """Return an archive entry rooted at the canonical ``lingtai/`` package.
 
-    Wheel entries already start with ``lingtai/tools``. Sdist entries add the
+    Wheel entries already start with ``lingtai/``. Sdist entries add the
     distribution root plus ``src/``; those prefixes are stripped only after the
-    exact ``lingtai`` / ``tools`` pair is found. A ``*.data/{purelib,platlib}/``
-    prefix is *not* normalized away — it is the auditwheel-rejected layout the
+    exact package-root segment is found. This also lets this test cover bundled
+    standalone intrinsic-skill assets, not just ``lingtai/tools`` resources. A
+    ``*.data/{purelib,platlib}/`` prefix is *not* normalized away — it is the
+    auditwheel-rejected layout the
     packaging fix eliminated. If one ever reappears it must surface as a broken
     path, not be silently accepted; ``test_wheel_platlib_layout.py`` asserts the
     native wheel never produces one.
@@ -177,8 +183,8 @@ def _logical(path: str) -> str:
                 "wheel entry under *.data/%s is the auditwheel-rejected layout: %r"
                 % (parts[i + 1], path)
             )
-    for i in range(len(parts) - 1):
-        if parts[i : i + 2] == ["lingtai", "tools"]:
+    for i, segment in enumerate(parts):
+        if segment == "lingtai":
             return "/".join(parts[i:])
     return path
 
@@ -243,6 +249,13 @@ def test_wheel_keeps_daemon_backend_manuals(wheel_entries: set[str]):
 def test_wheel_ships_first_level_notification_manual(wheel_entries: set[str]):
     missing = [path for path in _NOTIFICATION_MANUAL_FILES if path not in wheel_entries]
     assert not missing, "notification manual files missing from wheel: %r" % missing
+
+
+@pytest.mark.parametrize("entries_fixture", ("wheel_entries", "sdist_entries"), ids=("wheel", "sdist"))
+def test_archives_ship_system_manual_external_attach_diagnostic(request, entries_fixture: str):
+    entries = request.getfixturevalue(entries_fixture)
+    missing = [path for path in _SYSTEM_MANUAL_EXTERNAL_ATTACH_FILES if path not in entries]
+    assert not missing, "system-manual external attach files missing from %s: %r" % (entries_fixture, missing)
 
 
 # ---------------------------------------------------------------------------
@@ -358,6 +371,8 @@ def sdist_entries(tmp_path_factory) -> set[str]:
 def test_sdist_ships_browser_manual(sdist_entries: set[str]):
     missing = [path for path in _BROWSER_MANUAL_FILES if path not in sdist_entries]
     assert not missing, "browser manual files missing from sdist: %r" % missing
+
+
 
 
 def test_sdist_ships_every_glossary_resource(sdist_entries: set[str]):


### PR DESCRIPTION
## Summary

- replace the whole-directory notification mutation lock with canonical resource-scoped locks
- keep daemon publication on independent run files with durable tombstone/CAS semantics for aggregate clear and dismiss
- remove notification-store locks and report writes from the normal heartbeat read path
- add a mixed-version POSIX bridge and document the required Windows quiesced cutover
- add the reusable external attach/controlled-burst diagnostic under the bundled `system-manual`

## Why

Live sampling of SciAccelBench showed the main agent and a 40-way daemon publisher pool queued on `.notification/.store.lock`. The controlled 5,001-event burst did not change the freeze. The failure shape was a lock convoy/starvation problem: unrelated notification resources serialized behind daemon aggregate/report work.

## Behavior

- ordinary channels, acknowledgements, hooks, delay state, daemon runs, daemon control, and report projection use independent canonical scopes
- POSIX new writers take a shared legacy bridge plus their scoped exclusive lock; Windows requires old writers to be quiesced
- daemon appends avoid aggregate scans/report rebuilds; durable Store-owned tombstones linearize clear/dismiss/CAS and survive pre-compaction crashes
- snapshots remain read-only; corrupt daemon control fails loudly and is surfaced by doctor
- no-delay reconciliation takes the lock-free fast path; Core retains alarm policy
- the system refresh watcher uses the same canonical system scope/bridge

## Diagnostic

`system-manual` now routes to a macOS external attach diagnostic that:

- validates exact agent/PID incarnation with existing runtime helpers
- captures bounded, content-free stack/runtime evidence (not semantic stage timings)
- defaults to no mutation
- optionally creates one unique content-free external `mcp.*` burst behind an explicit flag
- removes only the exact self-authored run ID
- explicitly does not exercise Store locking

## Validation

- `102 passed` — notification Store, daemon notification channel, doctor
- `89 passed` — refresh handshake, daemon attention delay, notification delay alarm
- `47 passed` — refresh watcher focused rerun
- `24 passed` — external diagnostic + skill validation/copy
- `15 passed` — real wheel and sdist package-data tests
- changed governed-doc checks: pass
- nested/router skill validation with `--require-last-changed-at`: pass
- `py_compile` and `git diff --check`: pass

Whole-tree anatomy/docs checks retain unrelated current-main baseline findings; every affected file is recorded in the implementation receipt and the changed-doc checks pass. Native Windows concurrency remains a CI gate; this PR does not claim POSIX shared-lock parity on Windows.

## Review state

Frozen exact-base Opus 5 R1 returned `REQUEST CHANGES` (P0=2/P1=4/P2=10). Head `bf344c9f` repairs every P0/P1 and the owning narrow P2s: corrupt control is contained to a loud daemon/doctor payload while unrelated channels remain available; targeted tombstones preserve siblings; stale entries compact; notification-store ↔ refresh-watcher reciprocal docs and watcher lock identity are pinned; clear/dismiss overlap, zero-lock delay, Windows cutover, delay identity, fake-owner, supervisor error and real PID-incarnation tests are present.

Repair validation: daemon channel `43 passed`; refresh/delay/external/doctor/package `122 passed`; supervisor regression `1 passed`; reciprocal-doc regression `1 passed`; Store file has `59` executable passes plus one unrelated installed-MCP collection `ImportError`; py_compile and diff check pass. Ready for normal review. Remaining bounded risks are documented: native Windows enforcement/receipt, daemon-control serialization, bridge starvation, and manual rollback/repair.

Telegram: @lingtaidev3bot | Nickname: 澄一

Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai

## Live acceptance + final review (dev-3, 2026-08-24)

- Refreshed dev-3 once onto isolated clean `bf344c9f`, then dispatched group `dg-20260824-044041-19b8dc`: 40 concurrent LingTai daemons, each running one `shell sleep 10s`. **40/40 done**, **40/40 shell contracts**, **40/40 finish receipts**, **40/40 terminal receipts**; batch wall 57s; sleeps 10.035-10.083s (median 10.045s).
- Baseline vs aligned live sampling: heartbeat max age 1.205s -> 1.330s; max observed gap 1.507s -> 1.509s; all scoped/legacy nonblocking lock probes saw zero blocked samples. Main agent stayed active and replied on Telegram in 624ms.
- Live use found and repaired the external diagnostic Git-root identity misreport. A pure direct `claude-opus-5` whole-diff review (no Agent/Task/helpers; modelUsage contains only Opus 5) then found P0=1/P1=2. Head `67af238a` fixes all three: invalid pending-id containment, byte-stable compaction fingerprint, and doctor/Store control-validation agreement.
- Jason requested test compression. Shared builders and parameterization reduced the test footprint by exactly **100 net lines** (+865/-31 -> +785/-51) while retaining real concurrency/crash/mixed-version/privacy evidence. Parent affected matrix: **245 passed**; pycompile and diff check pass.
- Same-session pure Opus follow-up on clean exact `67af238a` is **APPROVE, P0=0/P1=0/P2=1 new nonblocking**. The P2 is a rare externally tampered daemon id containing `..` that doctor accepts while Store rejects; Store can never write it. Previously disclosed P2s remain nonblocking.
- PR head `67af238ab735ae2076185825139b3eb6afd64065` is clean/mergeable and safe to merge only after explicit human authorization. No second live refresh, merge, release, cleanup, or protected SciAccelBench/central-manager action was performed.
