### PR TITLE
ci: run platform checks only on releases

### DIFF
--- a/.github/workflows/kernel-macos-smoke-pr.yml
+++ b/.github/workflows/kernel-macos-smoke-pr.yml
@@ -1,26 +1,8 @@
-name: Kernel macOS smoke PR contract
+name: Kernel macOS smoke release contract
 
 on:
-  pull_request:
-    paths:
-      - ".github/workflows/kernel-macos-smoke-pr.yml"
-      - "src/lingtai/adapters/**"
-      - "src/lingtai/kernel/**"
-      - "src/lingtai/tools/daemon/**"
-      - "src/lingtai/tools/bash/**"
-      - "src/lingtai/cli.py"
-      - "src/lingtai/agent.py"
-      - "tests/test_shell_pr1_contract.py"
-      - "tests/test_bash_shell_dialect.py"
-      - "tests/test_shell_kind_classifier.py"
-      - "tests/test_shell_kind_spawn_args.py"
-      - "tests/test_process_identity.py"
-      - "tests/test_daemon_process_port.py"
-      - "tests/test_daemon_detached_supervisor.py"
-      - "tests/test_token_ledger.py"
-      - "tests/test_workdir_lease_posix_only.py"
-      - "tests/test_portable_adapter_encoding.py"
-  workflow_dispatch:
+  release:
+    types: [published]
 
 permissions:
   contents: read

--- a/.github/workflows/kernel-windows-pr.yml
+++ b/.github/workflows/kernel-windows-pr.yml
@@ -1,23 +1,8 @@
-name: Kernel Windows PR contract
+name: Kernel Windows release contract
 
 on:
-  pull_request:
-    paths:
-      - ".github/workflows/kernel-windows-pr.yml"
-      - "src/lingtai/adapters/**"
-      - "src/lingtai/kernel/**"
-      - "src/lingtai/tools/daemon/**"
-      - "src/lingtai/tools/avatar/**"
-      - "src/lingtai/cli.py"
-      - "src/lingtai/agent.py"
-      - "tests/test_workdir_lease*.py"
-      - "tests/test_refresh_watcher_windows.py"
-      - "tests/test_process_scan.py"
-      - "tests/test_process_match.py"
-      - "tests/test_daemon_windows_*.py"
-      - "tests/test_avatar_launcher_windows.py"
-      - "tests/test_portable_adapter_encoding.py"
-  workflow_dispatch:
+  release:
+    types: [published]
 
 permissions:
   contents: read

--- a/.github/workflows/shell-windows-pr.yml
+++ b/.github/workflows/shell-windows-pr.yml
@@ -1,19 +1,8 @@
-name: Shell PowerShell PR contract
+name: Shell PowerShell release contract
 
 on:
-  pull_request:
-    paths:
-      - ".github/workflows/shell-windows-pr.yml"
-      - "src/lingtai/adapters/shell*.py"
-      - "src/lingtai/adapters/windows/**"
-      - "src/lingtai/tools/bash/**"
-      - "src/lingtai/tools/registry.py"
-      - "tests/test_shell_pr1_contract.py"
-      - "tests/test_shell_windows_native.py"
-      - "tests/test_windows_taskkill_fallback.py"
-      - "tests/test_windows_regression.py"
-      - "tests/test_powershell_decode_windows_output.py"
-  workflow_dispatch:
+  release:
+    types: [published]
 
 permissions:
   contents: read

--- a/scripts/check_docs_governance.py
+++ b/scripts/check_docs_governance.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Standalone docs-governance validator (not itself a hosted CI workflow —
-kernel-windows-pr.yml and shell-windows-pr.yml already run pytest on every
-pull request; this script is runnable locally/anywhere and imported by
-tests/test_docs_governance.py so pytest exercises identical logic.
+kernel-windows-pr.yml and shell-windows-pr.yml run their expensive native
+pytest tiers only on published releases; this script stays runnable locally
+and is imported by tests/test_docs_governance.py so pytest exercises identical logic.
 
 docs.yaml is mechanically authoritative. related_files.target_policy is
 owner_validated_relative_link: this checker validates syntax (non-empty,

--- a/src/lingtai/kernel/base_agent/CONTRACT.md
+++ b/src/lingtai/kernel/base_agent/CONTRACT.md
@@ -237,9 +237,10 @@ graph survives missing POSIX mechanisms — the construction-gate proof), and
 `tests/test_cli.py` (duplicate-guard policy), and
 `tests/test_aed_recovery.py` (partial-output and exhausted provider-recovery
 terminal guards before transient/AED replay). The
-Windows CI lane (`.github/workflows/kernel-windows-pr.yml`) executes the
-platform-marked tiers natively; the capability matrix cites which rows carry
-native receipts.
+Windows release CI lane (`.github/workflows/kernel-windows-pr.yml`) executes the
+platform-marked tiers natively on `release.published`; routine pull requests do
+not spend a Windows runner. The capability matrix cites which rows carry native
+receipts.
 
 ## Maintenance
 

--- a/tests/test_platform_workflow_release_gating.py
+++ b/tests/test_platform_workflow_release_gating.py
@@ -1,0 +1,22 @@
+"""Static trigger contract for expensive hosted platform checks."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = (
+    "kernel-macos-smoke-pr.yml",
+    "kernel-windows-pr.yml",
+    "shell-windows-pr.yml",
+)
+
+
+@pytest.mark.parametrize("filename", WORKFLOWS)
+def test_expensive_platform_workflow_runs_only_on_published_release(filename: str) -> None:
+    data = yaml.safe_load((REPO_ROOT / ".github" / "workflows" / filename).read_text())
+    on = data.get("on") or data.get(True)  # PyYAML YAML 1.1 `on` quirk.
+    assert on == {"release": {"types": ["published"]}}
+    assert data["name"].endswith("release contract")


### PR DESCRIPTION
## Summary

- run the native macOS smoke, native Windows kernel, and PowerShell contract workflows only on `release.published`
- remove their `pull_request` path filters and `workflow_dispatch` triggers
- retain the existing jobs unchanged, so release coverage is preserved without spending hosted runners on routine PRs
- update the two owning governance statements and add a static trigger contract test

## Why

These three hosted platform lanes cost macOS/Windows runner time on ordinary pull requests even though the project only needs the full native CI gate for releases. The main branch has no required-check branch protection or active ruleset, so removing the PR triggers does not strand pull requests in a permanently pending state.

The existing `wheels.yml` release/publishing workflow is unchanged. Its manual exact-tag recovery path remains release tooling, not a routine PR CI check.

## Validation

- `3 passed` — `tests/test_platform_workflow_release_gating.py`
- changed `src/lingtai/kernel/base_agent/CONTRACT.md` governance check: pass
- `python3 -m py_compile scripts/check_docs_governance.py tests/test_platform_workflow_release_gating.py`: pass
- `git diff --check`: pass
- GitHub main protection check: branch is not protected; active rulesets: none

Telegram: @lingtaidev3bot | Nickname: 澄一

Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
