### PR TITLE
docs(web): add crawler UA fallback guidance

### DIFF
--- a/src/lingtai/tools/web_search/manual/SKILL.md
+++ b/src/lingtai/tools/web_search/manual/SKILL.md
@@ -4,7 +4,7 @@ description: >
   One web workflow: search first, browse a known result next, and use one
   explicit legacy fallback only when static browsing cannot serve the need.
 version: 8.2.0
-last_changed_at: "2026-08-05T08:40:00-07:00"
+last_changed_at: "2026-08-24T08:27:11Z"
 related_files:
   - src/lingtai/tools/web_search/__init__.py
   - src/lingtai/tools/web_search/settings.py
@@ -268,6 +268,13 @@ for structured data, or the documented Playwright/academic references under
 `reference/`. Do not advertise or invoke a second public tool; do not silently
 chain tiers. The scripts and deeper references in this bundle are procedure
 fallbacks, not additional capabilities.
+
+When fetching a public page through a documented HTTP fallback, if the default
+`curl` request returns empty or clearly incomplete content, retry once with a
+search/AI crawler User-Agent such as `OAI-SearchBot`, `Claude-User`, or
+`Bytespider` to seek a fuller public representation. Keep this a public,
+read-only, rate-respecting fallback: do not impersonate a person, bypass a
+login, paywall, robots directive, or other access control, or chain identities.
 
 For interactive browser work that browse cannot serve — forms, logins,
 JS-heavy SPAs, uploads — see [agent-native-browser.md](./reference/agent-native-browser.md)


### PR DESCRIPTION
## Summary
- Document a one-retry public-page fallback when a default `curl` request is empty or clearly incomplete.
- Name the requested search/AI crawler User-Agent examples: `OAI-SearchBot`, `Claude-User`, and `Bytespider`.
- Keep the guidance bounded to public, read-only, rate-respecting requests; it does not authorize impersonation, chained identities, or bypassing login, paywall, robots, or access controls.

## Validation
- `git diff --check` — PASS
- `python src/lingtai/tools/skills/manual/scripts/validate.py --require-last-changed-at src/lingtai/tools/web_search/manual` — PASS (pre-existing executable-bit warnings only)
- `python -m pytest -q tests/test_skills.py::test_web_manual_is_one_top_level_catalog_entry_matching_the_tool` — PASS
- `python scripts/check_docs_governance.py --check` — blocked by existing selected-base violations outside this diff (`IMPLEMENTATION_REPORT.md`, duplicate `related_files` in `src/lingtai/kernel/llm/ANATOMY.md`, and three Feishu reference frontmatters).

Telegram: @lingtaidev2bot | Nickname: N/A
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
