### PR TITLE
fix(wechat): align iLink 2.4.6 acceptance semantics

### DIFF
--- a/src/lingtai/mcp_servers/wechat/SKILL.md
+++ b/src/lingtai/mcp_servers/wechat/SKILL.md
@@ -6,8 +6,8 @@ description: |
   reply, check/read/search, media_path attachments (image/video/voice/file),
   contacts/accounts basics, and external-delivery side-effect caveats. Pulled on
   demand via action='manual'; you do not need to call it before every send.
-version: 1.2.0
-last_changed_at: "2026-07-29T01:00:00Z"
+version: 1.3.0
+last_changed_at: "2026-08-24T17:35:00-07:00"
 related_files:
 - src/lingtai/mcp_servers/wechat/manager.py
 - src/lingtai/mcp_servers/wechat/server.py
@@ -124,6 +124,14 @@ ATTACHMENTS below), not a mutually exclusive choice.
 
 - `send` and `reply` deliver to real users — external side effects. Confirm
   recipient and content before sending unsolicited messages.
+- A successful provider response requires an explicit integer `ret: 0`. The
+  result then says `delivery_status: provider_accepted` and
+  `delivery_confirmed: false`: iLink accepted the request, but recipient delivery
+  is not proven. Do not automatically replay an accepted request.
+- For text-plus-media partial outcomes, legacy `partial_delivery: true` is only a
+  replay-compatibility flag that a recipient-visible side effect may have occurred;
+  `partial_provider_acceptance` and `delivery_confirmed: false` carry the precise
+  meaning.
 - Actions return a result dict on success or `{'error': <message>}` on failure
   (e.g. missing `user_id`, unreadable `media_path`). Check for the `'error'` key
   and surface or act on it rather than assuming delivery.

--- a/src/lingtai/mcp_servers/wechat/api.py
+++ b/src/lingtai/mcp_servers/wechat/api.py
@@ -21,12 +21,11 @@ CDN_BASE_URL = "https://novac2c.cdn.weixin.qq.com/c2c"
 DEFAULT_LONG_POLL_TIMEOUT = 35.0
 DEFAULT_SEND_TIMEOUT = 15.0
 
-# iLink protocol identity. Mirrored from Hermes/OpenClaw adapters.
-# OpenClaw reads channel_version from package.json; Hermes currently uses 2.1.3.
-# ClientVersion is 0x00MMNNPP for 2.1.3 => 131331.
-_PKG_VERSION = "2.1.3"
+# iLink protocol identity, aligned with Tencent/openclaw-weixin 2.4.6.
+# ClientVersion is 0x00MMNNPP for 2.4.6 => 132102.
+_PKG_VERSION = "2.4.6"
 _ILINK_APP_ID = "bot"
-_ILINK_APP_CLIENT_VERSION = str((2 << 16) | (1 << 8) | 3)
+_ILINK_APP_CLIENT_VERSION = str((2 << 16) | (4 << 8) | 6)
 
 
 def _ensure_trailing_slash(url: str) -> str:
@@ -69,7 +68,7 @@ def _auth_headers(token: str | None) -> dict[str, str]:
 
 
 def _base_info() -> dict:
-    return {"channel_version": _PKG_VERSION}
+    return {"channel_version": _PKG_VERSION, "bot_agent": "LingTai"}
 
 
 async def get_qrcode(base_url: str = DEFAULT_BASE_URL) -> dict:
@@ -160,16 +159,11 @@ async def send_message(
     base_url: str,
     token: str,
     msg: WeixinMessage,
-) -> None:
-    """Send a message (text or media).
+) -> dict[str, int]:
+    """Submit one recipient-visible request and return a safe provider ack.
 
-    iLink occasionally returns HTTP 200 with a JSON body whose ``ret`` or
-    ``errcode`` indicates a logical failure (e.g. session expired,
-    rate-limited, malformed payload, target user blocked). The previous
-    implementation accepted any 2xx and silently let those reports bubble
-    up as success. Now we parse the body when it's JSON and raise on
-    obvious error fields so the caller can react instead of pretending
-    the send went through.
+    Success requires an explicit non-boolean integer ``ret == 0``.  This is
+    provider acceptance only; it does not confirm recipient delivery.
     """
     url = _ensure_trailing_slash(base_url) + "ilink/bot/sendmessage"
     body = {
@@ -184,31 +178,42 @@ async def send_message(
             timeout=DEFAULT_SEND_TIMEOUT,
         )
         resp.raise_for_status()
-        _raise_on_ilink_error(resp, "send_message")
+        return _parse_send_acknowledgement(resp)
 
 
-def _raise_on_ilink_error(resp: "httpx.Response", op: str) -> None:
-    """Raise if an iLink JSON response carries a non-zero ret/errcode.
+def _ack_code(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
 
-    HTTP 200 with ``ret != 0`` or ``errcode != 0`` is iLink's documented
-    way to report logical errors while keeping the transport layer happy.
-    Tolerant of non-JSON bodies — many CDN responses are plain text.
-    """
-    raw = resp.text
-    if not raw or not raw.strip().startswith("{"):
-        return
+
+def _parse_send_acknowledgement(resp: "httpx.Response") -> dict[str, int]:
+    """Require a strict JSON-object acknowledgement with explicit ``ret=0``."""
+    if not resp.text.strip():
+        raise RuntimeError("iLink send_message returned an empty response")
     try:
         body = resp.json()
-    except Exception:
-        return
+    except ValueError as exc:
+        raise RuntimeError("iLink send_message returned malformed JSON") from exc
+    if not isinstance(body, dict):
+        raise RuntimeError("iLink send_message returned non-object JSON")
+
     ret = body.get("ret")
-    errcode = body.get("errcode")
-    errmsg = body.get("errmsg")
-    if (ret is not None and ret != 0) or (errcode is not None and errcode != 0):
+    if not _ack_code(ret) or ret != 0:
+        detail = ret if _ack_code(ret) else "<missing-or-invalid>"
         raise RuntimeError(
-            f"iLink {op} reported logical error: "
-            f"ret={ret} errcode={errcode} errmsg={errmsg!r}"
+            f"iLink send_message returned invalid acknowledgement: ret={detail}"
         )
+
+    ack = {"ret": 0}
+    if "errcode" in body:
+        errcode = body.get("errcode")
+        if not _ack_code(errcode) or errcode != 0:
+            detail = errcode if _ack_code(errcode) else "<invalid>"
+            raise RuntimeError(
+                "iLink send_message returned invalid acknowledgement: "
+                f"errcode={detail}"
+            )
+        ack["errcode"] = 0
+    return ack
 
 
 async def get_upload_url(

--- a/src/lingtai/mcp_servers/wechat/manager.py
+++ b/src/lingtai/mcp_servers/wechat/manager.py
@@ -587,8 +587,27 @@ class WechatManager:
                 return {"error": f"File not found: {media_path}"}
 
         results = []
+        provider_acks: list[dict[str, int]] = []
 
-        def _persist_sent(status: str = "ok", media_error: dict | None = None) -> str:
+        def _acceptance_fields(*, partial: bool = False) -> dict:
+            return {
+                "delivery_status": (
+                    "partial_provider_acceptance" if partial
+                    else "provider_accepted"
+                ),
+                "delivery_confirmed": False,
+                "automatic_retry_allowed": False,
+                "provider_acknowledgement": {
+                    "request_count": len(provider_acks),
+                    "last_response": provider_acks[-1],
+                },
+            }
+
+        def _persist_sent(
+            status: str = "ok",
+            media_error: dict | None = None,
+            acceptance: dict | None = None,
+        ) -> str:
             """Persist an attempted outbound action for retry-safe inspection."""
             msg_id = str(uuid.uuid4())
             msg_dir = self._sent_dir / msg_id
@@ -603,6 +622,8 @@ class WechatManager:
             }
             if media_error is not None:
                 sent_data["media_error"] = media_error
+            if acceptance is not None:
+                sent_data.update(acceptance)
             (msg_dir / "message.json").write_text(
                 json.dumps(sent_data, ensure_ascii=False, indent=2), encoding="utf-8",
             )
@@ -618,10 +639,14 @@ class WechatManager:
             result = error.as_result()
             result["sent"] = list(results)
             if text and results:
+                acceptance = _acceptance_fields(partial=True)
                 result.update({
                     "status": "partial",
+                    # Legacy replay guard: not proof of recipient delivery.
                     "partial_delivery": True,
-                    "message_id": _persist_sent("partial", result),
+                    "partial_provider_acceptance": True,
+                    "message_id": _persist_sent("partial", result, acceptance),
+                    **acceptance,
                 })
             return result
 
@@ -645,9 +670,12 @@ class WechatManager:
                         text_item=TextItem(text=chunk),
                     )],
                 )
-                self._run_async(
+                acknowledgement = self._run_async(
                     api.send_message(self._base_url, self._token, msg)
                 )
+                if not isinstance(acknowledgement, dict):
+                    raise RuntimeError("iLink send_message returned no acknowledgement")
+                provider_acks.append(acknowledgement)
                 results.append(f"text ({len(chunk)} chars)")
 
         # Send media (already validated above)
@@ -671,17 +699,26 @@ class WechatManager:
                 item_list=[media_item],
             )
             try:
-                self._run_async(
+                acknowledgement = self._run_async(
                     api.send_message(self._base_url, self._token, msg)
                 )
+                if not isinstance(acknowledgement, dict):
+                    raise RuntimeError("iLink send_message returned no acknowledgement")
+                provider_acks.append(acknowledgement)
             except Exception as exc:
                 return _media_failure(media_mod.media_upload_error(
                     "send_media_reference_failed", self._base_url, exc
                 ))
             results.append(f"media ({path.name})")
 
-        msg_id = _persist_sent()
-        return {"status": "ok", "sent": results, "message_id": msg_id}
+        acceptance = _acceptance_fields()
+        msg_id = _persist_sent(acceptance=acceptance)
+        return {
+            "status": "ok",
+            "sent": results,
+            "message_id": msg_id,
+            **acceptance,
+        }
 
     def _handle_check(self, args: dict) -> dict:
         """List conversations with unread counts.

--- a/tests/test_outbound_file_containment.py
+++ b/tests/test_outbound_file_containment.py
@@ -296,6 +296,7 @@ def test_wechat_send_accepts_media_path_inside_workdir(tmp_path, monkeypatch):
 
     async def _fake_send_message(*args, **kwargs):
         seen["sent"] = True
+        return {"ret": 0}
 
     monkeypatch.setattr(wx_media, "upload_media", _fake_upload)
     monkeypatch.setattr(

--- a/tests/test_wechat_media_upload_diagnostics.py
+++ b/tests/test_wechat_media_upload_diagnostics.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from pathlib import Path
 
 import httpx
@@ -9,13 +10,90 @@ import pytest
 
 from lingtai.mcp_servers.wechat import api, media
 from lingtai.mcp_servers.wechat.manager import WechatManager
-from lingtai.mcp_servers.wechat.types import GetUploadUrlResp
+from lingtai.mcp_servers.wechat.types import GetUploadUrlResp, WeixinMessage
 
 
 BASE_URL = "https://ilink.example.test"
 PRESIGNED_URL = (
     "https://cdn.example.test/upload?token=secret-token&signature=secret-signature"
 )
+
+
+
+def _send_response(content: bytes) -> httpx.Response:
+    return httpx.Response(
+        200,
+        content=content,
+        request=httpx.Request("POST", f"{BASE_URL}/ilink/bot/sendmessage"),
+    )
+
+
+def test_send_message_uses_tencent_246_identity_and_safe_acceptance(monkeypatch) -> None:
+    captured = {}
+
+    class FakeClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+        async def post(self, url, **kwargs):
+            captured.update({"url": url, **kwargs})
+            return _send_response(json.dumps({
+                "ret": 0, "errcode": 0, "errmsg": "ok", "private": "drop"
+            }).encode("utf-8"))
+
+    monkeypatch.setattr(api.httpx, "AsyncClient", FakeClient)
+    ack = asyncio.run(api.send_message(
+        BASE_URL, "test-token",
+        WeixinMessage(to_user_id="wxid-recipient", client_id="client-id"),
+    ))
+
+    assert captured["json"]["base_info"] == {
+        "channel_version": "2.4.6", "bot_agent": "LingTai"
+    }
+    assert captured["headers"]["iLink-App-ClientVersion"] == "132102"
+    assert ack == {"ret": 0, "errcode": 0}
+
+
+@pytest.mark.parametrize("body", [
+    {}, {"ret": None}, {"errcode": 0}, {"ret": "0"}, {"ret": True},
+    {"ret": 17}, {"ret": 0, "errcode": 9},
+])
+def test_send_ack_requires_explicit_integer_zero_ret(body: dict) -> None:
+    response = _send_response(json.dumps(body).encode("utf-8"))
+    with pytest.raises(RuntimeError, match="invalid acknowledgement"):
+        api._parse_send_acknowledgement(response)
+
+
+@pytest.mark.parametrize("content", [b"", b"not-json", b"[]"])
+def test_send_ack_rejects_empty_malformed_or_nonobject(content: bytes) -> None:
+    with pytest.raises(RuntimeError):
+        api._parse_send_acknowledgement(_send_response(content))
+
+
+def test_public_send_result_is_acceptance_not_delivery(monkeypatch, tmp_path: Path) -> None:
+    manager = WechatManager(
+        token="test-token", user_id="test-bot", working_dir=tmp_path,
+        on_inbound=lambda event: None,
+    )
+
+    async def accept(*args, **kwargs):
+        return {"ret": 0}
+
+    monkeypatch.setattr(api, "send_message", accept)
+    monkeypatch.setattr(manager, "_run_async", asyncio.run)
+    result = manager._handle_send({"user_id": "wxid-recipient", "text": "hello"})
+
+    assert result["status"] == "ok"
+    assert result["delivery_status"] == "provider_accepted"
+    assert result["delivery_confirmed"] is False
+    assert result["automatic_retry_allowed"] is False
+    stored = (tmp_path / "wechat" / "sent" / result["message_id"] / "message.json")
+    stored_data = json.loads(stored.read_text(encoding="utf-8"))
+    assert stored_data["delivery_status"] == "provider_accepted"
+    assert stored_data["delivery_confirmed"] is False
 
 
 def test_safe_endpoint_discards_path_and_presigned_query() -> None:
@@ -97,7 +175,7 @@ def test_text_plus_media_returns_partial_result_and_persists_status(
     file_path.write_text("attachment", encoding="utf-8")
 
     async def send_text(*args, **kwargs):
-        return None
+        return {"ret": 0}
 
     async def fail_upload(*args, **kwargs):
         raise media.media_upload_error(
@@ -117,6 +195,10 @@ def test_text_plus_media_returns_partial_result_and_persists_status(
 
     assert result["status"] == "partial"
     assert result["partial_delivery"] is True
+    assert result["partial_provider_acceptance"] is True
+    assert result["delivery_status"] == "partial_provider_acceptance"
+    assert result["delivery_confirmed"] is False
+    assert result["automatic_retry_allowed"] is False
     assert result["sent"] == ["text (12 chars)"]
     assert result["stage"] == "cdn_tls_handshake_failed"
     assert result["media_upload"]["endpoint"] == "https://cdn.example.test"


### PR DESCRIPTION
## Summary

- align bundled WeChat iLink identity with Tencent/OpenClaw 2.4.6 (`channel_version`, encoded client version, and `bot_agent`)
- require an explicit integer `ret: 0` before reporting provider acceptance
- expose bounded provider-ack metadata while stating `delivery_confirmed: false` and disabling automatic replay
- document that provider acceptance is not proof of recipient delivery

## Context

The observed one-way incident returned HTTP 200 with `{ret:0}` even though the recipient did not see the message. This PR therefore does **not** claim to repair Tencent downstream delivery. It makes the protocol identity current and the result semantics honest and inspectable.

## Validation

- `30 passed` — focused acknowledgement/media/containment tests
- `169 passed` — all `tests/test_wechat_*.py`
- `38 passed` — MCP manuals + outbound containment
- `git diff --check` — pass
- added-line private path/credential scan — pass

## Out of scope

No automatic retry, merge, release, runtime deployment, account/config change, or recipient-delivery claim.
