### PR TITLE
fix(daemon): prevent Shell setup crash in detached supervisor

### DIFF
--- a/src/lingtai/kernel/daemon_supervisor/agent_stub.py
+++ b/src/lingtai/kernel/daemon_supervisor/agent_stub.py
@@ -61,5 +61,18 @@ class DaemonSupervisorAgentStub:
         if self._log_fn is not None:
             self._log_fn(event_type, **fields)
 
+    def _enqueue_system_notification(self, **_kwargs) -> None:
+        """Refuse the live-Agent notification route from detached composition.
+
+        This stand-in deliberately owns neither the parent Agent's notification
+        store nor its identity.  The detached supervisor publishes terminal
+        daemon receipts through its own daemon-channel publisher; callers that
+        request a live-Agent system notification must receive a truthful failure
+        rather than a false acknowledgement.
+        """
+        raise RuntimeError(
+            "daemon supervisor host cannot publish live-Agent system notifications"
+        )
+
 
 __all__ = ["DaemonSupervisorAgentStub"]

--- a/tests/test_daemon_detached_supervisor.py
+++ b/tests/test_daemon_detached_supervisor.py
@@ -140,6 +140,22 @@ def _spawn_lingtai_supervisor(run_dir: DaemonRunDir, *, task="say hi", timeout_s
     return proc
 
 
+def test_detached_shell_plugin_setup_does_not_require_live_agent_notification_route(tmp_path):
+    """The detached host can bind Shell without becoming a second Agent."""
+    from lingtai.kernel.daemon_supervisor.agent_stub import DaemonSupervisorAgentStub
+    from lingtai.tools.daemon import _ToolCollector
+    from lingtai.tools.registry import setup_capability
+
+    stub = DaemonSupervisorAgentStub(tmp_path)
+    collector = _ToolCollector(stub)
+    setup_capability(collector, "shell")
+
+    assert "shell" in collector.schemas
+    assert "shell" in collector.handlers
+    with pytest.raises(RuntimeError, match="cannot publish live-Agent system notifications"):
+        stub._enqueue_system_notification(source="daemon", ref_id="em-test", body="test")
+
+
 def test_supervisor_terminal_store_error_records_typed_retryable_evidence(tmp_path, monkeypatch):
     from lingtai.tools.daemon import supervisor_runtime
 


### PR DESCRIPTION
## Summary
- Give the detached daemon supervisors minimal host an explicit, truthful refusal for the live-Agent system-notification route.
- This lets Shells official tool-plugin host-port binding complete without constructing a second Agent or falsely acknowledging a notification.
- Add a focused regression that binds Shell through the real detached ToolCollector and verifies refusal remains explicit.

## Evidence
- Fixes the turn-0 `DaemonSupervisorAgentStub` AttributeError reported in #1492.
- Focused: `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=$PWD/src python3 -m pytest -q tests/test_daemon_detached_supervisor.py -k detached_shell_plugin_setup_does_not_require_live_agent_notification_route` → 1 passed, 43 deselected.
- `git diff --check` passed.

## Non-goals
No live runtime/config/auth change, no second Agent, no notification no-op, no rollout or merge.