### PR TITLE
fix(email): boot official plugin once per refresh

### DIFF
--- a/src/lingtai/agent.py
+++ b/src/lingtai/agent.py
@@ -2145,7 +2145,8 @@ class Agent(BaseAgent):
             self.override_intrinsic("soul")
             _soul.setup(self)
 
-        # Reset capability-owned flags (email.boot below resets to "email box"/"email")
+        # Reset capability-owned flags (``email.boot``, run once by
+        # ``_boot_official_intrinsics()`` below, resets to "email box"/"email")
         self._mailbox_name = "email box"
         self._mailbox_tool = "email"
         if hasattr(self, "_post_molt_hooks"):
@@ -2249,13 +2250,12 @@ class Agent(BaseAgent):
         else:
             self._summarize_notification_threshold = 3000
 
-        # Re-boot email so a fresh EmailManager + scheduler thread are wired.
-        # ``email.boot`` stops the previous manager's scheduler before
-        # starting a new one — without that, the prior daemon thread keeps
-        # polling ``mailbox/schedules/*/schedule.json`` and races the new
-        # thread, double-sending the same due tick (issue #154).
-        from lingtai.tools import email as _email
-        _email.boot(self)
+        # Email is re-booted exactly once per refresh by
+        # ``_boot_official_intrinsics()`` below, together with the other
+        # ``official_plugin`` intrinsics. The historical early ``email.boot``
+        # here (issue #154's scheduler-thread reset) is gone: the manager no
+        # longer owns a scheduler, and a second boot would repeat the
+        # manager/grant/bind/mount work for the same declaration.
 
         # Decompress addons BEFORE capability setup so the `mcp` capability
         # sees the populated registry on its first reconcile.

--- a/src/lingtai/tools/email/CONTRACT.md
+++ b/src/lingtai/tools/email/CONTRACT.md
@@ -291,11 +291,12 @@ mailbox/contacts.json                 — contact book (list of {address,name,no
 | Cross-action smuggle rejected before side effects | `tests/test_tool_family_email_migration.py::test_send_fields_cannot_be_smuggled_through_a_read_call` | Call `read` with `address`/`message` in `input` | Mail could leave the agent via a read-shaped call |
 | Email manager requests use the typed domain port and reject foreign actions | `tests/test_email_official_tool_plugin.py::test_email_runtime_port_is_domain_specific_and_rejects_foreign_action` | Bind the runtime adapter and inspect its request | A generic dispatcher leaks unrelated capability vocabulary |
 | Official Email mount creates no dynamic capability or persisted manifest row | `tests/test_email_official_tool_plugin.py::test_official_email_mount_keeps_real_agent_runtime_and_package_manual`, `::test_email_opt_out_forms_keep_one_official_surface_on_construction_and_refresh` | Inspect `_capabilities` and `_build_manifest()` after construction and refresh | Avatar replay/identity state gains a false Email capability |
+| `email.boot` runs exactly once per construction and per refresh | `tests/test_email_official_tool_plugin.py::test_email_official_boot_runs_exactly_once_per_construction_and_refresh` | Count official boots, Email registrar calls, and `EmailManager` constructions per phase | A second boot silently repeats manager/grant/bind/mount work behind one final surface |
 
 Run before merging email changes:
 
 ```bash
-python -m pytest tests/test_layers_email.py tests/test_email_identity.py tests/test_email_abs_reply_route.py tests/test_system_dismiss.py tests/test_tool_family_email_migration.py tests/test_tool_family_email_wire_parity.py -q
+python -m pytest tests/test_layers_email.py tests/test_email_identity.py tests/test_email_abs_reply_route.py tests/test_system_dismiss.py tests/test_tool_family_email_migration.py tests/test_tool_family_email_wire_parity.py tests/test_email_official_tool_plugin.py -q
 ```
 
 ## Schema and glossary ownership

--- a/tests/test_email_official_tool_plugin.py
+++ b/tests/test_email_official_tool_plugin.py
@@ -221,6 +221,78 @@ def test_email_official_adapter_reads_replaced_manager_after_refresh(email_agent
     assert replacement.calls == [{"action": "check"}]
 
 
+def test_email_official_boot_runs_exactly_once_per_construction_and_refresh(
+    tmp_path, monkeypatch
+):
+    """Each official intrinsic boots once per phase; Email registers once.
+
+    Counts every ``official_plugin`` module's ``boot`` (the seam
+    ``BaseAgent._boot_official_intrinsics`` invokes) plus Email's registrar
+    call and ``EmailManager`` construction, on construction and again on a
+    real ``_setup_from_init`` refresh. A second boot repeats the
+    manager/grant/bind/mount work while the final surface still looks
+    singular, so only the counts expose it.
+    """
+    import lingtai.tools.email as email_module
+    from lingtai.adapters import tool_plugin_host
+    from lingtai.tools.email import DECLARATION
+    from lingtai.tools.registry import INTRINSICS
+
+    boots: dict[str, int] = {}
+    email_work = {"register": 0, "manager": 0}
+
+    def _counted_boot(name, real_boot):
+        def boot(agent):
+            boots[name] = boots.get(name, 0) + 1
+            real_boot(agent)
+
+        return boot
+
+    official = [name for name, info in INTRINSICS.items() if info.get("official_plugin")]
+    assert "email" in official
+    for name in official:
+        module = INTRINSICS[name]["module"]
+        monkeypatch.setattr(module, "boot", _counted_boot(name, module.boot))
+
+    real_register = tool_plugin_host.register_agent_tool_plugins
+
+    def counted_register(agent, declarations, **kwargs):
+        if any(declaration is DECLARATION for declaration in declarations):
+            email_work["register"] += 1
+        return real_register(agent, declarations, **kwargs)
+
+    monkeypatch.setattr(tool_plugin_host, "register_agent_tool_plugins", counted_register)
+
+    class CountedEmailManager(email_module.EmailManager):
+        def __init__(self, agent):
+            email_work["manager"] += 1
+            super().__init__(agent)
+
+    monkeypatch.setattr(email_module, "EmailManager", CountedEmailManager)
+
+    workdir = tmp_path / "agent"
+    agent = Agent(
+        service=make_gemini_mock_service(),
+        agent_name="email-exact-once",
+        working_dir=workdir,
+        capabilities={},
+    )
+    try:
+        _write_refresh_init(workdir, capabilities={}, disable=None)
+        for phase in ("construction", "refresh"):
+            if phase == "refresh":
+                boots.clear()
+                email_work["register"] = email_work["manager"] = 0
+                agent._setup_from_init()
+            assert boots == {name: 1 for name in official}, phase
+            assert email_work == {"register": 1, "manager": 1}, phase
+            assert isinstance(agent._email_manager, CountedEmailManager)
+            assert agent.official_tool_plugins["email"] is DECLARATION
+            assert [schema.name for schema in agent._tool_schemas].count("email") == 1
+    finally:
+        agent.stop(timeout=1.0)
+
+
 @pytest.mark.parametrize(
     ("capabilities", "disable"),
     [


### PR DESCRIPTION
## Summary

- Remove the obsolete early refresh-local Email boot so the official intrinsic registry is the single lifecycle owner.
- Preserve normal construction, CLI deferred init, refresh manager replacement, and the one final model-facing Email surface.
- Add an exact-once construction/refresh regression and include it in the Email Contract's advertised pre-merge command.

## Validation

- Focused Email lifecycle / identity / migration / wire suite — **185 passed** (independent Terra review and parent rerun).
- Exact new lifecycle regression — pass.
- `git diff --check` — pass.

Exact base: `c3e62dea6983c04a069e95252ce077313d62562a`. No full-suite claim.

Telegram: @lingtaidev1bot | Nickname: 知微

Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
