### PR TITLE
fix(vision): dedupe presets by physical path

### DIFF
--- a/src/lingtai/tools/vision/ANATOMY.md
+++ b/src/lingtai/tools/vision/ANATOMY.md
@@ -33,30 +33,34 @@ Vision result shape.
 
 ## Components
 
-- `__init__.py:200-260` — strict declaration-owned input schemas: `analyze`
+- `__init__.py:129-144` — `_canonical_preset_path` resolves one allowed preset
+  reference (`~`, absolute, or workdir-relative spelling) to its canonical
+  physical path; `list` keys its rows on it so one file appears once.
+- `__init__.py:218-278` — strict declaration-owned input schemas: `analyze`
   requires `image_path` and nullable `question` and accepts nullable `preset`,
   `check` requires nullable `preset`, and `list` is strict empty input.
-- `__init__.py:263-361` — immutable `VisionConfiguration` (with
+- `__init__.py:281-379` — immutable `VisionConfiguration` (with
   `port_values`/`from_port_values`, the only translation to and from the kernel
   `ConfigurationPort` mapping), static description, and declaration-derived
   `_build_family`; import-time and host-bound families therefore expose the
   same three operational children plus `manual`.
-- `__init__.py:374-395` — `VisionManager` retains only the granted workdir and
+- `__init__.py:392-413` — `VisionManager` retains only the granted workdir and
   live active-provider ports, the resolved service/reason, and the installed
   manual child; it does not retain an Agent.
-- `__init__.py:401-482` — `_build_service_from_preset` checks
+- `__init__.py:419-500` — `_build_service_from_preset` checks
   `manifest.preset.allowed`, loads the authorized preset read-only, and passes
   that preset's provider/model/credential identity to the direct resolver.
-- `__init__.py:484-571` — `_dispatch_analyze` resolves relative image paths,
+- `__init__.py:502-589` — `_dispatch_analyze` resolves relative image paths,
   performs one request on either the default or explicitly borrowed service, and
   returns the exact success/error shapes.
-- `__init__.py:573-620` — `_dispatch_check` constructs/resolves the selected route
+- `__init__.py:591-638` — `_dispatch_check` constructs/resolves the selected route
   and reports provider/model without sending an image request.
-- `__init__.py:622-670` — `_dispatch_list` mechanically classifies the active route
-  and only the authorized preset definitions; it constructs no provider service.
-- `__init__.py:672-717` — `manual` reads the installed package manual through the
+- `__init__.py:640-693` — `_dispatch_list` mechanically classifies the active route
+  and only the authorized preset definitions, one row per physical preset in its
+  declared spelling; it constructs no provider service.
+- `__init__.py:695-740` — `manual` reads the installed package manual through the
   reserved child, then the host flattens its canonical body/path result once.
-- `__init__.py:721-785` — `_bind` and `DECLARATION` (with `setup` at the module
+- `__init__.py:744-808` — `_bind` and `DECLARATION` (with `setup` at the module
   tail) compose Vision through the official registrar with `workdir`,
   `active_provider`, and opaque `configuration` ports: `setup` hands the
   registrar `StaticConfigurationAdapter(VisionConfiguration(...).port_values())`

--- a/src/lingtai/tools/vision/__init__.py
+++ b/src/lingtai/tools/vision/__init__.py
@@ -126,6 +126,24 @@ def _responses_vision(provider: str | None) -> bool:
     return bool(provider and provider.lower() in _CODEX_FAMILY)
 
 
+def _canonical_preset_path(ref: str, working_dir: Path) -> str:
+    """Return the canonical physical path a preset reference denotes.
+
+    ``~/x.json``, its expanded absolute spelling, and a working-dir-relative
+    spelling all name one file, so ``list`` keys its rows on this value (the
+    same normalization the kernel's allowed-preset membership test applies).
+    A reference that cannot be resolved keys on its own spelling: it is never
+    dropped here, and it stays exactly as authorization-bounded as before.
+    """
+    try:
+        path = Path(ref).expanduser()
+        if not path.is_absolute():
+            path = Path(working_dir) / path
+        return str(path.resolve(strict=False))
+    except (ValueError, OSError, RuntimeError):
+        return ref
+
+
 def _normalize_codex_auth_path(raw: object) -> str | None:
     """Return a trimmed nonblank Codex auth path, or ``None``.
 
@@ -622,7 +640,7 @@ class VisionManager:
     def _dispatch_list(self, action_input: Mapping[str, Any]) -> dict[str, Any]:
         # mechanical enumeration; never constructs a service or makes a provider call
         import json as _json
-        from lingtai.kernel.presets import load_preset, resolve_allowed_presets
+        from lingtai.kernel.presets import load_preset
 
         active_service = self._active_provider.service
         active_provider = getattr(active_service, "provider", None)
@@ -642,10 +660,15 @@ class VisionManager:
             try:
                 init_data = _json.loads(init_path.read_text(encoding="utf-8"))
                 manifest = init_data.get("manifest") or {}
-                allowed = sorted(
-                    {str(p) for p in resolve_allowed_presets(manifest, self._workdir.path)}
-                    | {str(p) for p in (manifest.get("preset", {}).get("allowed") or [])}
-                )
+                # One row per physical preset. A raw ``~/x.json`` entry and
+                # its expanded absolute path are the same file, so key on the
+                # canonical path and keep the first declared spelling, which
+                # is exactly what ``analyze``/``check`` accept as ``preset``.
+                by_path: dict[str, str] = {}
+                for ref in manifest.get("preset", {}).get("allowed") or []:
+                    if isinstance(ref, str) and ref:
+                        by_path.setdefault(_canonical_preset_path(ref, self._workdir.path), ref)
+                allowed = sorted(by_path.values())
             except Exception:
                 allowed = []
         presets: list[dict[str, Any]] = []

--- a/tests/test_tool_family_vision_migration.py
+++ b/tests/test_tool_family_vision_migration.py
@@ -1111,6 +1111,65 @@ def test_list_action_enumerates_default_route_and_vision_capable_presets(tmp_pat
     assert result["count"] == 1
 
 
+def test_list_action_dedupes_tilde_and_absolute_aliases_of_one_preset(
+    tmp_path, monkeypatch
+):
+    """One physical allowed preset is one ``list`` row, however it is spelled.
+
+    Production allowlists use ``~/...`` spellings. ``list`` must not report the
+    raw ``~`` reference and its expanded absolute path as two presets (12
+    declared presets were enumerated as 24 rows), nor double-count an operator
+    who lists the same file under both spellings. Rows keep the declared
+    manifest spelling, which is exactly what ``analyze``/``check`` accept.
+    """
+    home = tmp_path / "home"
+    preset = home / "presets" / "codex-pool.json"
+    preset.parent.mkdir(parents=True)
+    preset.write_text(
+        """{
+          "name": "codex-pool",
+          "description": {"summary": "fixture preset with gpt-5.6 vision"},
+          "manifest": {
+            "llm": {"provider": "codex-pool", "model": "gpt-5.6"},
+            "capabilities": {"vision": {"provider": "codex-pool"}}
+          }
+        }
+        """,
+        encoding="utf-8",
+    )
+    # ``Path.expanduser`` reads HOME on POSIX and USERPROFILE on Windows.
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    tilde_ref = "~/presets/codex-pool.json"
+    assert Path(tilde_ref).expanduser() == preset
+    manifest = {"preset": {"allowed": [tilde_ref, str(preset)]}}
+    (tmp_path / "init.json").write_text(
+        '{"manifest": ' + __import__("json").dumps(manifest) + "}",
+        encoding="utf-8",
+    )
+    agent = _StubAgent(tmp_path)
+    agent.service = MagicMock()
+    agent.service.provider = "codex"
+    agent.service._model = "gpt-5.5"
+    mgr = _bound_manager(agent, service=None)
+
+    with patch("lingtai.services.vision.create_vision_service") as mock_factory:
+        result = mgr.handle(
+            {"action": "list", "input": {}, "reasoning": "enumerate vision routes"}
+        )
+    mock_factory.assert_not_called()
+
+    assert result["status"] == "ok"
+    assert result["count"] == 1
+    assert len(result["presets"]) == 1
+    entry = result["presets"][0]
+    # The surviving row is the first declared spelling of that physical file.
+    assert entry["preset"] == tilde_ref
+    assert entry["provider"] == "codex-pool"
+    assert entry["model"] == "gpt-5.6"
+    assert entry["endpoint"] == "responses"
+
+
 @pytest.mark.parametrize(
     ("provider", "expected_endpoint", "expected_responses"),
     [


### PR DESCRIPTION
## Summary

- Canonicalize allowed Vision preset paths by physical path before list aggregation.
- Deduplicate tilde, absolute, relative, and symlink aliases while preserving the first declared usable spelling.
- Keep deterministic output order and existing fail-closed behavior for missing, malformed, or wrong-extension entries.
- Document the normalization and presentation contract in the owning Anatomy.

## Validation

- `tests/test_tool_family_vision_migration.py` — **66 passed** (independent Terra review and parent rerun).
- Independent temporary probes covered alias directions, symlinks, stable order, retained spelling, and unusable entries.
- `git diff --check` — pass.

Exact base: `c3e62dea6983c04a069e95252ce077313d62562a`. No full-suite claim.

Telegram: @lingtaidev1bot | Nickname: 知微

Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
