### PR TITLE
test(daemon): align fixtures with dispatch contracts

### DIFF
--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -2848,6 +2848,9 @@ def test_crash_after_publish_before_receipt_retry_is_idempotent(tmp_path):
         terminal_notified=False,
     )
     workdir = tmp_path / "daemon-agent"
+    # A per-run daemon append must carry its daemon id so the Store routes it
+    # to the run's own `.notification/daemon/<id>.json` mini-file, exactly as
+    # the production terminal publishers stamp it.
     submit(
         store_agent_for(workdir),
         "daemon",
@@ -2855,6 +2858,7 @@ def test_crash_after_publish_before_receipt_retry_is_idempotent(tmp_path):
         icon="🔔",
         priority="normal",
         data={
+            "daemon_id": "em-crash",
             "events": [{
                 "event_id": "evt_existing",
                 "source": "daemon",
@@ -2866,6 +2870,10 @@ def test_crash_after_publish_before_receipt_retry_is_idempotent(tmp_path):
         },
     )
 
+    # Startup recovery retries only explicitly pending markers, never a
+    # lifetime scan of run directories; the crash left this one pending.
+    from lingtai.kernel.daemon_dispatch import mark_pending_terminal_notification
+    mark_pending_terminal_notification(workdir, "em-crash")
     agent = _make_agent(tmp_path, ["daemon"])
 
     events = snapshot_notifications(agent._working_dir)["daemon"]["data"]["events"]
@@ -3684,7 +3692,10 @@ def test_emanate_without_preset_persists_the_detached_effective_model(tmp_path, 
 
 def test_emanate_without_preset_inherits_parent(tmp_path, monkeypatch):
     """Omitted preset inherits parent effective identity without allowlist reads."""
-    agent = _make_agent(tmp_path, ["file", "daemon"])
+    # Disable the resident central manager so dispatch goes through the
+    # patched supervisor adapter below instead of enqueueing to a real
+    # manager process the fake owner would never observe.
+    agent = _make_agent(tmp_path, {"daemon": {"manager_pool_size": 0}, "file": {}})
     agent.service.provider = "anthropic"
     agent.service.model = "claude-opus-4-8"
     agent.service._base_url = "https://api.anthropic.com"

--- a/tests/test_daemon_detached_supervisor.py
+++ b/tests/test_daemon_detached_supervisor.py
@@ -298,9 +298,17 @@ def test_parent_pool_and_cli_procs_never_track_detached_run(tmp_path):
 def test_fresh_manager_lists_and_checks_detached_run_after_registry_reset(tmp_path):
     """Acceptance test 3: fresh manager (empty in-memory registry) still sees the run."""
     from lingtai.tools import daemon as daemon_module
+    from lingtai.kernel.daemon_dispatch import append_dispatch
     from types import SimpleNamespace
 
     run_dir = _make_run_dir(tmp_path, task="say hi", timeout_s=30.0)
+    # `list` reads accepted dispatch records, never a directory scan; commit
+    # this run to the ledger before launch exactly as the parent manager does.
+    append_dispatch(
+        run_dir.path.parent.parent,
+        run_id=run_dir.run_id,
+        created_at=run_dir.state_snapshot()["started_at"],
+    )
     proc = _spawn_lingtai_supervisor(run_dir, task="say hi", timeout_s=30.0)
     try:
         _poll_until(lambda: _disk_state(run_dir).get("state") == "done", timeout=20.0)
@@ -321,8 +329,7 @@ def test_fresh_manager_lists_and_checks_detached_run_after_registry_reset(tmp_pa
         ids = [e.get("id") or e.get("run_id") for e in listing.get("emanations", listing.get("data", {}).get("emanations", []) if isinstance(listing.get("data"), dict) else [])]
         # _handle_list's exact top-level shape is exercised by other tests;
         # here we only need proof the run is discoverable post-refresh.
-        found = "em-test" in json.dumps(listing)
-        assert found
+        assert "em-test" in ids
     finally:
         if proc.poll() is None:
             proc.terminate()


### PR DESCRIPTION
## Summary

- Align crash-recovery fixtures with per-run daemon notification routing and the marker-only terminal recovery contract.
- Route the patched classic supervisor test explicitly with `manager_pool_size=0`.
- Add the accepted dispatch-ledger record required by a fresh manager's list projection.
- Tighten detached-run list membership to assert the structured emanation IDs rather than a raw JSON substring.

## Validation

- Four repaired fixture tests plus five #1497 runtime-identity/direct-route controls — **9 passed** in the parent gate.
- `git diff --check` — pass.
- Broader `tests/test_daemon_central_manager.py`: **16 passed / 4 failed**; the four failures are pre-existing legacy `system.json` notification-location expectations and are outside these two test-only files.

Exact base: `c3e62dea6983c04a069e95252ce077313d62562a`. Production code is unchanged; no full-suite claim.

Telegram: @lingtaidev1bot | Nickname: 知微

Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
