### PR TITLE
docs(kernel): correct 1.0.3 post-tag migration guidance

### DIFF
--- a/migration/migration.md
+++ b/migration/migration.md
@@ -1,8 +1,8 @@
 ---
 product: kernel
-release_version: "1.0.0"
-release_tag: "v1.0.0"
-migration: no-op
+release_version: "1.0.3"
+release_tag: "v1.0.3"
+migration: manual
 refresh_required: true
 related_files:
   - RELEASING.md
@@ -17,18 +17,34 @@ maintenance: |
   per-release versions. Never append a second release history here or invent a
   version that disagrees with package metadata.
 ---
-# LingTai kernel 1.0.0 migration
+# LingTai kernel 1.0.3 post-tag corrective migration
 
 ## Applies when
 
-The target kernel release is `1.0.0` / tag `v1.0.0` and that tag lies in the
+The target kernel release is `1.0.3` / tag `v1.0.3` and that tag lies in the
 open update interval `(current, target]`.
 
-## Migration
+## Post-tag provenance
 
-**No configuration rewrite.** This release contains kernel/backend feature and
-maintenance changes, but does not change an agent workdir, preset, `init.json`,
-or another kernel-owned on-disk configuration shape.
+`v1.0.3` was already cut and retained stale migration text. This stable-path
+main-branch correction must not be represented as content of `v1.0.3`.
+Do not move or recreate `v1.0.3`. This document does not establish a corrected
+publication.
+
+## Conditional migration
+
+If an existing `init.json` has
+`manifest.capabilities.daemon.max_emanations`, daemon capability setup can be
+skipped after upgrade because `max_emanations` was removed before `1.0.3`.
+The configuration owner must choose explicitly:
+
+1. Remove `max_emanations` and accept the current default
+   `manager_pool_size=100`.
+2. Remove `max_emanations` and deliberately set an appropriate
+   `manager_pool_size`.
+
+These controls are not a 1:1 mapping; no automatic conversion exists. If this
+legacy key is absent, leave existing configuration unchanged.
 
 Before mutation, confirm that the installer selected the intended
 `LINGTAI_RUNTIME_PYTHON`. If more than one LingTai runtime is present, rerun with
@@ -39,8 +55,10 @@ user machine, and do not use PyPI metadata to choose the release version.
 
 ## Validate
 
-- Do not rewrite agent configuration for this kernel migration.
-- Confirm this file was read from the kernel repository at exact tag `v0.19.5`.
+- Treat this stable-path document as a post-tag correction, not a `v1.0.3` tag
+  snapshot.
+- If the legacy key is present, verify it was removed and that the selected
+  `manager_pool_size` choice is intentional.
 - Verify `lingtai.__version__`, `lingtai.__file__`, and
   `lingtai.kernel.__file__` from the selected runtime interpreter after install.
 - If the product, version, tag, stable path, mirror content, or artifact hash does
@@ -52,4 +70,4 @@ user machine, and do not use PyPI metadata to choose the release version.
 The verified wheel changes bytes on disk but a running agent still has the old
 code loaded. After active work is checkpointed and refresh is authorized, call
 `system(action='refresh')` and verify the new process uses the selected
-interpreter and reports `0.19.5`.
+interpreter and reports `1.0.3`.

--- a/tests/test_kernel_update_contract.py
+++ b/tests/test_kernel_update_contract.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 
+_MIGRATION = ROOT / "migration/migration.md"
 _SUBSTRATE = ROOT / "src/lingtai/prompts/substrate/substrate.md"
 _CHANNEL_MODEL = ROOT / "src/lingtai/tools/notification/manual/reference/channel-model/SKILL.md"
 _RUNTIME_UPDATE = ROOT / "src/lingtai/intrinsic_skills/system-manual/reference/runtime-update-checks/SKILL.md"
@@ -18,7 +19,10 @@ def _frontmatter(path: Path) -> dict[str, str]:
     assert match, f"{path} has no YAML frontmatter"
     values: dict[str, str] = {}
     for line in match.group(1).splitlines():
-        parsed = re.match(r"^(release_version|release_tag):\s*[\"']?([^\"']+?)[\"']?\s*$", line)
+        parsed = re.match(
+            r"^(release_version|release_tag|migration):\s*[\"']?([^\"']+?)[\"']?\s*$",
+            line,
+        )
         if parsed:
             values[parsed.group(1)] = parsed.group(2)
     return values
@@ -27,9 +31,39 @@ def _frontmatter(path: Path) -> dict[str, str]:
 def test_migration_frontmatter_matches_authoritative_package_version_and_tag():
     package = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
     version = package["project"]["version"]
-    metadata = _frontmatter(ROOT / "migration/migration.md")
+    metadata = _frontmatter(_MIGRATION)
     assert metadata["release_version"] == version
     assert metadata["release_tag"] == f"v{version}"
+
+
+def test_migration_is_a_post_tag_manual_correction_for_legacy_daemon_config():
+    package = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    version = package["project"]["version"]
+    tag = f"v{version}"
+    document = _MIGRATION.read_text(encoding="utf-8")
+    body = " ".join(document.split())
+    metadata = _frontmatter(_MIGRATION)
+
+    assert metadata["migration"] == "manual"
+    assert metadata["migration"] != "no-op"
+    assert "**No configuration rewrite.**" not in body
+    assert f"# LingTai kernel {version} post-tag corrective migration" in body
+    assert f"The target kernel release is `{version}` / tag `{tag}`" in body
+    assert "`1.0.0`" not in body
+    assert "`v1.0.0`" not in body
+    assert "`v0.19.5`" not in body
+    assert "`0.19.5`" not in body
+    assert f"`{tag}` was already cut and retained stale migration text." in body
+    assert f"must not be represented as content of `{tag}`." in body
+    assert f"Do not move or recreate `{tag}`." in body
+    assert "This document does not establish a corrected publication." in body
+    assert "`manifest.capabilities.daemon.max_emanations`" in body
+    assert f"`max_emanations` was removed before `{version}`." in body
+    assert "daemon capability setup can be skipped after upgrade" in body
+    assert "`manager_pool_size=100`" in body
+    assert "not a 1:1 mapping; no automatic conversion exists." in body
+    assert "If this legacy key is absent, leave existing configuration unchanged." in body
+    assert f"interpreter and reports `{version}`." in body
 
 
 def test_kernel_update_guidance_uses_only_the_installer_route():


### PR DESCRIPTION
## Summary

- Replace the false v1.0.3 no-op migration claim with a manual, conditional migration for legacy `manifest.capabilities.daemon.max_emanations` configuration.
- Tell affected config owners to remove the retired key and either accept the current `manager_pool_size=100` default or deliberately choose an appropriate value; there is no automatic 1:1 conversion.
- Mark this stable-path document as a post-tag main-branch correction. The immutable `v1.0.3` tag still contains stale migration bytes; this PR does not move/recreate the tag or publish a corrected release.
- Add direct contract coverage for version/body consistency, legacy-key guidance, no-op prohibition, and immutable-tag provenance.

## Validation

- `tests/test_kernel_update_contract.py` — **5 passed** (repair run and parent rerun).
- `git diff --check` — pass.
- Repository-wide docs governance / architecture checks still report exact-base failures in unrelated unchanged files (IMPLEMENTATION_REPORT, kernel LLM Anatomy, Feishu references, and Bash ownership graph); none is introduced by this two-file diff.

Exact base: `c3e62dea6983c04a069e95252ce077313d62562a`. No release, tag, publication, or full-suite claim.

Telegram: @lingtaidev1bot | Nickname: 知微

Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
