### PR TITLE
docs(daemon): timestamp dispatch ledger manual

### DIFF
--- a/src/lingtai/tools/daemon/manual/reference/dispatch-ledger/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/dispatch-ledger/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: daemon-dispatch-ledger
 version: 0.1.0
+last_changed_at: 2026-08-25T06:09:40Z
 related_files:
 - src/lingtai/tools/daemon/manual/SKILL.md
 - src/lingtai/tools/daemon/CONTRACT.md


### PR DESCRIPTION
## Summary

- Add the missing ISO-8601 UTC `last_changed_at` frontmatter field to the daemon dispatch-ledger reference manual.
- Keep the manual body byte-identical and isolate this metadata repair from the Tools inventory and TP002 regression PRs.

## Validation

- Target frontmatter PyYAML parse + UTC timestamp assertion — pass.
- Target-only docs governance check — pass.
- `tests/test_skills.py::test_lingtai_owned_skill_frontmatter_has_last_changed_at` — **1 passed**.
- `git diff --check` — pass.
- The generic skill validator still reports the pre-existing missing `description` field; repository-wide docs governance still reports unrelated exact-base paths. Neither is introduced by this one-line diff.

Exact base: `c3e62dea6983c04a069e95252ce077313d62562a`. No body, runtime, config, or full-suite change.

Telegram: @lingtaidev1bot | Nickname: 知微

Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
