### PR TITLE
test(plugin): cover registrar and refresh contracts

### DIFF
--- a/src/lingtai/kernel/tool_plugin/BEHAVIORS.md
+++ b/src/lingtai/kernel/tool_plugin/BEHAVIORS.md
@@ -30,6 +30,7 @@ related_files:
   - src/lingtai/tools/web_search/manual/SKILL.md
   - src/lingtai/kernel/notifications.py
   - tests/test_tool_plugin_declaration.py
+  - tests/test_deep_refresh.py
   - tests/test_tool_family_avatar_migration.py
   - tests/test_context_declared_tool_plugin.py
   - tests/test_daemon.py
@@ -349,8 +350,7 @@ writes.
 
 - **id**: TP002
 - **title**: a reserved official name is claimed once and a conflict is refused before any bind or mount
-- **guards**: `declared-host-tool-plugin` §
-  [Contract rules](CONTRACT.md#contract-rules)
+- **guards**: `declared-host-tool-plugin` § [Contract rules](CONTRACT.md#contract-rules)
 - **runner**: any LingTai agent with `shell` and `file` access to a clean
   checkout of the `lingtai-kernel` repository
 - **prerequisites**: a clean checkout; a working `.venv/`
@@ -358,143 +358,66 @@ writes.
 
 ### Steps
 
-1. Read the kernel-owned reserved list and confirm it holds names only:
+1. Read `register_official_tool_plugins` in
+   `src/lingtai/kernel/tool_plugin/__init__.py`. Confirm its whole-batch name
+   preflight completes before the registration loop can grant a host, bind,
+   activate, mount, or claim a declaration.
 
-   ```bash
-   grep -n "OFFICIAL_TOOL_PLUGIN_NAMES" src/lingtai/kernel/tool_plugin/__init__.py
-   ```
-
-   Expect the module docstring, `__all__`, module-level tuple, and registrar check/error as the relevant matches.
-   Confirm the literal is exactly `('mcp', 'avatar', 'context', 'daemon',
-   'email', 'file', 'plugin', 'notification', 'shell', 'soul', 'system',
-   'task_card', 'vision', 'web')` in that order and contains bare names only —
-   no module path, import, or family behavior.
-
-2. Prove a conflicting declaration is refused with nothing bound and nothing
-   mounted:
+2. Run the direct preflight regression:
 
    ```bash
    PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -q -p no:cacheprovider \
-     tests/test_tool_plugin_declaration.py::test_unreserved_name_is_refused_before_any_bind_or_mount \
-     tests/test_tool_plugin_declaration.py::test_duplicate_name_in_one_batch_is_refused_before_any_mount \
-     tests/test_tool_plugin_declaration.py::test_a_second_different_declaration_cannot_take_a_claimed_name \
-     tests/test_tool_plugin_declaration.py::test_repeat_registration_of_the_same_declaration_is_idempotent \
-     tests/test_tool_plugin_declaration.py::test_activation_runs_before_mount_and_only_after_the_name_checks
+     tests/test_tool_plugin_declaration.py::test_registrar_refuses_unreserved_duplicate_and_claimed_names_before_any_bind_or_mount
    ```
 
-   Expect `5 passed`.
+   Expect the selected test to pass. It refuses an unreserved name, an in-batch
+   duplicate, and a different declaration against a live claim while preserving
+   the call record, mounted transactions, and claim map.
 
-3. Prove the refusal reaches a live agent's tool surface, including the
-   review's forged transaction and mutable-claim-map attempts:
+3. Run the direct ordering, issuance, idempotency, and limited-atomicity
+   regression:
 
    ```bash
    PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -q -p no:cacheprovider \
-     tests/test_tool_plugin_declaration.py::test_boot_claims_the_official_name_and_mounts_exactly_one_mcp_tool \
-     tests/test_tool_plugin_declaration.py::test_a_foreign_declaration_cannot_take_the_live_mcp_name \
-     tests/test_tool_plugin_declaration.py::test_registration_after_the_tool_surface_is_sealed_raises \
-     tests/test_tool_plugin_declaration.py::test_public_mount_bypass_cannot_publish_a_foreign_bound_plugin \
-     tests/test_tool_plugin_declaration.py::test_a_constructed_transaction_cannot_replace_the_canonical_mcp_binding \
-     tests/test_tool_plugin_declaration.py::test_clearing_the_backing_claim_cannot_admit_a_foreign_declaration \
-     tests/test_tool_plugin_declaration.py::test_public_claim_view_cannot_clear_the_live_claim_or_admit_a_foreign_declaration
+     tests/test_tool_plugin_declaration.py::test_registrar_binds_then_activates_then_mounts_and_scopes_atomicity_to_names
    ```
 
-   Expect `7 passed`: boot claims the official name, foreign registration and
-   post-seal registration are refused, an arbitrary bound plugin and a directly
-   constructed transaction cannot replace handler/schema/claim, clearing the
-   mutable backing map cannot admit a foreign declaration, and the public claim
-   view cannot be used to unlock one. The provenance promise is for ordinary
-   public/declared and extension paths; Python trusted internals are not an
-   absolute security boundary.
+   Expect the selected test to pass. `bind()` alone is side-effect-free; a
+   successful member runs bind → activate → mount → claim; the same declaration
+   object can be registered again through that controlled route; and the
+   registrar alone issues the transaction carrying its exact bound result. A
+   later host-port failure propagates after retaining the earlier mount and
+   claim, so atomicity applies only to name checks.
 
-4. Prove the whole reserved namespace still mounts exactly once together:
+4. Run the refresh-owner regression for the opt-in Web surface:
 
    ```bash
    PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -q -p no:cacheprovider \
-     tests/test_tool_plugin_declaration.py::test_all_fourteen_official_families_mount_exactly_once_together
+     tests/test_deep_refresh.py::test_deep_refresh_drops_and_reclaims_web_official_surface
    ```
 
-   Expect `1 passed`: every name in `OFFICIAL_TOOL_PLUGIN_NAMES` is claimed by
-   one declaration and appears exactly once in the live schema list, with no
-   family displacing another.
-
-5. Confirm the registrar's ordering is structural, not incidental: read
-   `register_official_tool_plugins` in
-   `src/lingtai/kernel/tool_plugin/__init__.py` and verify the name-checking
-   loop over the whole batch completes before the second loop performs the
-   first `ToolPluginHost.grant` / `bind` / `activate` / `mount_tool`; verify
-   issuance records the exact bind result and claims receive only the mounted
-   transaction.
-
-6. Prove the refusal is *observable* — that it fails the boot instead of being
-   absorbed as a skipped capability:
-
-   ```bash
-   grep -n "class ToolPluginError" src/lingtai/kernel/tool_plugin/__init__.py
-   grep -n "except (ValueError, ImportError, TypeError)" src/lingtai/agent.py
-   PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -q -p no:cacheprovider \
-     tests/test_tool_plugin_declaration.py::test_an_official_name_conflict_is_not_swallowed_as_capability_skipped \
-     tests/test_tool_plugin_declaration.py::test_an_unreserved_official_name_fails_the_boot_rather_than_skipping_mcp \
-     tests/test_tool_plugin_declaration.py::test_a_missing_host_port_fails_the_boot_rather_than_skipping_mcp \
-     tests/test_tool_plugin_declaration.py::test_only_name_conflicts_are_all_or_nothing_across_a_batch \
-     tests/test_tool_plugin_declaration.py::test_a_refresh_that_disables_the_capability_drops_its_official_claim \
-     tests/test_tool_plugin_declaration.py::test_a_refresh_that_keeps_the_capability_re_claims_the_official_name
-   ```
-
-   Expect `ToolPluginError(Exception)` — **not** `ValueError` — beside the two
-   Composition-Root capability guards that catch
-   `(ValueError, ImportError, TypeError)` and log `capability_skipped`, then
-   `6 passed`: a conflict, an unreserved name, and a missing host port each
-   reach the caller of `_setup_capability` (two of them failing a real
-   `Agent(...)` boot), a mid-batch host-port failure is *not* rolled back, and
-   the claim map tracks the live namespace across refresh.
-
-7. Confirm the non-official mount path is untouched:
-
-   ```bash
-   grep -n "Remove any existing schema with same name" src/lingtai/kernel/base_agent/tools.py
-   ```
-
-   Expect one match inside `_add_tool`,
-   immediately followed by the line rebuilding `agent._tool_schemas` with
-   `s.name != name`. The reserved-name check is at this common model-facing
-   boundary: generic `add_tool` refuses `mcp`, while the registrar-issued
-   canonical one-use transaction is the sole official route. External
-   stdio/HTTP catalogs are preflighted and rejected before publication, and
-   same-name replacement remains for nonreserved tools.
+   Expect the selected test to pass. Removing Web from `init.json` removes its
+   claim, schema, and handler; re-adding the capability restores the static
+   declaration with one schema and handler.
 
 ### Expected evidence
 
-- [ ] Step 1: `OFFICIAL_TOOL_PLUGIN_NAMES` is the exact ordered static tuple
-      `mcp, avatar, context, daemon, email, file, plugin, notification, shell,
-      soul, system, task_card, vision, web` of bare names.
-- [ ] Step 2: `5 passed` — an unreserved name, an in-batch duplicate, and a
-      second declaration against a live claim are each refused with zero binds,
-      zero mounts, and an unchanged claim map; the same declaration re-registers
-      idempotently; `activate` precedes `mount`.
-- [ ] Step 3: `7 passed` — boot claims `mcp` and mounts exactly one `mcp` tool,
-      a foreign declaration cannot take it, a post-seal mount raises, the old
-      public adapter/factory bypass and a forged transaction are unavailable,
-      backing-map tampering cannot admit a foreign declaration, and the public
-      claim view cannot unlock one.
-- [ ] Step 4: `1 passed` — all fourteen reserved names mount exactly once in
-      one live composition.
-- [ ] Step 5: the batch-wide check loop precedes the bind/mount loop in source
-      order.
-- [ ] Step 6: `6 passed` — official-plugin failures propagate past the
-      capability skip-guard, the all-or-nothing promise is scoped to names, and
-      the claim map matches the live namespace across refresh and disable.
-- [ ] Step 7: `_add_tool`'s same-name replacement is still present and
-      unmodified.
+- [ ] The registrar preflights every name before bind, activation, mount, or
+      claim and leaves a refused batch unchanged.
+- [ ] Registration uses bind → activate → mount → claim; same-object
+      re-registration remains controlled; and only the registrar can issue an
+      official mount transaction.
+- [ ] A failure after the name checks does not imply rollback of an earlier
+      member; name checks are the only atomic phase.
+- [ ] The refresh owner observes the opt-in Web claim, schema, and handler
+      disappear together and return together after re-add.
 
 ### Pass / Fail
 
 Pass when every box above is observed. **Fail loudly** if a name conflict is
-detected only after a bind, an activate, or a mount; if a second declaration can
-overwrite a claimed official name; if a refused batch leaves any tool mounted or
-any claim recorded; if any of these failures is downgraded to a
-`capability_skipped` log line instead of failing the boot; if a claim outlives
-the tool it claims across a refresh; if the reserved list grows a module path,
-an import, or a discovery mechanism; or if third-party mount semantics in
-`_add_tool` changed.
+noticed after any bind, activation, or mount; a second declaration replaces a
+live official claim; a caller can manufacture an official mount transaction; a
+post-name-check failure rolls back or conceals an earlier member; or a refresh
+leaves a Web claim, schema, or handler out of sync with its opt-in capability.
 Record the exact command output in the task report. This task performs no
 writes.

--- a/src/lingtai/kernel/tool_plugin/CONTRACT.md
+++ b/src/lingtai/kernel/tool_plugin/CONTRACT.md
@@ -461,6 +461,8 @@ This component never selects.
 ## Contract tests
 
 `tests/test_tool_plugin_declaration.py` is the shared primitive/slice suite;
+`tests/test_deep_refresh.py` owns init reconstruction, including the opt-in Web
+claim/schema/handler removal and re-add regression; and
 `tests/test_tool_family_avatar_migration.py` supplies Avatar's focused declared
 vertical proof; `tests/test_context_declared_tool_plugin.py` supplies Context's
 focused static-declaration, restricted-runtime-port, canonical-manual, and
@@ -493,8 +495,8 @@ preserve Notification Core delay/timer and Store behavior:
   port, missing-port failure, foreign-host refusal, and that neither the facade
   nor the bound plugin exposes the `Agent` on its public surface;
 - fail-fast names — unreserved name, duplicate within one batch, and a second
-  different declaration against a live claim, each asserting zero mounts, zero
-  binds, and an unchanged claim map;
+  different declaration against a live claim, each asserting zero binds,
+  activations, and mounts with an unchanged claim map;
 - boot-path observability — an official-name conflict raised out of
   `Agent._setup_capability`, an unreserved name and a missing host port each
   failing a real `Agent(...)` boot instead of being absorbed as
@@ -503,17 +505,15 @@ preserve Notification Core delay/timer and Store behavior:
   or no action enum is refused at `bind()` with nothing mounted or claimed, and
   `mcp`'s manual destination and per-action `input` schemas follow its
   declaration;
-- atomicity, stated exactly — a mid-batch host-port failure leaves the earlier
-  member mounted and claimed;
-- claim-map lifecycle — the claim is reachable through the public
-  `official_tool_plugins` property, whose view cannot be cleared or overwritten;
-  persistent declaration anchors prevent mutable backing-map tampering from
-  admitting a foreign declaration, the live claim is dropped when a refresh
-  disables the capability, and it is re-claimed (and still not overwritable)
-  when it does;
-- ordering — `bind` alone activates and mounts nothing;
-  `activate` runs before `mount`;
-- idempotent re-registration (the refresh path);
+- registrar ordering and issuance — `bind()` alone activates and mounts nothing;
+  each successful member runs bind, activate, mount, then claim; re-registering
+  the same declaration object repeats that controlled sequence; and only the
+  registrar can issue the transaction carrying the exact bound result;
+- name-check-only atomicity — a later host-port failure propagates after leaving
+  an earlier member mounted and claimed, because no unmount capability exists;
+- claim lifecycle across refresh — the deep-refresh owner proves that removing
+  and re-adding opt-in Web keeps its public claim, schema, and handler surface
+  synchronized.
 - the live slices — boot claims and mounts exactly one `mcp`, one `vision`,
   and one `web` tool; a post-seal mount raises, a foreign declaration cannot take a live
   name, and

--- a/tests/test_deep_refresh.py
+++ b/tests/test_deep_refresh.py
@@ -408,6 +408,34 @@ def test_deep_refresh_removes_old_capabilities(tmp_path):
     assert "web" not in cap_names_after
 
 
+def test_deep_refresh_drops_and_reclaims_web_official_surface(tmp_path):
+    """An opt-in Web refresh leaves claims, schemas, and handlers in sync."""
+    from lingtai.tools.web_search import DECLARATION
+
+    agent = _make_agent(tmp_path, _make_init(capabilities={"web": {}}))
+    try:
+        agent._setup_from_init()
+        assert agent.official_tool_plugins["web"] is DECLARATION
+        assert [schema.name for schema in agent._tool_schemas].count("web") == 1
+        assert "web" in agent._tool_handlers
+
+        (tmp_path / "init.json").write_text(json.dumps(_make_init(capabilities={})))
+        agent._setup_from_init()
+        assert "web" not in agent.official_tool_plugins
+        assert "web" not in [schema.name for schema in agent._tool_schemas]
+        assert "web" not in agent._tool_handlers
+
+        (tmp_path / "init.json").write_text(
+            json.dumps(_make_init(capabilities={"web": {}}))
+        )
+        agent._setup_from_init()
+        assert agent.official_tool_plugins["web"] is DECLARATION
+        assert [schema.name for schema in agent._tool_schemas].count("web") == 1
+        assert "web" in agent._tool_handlers
+    finally:
+        agent._workdir_lease.release()
+
+
 def test_deep_refresh_preserves_chat_history(tmp_path):
     """ChatInterface is passed through to _rebuild_session after refresh."""
     agent = _make_agent(tmp_path, _make_init())

--- a/tests/test_tool_plugin_declaration.py
+++ b/tests/test_tool_plugin_declaration.py
@@ -608,3 +608,148 @@ def test_standard_port_table_grants_each_declaration_only_its_requires(plugin_ag
         mcp_host.plugin_catalog
     with pytest.raises(AttributeError):
         mcp_host.avatar_parent
+
+
+# ---------------------------------------------------------------------------
+# Kernel registrar: whole-batch name preflight, order, and name-only atomicity
+# (TP002). A recording mount keeps these assertions at the owning kernel seam.
+# ---------------------------------------------------------------------------
+
+
+def _kernel_declaration(name, *, calls, requires=("workdir",)):
+    """Return a minimal valid declaration whose bind and activate record calls."""
+    from lingtai.kernel.tool_plugin import BoundToolPlugin, ToolPluginDeclaration
+
+    def binder(host):
+        calls.append(("bind", name))
+        return BoundToolPlugin(
+            name=name,
+            schema={"properties": {"action": {"enum": ["ping", "manual"]}}},
+            handler=lambda _args: {"status": "ok"},
+            description=f"{name} kernel test plugin",
+            activate=lambda: calls.append(("activate", name)),
+        )
+
+    empty = {"type": "object", "properties": {}, "additionalProperties": False}
+    return ToolPluginDeclaration(
+        name=name,
+        actions=("ping",),
+        input_schemas={"ping": empty},
+        manual_input_schema=empty,
+        manual=f"{name}-manual",
+        description=f"{name} kernel test declaration",
+        binder=binder,
+        requires=requires,
+    )
+
+
+class _RecordingMount:
+    def __init__(self, calls):
+        self.calls = calls
+        self.transactions = []
+
+    def mount_tool(self, transaction):
+        self.calls.append(("mount", transaction.declaration.name))
+        self.transactions.append(transaction)
+
+
+def test_registrar_refuses_unreserved_duplicate_and_claimed_names_before_any_bind_or_mount():
+    """The whole batch is preflighted before bind, activation, or mount runs."""
+    from lingtai.kernel.tool_plugin import (
+        DuplicateToolPluginNameError,
+        UnreservedToolPluginNameError,
+        register_official_tool_plugins,
+    )
+
+    calls: list[tuple[str, str]] = []
+    mount = _RecordingMount(calls)
+    ports = {"workdir": object()}
+    live = _kernel_declaration("mcp", calls=calls)
+    claimed = {"mcp": live}
+
+    refused = [
+        (
+            [
+                _kernel_declaration("avatar", calls=calls),
+                _kernel_declaration("not_official", calls=calls),
+            ],
+            UnreservedToolPluginNameError,
+        ),
+        (
+            [
+                _kernel_declaration("avatar", calls=calls),
+                _kernel_declaration("avatar", calls=calls),
+            ],
+            DuplicateToolPluginNameError,
+        ),
+        (
+            [
+                _kernel_declaration("avatar", calls=calls),
+                _kernel_declaration("mcp", calls=calls),
+            ],
+            DuplicateToolPluginNameError,
+        ),
+    ]
+    for batch, error in refused:
+        with pytest.raises(error):
+            register_official_tool_plugins(
+                batch, ports_for=lambda _declaration: ports, mount=mount, claimed=claimed
+            )
+        assert calls == []
+        assert mount.transactions == []
+        assert claimed == {"mcp": live}
+
+
+def test_registrar_binds_then_activates_then_mounts_and_scopes_atomicity_to_names():
+    """Registration is ordered, same-object repeatable, and transactional only for names."""
+    from lingtai.kernel.tool_plugin import (
+        BoundToolPlugin,
+        HostPortError,
+        ToolPluginHost,
+        _OfficialMountTransaction,
+        register_official_tool_plugins,
+    )
+
+    calls: list[tuple[str, str]] = []
+    mount = _RecordingMount(calls)
+    ports = {"workdir": object()}
+    mcp = _kernel_declaration("mcp", calls=calls)
+    avatar = _kernel_declaration(
+        "avatar", calls=calls, requires=("workdir", "avatar_parent")
+    )
+    claimed: dict[str, object] = {}
+
+    bound = mcp.bind(ToolPluginHost.grant(mcp, ports))
+    assert isinstance(bound, BoundToolPlugin)
+    assert calls == [("bind", "mcp")]
+    assert mount.transactions == []
+    assert claimed == {}
+
+    calls.clear()
+    (mounted,) = register_official_tool_plugins(
+        [mcp], ports_for=lambda _declaration: ports, mount=mount, claimed=claimed
+    )
+    assert calls == [("bind", "mcp"), ("activate", "mcp"), ("mount", "mcp")]
+    assert claimed == {"mcp": mcp}
+    transaction = mount.transactions[-1]
+    assert transaction.declaration is mcp
+    assert transaction.plugin is mounted
+
+    calls.clear()
+    register_official_tool_plugins(
+        [mcp], ports_for=lambda _declaration: ports, mount=mount, claimed=claimed
+    )
+    assert calls == [("bind", "mcp"), ("activate", "mcp"), ("mount", "mcp")]
+    assert claimed == {"mcp": mcp}
+
+    with pytest.raises(PermissionError):
+        _OfficialMountTransaction(mcp, mounted)
+
+    calls.clear()
+    claimed.clear()
+    with pytest.raises(HostPortError):
+        register_official_tool_plugins(
+            [mcp, avatar], ports_for=lambda _declaration: ports, mount=mount, claimed=claimed
+        )
+    assert calls == [("bind", "mcp"), ("activate", "mcp"), ("mount", "mcp")]
+    assert claimed == {"mcp": mcp}


### PR DESCRIPTION
## Summary

- Add direct registrar regressions for whole-batch official-name preflight before bind/activate/mount and for bind → activate → mount → claim ordering.
- Prove registrar-only transaction issuance, controlled same-object repeat registration, and the intended **name-check-only** atomicity boundary when a later host-port failure occurs.
- Put the opt-in Web removal/re-add assertion in the existing deep-refresh owner, observing only claim/schema/handler synchronization.
- Narrow TP002 Contract/Behavior evidence to these owning seams and remove fragile pass-count / guard-census prose.

## Validation

- Combined affected modules (`test_tool_plugin_declaration.py`, `test_deep_refresh.py`, `test_web_official_plugin.py`) — **59 passed** in the parent gate.
- Focused three new selectors — pass.
- `git diff --check` — pass.
- Parent review corrected the test terminology from side-effect “idempotent” to controlled/repeatable registration.

Exact base: `c3e62dea6983c04a069e95252ce077313d62562a`. No production implementation or full-suite claim.

Telegram: @lingtaidev1bot | Nickname: 知微

Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
