### PR TITLE
Forward ACP execution workspace through BaseAgent

### DIFF
--- a/src/lingtai/adapters/acp/CONTRACT.md
+++ b/src/lingtai/adapters/acp/CONTRACT.md
@@ -63,8 +63,8 @@ therefore prohibited while ACP owns the transport.
 
 ## Port
 
-The Adapter consumes `BaseAgent.submit_turn(content, sender, correlation_id) ->
-TurnHandle` and `TurnHandle.cancel()/result()` from
+The Adapter consumes `BaseAgent.submit_turn(content, sender, correlation_id,
+execution_workspace) -> TurnHandle` and `TurnHandle.cancel()/result()` from
 `src/lingtai/kernel/turns.py`. The terminal `TurnResult` distinguishes
 `normal`, `cancelled`, and `failed` and carries the complete response text for
 normal settlement. This Port contains no ACP method, JSON-RPC object, session

--- a/src/lingtai/kernel/base_agent/__init__.py
+++ b/src/lingtai/kernel/base_agent/__init__.py
@@ -63,6 +63,7 @@ from ..token_ledger import append_token_entry
 from .._fsutil import atomic_write_json, atomic_write_text
 from ..trace_redaction import redact_for_trajectory
 from ..runtime_identity import runtime_identity_event_fields
+from ..execution_workspace import ExecutionWorkspace
 from ..turns import TurnHandle
 from .lifecycle import StopResult, StopStatus
 
@@ -2875,6 +2876,7 @@ class BaseAgent:
         *,
         sender: str = "user",
         correlation_id: str | None = None,
+        execution_workspace: str | Path | ExecutionWorkspace | None = None,
     ) -> TurnHandle:
         """Queue one text turn and return its protocol-neutral terminal handle."""
         from ..turns import submit_turn
@@ -2883,6 +2885,7 @@ class BaseAgent:
             content,
             sender=sender,
             correlation_id=correlation_id,
+            execution_workspace=execution_workspace,
         )
 
     def cancel_turn(self, correlation_id: str) -> bool:

--- a/tests/test_acp_stdio.py
+++ b/tests/test_acp_stdio.py
@@ -14,8 +14,8 @@ from types import SimpleNamespace
 import pytest
 
 from lingtai.adapters.acp.server import AcpStdioServer
-from lingtai.kernel.base_agent import StopResult, StopStatus
-from lingtai.kernel.turns import TurnOutcome, TurnResult
+from lingtai.kernel.base_agent import BaseAgent, StopResult, StopStatus
+from lingtai.kernel.turns import TurnOutcome, TurnResult, control_from_message
 
 
 class _Handle:
@@ -144,6 +144,34 @@ def test_session_new_canonicalizes_existing_directory_and_mounts_stdio_mcp(tmp_p
     server.close()
     server.close()
     assert agent.lease.closed == 1
+
+
+def test_acp_prompt_queues_canonical_workspace_through_real_base_agent(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    alias = tmp_path / "alias"
+    alias.symlink_to(workspace, target_is_directory=True)
+    agent = object.__new__(BaseAgent)
+    agent._shutdown = threading.Event()
+    agent.inbox = queue.Queue()
+    server = AcpStdioServer(agent, io.StringIO(), io.StringIO())
+
+    session_id = server._new_session({"cwd": str(alias), "mcpServers": []})[
+        "sessionId"
+    ]
+    server._prompt(
+        {
+            "sessionId": session_id,
+            "prompt": [{"type": "text", "text": "go"}],
+        },
+        "prompt-real-facade",
+    )
+
+    control = control_from_message(agent.inbox.get_nowait())
+    server.close()
+    assert control is not None
+    assert control.execution_workspace is server._execution_workspace
+    assert control.execution_workspace.root == workspace.resolve()
 
 
 @pytest.mark.parametrize("cwd,mcp_servers", [


### PR DESCRIPTION
## Context

Follow-up corrective slice to #1511.

#1511 made ACP `session/new.cwd` a real protocol-neutral execution workspace and passed that workspace from `AcpStdioServer._prompt()` into `agent.submit_turn(...)`. The production `BaseAgent.submit_turn()` facade, however, still accepted only `content`, `sender`, and `correlation_id`. A real ACP prompt therefore failed with `TypeError` before its correlated turn reached the inbox.

Existing ACP wire tests did not catch this because their fake agent already accepted the workspace keyword, while Core correlated-turn tests called the lower-level `turns.submit_turn()` function directly.

## Root cause

The outer ACP adapter and lower-level Core turn API were updated together, but the public production `BaseAgent` forwarding facade between them retained its old signature. The generic `ExecutionWorkspace` promise was already normative in the BaseAgent contract and anatomy; only the facade implementation and real-path regression were missing.

## What changed

- Add an optional, defaulted, keyword-only `execution_workspace` parameter to `BaseAgent.submit_turn()`.
- Forward that neutral value unchanged to `kernel.turns.submit_turn()`; all existing content/sender/correlation forwarding remains unchanged.
- Add a failing-first regression that goes through `AcpStdioServer._prompt()` and the real `BaseAgent.submit_turn()` method, dequeues the production correlated control, and verifies both exact workspace object identity and symlink-resolved canonical root.
- Correct the ACP contract's consumed facade signature.

## Intentional boundaries

- No ACP event/tool projection, permission brokerage, rich content, multi-session behavior, ACP v2, or remote transport.
- No changes to `turns.py`, `Agent`, the ACP server, workspace semantics, or persistent configuration.
- No unrelated repository architecture/document debt cleanup.

## Validation

- Real-path regression reproduced the pre-fix `TypeError`, then passed after the facade repair.
- Focused ACP/correlated-turn/execution-workspace/BaseAgent suite: **71 passed**.
- Changed Python/test files: `py_compile` passed.
- `git diff --check` passed before review and on the fully staged patch.
- Independent immutable exact-patch review: **PASS**; reviewed patch SHA-256 `8d6f1283125fab48611293e0be0738e2b2fa09c05fed2f3f971f58d646ab863f`.

Required repo-wide document gates currently carry unrelated exact-base debt. The clean base with the identical Git tree reproduced every result unchanged:

- architecture documents: current/base both **2 failed, 2 passed** (duplicate LLM Anatomy path; Bash Anatomy/Contract owner mismatch);
- docs governance script: current/base both exit 1 with byte-identical output;
- docs governance pytest: current/base both **2 failed, 68 passed** with identical failures.

This PR does not touch any file named by those failures.

## Base and replay

Canonical `main` remained at `d4a125f3ea9c4ee971c2c44f89dae2f29c7815be` after review; no rebase or replay was needed.
