### PR TITLE
Fix ACP permission wire conformance

### DIFF
--- a/src/lingtai/adapters/acp/BEHAVIORS.md
+++ b/src/lingtai/adapters/acp/BEHAVIORS.md
@@ -47,11 +47,14 @@ maintenance: |
 2. Inspect the captured normal-turn frames in the passing wire test: initialize result, session/new result, one `session/update` with `sessionUpdate=agent_message_chunk` and Text content, then the original prompt result with `stopReason=end_turn`; inspect the ResourceLink case and confirm validated link metadata reaches the Core text boundary.
 3. Inspect lifecycle tests: serial, parallel, denied, and failed tools emit minimal ordered `tool_call`/`tool_call_update` status frames before terminal response; collector-owned future exceptions, timeout boundaries after worker return, and cancellation each produce one FAILED terminal with no late completion; arguments/results/raw payloads are absent; observer exceptions, late terminal events, and close do not leak or alter Core execution.
 4. Inspect permission tests: every otherwise-allowed known tool emits pending and
-   the exact two-option request; only matching `selected/allow_once` received
-   after request write+flush reaches STARTED. A response captured before flush
+   the exact two-option request with a plain `ToolCallUpdate` carrying no
+   `sessionUpdate`; only the exact nested result
+   `{outcome: {outcome: "selected", optionId: "allow_once"}}` received after
+   request write+flush reaches STARTED. A response captured before flush
    remains denied after publication; cancel-before-registration emits no orphan,
    and cancel during a blocked pending write yields pending→failed without request;
-   reject/cancel, malformed/error/late responses, timeout, close, queue/write/
+   nested reject/cancel, flattened legacy, malformed/extra-field/error/late
+   responses, timeout, close, queue/write/
    flush failure deny and wake without exposing private tool data.
 5. Inspect the cancellation test: while the original prompt is unresolved, send a no-id `session/cancel` for the same session and confirm only the original prompt id receives `stopReason=cancelled`.
 6. Inspect every Adapter-authored stdout line with `json.loads`; confirm there is one complete JSON-RPC object per physical line and Python boot/runtime/stop `print` output is captured only on stderr. Confirm docs prohibit native fd 1, pre-captured stdout, and child stdout rather than claiming to quarantine them.

--- a/src/lingtai/adapters/acp/CONTRACT.md
+++ b/src/lingtai/adapters/acp/CONTRACT.md
@@ -177,14 +177,17 @@ library JSON/threading streams directly.
    underlying tool, but queue/framing failure still aborts the transport under rule
    6. Tool-call ids are session-unique and no argument/result/raw payload is sent.
 10. `acp-local-stdio.permission.v1` — every otherwise-allowed known ACP tool is
-   announced `pending` and requested with the same minimal id/title/status plus
-   exactly `allow_once` and `reject_once`. Only the first valid matching
-   `selected/allow_once` that arrives after the request frame is physically
+   announced `pending`; the permission request carries a plain minimal
+   `ToolCallUpdate` with the same id/title/status but no `sessionUpdate`
+   discriminator, plus exactly `allow_once` and `reject_once`. Only the first
+   valid matching nested result
+   `{outcome: {outcome: "selected", optionId: "allow_once"}}` that arrives
+   after the request frame is physically
    written and flushed dispatches; response arrival and the post-flush published
    bit linearize under the state lock, so a guessed/pre-flush response remains
    denied even if descheduled until after publication. A per-request publication
    lock protects the wire boundary without holding the global state lock across
-   stdout. Reject/cancel, malformed/error/unknown-option
+   stdout. Nested reject/cancel, flattened legacy, malformed/error/unknown-option
    responses, timeout after 60 seconds, close/EOF, queue/framing/write failure,
    and broker failure deny and wake the waiter. Unknown, duplicate, and late
    responses are ignored. Tagged batches suppress an unwritten resolved request;

--- a/src/lingtai/adapters/acp/MANUAL.md
+++ b/src/lingtai/adapters/acp/MANUAL.md
@@ -87,7 +87,8 @@ A minimal client sequence is:
    list. ResourceLink metadata is forwarded to Core as compact text; this slice
    does not fetch the URI.
 5. For each tool, answer `session/request_permission` with
-   `selected/allow_once` to permit it or reject/cancel to deny it. Then read the
+   `{"result":{"outcome":{"outcome":"selected","optionId":"allow_once"}}}`
+   to permit it, or a nested reject/cancel outcome to deny it. Then read the
    minimal lifecycle `session/update` frames, followed by zero or one
    completed Text `agent_message_chunk`, then the response carrying
    `stopReason: "end_turn"`.
@@ -106,8 +107,9 @@ Example shapes (one compact object per real line in an actual transport):
 ## Tool lifecycle projection
 
 For each tool call, the server first emits a pending `tool_call` and a
-`session/request_permission` carrying the same safe id/title/status and only
-Allow once / Reject options. Only Allow once received after the request frame's
+`session/request_permission` carrying a plain `ToolCallUpdate` with the same
+safe id/title/status, no `sessionUpdate` discriminator, and only Allow once /
+Reject options. Only the exact nested selected Allow once outcome received after the request frame's
 physical write+flush boundary dispatches. Response arrival and the post-flush
 published bit linearize under the state lock, so a pre-flush response stays denied
 even if it resumes after publication. The per-request publication lock does not

--- a/src/lingtai/adapters/acp/server.py
+++ b/src/lingtai/adapters/acp/server.py
@@ -770,11 +770,24 @@ class AcpStdioServer:
                     )
                     if (
                         meta_valid
-                        and result_fields == {"outcome", "optionId"}
-                        and result.get("outcome") == "selected"
-                        and result.get("optionId") == "allow_once"
+                        and result_fields == {"outcome"}
+                        and isinstance(result.get("outcome"), dict)
                     ):
-                        decision = PermissionDecision.ALLOW
+                        outcome = result["outcome"]
+                        outcome_fields = set(outcome) - {"_meta"}
+                        outcome_meta = outcome.get("_meta")
+                        outcome_meta_valid = (
+                            "_meta" not in outcome
+                            or outcome_meta is None
+                            or isinstance(outcome_meta, dict)
+                        )
+                        if (
+                            outcome_meta_valid
+                            and outcome_fields == {"outcome", "optionId"}
+                            and outcome.get("outcome") == "selected"
+                            and outcome.get("optionId") == "allow_once"
+                        ):
+                            decision = PermissionDecision.ALLOW
                 self._pending_permissions.pop(request_id, None)
                 pending.decision = decision
         pending.event.set()
@@ -814,12 +827,12 @@ class AcpStdioServer:
             )
             observer._track_permission(tool_call_id, pending.publication_lock)
 
-        update = {
-            "sessionUpdate": "tool_call",
+        tool_call = {
             "toolCallId": tool_call_id,
             "title": tool_name,
             "status": "pending",
         }
+        update = {"sessionUpdate": "tool_call", **tool_call}
         messages = ({
             "jsonrpc": JSONRPC_VERSION,
             "method": "session/update",
@@ -830,7 +843,7 @@ class AcpStdioServer:
             "method": "session/request_permission",
             "params": {
                 "sessionId": active.session_id,
-                "toolCall": update,
+                "toolCall": tool_call,
                 "options": [
                     {"optionId": "allow_once", "name": "Allow once", "kind": "allow_once"},
                     {"optionId": "reject_once", "name": "Reject", "kind": "reject_once"},

--- a/tests/test_acp_stdio.py
+++ b/tests/test_acp_stdio.py
@@ -230,13 +230,18 @@ def test_permission_wire_allows_only_matching_allow_once_then_lifecycle_progress
         "method": "session/request_permission",
         "params": {
             "sessionId": session_id,
-            "toolCall": pending["params"]["update"],
+            "toolCall": {
+                "toolCallId": safe_id,
+                "title": "shell",
+                "status": "pending",
+            },
             "options": [
                 {"optionId": "allow_once", "name": "Allow once", "kind": "allow_once"},
                 {"optionId": "reject_once", "name": "Reject", "kind": "reject_once"},
             ],
         },
     }
+    assert "sessionUpdate" not in request["params"]["toolCall"]
     projected = json.dumps((pending, request))
     for forbidden in (
         "arguments", "command", "paths", "env", "results", "content",
@@ -248,9 +253,12 @@ def test_permission_wire_allows_only_matching_allow_once_then_lifecycle_progress
         "jsonrpc": "2.0",
         "id": request["id"],
         "result": {
-            "outcome": "selected",
-            "optionId": "allow_once",
             "_meta": {"source": "client"},
+            "outcome": {
+                "outcome": "selected",
+                "optionId": "allow_once",
+                "_meta": {"source": "user"},
+            },
         },
     })
     waiter.join(timeout=2)
@@ -296,7 +304,9 @@ def test_guessed_allow_before_permission_request_flush_cannot_authorize():
     responder = threading.Thread(target=lambda: server._dispatch({
         "jsonrpc": "2.0",
         "id": "lingtai-permission-1",
-        "result": {"outcome": "selected", "optionId": "allow_once"},
+        "result": {
+            "outcome": {"outcome": "selected", "optionId": "allow_once"},
+        },
     }))
     responder.start()
     time.sleep(0.02)
@@ -362,7 +372,9 @@ def test_response_captured_before_request_flush_stays_denied_after_publication()
         target=lambda: server._dispatch({
             "jsonrpc": "2.0",
             "id": pending.request_id,
-            "result": {"outcome": "selected", "optionId": "allow_once"},
+            "result": {
+                "outcome": {"outcome": "selected", "optionId": "allow_once"},
+            },
         }),
     )
     responder.start()
@@ -435,10 +447,22 @@ def test_cancel_during_blocked_pending_write_emits_adjacent_failed_terminal():
 
 
 @pytest.mark.parametrize("response", [
-    {"result": {"outcome": "selected", "optionId": "reject_once"}},
-    {"result": {"outcome": "selected", "optionId": "allow_always"}},
-    {"result": {"outcome": "cancelled"}},
-    {"result": {"outcome": "selected"}},
+    {"result": {"outcome": {
+        "outcome": "selected", "optionId": "reject_once",
+    }}},
+    {"result": {"outcome": {
+        "outcome": "selected", "optionId": "allow_always",
+    }}},
+    {"result": {"outcome": {"outcome": "cancelled"}}},
+    {"result": {"outcome": "selected", "optionId": "allow_once"}},
+    {"result": {"outcome": {"outcome": "selected"}}},
+    {"result": {"outcome": {
+        "outcome": "selected", "optionId": "allow_once", "extra": True,
+    }}},
+    {"result": {
+        "outcome": {"outcome": "selected", "optionId": "allow_once"},
+        "extra": True,
+    }},
     {"error": {"code": -32000, "message": "client failed"}},
 ])
 def test_matching_non_allow_permission_responses_deny_without_response(response):
@@ -486,7 +510,9 @@ def test_permission_timeout_denies_and_late_allow_cannot_authorize(monkeypatch):
     server._dispatch({
         "jsonrpc": "2.0",
         "id": request["id"],
-        "result": {"outcome": "selected", "optionId": "allow_once"},
+        "result": {
+            "outcome": {"outcome": "selected", "optionId": "allow_once"},
+        },
     })
     assert request["id"] not in server._pending_permissions
     server.close()
@@ -545,7 +571,9 @@ def test_unknown_response_id_is_ignored_and_cannot_authorize_pending_request():
     server._dispatch({
         "jsonrpc": "2.0",
         "id": "unknown-permission",
-        "result": {"outcome": "selected", "optionId": "allow_once"},
+        "result": {
+            "outcome": {"outcome": "selected", "optionId": "allow_once"},
+        },
     })
     time.sleep(0.02)
     assert len(_messages(output)) == before
@@ -553,7 +581,7 @@ def test_unknown_response_id_is_ignored_and_cannot_authorize_pending_request():
     server._dispatch({
         "jsonrpc": "2.0",
         "id": request["id"],
-        "result": {"outcome": "cancelled"},
+        "result": {"outcome": {"outcome": "cancelled"}},
     })
     waiter.join(timeout=2)
     assert result == [PermissionDecision.DENY]


### PR DESCRIPTION
Follow-up to #1514: correct the ACP v1 permission request/response wire shape so conforming clients can actually authorize a tool call.

## Context

#1514 added metadata-only, fail-closed permission brokerage for the local stdio ACP adapter. Its publication boundary, cancellation handling, teardown, and privacy gates were correct, but a post-merge comparison with the official ACP v1 schema found two structural mismatches:

1. `RequestPermissionResponse` owns a required `outcome: RequestPermissionOutcome`, and the selected union member is itself an object. The conforming allow response is therefore nested:

```json
{"result":{"outcome":{"outcome":"selected","optionId":"allow_once"}}}
```

The adapter instead expected a flattened result, so a real conforming client would always be denied.

2. `RequestPermissionRequest.toolCall` is a plain `ToolCallUpdate`. The adapter reused the discriminated `SessionUpdate` object and therefore emitted an extra `sessionUpdate: "tool_call"` field in the permission request.

## Root cause

The implementation and fixtures matched the field names but not the schema's nested object/union boundary, and they conflated the `SessionUpdate` wrapper used by `session/update` with the plain `ToolCallUpdate` required inside `session/request_permission`.

## What changed

- Parse only the official nested selected outcome as ALLOW.
- Continue accepting ACP-reserved `_meta` at the response-result and selected-outcome levels only when it is null or an object.
- Fail closed for nested reject/cancel, flattened legacy results, unknown options, missing/non-object fields, extra fields, JSON-RPC errors, and all existing timeout/cancel/close/transport cases.
- Send `session/request_permission.params.toolCall` as a plain minimal `ToolCallUpdate` (`toolCallId`, `title`, `status`) without `sessionUpdate`.
- Keep the preceding `session/update.params.update` as a discriminated `SessionUpdate` with `sessionUpdate: "tool_call"`.
- Update the ACP Contract, Manual, Behavior evidence, and stdio tests to pin the official shapes.

## Preserved behavior

This does not refactor the first-claim arbitration, response-arrival versus post-write/flush publication boundary, per-request publication lock, timeout, cancellation, close/EOF, blocked-write, transport failure, teardown/drain/wakeup, tool lifecycle ordering, or metadata-only privacy projection introduced by #1514.

## Validation

- `python -m pytest -q tests/test_acp_stdio.py` → **55 passed**
- permission-focused subset → **14 passed**
- changed Python `py_compile` → **passed**
- `git diff --check` → **passed**
- private-path/internal-marker scan → **passed**
- fresh canonical fetch confirmed exact base equality before commit
- independent exact-patch review → **PASS**

Repository-wide documentation governance/architecture checks still expose unrelated baseline defects in files untouched by this patch (missing frontmatter, a duplicate LLM Anatomy path, notification-template hash drift, and an existing Bash contract-ownership mismatch). This focused change does not widen scope to alter those files.

## Non-goals

- RequestId `null` conformance or local JSON-RPC error taxonomy (kept for the next independent slice)
- ACP v2 or remote transports
- persistent/list/load/delete sessions
- client filesystem or terminal features, extra roots, image/audio, or elicitation
- persistent permission choices, richer optional streaming fields, or timeout configurability

## Why this is separate

The permission shape is the immediate interoperability blocker. Keeping nullable RequestId and error taxonomy in a follow-up makes each patch independently reviewable and lets the real-client lifecycle smoke isolate failures cleanly after both merge.
