### PR TITLE
Conform ACP RequestIds and local error codes

### DIFF
--- a/src/lingtai/adapters/acp/BEHAVIORS.md
+++ b/src/lingtai/adapters/acp/BEHAVIORS.md
@@ -57,8 +57,15 @@ maintenance: |
    responses, timeout, close, queue/write/
    flush failure deny and wake without exposing private tool data.
 5. Inspect the cancellation test: while the original prompt is unresolved, send a no-id `session/cancel` for the same session and confirm only the original prompt id receives `stopReason=cancelled`.
-6. Inspect every Adapter-authored stdout line with `json.loads`; confirm there is one complete JSON-RPC object per physical line and Python boot/runtime/stop `print` output is captured only on stderr. Confirm docs prohibit native fd 1, pre-captured stdout, and child stdout rather than claiming to quarantine them.
-7. Inspect explicit-scope/lifecycle tests: malformed cwd/MCP, a second session, concurrent prompt, invalid ResourceLink, and failed Core turn each produce the named error path. Confirm canonical outside-agent workspace rooting, parent/symlink refusal, parallel propagation without later leakage, atomic stdio MCP publication/rollback/collision refusal, and lease teardown on close/EOF. Confirm the existing blocked-write and typed-stop lifecycle evidence remains intact.
+6. Inspect request-id/error-taxonomy tests: explicit null/string/signed-int64
+   boundary ids round-trip, missing id remains notification-only, and bool,
+   fractional, structured, or out-of-range integer ids fail with diagnostic id
+   null. Confirm methodless permission responses keep their
+   existing routing. Confirm local session busy/not-initialized errors are
+   `-32010`/`-32011`, not ACP's predefined authentication/resource errors
+   `-32000`/`-32002` or the Adapter's established session-not-found `-32001`.
+7. Inspect every Adapter-authored stdout line with `json.loads`; confirm there is one complete JSON-RPC object per physical line and Python boot/runtime/stop `print` output is captured only on stderr. Confirm docs prohibit native fd 1, pre-captured stdout, and child stdout rather than claiming to quarantine them.
+8. Inspect explicit-scope/lifecycle tests: malformed cwd/MCP, a second session, concurrent prompt, invalid ResourceLink, and failed Core turn each produce the named error path. Confirm canonical outside-agent workspace rooting, parent/symlink refusal, parallel propagation without later leakage, atomic stdio MCP publication/rollback/collision refusal, and lease teardown on close/EOF. Confirm the existing blocked-write and typed-stop lifecycle evidence remains intact.
 
 ### Expected evidence
 - [ ] Step 1 reports all focused tests passing with no network/provider call.
@@ -66,6 +73,10 @@ maintenance: |
 - [ ] Tool lifecycle frames use session-unique ids and only title/status metadata; no arguments, results, content, locations, rawInput/rawOutput, or internal error detail is projected.
 - [ ] Cancel has no response of its own and the original prompt settles exactly once as `cancelled`; no later agent update is emitted for it.
 - [ ] Every Adapter-authored stdout line parses independently as JSON-RPC 2.0; Python diagnostic prints are stderr-only and unsupported native/child fd 1 paths are documented.
+- [ ] Included null/string/signed-int64 request ids echo exactly, invalid ids use
+  diagnostic id null, missing ids remain notifications, and local session-state
+  errors avoid ACP's predefined `-32000` authentication / `-32002` resource
+  meanings plus the Adapter's established `-32001` session-not-found meaning.
 - [ ] Baseline ResourceLink reaches Core as validated compact metadata; strict stdio MCP publishes atomically while malformed/remote variants fail explicitly, and Core failure uses the fixed `LingTai turn failed` wire message.
 - [ ] Agent shutdown cannot wait on EOF or any client write; not-yet-started prompt frames are invalidated, fatal queue/write failures abort, typed timeout retains liveness/lease until ACP process termination, a successful poisoned stop emits no post-release workdir log before exit 0, and invalid UTF-8 has a fixed Parse error only.
 

--- a/src/lingtai/adapters/acp/CONTRACT.md
+++ b/src/lingtai/adapters/acp/CONTRACT.md
@@ -97,7 +97,14 @@ library JSON/threading streams directly.
    `protocolVersion` and negotiates by returning this Agent's latest supported
    `protocolVersion: 1`, plus empty
    `agentCapabilities`, LingTai `agentInfo`, and `authMethods: []`. Unsupported
-   methods/params use JSON-RPC errors; notifications receive no response.
+   methods/params use JSON-RPC errors; notifications receive no response. An
+   included request id may be a string, non-boolean signed 64-bit integer, or explicit null
+   and is echoed exactly; a missing id alone denotes a notification. Invalid
+   ids produce the JSON-RPC diagnostic id null. Local session busy and
+   not-initialized errors use unreserved server-error codes `-32010` and
+   `-32011`, respectively, rather than colliding with ACP's predefined
+   authentication `-32000` / resource-not-found `-32002` meanings or this
+   Adapter's established session-not-found `-32001` meaning.
 2. `acp-local-stdio.session.v1` — one process owns at most one initialized ACP
    session and one active prompt. A second `session/new` or concurrent prompt
    fails explicitly. `cwd` must be absolute, exist, and be a directory; it is
@@ -200,7 +207,8 @@ library JSON/threading streams directly.
 
 ## Contract tests
 
-`tests/test_acp_stdio.py` pins initialize/session/prompt/update/end-turn framing,
+`tests/test_acp_stdio.py` pins request-id and error-taxonomy conformance,
+initialize/session/prompt/update/end-turn framing,
 permission response arbitration and fail-closed teardown,
 cancel settlement, ResourceLink projection, fixed failure redaction, single-
 session/busy/unsupported errors, strict JSON line framing, invalid UTF-8, EOF,

--- a/src/lingtai/adapters/acp/MANUAL.md
+++ b/src/lingtai/adapters/acp/MANUAL.md
@@ -104,6 +104,10 @@ Example shapes (one compact object per real line in an actual transport):
 {"jsonrpc":"2.0","id":3,"method":"session/prompt","params":{"sessionId":"<returned-id>","prompt":[{"type":"text","text":"Hello"}]}}
 ```
 
+ACP v1 request ids may be strings, signed 64-bit integers, or explicit `null`; the response
+echoes an included id exactly. Omitting `id` instead makes the message a
+notification, so these two wire shapes are not interchangeable.
+
 ## Tool lifecycle projection
 
 For each tool call, the server first emits a pending `tool_call` and a
@@ -167,11 +171,17 @@ stdout: code launched in this host must not use those paths. Common explicit err
   tool-name collision closes earlier clients and publishes nothing;
 - non-empty `additionalDirectories`: unsupported (additional roots are not advertised);
 - second `session/new`: unsupported;
-- second prompt while one is active: session busy;
+- second prompt while one is active: session busy (`-32010`);
+- session methods before initialization: server not initialized (`-32011`);
 - ResourceLink without non-empty `uri`/`name` or with invalid metadata: invalid params;
 - image/audio/embedded-resource prompt block: unsupported;
 - failed Core turn: fixed `LingTai turn failed` Internal error, with details kept
   out of the ACP wire.
+
+The two local session-state codes are distinct from ACP v1's predefined
+authentication (`-32000`) and resource-not-found (`-32002`) errors, and from
+this Adapter's existing session-not-found code (`-32001`); clients must not
+interpret them as any of those errors.
 
 After correcting client input, launch a fresh process if session creation already
 succeeded; the one-session state is intentionally process-local. For agent boot

--- a/src/lingtai/adapters/acp/server.py
+++ b/src/lingtai/adapters/acp/server.py
@@ -25,15 +25,17 @@ from lingtai.services.session_mcp import StdioMCPServerConfig
 
 JSONRPC_VERSION = "2.0"
 ACP_PROTOCOL_VERSION = 1
+_REQUEST_ID_MIN = -(1 << 63)
+_REQUEST_ID_MAX = (1 << 63) - 1
 
 PARSE_ERROR = -32700
 INVALID_REQUEST = -32600
 METHOD_NOT_FOUND = -32601
 INVALID_PARAMS = -32602
 INTERNAL_ERROR = -32603
-SERVER_NOT_INITIALIZED = -32002
+SERVER_NOT_INITIALIZED = -32011
 SESSION_NOT_FOUND = -32001
-SESSION_BUSY = -32000
+SESSION_BUSY = -32010
 UNSUPPORTED = -32004
 
 
@@ -46,7 +48,7 @@ class _RpcError(Exception):
 
 @dataclass(slots=True)
 class _ActivePrompt:
-    request_id: str | int
+    request_id: str | int | None
     session_id: str
     handle: TurnHandle
     generation: int
@@ -431,9 +433,17 @@ class AcpStdioServer:
 
     @staticmethod
     def _valid_id(value: Any) -> bool:
-        # ACP's generated request-id shape is integer-or-string. In particular,
-        # reject bool (an int subclass), null, and fractional JSON-RPC numbers.
-        return isinstance(value, (str, int)) and not isinstance(value, bool)
+        # ACP v1 permits string, signed-int64, or explicit null request ids.
+        # Reject bool (an int subclass), fractional numbers, and out-of-range ints.
+        return (
+            value is None
+            or isinstance(value, str)
+            or (
+                isinstance(value, int)
+                and not isinstance(value, bool)
+                and _REQUEST_ID_MIN <= value <= _REQUEST_ID_MAX
+            )
+        )
 
     @staticmethod
     def _params_object(params: Any) -> dict[str, Any]:
@@ -583,7 +593,7 @@ class AcpStdioServer:
             raise _RpcError(SESSION_NOT_FOUND, "session not found")
         return session_id
 
-    def _prompt(self, params: Any, request_id: str | int) -> None:
+    def _prompt(self, params: Any, request_id: str | int | None) -> None:
         params = self._params_object(params)
         session_id = self._validate_session(params)
         prompt = params.get("prompt")

--- a/tests/test_acp_stdio.py
+++ b/tests/test_acp_stdio.py
@@ -602,6 +602,37 @@ def test_methodless_nonresponse_remains_an_invalid_request():
     server.close()
 
 
+@pytest.mark.parametrize("request_id", [None, -(1 << 63), (1 << 63) - 1, "req-1"])
+def test_initialize_accepts_and_echoes_valid_request_ids(request_id):
+    output = io.StringIO()
+    server = AcpStdioServer(_Agent(_Handle("placeholder")), io.StringIO(), output)
+
+    _request(server, request_id, "initialize", {"protocolVersion": 1})
+
+    response = _wait_for(output, 1)[0]
+    assert response["id"] == request_id
+    assert response["result"]["protocolVersion"] == 1
+    server.close()
+
+
+@pytest.mark.parametrize(
+    "request_id",
+    [True, False, 1.5, [], {}, -(1 << 63) - 1, 1 << 63],
+)
+def test_invalid_request_ids_use_null_diagnostic_id(request_id):
+    output = io.StringIO()
+    server = AcpStdioServer(_Agent(_Handle("placeholder")), io.StringIO(), output)
+
+    _request(server, request_id, "initialize", {"protocolVersion": 1})
+
+    assert _wait_for(output, 1) == [{
+        "jsonrpc": "2.0",
+        "id": None,
+        "error": {"code": -32600, "message": "Invalid Request"},
+    }]
+    server.close()
+
+
 def test_cancelled_turn_cannot_register_a_new_permission_request():
     handle = _Handle("placeholder")
     agent = _Agent(handle)
@@ -925,7 +956,8 @@ def test_failure_busy_second_session_and_unsupported_inputs_are_explicit():
     messages = _wait_for(output, 4)
     errors = {message.get("id"): message.get("error") for message in messages}
     assert errors[3]["code"] == -32004
-    assert errors[5]["code"] == -32000
+    assert errors[5]["code"] == -32010
+    assert errors[5]["code"] not in {-32000, -32001, -32002}
 
     handle._future.set_result(
         TurnResult(handle.correlation_id, TurnOutcome.FAILED, error="secret detail")
@@ -984,8 +1016,11 @@ def test_initialize_negotiates_v1_and_enforces_rpc_method_kinds():
     assert _wait_for(fresh_output, 1) == [{
         "jsonrpc": "2.0",
         "id": 3,
-        "error": {"code": -32002, "message": "server is not initialized"},
+        "error": {"code": -32011, "message": "server is not initialized"},
     }]
+    assert _messages(fresh_output)[0]["error"]["code"] not in {
+        -32000, -32001, -32002
+    }
     fresh.close()
 
 


### PR DESCRIPTION
Follow-up to #1515: make the local stdio ACP v1 adapter conform to the protocol's RequestId domain and stop using ACP-predefined error-code values for Adapter-local lifecycle states.

## Context

The preceding ACP slices established correlated local-stdio turns, workspace/session MCP integration, metadata-only tool lifecycle, permission brokerage, and the official nested permission wire shape. A post-merge comparison with the official ACP v1 schema found two remaining JSON-RPC conformance gaps:

1. ACP `RequestId` is a union of `null`, string, and signed-int64 Number. The adapter rejected explicit `null`, accepted arbitrary-size Python integers, and did not distinguish a missing `id` from an explicit null ID at the request boundary.
2. Local session-busy and server-not-initialized failures reused `-32000` and `-32002`, which ACP defines as Authentication required and Resource not found. That made Adapter-local lifecycle failures look like protocol-defined errors with different meanings.

These mismatches could reject a legal conforming request, echo an out-of-domain numeric ID, or cause clients to interpret local lifecycle state as an ACP authentication/resource failure.

## Root cause

The adapter validated Python runtime shapes rather than the schema's full Number domain, and its request path treated `dict.get("id")` as sufficient even though JSON-RPC distinguishes a missing member from an explicit null value. Separately, local lifecycle codes were chosen from the server-error range without reserving the ACP v1 predefined values or documenting which codes are Adapter-local.

## What changed

- Accept explicit null, strings, and non-boolean signed-int64 integers as ACP RequestIds.
- Preserve exact valid IDs in responses, including both signed-int64 boundary values.
- Treat a missing `id` as a notification while keeping an explicit null `id` as a request ID.
- Reject booleans, floats/fractional values, arrays, objects, and integers outside `[-2^63, 2^63-1]` with an Invalid Request diagnostic whose `id` is null.
- Ensure invalid IDs are rejected before initialize/session state can mutate.
- Preserve methodless JSON-RPC response routing so pending string-ID permission responses still reach the permission broker before ordinary request validation.
- Move Adapter-local session-busy to `-32010` and server-not-initialized to `-32011`.
- Keep the existing Adapter-local session-not-found code at `-32001`, while documenting that ACP itself predefines Authentication required at `-32000` and Resource not found at `-32002`.
- Update the ACP Contract, Manual, Behavior evidence, and stdio regression tests.

## Preserved behavior

This patch does not change the merged permission-response nesting/plain ToolCallUpdate wire behavior from #1515, permission fail-closed/race/teardown handling, tool lifecycle ordering, cancellation, stdout purity/backpressure, workspace handling, or session-scoped stdio MCP behavior.

## Validation

- `python -m pytest -q tests/test_acp_stdio.py` → **66 passed**
- changed Python `py_compile` → **passed**
- `git diff --check` → **passed**
- private-path/internal-marker scan → **passed**
- ACP-versus-Adapter error-attribution scan → **passed**
- fresh canonical fetch confirmed exact base equality before commit
- independent exact-patch review → **PASS**

Repository-wide documentation governance/architecture checks still expose four unrelated baseline defects in files untouched by this patch (missing frontmatter, a duplicate LLM Anatomy path, notification-template hash drift, and an existing Bash contract-ownership mismatch). This focused change does not widen scope to alter those files.

## Non-goals

- ACP v2 or remote transports
- persistent/list/load/delete sessions
- client filesystem or terminal features, extra roots, image/audio, or elicitation
- persistent permission choices, richer optional streaming fields, or timeout configurability
- changing the Adapter's established `-32001` session-not-found convention

## Why this is separate

The permission-wire correction in #1515 was the immediate interoperability blocker. Keeping RequestId and error taxonomy in this independent slice made the exact schema domains, invalid-state-mutation behavior, and error-code provenance reviewable without reopening permission arbitration or tool lifecycle semantics. A real ACP client/SDK local-stdio lifecycle smoke remains the final closure gate after this merges.
