### PR TITLE
feat(acp): add puffo-v0 registry/session-policy foundation

### DIFF
--- a/src/lingtai/ANATOMY.md
+++ b/src/lingtai/ANATOMY.md
@@ -7,6 +7,7 @@ related_files:
   - src/lingtai/agent.py
   - src/lingtai/adapters/__init__.py
   - src/lingtai/adapters/acp/ANATOMY.md
+  - src/lingtai/adapters/acp/puffo_v0.py
   - src/lingtai/adapters/posix/ANATOMY.md
   - src/lingtai/adapters/windows/ANATOMY.md
   - src/lingtai/adapters/shell.py
@@ -23,6 +24,7 @@ related_files:
   - src/lingtai/cli.py
   - src/lingtai/cli_project.py
   - src/lingtai/cli_acp.py
+  - src/lingtai/cli_puffo_v0.py
   - src/lingtai/cli_daemon.py
   - src/lingtai/tools/ANATOMY.md
   - src/lingtai/tools/avatar/ANATOMY.md
@@ -109,9 +111,9 @@ PyPI wrapper package — `Agent(BaseAgent)` with composable capabilities, preset
 | `adapters/browser_transport.py` | Production static HTTP(S) Adapter for the internal browse Core-owned `BrowserPort`; bounds DNS wait with one in-flight resolver job, pins vetted IPs, and preserves Host/SNI, selected lazily by unified web setup. |
 | `adapters/lifecycle_clock.py` | The one portable production `SystemLifecycleClockAdapter` for the Core-owned `LifecycleClockPort` — direct `wall_seconds()`→`time.time()` / `monotonic_seconds()`→`time.monotonic()`, no caching or policy. Not POSIX (no filesystem/`fcntl`/platform selection), so it sits at the top of `adapters/` rather than under `adapters/posix/`; its promise/navigation are owned by the kernel `lifecycle_clock/` governed pair (`src/lingtai/kernel/lifecycle_clock/CONTRACT.md` + `ANATOMY.md`). |
 | `adapters/project_workspace.py` | Filesystem implementation of the Project Core Port: exclusively creates one fresh `.lingtai` tree, writes its seed, and applies an injected init-reader validation. |
-| `cli.py` | `lingtai-agent run <dir>` / `lingtai-agent acp --agent-dir <dir>` / `lingtai-agent project create ...` / `lingtai-agent check-caps` / `lingtai-agent log ...` / `lingtai-agent maintenance cleanup <target>` entry points; the `run` composition root performs a post-stop hard exit only when existing worker-poison state would otherwise keep the old process alive and block the refresh watcher |
+| `cli.py` | `lingtai-agent run <dir>` / `lingtai-agent acp --agent-dir <dir>` / `lingtai-agent acp --profile puffo-v0 --runtime-id <id>` / `lingtai-agent puffo-v0 provision\|revoke` / `lingtai-agent project create ...` / `lingtai-agent check-caps` / `lingtai-agent log ...` / `lingtai-agent maintenance cleanup <target>` entry points; the `run` composition root performs a post-stop hard exit only when existing worker-poison state would otherwise keep the old process alive and block the refresh watcher |
 | `cli_project.py` | Inbound composition for one fresh `project create` seed: caller inputs, wrapper preset loading, current-reader validation, Project adapter, and output; it does not start an Agent. |
-| `cli_acp.py` | Outer composition root for `lingtai-agent acp`: captures the original stdout wire and quarantines Python `sys.stdout` before Agent construction, reuses existing init/venv/build/lifecycle paths, serves `AcpStdioServer`, consumes typed stop proof, and process-terminates on timeout/error without writing the workdir after lease release. |
+| `cli_acp.py` / `adapters/acp/puffo_v0.py` / `cli_puffo_v0.py` | ACP outer composition and constrained Puffo profile: generic ACP accepts a local existing agent directory; `puffo-v0` resolves only an operator-provisioned opaque runtime id to canonical identity/workspace, forces no session MCP plus `avatar`/`daemon`/`mcp` disable, and provides local provision/revoke control. It is a controlled-entrypoint gate, not same-OS host isolation. |
 | `cli_daemon.py` | `lingtai-agent daemon emanate|list|check` — the programmatic (shell/Python/CI) skin over the daemon engine. `_CliDaemonAgent` is the minimal parent-agent facade `DaemonManager` reads (no lease, heartbeat, or agent identity), built from the agent's effective config through the canonical `init_reader.read_init`; `emanate` validates the tasks file against the tool's own emanate schema and enforces the preset allowlist and effective capability policy before previewing, then dispatches through the `DaemonFamilyDispatcher` envelope only under `--yes`; `_ReadOnlyDaemonView` binds the manager's unmodified `_handle_list`/`_handle_check` with both of its write paths (startup reconciliation, lazy daemon.json repair) removed |
 | `network.py` | Read-only network topology crawler — avatar/contact/mail edge discovery |
 | `presets.py` | Compatibility shim re-exporting the kernel preset library (`lingtai.kernel.presets`) |

--- a/src/lingtai/adapters/acp/ANATOMY.md
+++ b/src/lingtai/adapters/acp/ANATOMY.md
@@ -60,8 +60,9 @@ co-located [`CONTRACT.md`](CONTRACT.md), and its operator/developer procedure is
 - `puffo_v0.py` — local operator registry for the constrained `puffo-v0`
   profile. It resolves an opaque runtime id to one canonical persistent identity
   and workspace, verifies a configuration digest, serializes provision/revoke
-  read-modify-write operations with a POSIX lock, and refuses missing, malformed,
-  tampered, or revoked entries before Agent construction. Its Phase A
+  read-modify-write operations with a POSIX lock, records terminal revocations
+  in an append-only tombstone log, and refuses missing, malformed, tampered, or
+  revoked entries before Agent construction. Its Phase A
   owner-only-filesystem implementation deliberately rejects Windows until an
   equivalent ACL-backed adapter exists.
 - `../../cli_acp.py` — outer composition root. Captures the original stdout wire,

--- a/src/lingtai/adapters/acp/ANATOMY.md
+++ b/src/lingtai/adapters/acp/ANATOMY.md
@@ -5,8 +5,10 @@ related_files:
   - src/lingtai/adapters/acp/BEHAVIORS.md
   - src/lingtai/adapters/acp/MANUAL.md
   - src/lingtai/adapters/acp/__init__.py
+  - src/lingtai/adapters/acp/puffo_v0.py
   - src/lingtai/adapters/acp/server.py
   - src/lingtai/cli_acp.py
+  - src/lingtai/cli_puffo_v0.py
   - src/lingtai/cli.py
   - src/lingtai/kernel/turns.py
   - src/lingtai/kernel/execution_workspace.py
@@ -19,6 +21,7 @@ related_files:
   - src/lingtai/kernel/base_agent/ANATOMY.md
   - src/lingtai/kernel/base_agent/CONTRACT.md
   - tests/test_acp_stdio.py
+  - tests/test_puffo_v0_profile.py
   - tests/test_correlated_turns.py
   - tests/test_execution_workspace.py
   - tests/test_turn_events.py
@@ -54,6 +57,10 @@ co-located [`CONTRACT.md`](CONTRACT.md), and its operator/developer procedure is
   transport and active prompt without making stdout teardown authority. Implements
   behavior [ACP001](BEHAVIORS.md#behavior-acp001).
 - `__init__.py` — small public package export for the protocol version and server.
+- `puffo_v0.py` — local operator registry for the constrained `puffo-v0`
+  profile. It resolves an opaque runtime id to one canonical persistent identity
+  and workspace, verifies a configuration digest, and refuses missing, malformed,
+  tampered, or revoked entries before Agent construction.
 - `../../cli_acp.py` — outer composition root. Captures the original stdout wire,
   quarantines Python application stdout to stderr before Agent construction,
   composes the existing Agent, consumes the typed bounded stop proof, and hard-
@@ -61,6 +68,9 @@ co-located [`CONTRACT.md`](CONTRACT.md), and its operator/developer procedure is
   Shared poisoned-worker exit logging is lease-aware: retained ownership may log,
   while a successful `STOPPED` release skips every later workdir append and still
   reaches the unconditional process exit.
+- `../../cli_puffo_v0.py` — local-only control plane that provisions an existing
+  persistent identity or revokes it for future `puffo-v0` launches; it is not an
+  ACP data-plane surface.
 - `../../kernel/process_match.py` — exact duplicate-host grammar for module,
   console, legacy, and quoted Windows `.exe` ACP launch forms.
 - `../../kernel/turns.py`, `../../kernel/execution_workspace.py`, `../../kernel/turn_events.py`, `../../kernel/turn_permissions.py`, and `../../kernel/tool_executor.py` — inward Core boundary consumed by the Adapter:
@@ -70,7 +80,7 @@ co-located [`CONTRACT.md`](CONTRACT.md), and its operator/developer procedure is
   They contain no ACP vocabulary.
 - `../../services/session_mcp.py` — atomic outer stdio overlay: start/list all,
   collision preflight, one publication, explicit lease, and rollback/close.
-- `tests/test_acp_stdio.py` / `tests/test_correlated_turns.py` /
+- `tests/test_acp_stdio.py` / `tests/test_puffo_v0_profile.py` / `tests/test_correlated_turns.py` /
   `tests/test_turn_events.py` / `tests/test_turn_permissions.py` / `tests/test_tool_executor.py` /
   `tests/test_process_match.py` — wire, Core settlement, and duplicate-host
   conformance evidence. `tests/test_tools_package_data.py` pins wheel/sdist
@@ -79,7 +89,10 @@ co-located [`CONTRACT.md`](CONTRACT.md), and its operator/developer procedure is
 ## Connections
 
 Inbound: a local ACP client launches `lingtai-agent acp --agent-dir <dir>` and
-exchanges one JSON-RPC object per stdio line. Outbound: the Adapter calls only the
+exchanges one JSON-RPC object per stdio line. The constrained Puffo profile instead
+launches `lingtai-agent acp --profile puffo-v0 --runtime-id <opaque-id>`; its
+registry resolves the full spawn identity locally and server policy fixes the
+workspace and denies session MCP. Outbound: the Adapter calls only the
 protocol-neutral `BaseAgent.submit_turn`/`TurnHandle` boundary with an optional
 turn-scoped tool observer. The CLI root
 reuses `cli.load_init`, `cli.build_agent`, venv resolution, logging, lifecycle,
@@ -101,8 +114,10 @@ one lock-owned pending-permission registry,
 closing/aborted generation, a bounded 64-batch FIFO, one disposable
 daemon writer, and short-lived waiter thread records. Active/busy ownership lasts
 through physical terminal-batch completion, close invalidation, or fatal abort.
-ACP session/correlation identifiers are not persisted. Durable agent state remains
-owned by the existing Agent/workdir lifecycle. Closing requests active cancellation
+ACP session/correlation identifiers are not persisted. `puffo-v0` additionally
+reads an operator-managed local registry at spawn time; it neither creates a
+durable ACP session nor changes the Agent's own durable identity state. Durable
+agent state remains owned by the existing Agent/workdir lifecycle. Closing requests active cancellation
 and suppresses prompt frames that have not crossed the writer start check; typed
 Agent stop retains services/heartbeat/lease until execution quiescence is proven.
 
@@ -114,3 +129,7 @@ plus baseline Text and ResourceLink prompts are accepted; remote MCP and
 capability-gated rich content fail explicitly. Capability objects stay empty so omitted optional
 features are never advertised. Follow the manual and Contract before widening
 scope.
+
+`puffo-v0` is a second gate on its controlled entrypoint, not host isolation:
+the same OS identity can still alter the registry or bypass it by launching the
+generic `--agent-dir` ACP command. That is an explicit host trust boundary.

--- a/src/lingtai/adapters/acp/ANATOMY.md
+++ b/src/lingtai/adapters/acp/ANATOMY.md
@@ -59,10 +59,13 @@ co-located [`CONTRACT.md`](CONTRACT.md), and its operator/developer procedure is
 - `__init__.py` — small public package export for the protocol version and server.
 - `puffo_v0.py` — local operator registry for the constrained `puffo-v0`
   profile. It resolves an opaque runtime id to one canonical persistent identity
-  and workspace, verifies a configuration digest, serializes provision/revoke
-  read-modify-write operations with a POSIX lock, records terminal revocations
-  in an append-only tombstone log, and refuses missing, malformed, tampered, or
-  revoked entries before Agent construction. Its Phase A
+  and workspace, verifies an entry digest plus provision-time filesystem
+  identity, serializes provision/revoke read-modify-write operations with a
+  POSIX lock, records terminal revocations in an append-only tombstone log, and
+  refuses missing, malformed, tampered, retargeted, or revoked entries before
+  Agent construction. Its `entry_digest` authenticates registry data rather
+  than claiming to authenticate the effective manifest, tool/action, or full
+  launch policy. Its Phase A
   owner-only-filesystem implementation deliberately rejects Windows until an
   equivalent ACL-backed adapter exists.
 - `../../cli_acp.py` — outer composition root. Captures the original stdout wire,
@@ -96,7 +99,10 @@ Inbound: a local ACP client launches `lingtai-agent acp --agent-dir <dir>` and
 exchanges one JSON-RPC object per stdio line. The constrained Puffo profile instead
 launches `lingtai-agent acp --profile puffo-v0 --runtime-id <opaque-id>`; its
 registry resolves the full spawn identity locally and server policy fixes the
-workspace and denies session MCP. Outbound: the Adapter calls only the
+workspace and denies session MCP. The composition root re-resolves a profile
+runtime immediately before Agent composition so a normal resolve-to-start drift
+fails closed; host-principal filesystem replacement after that check remains
+outside this profile's trust boundary. Outbound: the Adapter calls only the
 protocol-neutral `BaseAgent.submit_turn`/`TurnHandle` boundary with an optional
 turn-scoped tool observer. The CLI root
 reuses `cli.load_init`, `cli.build_agent`, venv resolution, logging, lifecycle,

--- a/src/lingtai/adapters/acp/ANATOMY.md
+++ b/src/lingtai/adapters/acp/ANATOMY.md
@@ -59,8 +59,11 @@ co-located [`CONTRACT.md`](CONTRACT.md), and its operator/developer procedure is
 - `__init__.py` — small public package export for the protocol version and server.
 - `puffo_v0.py` — local operator registry for the constrained `puffo-v0`
   profile. It resolves an opaque runtime id to one canonical persistent identity
-  and workspace, verifies a configuration digest, and refuses missing, malformed,
-  tampered, or revoked entries before Agent construction.
+  and workspace, verifies a configuration digest, serializes provision/revoke
+  read-modify-write operations with a POSIX lock, and refuses missing, malformed,
+  tampered, or revoked entries before Agent construction. Its Phase A
+  owner-only-filesystem implementation deliberately rejects Windows until an
+  equivalent ACL-backed adapter exists.
 - `../../cli_acp.py` — outer composition root. Captures the original stdout wire,
   quarantines Python application stdout to stderr before Agent construction,
   composes the existing Agent, consumes the typed bounded stop proof, and hard-

--- a/src/lingtai/adapters/acp/BEHAVIORS.md
+++ b/src/lingtai/adapters/acp/BEHAVIORS.md
@@ -102,7 +102,8 @@ the evidence trail in the task report.
 
 1. Run `python -m pytest -q -x tests/test_puffo_v0_profile.py`.
 2. Inspect the registry cases: only an active, digest-valid opaque id resolves;
-   tampered and revoked entries fail before composition.
+   tampered and revoked entries, including a missing required revocation log,
+   fail before composition.
 3. Inspect the profile session cases: another workspace and every non-empty
    `mcpServers` input fail; `avatar`, `daemon`, and `mcp` are absent from the
    composed Agent floor.

--- a/src/lingtai/adapters/acp/BEHAVIORS.md
+++ b/src/lingtai/adapters/acp/BEHAVIORS.md
@@ -1,6 +1,6 @@
 ---
 name: acp-local-stdio-behavior-tests
-behavior_version: 1
+behavior_version: 2
 labt_version: 2
 contract: CONTRACT.md
 anatomy: ANATOMY.md
@@ -88,3 +88,36 @@ implicit second session, ignored non-empty session MCP input, leaked internal
 failure/tool payload, out-of-order or post-terminal lifecycle updates, or any
 claimed remote/v2/persistent-permission/workspace capability; record
 the evidence trail in the task report.
+
+## Behavior ACP002 — puffo-v0 accepts only an operator-provisioned local runtime
+
+- **id**: ACP002
+- **title**: puffo-v0 accepts only an operator-provisioned local runtime
+- **guards**: `acp-local-stdio` § Contract rules 11 — see [CONTRACT.md](CONTRACT.md#contract-rules)
+- **runner**: any LingTai coding agent with shell access to this repository
+- **prerequisites**: a project Python with test dependencies
+- **estimate**: ≈ 1 minute
+
+### Steps
+
+1. Run `python -m pytest -q -x tests/test_puffo_v0_profile.py`.
+2. Inspect the registry cases: only an active, digest-valid opaque id resolves;
+   tampered and revoked entries fail before composition.
+3. Inspect the profile session cases: another workspace and every non-empty
+   `mcpServers` input fail; `avatar`, `daemon`, and `mcp` are absent from the
+   composed Agent floor.
+
+### Expected evidence
+
+- [ ] A remote ACP payload cannot provide a filesystem path or an MCP process
+  launch through the profile.
+- [ ] The profile denies unavailable identities and retains fail-closed,
+  metadata-only permission handling.
+- [ ] The host-boundary non-guarantee remains documented.
+
+### Pass / Fail
+
+Pass when the focused tests prove every profile startup field comes from the
+local registry and constrained session policy. Fail on a remote-controlled
+workspace/MCP input, enabled derived/background capability, accepted revoked id,
+or any claim that this controlled entrypoint isolates a same-OS principal.

--- a/src/lingtai/adapters/acp/BEHAVIORS.md
+++ b/src/lingtai/adapters/acp/BEHAVIORS.md
@@ -101,9 +101,10 @@ the evidence trail in the task report.
 ### Steps
 
 1. Run `python -m pytest -q -x tests/test_puffo_v0_profile.py`.
-2. Inspect the registry cases: only an active, digest-valid opaque id resolves;
-   tampered and revoked entries, including a missing required revocation log,
-   fail before composition.
+2. Inspect the registry cases: only an active, entry-digest-valid opaque id
+   with its original directory identity resolves; tampered, retargeted, or
+   revoked entries, including a missing required revocation log, fail before
+   composition. An active identity and workspace cannot be bound twice.
 3. Inspect the profile session cases: another workspace and every non-empty
    `mcpServers` input fail; `avatar`, `daemon`, and `mcp` are absent from the
    composed Agent floor.
@@ -122,3 +123,5 @@ Pass when the focused tests prove every profile startup field comes from the
 local registry and constrained session policy. Fail on a remote-controlled
 workspace/MCP input, enabled derived/background capability, accepted revoked id,
 or any claim that this controlled entrypoint isolates a same-OS principal.
+This behavior is a registry/session-policy foundation: its entry digest does
+not by itself prove a complete effective tool/action or launch-security policy.

--- a/src/lingtai/adapters/acp/CONTRACT.md
+++ b/src/lingtai/adapters/acp/CONTRACT.md
@@ -217,8 +217,19 @@ argv, environment, or MCP command from the remote caller.
 11. `acp-local-stdio.puffo-v0.v1` — `lingtai-agent acp --profile puffo-v0
     --runtime-id <id>` resolves `<id>` only through the local
     operator-managed registry. The entry must be active, structurally exact,
-    digest-valid, and point to an initialized agent directory and existing
-    canonical workspace. A profile session accepts only that workspace and
+    entry-digest-valid, and bind one initialized agent directory and canonical
+    workspace to their provision-time canonical path plus POSIX device/inode/
+    owner/group identity. Resolve rejects a symlink retarget, canonical-path
+    drift, or replacement at the same path; active runtime bindings are unique
+    for both agent directory and workspace. The composition root resolves the
+    runtime again immediately before Agent construction. This narrows ordinary
+    resolve-to-start drift; a same-OS principal that rewrites the filesystem
+    after that check remains within the explicit host trust boundary below.
+    `entry_digest` protects the exact registry entry only; it is not a digest
+    of `init.json`, effective tool/action policy, executable/argv/environment,
+    or addon/plugin policy. Those full restricted-profile guarantees remain
+    outside this registry/session-policy foundation. A profile session accepts
+    only that workspace and
     `mcpServers: []`; it never starts a client-supplied process. The composed
     Agent forcibly disables `avatar`, `daemon`, and `mcp`, including after an
     in-process refresh. Permission remains one-shot and fail-closed under rule

--- a/src/lingtai/adapters/acp/CONTRACT.md
+++ b/src/lingtai/adapters/acp/CONTRACT.md
@@ -1,14 +1,16 @@
 ---
 name: acp-local-stdio
-contract_version: 1
+contract_version: 2
 root_contract: CONTRACT.md
 related_files:
   - src/lingtai/adapters/acp/ANATOMY.md
   - src/lingtai/adapters/acp/BEHAVIORS.md
   - src/lingtai/adapters/acp/MANUAL.md
   - src/lingtai/adapters/acp/__init__.py
+  - src/lingtai/adapters/acp/puffo_v0.py
   - src/lingtai/adapters/acp/server.py
   - src/lingtai/cli_acp.py
+  - src/lingtai/cli_puffo_v0.py
   - src/lingtai/cli.py
   - src/lingtai/kernel/turns.py
   - src/lingtai/kernel/execution_workspace.py
@@ -21,6 +23,7 @@ related_files:
   - src/lingtai/kernel/base_agent/CONTRACT.md
   - pyproject.toml
   - tests/test_acp_stdio.py
+  - tests/test_puffo_v0_profile.py
   - tests/test_correlated_turns.py
   - tests/test_execution_workspace.py
   - tests/test_turn_events.py
@@ -54,7 +57,8 @@ multi-session persistence are not advertised.
 
 ## Behavior
 
-Guarded by: [ACP001](BEHAVIORS.md#behavior-acp001).
+Guarded by: [ACP001](BEHAVIORS.md#behavior-acp001) and
+[ACP002](BEHAVIORS.md#behavior-acp002).
 
 A successful process negotiates ACP protocol version `1`, creates exactly one
 opaque session, accepts baseline Text and ResourceLink prompt blocks, emits the
@@ -90,6 +94,12 @@ a typed bounded stop on EOF or interrupt. A timed-out/non-quiescent stop retains
 services, heartbeat, and lease until the process owner hard-exits; no later Python
 state write can occur after OS release. It adds no dependency and uses standard
 library JSON/threading streams directly.
+
+`puffo_v0` and `cli_puffo_v0` provide a narrower composition profile. An
+operator locally provisions an existing persistent identity and canonical
+execution workspace under an opaque runtime id. The profile data plane receives
+only that id; it never accepts an agent directory, workspace path, executable,
+argv, environment, or MCP command from the remote caller.
 
 ## Contract rules
 
@@ -204,6 +214,27 @@ library JSON/threading streams directly.
    Arguments, commands, paths, environment, results, content, locations, raw
    input/output, internal errors, and private paths never enter permission wire.
    The existing risky-action gate remains first and may deny without a request.
+11. `acp-local-stdio.puffo-v0.v1` — `lingtai-agent acp --profile puffo-v0
+    --runtime-id <id>` resolves `<id>` only through the local
+    operator-managed registry. The entry must be active, structurally exact,
+    digest-valid, and point to an initialized agent directory and existing
+    canonical workspace. A profile session accepts only that workspace and
+    `mcpServers: []`; it never starts a client-supplied process. The composed
+    Agent forcibly disables `avatar`, `daemon`, and `mcp`, including after an
+    in-process refresh. Permission remains one-shot and fail-closed under rule
+    10: only the existing minimal metadata projection reaches the ACP client;
+    a permission answer cannot change startup configuration. `puffo-v0` creates
+    neither a persistent ACP session nor a background worker, and it does not
+    make ordinary tool side effects safe to retry. A revoked registry entry
+    denies only future profile spawns. This is a controlled-entrypoint guard,
+    not host isolation: an OS principal able to edit the registry or launch the
+    generic `--agent-dir` command remains outside this profile's threat model.
+    The required Puffo integration seam is outside this repository: before ACP
+    spawn, Puffo's trusted ACP driver must derive its `ValidatedLaunchPlan`
+    (executable, complete argv, environment, workspace, and empty MCP session
+    plan) from operator-managed binding/configuration, then emit only this
+    profile command and opaque id. `puffo-v0` identity binding is valid only
+    through that ACP entrypoint; Puffo's OpenCode driver is explicitly excluded.
 
 ## Contract tests
 
@@ -215,6 +246,9 @@ session/busy/unsupported errors, strict JSON line framing, invalid UTF-8, EOF,
 blocked coordinator/prompt output, FIFO/generation/queue-full/write-failure paths,
 Agent-stop-with-open-stdin, Windows duplicate-before-cleanup, typed quiescence,
 and CLI Python-stdout quarantine/hard-exit ownership.
+`tests/test_puffo_v0_profile.py` pins opaque-id provisioning/resolution,
+tamper/revocation rejection, forced capability removal, fixed-workspace and
+empty-session-MCP rejection, and profile CLI composition.
 `tests/test_execution_workspace.py`, `tests/test_turn_events.py`, `tests/test_turn_permissions.py`, `tests/test_tool_executor.py`, `tests/test_session_mcp.py`, and the ACP
 wire tests pin workspace rooting/escape/isolation, stdio validation, atomic
 publication/rollback, collisions, and close/EOF ownership.

--- a/src/lingtai/adapters/acp/CONTRACT.md
+++ b/src/lingtai/adapters/acp/CONTRACT.md
@@ -228,10 +228,12 @@ argv, environment, or MCP command from the remote caller.
     make ordinary tool side effects safe to retry. Registry provision/revoke
     mutations are process-serialized; revocation additionally writes an
     append-only tombstone before the mutable registry, so a stale full-registry
-    snapshot cannot reactivate an id. Its POSIX directory is owner-only (`0700`)
-    and its lock, temporary, registry, and tombstone files are owner-only
-    (`0600`), independent of umask; existing registry artifacts are tightened
-    before use. This Phase A registry fails closed on Windows until an
+    snapshot cannot reactivate an id. The versioned registry declares this log
+    mandatory: a missing, unreadable, malformed, or mismatched log rejects
+    resolve/provision rather than being treated as an empty history. Its POSIX
+    directory is owner-only (`0700`) and its lock, temporary, registry, and
+    tombstone files are owner-only (`0600`), independent of umask; existing
+    registry artifacts are tightened before use. This Phase A registry fails closed on Windows until an
     equivalent owner-only ACL adapter exists. The local control plane is its
     only supported writer: manual or third-party mutation is unsupported and
     malformed/rollback state is rejected rather than treated as authority. A

--- a/src/lingtai/adapters/acp/CONTRACT.md
+++ b/src/lingtai/adapters/acp/CONTRACT.md
@@ -226,11 +226,16 @@ argv, environment, or MCP command from the remote caller.
     a permission answer cannot change startup configuration. `puffo-v0` creates
     neither a persistent ACP session nor a background worker, and it does not
     make ordinary tool side effects safe to retry. Registry provision/revoke
-    mutations are process-serialized; its POSIX directory is owner-only
-    (`0700`) and its lock, temporary, and registry files are owner-only
-    (`0600`), independent of umask. This Phase A registry fails closed on
-    Windows until an equivalent owner-only ACL adapter exists. A revoked entry
-    denies only future profile spawns. This is a controlled-entrypoint guard,
+    mutations are process-serialized; revocation additionally writes an
+    append-only tombstone before the mutable registry, so a stale full-registry
+    snapshot cannot reactivate an id. Its POSIX directory is owner-only (`0700`)
+    and its lock, temporary, registry, and tombstone files are owner-only
+    (`0600`), independent of umask; existing registry artifacts are tightened
+    before use. This Phase A registry fails closed on Windows until an
+    equivalent owner-only ACL adapter exists. The local control plane is its
+    only supported writer: manual or third-party mutation is unsupported and
+    malformed/rollback state is rejected rather than treated as authority. A
+    revoked entry denies only future profile spawns. This is a controlled-entrypoint guard,
     not host isolation: an OS principal able to edit the registry or launch the
     generic `--agent-dir` command remains outside this profile's threat model.
     The required Puffo integration seam is outside this repository: before ACP

--- a/src/lingtai/adapters/acp/CONTRACT.md
+++ b/src/lingtai/adapters/acp/CONTRACT.md
@@ -225,7 +225,11 @@ argv, environment, or MCP command from the remote caller.
     10: only the existing minimal metadata projection reaches the ACP client;
     a permission answer cannot change startup configuration. `puffo-v0` creates
     neither a persistent ACP session nor a background worker, and it does not
-    make ordinary tool side effects safe to retry. A revoked registry entry
+    make ordinary tool side effects safe to retry. Registry provision/revoke
+    mutations are process-serialized; its POSIX directory is owner-only
+    (`0700`) and its lock, temporary, and registry files are owner-only
+    (`0600`), independent of umask. This Phase A registry fails closed on
+    Windows until an equivalent owner-only ACL adapter exists. A revoked entry
     denies only future profile spawns. This is a controlled-entrypoint guard,
     not host isolation: an OS principal able to edit the registry or launch the
     generic `--agent-dir` command remains outside this profile's threat model.

--- a/src/lingtai/adapters/acp/MANUAL.md
+++ b/src/lingtai/adapters/acp/MANUAL.md
@@ -102,6 +102,11 @@ to the entire canonical spawn configuration. The profile rejects an unknown,
 tampered, or revoked id before constructing the Agent. Revoke a future launch
 with `lingtai-agent puffo-v0 revoke --runtime-id puffo-agent-7`.
 
+The Phase A registry is POSIX-only: it serializes provision/revoke updates and
+creates its registry directory as `0700` and registry, temporary, and lock files
+as `0600`, independent of umask. On Windows the command fails closed until an
+equivalent owner-only ACL implementation is available.
+
 In this profile, `session/new.cwd` must be exactly the provisioned workspace and
 `mcpServers` must be `[]`. The profile disables the `avatar`, `daemon`, and
 `mcp` capabilities even if the agent manifest asks for them, including after an

--- a/src/lingtai/adapters/acp/MANUAL.md
+++ b/src/lingtai/adapters/acp/MANUAL.md
@@ -102,10 +102,14 @@ to the entire canonical spawn configuration. The profile rejects an unknown,
 tampered, or revoked id before constructing the Agent. Revoke a future launch
 with `lingtai-agent puffo-v0 revoke --runtime-id puffo-agent-7`.
 
-The Phase A registry is POSIX-only: it serializes provision/revoke updates and
-creates its registry directory as `0700` and registry, temporary, and lock files
-as `0600`, independent of umask. On Windows the command fails closed until an
-equivalent owner-only ACL implementation is available.
+The Phase A registry is POSIX-only: it serializes provision/revoke updates,
+records terminal revocations in an append-only local tombstone log, and creates
+its registry directory as `0700` and registry, tombstone, temporary, and lock
+files as `0600`, independent of umask. Loading an older registry tightens its
+directory and file modes before use. On Windows the command fails closed until
+an equivalent owner-only ACL implementation is available. The `puffo-v0`
+control-plane commands are the only supported writers; do not hand-edit the
+registry or use a third-party writer.
 
 In this profile, `session/new.cwd` must be exactly the provisioned workspace and
 `mcpServers` must be `[]`. The profile disables the `avatar`, `daemon`, and

--- a/src/lingtai/adapters/acp/MANUAL.md
+++ b/src/lingtai/adapters/acp/MANUAL.md
@@ -3,8 +3,10 @@ related_files:
   - src/lingtai/adapters/acp/CONTRACT.md
   - src/lingtai/adapters/acp/ANATOMY.md
   - src/lingtai/adapters/acp/BEHAVIORS.md
+  - src/lingtai/adapters/acp/puffo_v0.py
   - src/lingtai/adapters/acp/server.py
   - src/lingtai/cli_acp.py
+  - src/lingtai/cli_puffo_v0.py
   - src/lingtai/kernel/turns.py
   - src/lingtai/kernel/execution_workspace.py
   - src/lingtai/kernel/turn_events.py
@@ -13,6 +15,7 @@ related_files:
   - src/lingtai/services/session_mcp.py
   - src/lingtai/kernel/base_agent/lifecycle.py
   - tests/test_acp_stdio.py
+  - tests/test_puffo_v0_profile.py
   - tests/test_correlated_turns.py
   - tests/test_execution_workspace.py
   - tests/test_turn_events.py
@@ -74,6 +77,71 @@ stdin/stdout. Do not run the command interactively and type prose into stdin:
 each input line must be one complete JSON-RPC object. The agent directory keeps
 its ordinary workdir lease, so another live LingTai process cannot safely share
 it.
+
+### Constrained Puffo profile
+
+For Puffo Phase A, an operator first provisions an already-initialized,
+persistent LingTai identity and its canonical execution workspace locally:
+
+```bash
+lingtai-agent puffo-v0 provision \
+  --runtime-id puffo-agent-7 \
+  --agent-dir /operator/managed/agent \
+  --workspace /operator/managed/workspace
+```
+
+The controlled Puffo driver then launches only:
+
+```bash
+lingtai-agent acp --profile puffo-v0 --runtime-id puffo-agent-7
+```
+
+The ACP command accepts no profile `agent_dir` path. The runtime id is resolved
+through the local operator registry (`~/.lingtai/puffo-v0/runtime-registry.json`)
+to the entire canonical spawn configuration. The profile rejects an unknown,
+tampered, or revoked id before constructing the Agent. Revoke a future launch
+with `lingtai-agent puffo-v0 revoke --runtime-id puffo-agent-7`.
+
+In this profile, `session/new.cwd` must be exactly the provisioned workspace and
+`mcpServers` must be `[]`. The profile disables the `avatar`, `daemon`, and
+`mcp` capabilities even if the agent manifest asks for them, including after an
+in-process refresh. It therefore does not start child avatars, independent
+background work, manifest MCP, or client-supplied MCP processes.
+
+Permission requests remain intentionally small and fail closed: the client can
+receive only the existing tool id/title/status projection and can allow once or
+reject once. A Puffo UI must bind any approval to that concrete request and
+audit it; it cannot use approval to alter the executable, argv, environment,
+agent identity, workspace, or MCP configuration. This profile does not make a
+tool's already-started side effect safe to replay after an interrupted turn.
+
+`puffo-v0` is a second gate for this controlled entrypoint, not complete host
+isolation. A principal with the same OS authority can edit the local registry or
+invoke the generic `lingtai-agent acp --agent-dir ...` command directly; that is
+the host trust boundary, not a guarantee provided by this profile.
+
+### Puffo driver integration boundary
+
+The Puffo ACP driver owns the first gate. Before it starts this process, its
+single `open()` seam must derive a `ValidatedLaunchPlan` from the authorized
+Puffo route, local binding, and operator-managed configuration. That plan covers
+the executable, complete argv, environment, workspace, and the fixed empty MCP
+session plan; `_spawn` must accept only that validated type. The only
+identity-bound command the seam may emit is:
+
+```bash
+lingtai-agent acp --profile puffo-v0 --runtime-id <operator-bound-id>
+```
+
+Lingtai is deliberately not a substitute for that driver proof: it has no way
+to attest to another process's executable, argv, or environment. Its second
+gate accepts only the opaque id and re-resolves the canonical local identity and
+workspace. A message sender cannot submit either a LingTai identity id or a
+filesystem path.
+
+The Puffo OpenCode driver is explicitly outside this trust path. It must not
+launch a `puffo-v0` bound identity or be presented as an alternative identity
+binding entrypoint; only the ACP driver participates in this profile.
 
 ## Wire sequence
 

--- a/src/lingtai/adapters/acp/MANUAL.md
+++ b/src/lingtai/adapters/acp/MANUAL.md
@@ -98,9 +98,23 @@ lingtai-agent acp --profile puffo-v0 --runtime-id puffo-agent-7
 
 The ACP command accepts no profile `agent_dir` path. The runtime id is resolved
 through the local operator registry (`~/.lingtai/puffo-v0/runtime-registry.json`)
-to the entire canonical spawn configuration. The profile rejects an unknown,
+to its bound persistent identity and workspace. The profile rejects an unknown,
 tampered, or revoked id before constructing the Agent. Revoke a future launch
 with `lingtai-agent puffo-v0 revoke --runtime-id puffo-agent-7`.
+
+Provision stores each directory's canonical path and POSIX device/inode/owner/
+group identity. An active agent directory or workspace may be bound to only one
+runtime. At launch the profile rejects symlink retargeting, a changed canonical
+path, or a replacement directory at the same path, then rechecks the binding
+immediately before Agent construction. This detects normal configuration drift;
+it is not host isolation against a same-OS principal that changes the filesystem
+after that final check.
+
+`entry_digest` protects the exact registry record, not the complete effective
+security configuration. In particular, this foundation does not yet freeze or
+hash `init.json`, presets, executable/argv/environment policy, addon/plugin
+policy, or a positive tool/action allowlist. Those constraints need a later,
+typed restricted-runtime policy rather than an implication from this registry.
 
 The Phase A registry is POSIX-only: it serializes provision/revoke updates,
 records terminal revocations in an append-only local tombstone log, and creates

--- a/src/lingtai/adapters/acp/MANUAL.md
+++ b/src/lingtai/adapters/acp/MANUAL.md
@@ -109,7 +109,9 @@ files as `0600`, independent of umask. Loading an older registry tightens its
 directory and file modes before use. On Windows the command fails closed until
 an equivalent owner-only ACL implementation is available. The `puffo-v0`
 control-plane commands are the only supported writers; do not hand-edit the
-registry or use a third-party writer.
+registry or use a third-party writer. The current versioned registry requires
+its tombstone log to exist: missing, unreadable, malformed, or mismatched
+history fails closed instead of being interpreted as no prior revocations.
 
 In this profile, `session/new.cwd` must be exactly the provisioned workspace and
 `mcpServers` must be `[]`. The profile disables the `avatar`, `daemon`, and

--- a/src/lingtai/adapters/acp/puffo_v0.py
+++ b/src/lingtai/adapters/acp/puffo_v0.py
@@ -1,0 +1,194 @@
+"""Operator-managed runtime registry for the constrained Puffo ACP profile."""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+PROFILE_NAME = "puffo-v0"
+REGISTRY_VERSION = 1
+FORCED_DISABLED_CAPABILITIES = frozenset({"avatar", "daemon", "mcp"})
+_RUNTIME_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9_-]{0,127}\Z")
+
+
+class PuffoV0RegistryError(ValueError):
+    """A registry failure safe to expose as a bounded local startup error."""
+
+
+@dataclass(frozen=True, slots=True)
+class PuffoV0Runtime:
+    """One pre-provisioned local identity selected by an opaque runtime id."""
+
+    runtime_id: str
+    agent_dir: Path
+    workspace: Path
+    config_digest: str
+
+
+def default_registry_path() -> Path:
+    """Return the one operator-managed registry location for this profile."""
+
+    return Path.home() / ".lingtai" / PROFILE_NAME / "runtime-registry.json"
+
+
+def _valid_runtime_id(runtime_id: object) -> str:
+    if not isinstance(runtime_id, str) or _RUNTIME_ID.fullmatch(runtime_id) is None:
+        raise PuffoV0RegistryError("runtime_id must be an opaque local identifier")
+    return runtime_id
+
+
+def _canonical_directory(path: Path, *, field: str) -> Path:
+    try:
+        resolved = path.expanduser().resolve(strict=True)
+    except (OSError, RuntimeError) as exc:
+        raise PuffoV0RegistryError(f"{field} must be an existing directory") from exc
+    if not resolved.is_dir():
+        raise PuffoV0RegistryError(f"{field} must be an existing directory")
+    return resolved
+
+
+def _canonical_entry(runtime_id: str, agent_dir: Path, workspace: Path) -> dict[str, Any]:
+    return {
+        "agent_dir": str(agent_dir),
+        "disabled_capabilities": sorted(FORCED_DISABLED_CAPABILITIES),
+        "mcp_servers": [],
+        "profile": PROFILE_NAME,
+        "runtime_id": runtime_id,
+        "status": "active",
+        "workspace": str(workspace),
+    }
+
+
+def _digest(entry: dict[str, Any]) -> str:
+    canonical = json.dumps(entry, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _read_registry(path: Path) -> dict[str, Any]:
+    try:
+        raw = path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise PuffoV0RegistryError("puffo-v0 runtime registry is unavailable or invalid") from exc
+    if not isinstance(data, dict) or set(data) != {"runtimes", "version"}:
+        raise PuffoV0RegistryError("puffo-v0 runtime registry has an invalid shape")
+    if data["version"] != REGISTRY_VERSION or not isinstance(data["runtimes"], dict):
+        raise PuffoV0RegistryError("puffo-v0 runtime registry has an unsupported version")
+    return data
+
+
+def _write_registry(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    try:
+        temporary.write_text(
+            json.dumps(data, ensure_ascii=False, sort_keys=True, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        os.replace(temporary, path)
+    except OSError as exc:
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise PuffoV0RegistryError("puffo-v0 runtime registry could not be written") from exc
+
+
+def provision_runtime(
+    runtime_id: str,
+    agent_dir: Path,
+    workspace: Path,
+    *,
+    registry_path: Path | None = None,
+) -> PuffoV0Runtime:
+    """Bind one existing persistent agent identity to a local runtime id.
+
+    This is an operator control-plane operation.  The ACP data-plane accepts
+    only the resulting id and never accepts either filesystem path.
+    """
+
+    runtime_id = _valid_runtime_id(runtime_id)
+    agent_dir = _canonical_directory(agent_dir, field="agent_dir")
+    workspace = _canonical_directory(workspace, field="workspace")
+    if not (agent_dir / "init.json").is_file():
+        raise PuffoV0RegistryError("agent_dir must contain init.json")
+    path = registry_path or default_registry_path()
+    if path.exists():
+        registry = _read_registry(path)
+    else:
+        registry = {"version": REGISTRY_VERSION, "runtimes": {}}
+    runtimes = registry["runtimes"]
+    if runtime_id in runtimes:
+        raise PuffoV0RegistryError("runtime_id is already provisioned")
+    entry = _canonical_entry(runtime_id, agent_dir, workspace)
+    entry["config_digest"] = _digest(entry)
+    runtimes[runtime_id] = entry
+    _write_registry(path, registry)
+    return PuffoV0Runtime(runtime_id, agent_dir, workspace, entry["config_digest"])
+
+
+def revoke_runtime(runtime_id: str, *, registry_path: Path | None = None) -> None:
+    """Mark a provisioned profile identity unavailable for future ACP spawns."""
+
+    runtime_id = _valid_runtime_id(runtime_id)
+    registry = _read_registry(registry_path or default_registry_path())
+    entry = registry["runtimes"].get(runtime_id)
+    if not isinstance(entry, dict):
+        raise PuffoV0RegistryError("runtime_id is not provisioned")
+    entry["status"] = "revoked"
+    canonical = {key: value for key, value in entry.items() if key != "config_digest"}
+    entry["config_digest"] = _digest(canonical)
+    _write_registry(registry_path or default_registry_path(), registry)
+
+
+def resolve_runtime(
+    runtime_id: str, *, registry_path: Path | None = None
+) -> PuffoV0Runtime:
+    """Resolve one active runtime id into an immutable local spawn specification."""
+
+    runtime_id = _valid_runtime_id(runtime_id)
+    registry = _read_registry(registry_path or default_registry_path())
+    entry = registry["runtimes"].get(runtime_id)
+    if not isinstance(entry, dict):
+        raise PuffoV0RegistryError("runtime_id is not provisioned")
+    expected_keys = {
+        "agent_dir", "config_digest", "disabled_capabilities", "mcp_servers",
+        "profile", "runtime_id", "status", "workspace",
+    }
+    if set(entry) != expected_keys:
+        raise PuffoV0RegistryError("runtime registry entry has an invalid shape")
+    canonical = {key: value for key, value in entry.items() if key != "config_digest"}
+    if (
+        entry.get("profile") != PROFILE_NAME
+        or entry.get("runtime_id") != runtime_id
+        or entry.get("status") != "active"
+        or entry.get("disabled_capabilities") != sorted(FORCED_DISABLED_CAPABILITIES)
+        or entry.get("mcp_servers") != []
+        or not isinstance(entry.get("config_digest"), str)
+        or entry["config_digest"] != _digest(canonical)
+    ):
+        raise PuffoV0RegistryError("runtime registry entry is inactive or does not match puffo-v0")
+    if not isinstance(entry.get("agent_dir"), str) or not isinstance(entry.get("workspace"), str):
+        raise PuffoV0RegistryError("runtime registry entry has invalid paths")
+    agent_dir = _canonical_directory(Path(entry["agent_dir"]), field="agent_dir")
+    workspace = _canonical_directory(Path(entry["workspace"]), field="workspace")
+    if not (agent_dir / "init.json").is_file():
+        raise PuffoV0RegistryError("registered agent identity is no longer initialized")
+    return PuffoV0Runtime(runtime_id, agent_dir, workspace, entry["config_digest"])
+
+
+__all__ = [
+    "FORCED_DISABLED_CAPABILITIES",
+    "PROFILE_NAME",
+    "PuffoV0RegistryError",
+    "PuffoV0Runtime",
+    "default_registry_path",
+    "provision_runtime",
+    "resolve_runtime",
+    "revoke_runtime",
+]

--- a/src/lingtai/adapters/acp/puffo_v0.py
+++ b/src/lingtai/adapters/acp/puffo_v0.py
@@ -14,7 +14,7 @@ from typing import Any, Iterator
 
 
 PROFILE_NAME = "puffo-v0"
-REGISTRY_VERSION = 2
+REGISTRY_VERSION = 3
 REVOCATION_LOG_REQUIRED = "required"
 FORCED_DISABLED_CAPABILITIES = frozenset({"avatar", "daemon", "mcp"})
 _RUNTIME_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9_-]{0,127}\Z")
@@ -25,13 +25,25 @@ class PuffoV0RegistryError(ValueError):
 
 
 @dataclass(frozen=True, slots=True)
+class DirectoryBinding:
+    """The stable local filesystem identity of one bound directory."""
+
+    device: int
+    inode: int
+    owner: int
+    group: int
+
+
+@dataclass(frozen=True, slots=True)
 class PuffoV0Runtime:
     """One pre-provisioned local identity selected by an opaque runtime id."""
 
     runtime_id: str
     agent_dir: Path
     workspace: Path
-    config_digest: str
+    entry_digest: str
+    agent_dir_binding: DirectoryBinding
+    workspace_binding: DirectoryBinding
 
 
 def default_registry_path() -> Path:
@@ -56,15 +68,62 @@ def _canonical_directory(path: Path, *, field: str) -> Path:
     return resolved
 
 
-def _canonical_entry(runtime_id: str, agent_dir: Path, workspace: Path) -> dict[str, Any]:
+def _directory_binding(path: Path, *, field: str) -> DirectoryBinding:
+    """Read the no-symlink directory identity used by the local binding."""
+
+    try:
+        metadata = path.lstat()
+    except OSError as exc:
+        raise PuffoV0RegistryError(f"{field} must be an existing directory") from exc
+    if not stat.S_ISDIR(metadata.st_mode):
+        raise PuffoV0RegistryError(f"{field} must be an existing non-symlink directory")
+    return DirectoryBinding(
+        device=metadata.st_dev,
+        inode=metadata.st_ino,
+        owner=metadata.st_uid,
+        group=metadata.st_gid,
+    )
+
+
+def _binding_payload(binding: DirectoryBinding) -> dict[str, int]:
+    return {
+        "device": binding.device,
+        "group": binding.group,
+        "inode": binding.inode,
+        "owner": binding.owner,
+    }
+
+
+def _parse_binding(value: object) -> DirectoryBinding:
+    if not isinstance(value, dict) or set(value) != {"device", "group", "inode", "owner"}:
+        raise PuffoV0RegistryError("runtime registry entry has an invalid directory binding")
+    if any(not isinstance(item, int) or isinstance(item, bool) or item < 0 for item in value.values()):
+        raise PuffoV0RegistryError("runtime registry entry has an invalid directory binding")
+    return DirectoryBinding(
+        device=value["device"],
+        inode=value["inode"],
+        owner=value["owner"],
+        group=value["group"],
+    )
+
+
+def _canonical_entry(
+    runtime_id: str,
+    agent_dir: Path,
+    workspace: Path,
+    agent_dir_binding: DirectoryBinding,
+    workspace_binding: DirectoryBinding,
+) -> dict[str, Any]:
     return {
         "agent_dir": str(agent_dir),
+        "agent_dir_binding": _binding_payload(agent_dir_binding),
         "disabled_capabilities": sorted(FORCED_DISABLED_CAPABILITIES),
         "mcp_servers": [],
         "profile": PROFILE_NAME,
         "runtime_id": runtime_id,
         "status": "active",
         "workspace": str(workspace),
+        "workspace_binding": _binding_payload(workspace_binding),
     }
 
 
@@ -272,6 +331,46 @@ def _write_registry(path: Path, data: dict[str, Any]) -> None:
         raise PuffoV0RegistryError("puffo-v0 runtime registry could not be written") from exc
 
 
+def _bound_directory(
+    path_value: object,
+    binding_value: object,
+    *,
+    field: str,
+) -> tuple[Path, DirectoryBinding]:
+    """Resolve one stored path and require its present identity to match."""
+
+    if not isinstance(path_value, str):
+        raise PuffoV0RegistryError("runtime registry entry has invalid paths")
+    expected = _parse_binding(binding_value)
+    stored = Path(path_value)
+    resolved = _canonical_directory(stored, field=field)
+    if str(resolved) != path_value:
+        raise PuffoV0RegistryError(f"{field} binding no longer matches its canonical path")
+    observed = _directory_binding(resolved, field=field)
+    if observed != expected:
+        raise PuffoV0RegistryError(f"{field} binding no longer matches its provisioned identity")
+    return resolved, expected
+
+
+def _active_binding_conflicts(
+    runtimes: dict[str, Any],
+    *,
+    agent_dir: Path,
+    workspace: Path,
+) -> None:
+    """Require the Phase A active binding to remain one-to-one."""
+
+    for existing_runtime_id, entry in runtimes.items():
+        if not isinstance(existing_runtime_id, str) or not isinstance(entry, dict):
+            raise PuffoV0RegistryError("runtime registry entry has an invalid shape")
+        if entry.get("status") != "active":
+            continue
+        if entry.get("agent_dir") == str(agent_dir):
+            raise PuffoV0RegistryError("agent_dir is already bound to an active runtime")
+        if entry.get("workspace") == str(workspace):
+            raise PuffoV0RegistryError("workspace is already bound to an active runtime")
+
+
 def provision_runtime(
     runtime_id: str,
     agent_dir: Path,
@@ -288,6 +387,8 @@ def provision_runtime(
     runtime_id = _valid_runtime_id(runtime_id)
     agent_dir = _canonical_directory(agent_dir, field="agent_dir")
     workspace = _canonical_directory(workspace, field="workspace")
+    agent_dir_binding = _directory_binding(agent_dir, field="agent_dir")
+    workspace_binding = _directory_binding(workspace, field="workspace")
     if not (agent_dir / "init.json").is_file():
         raise PuffoV0RegistryError("agent_dir must contain init.json")
     path = registry_path or default_registry_path()
@@ -308,11 +409,25 @@ def provision_runtime(
         runtimes = registry["runtimes"]
         if runtime_id in runtimes:
             raise PuffoV0RegistryError("runtime_id is already provisioned")
-        entry = _canonical_entry(runtime_id, agent_dir, workspace)
-        entry["config_digest"] = _digest(entry)
+        _active_binding_conflicts(runtimes, agent_dir=agent_dir, workspace=workspace)
+        entry = _canonical_entry(
+            runtime_id,
+            agent_dir,
+            workspace,
+            agent_dir_binding,
+            workspace_binding,
+        )
+        entry["entry_digest"] = _digest(entry)
         runtimes[runtime_id] = entry
         _write_registry(path, registry)
-    return PuffoV0Runtime(runtime_id, agent_dir, workspace, entry["config_digest"])
+    return PuffoV0Runtime(
+        runtime_id,
+        agent_dir,
+        workspace,
+        entry["entry_digest"],
+        agent_dir_binding,
+        workspace_binding,
+    )
 
 
 def revoke_runtime(runtime_id: str, *, registry_path: Path | None = None) -> None:
@@ -328,8 +443,8 @@ def revoke_runtime(runtime_id: str, *, registry_path: Path | None = None) -> Non
         if runtime_id not in _read_revoked_runtime_ids(path):
             _append_revocation_tombstone(path, runtime_id)
         entry["status"] = "revoked"
-        canonical = {key: value for key, value in entry.items() if key != "config_digest"}
-        entry["config_digest"] = _digest(canonical)
+        canonical = {key: value for key, value in entry.items() if key != "entry_digest"}
+        entry["entry_digest"] = _digest(canonical)
         _write_registry(path, registry)
 
 
@@ -348,32 +463,42 @@ def resolve_runtime(
     if not isinstance(entry, dict):
         raise PuffoV0RegistryError("runtime_id is not provisioned")
     expected_keys = {
-        "agent_dir", "config_digest", "disabled_capabilities", "mcp_servers",
-        "profile", "runtime_id", "status", "workspace",
+        "agent_dir", "agent_dir_binding", "disabled_capabilities", "entry_digest",
+        "mcp_servers", "profile", "runtime_id", "status", "workspace", "workspace_binding",
     }
     if set(entry) != expected_keys:
         raise PuffoV0RegistryError("runtime registry entry has an invalid shape")
-    canonical = {key: value for key, value in entry.items() if key != "config_digest"}
+    canonical = {key: value for key, value in entry.items() if key != "entry_digest"}
     if (
         entry.get("profile") != PROFILE_NAME
         or entry.get("runtime_id") != runtime_id
         or entry.get("status") != "active"
         or entry.get("disabled_capabilities") != sorted(FORCED_DISABLED_CAPABILITIES)
         or entry.get("mcp_servers") != []
-        or not isinstance(entry.get("config_digest"), str)
-        or entry["config_digest"] != _digest(canonical)
+        or not isinstance(entry.get("entry_digest"), str)
+        or entry["entry_digest"] != _digest(canonical)
     ):
         raise PuffoV0RegistryError("runtime registry entry is inactive or does not match puffo-v0")
-    if not isinstance(entry.get("agent_dir"), str) or not isinstance(entry.get("workspace"), str):
-        raise PuffoV0RegistryError("runtime registry entry has invalid paths")
-    agent_dir = _canonical_directory(Path(entry["agent_dir"]), field="agent_dir")
-    workspace = _canonical_directory(Path(entry["workspace"]), field="workspace")
+    agent_dir, agent_dir_binding = _bound_directory(
+        entry.get("agent_dir"), entry.get("agent_dir_binding"), field="agent_dir"
+    )
+    workspace, workspace_binding = _bound_directory(
+        entry.get("workspace"), entry.get("workspace_binding"), field="workspace"
+    )
     if not (agent_dir / "init.json").is_file():
         raise PuffoV0RegistryError("registered agent identity is no longer initialized")
-    return PuffoV0Runtime(runtime_id, agent_dir, workspace, entry["config_digest"])
+    return PuffoV0Runtime(
+        runtime_id,
+        agent_dir,
+        workspace,
+        entry["entry_digest"],
+        agent_dir_binding,
+        workspace_binding,
+    )
 
 
 __all__ = [
+    "DirectoryBinding",
     "FORCED_DISABLED_CAPABILITIES",
     "PROFILE_NAME",
     "PuffoV0RegistryError",

--- a/src/lingtai/adapters/acp/puffo_v0.py
+++ b/src/lingtai/adapters/acp/puffo_v0.py
@@ -1,13 +1,15 @@
 """Operator-managed runtime registry for the constrained Puffo ACP profile."""
 from __future__ import annotations
 
+from contextlib import contextmanager, suppress
 import hashlib
 import json
 import os
 import re
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
 
 
 PROFILE_NAME = "puffo-v0"
@@ -69,6 +71,65 @@ def _digest(entry: dict[str, Any]) -> str:
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
+def _require_posix_registry_security() -> None:
+    """Fail closed until puffo-v0 has an owner-only Windows ACL adapter.
+
+    POSIX file modes are part of this profile's control-plane confidentiality
+    boundary.  Windows cannot provide the equivalent guarantee through chmod,
+    so this Phase A registry deliberately has no Windows implementation rather
+    than silently creating a broadly readable registry there.
+    """
+
+    if os.name != "posix":
+        raise PuffoV0RegistryError(
+            "puffo-v0 registry requires POSIX owner-only filesystem permissions"
+        )
+
+
+def _secure_registry_directory(path: Path) -> None:
+    """Create and harden the registry parent independently of umask."""
+
+    _require_posix_registry_security()
+    try:
+        path.mkdir(parents=True, mode=0o700, exist_ok=True)
+        os.chmod(path, 0o700)
+    except OSError as exc:
+        raise PuffoV0RegistryError(
+            "puffo-v0 runtime registry directory could not be secured"
+        ) from exc
+
+
+@contextmanager
+def _registry_mutation_lock(path: Path) -> Iterator[None]:
+    """Serialize one registry read-modify-write across local processes."""
+
+    _secure_registry_directory(path.parent)
+    lock_path = path.with_name(f".{path.name}.lock")
+    try:
+        flags = os.O_CREAT | os.O_RDWR
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(lock_path, flags, 0o600)
+        os.fchmod(descriptor, 0o600)
+    except OSError as exc:
+        raise PuffoV0RegistryError("puffo-v0 runtime registry lock is unavailable") from exc
+
+    try:
+        import fcntl
+
+        fcntl.flock(descriptor, fcntl.LOCK_EX)
+    except OSError as exc:
+        with suppress(OSError):
+            os.close(descriptor)
+        raise PuffoV0RegistryError("puffo-v0 runtime registry lock is unavailable") from exc
+    try:
+        yield
+    finally:
+        with suppress(OSError):
+            fcntl.flock(descriptor, fcntl.LOCK_UN)
+        with suppress(OSError):
+            os.close(descriptor)
+
+
 def _read_registry(path: Path) -> dict[str, Any]:
     try:
         raw = path.read_text(encoding="utf-8")
@@ -83,19 +144,26 @@ def _read_registry(path: Path) -> dict[str, Any]:
 
 
 def _write_registry(path: Path, data: dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    _secure_registry_directory(path.parent)
+    temporary: Path | None = None
     try:
-        temporary.write_text(
-            json.dumps(data, ensure_ascii=False, sort_keys=True, indent=2) + "\n",
-            encoding="utf-8",
+        descriptor, raw_temporary = tempfile.mkstemp(
+            prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
         )
+        temporary = Path(raw_temporary)
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(json.dumps(data, ensure_ascii=False, sort_keys=True, indent=2) + "\n")
+            handle.flush()
+            os.fsync(handle.fileno())
         os.replace(temporary, path)
+        os.chmod(path, 0o600)
     except OSError as exc:
-        try:
-            temporary.unlink(missing_ok=True)
-        except OSError:
-            pass
+        if temporary is not None:
+            try:
+                temporary.unlink(missing_ok=True)
+            except OSError:
+                pass
         raise PuffoV0RegistryError("puffo-v0 runtime registry could not be written") from exc
 
 
@@ -118,17 +186,18 @@ def provision_runtime(
     if not (agent_dir / "init.json").is_file():
         raise PuffoV0RegistryError("agent_dir must contain init.json")
     path = registry_path or default_registry_path()
-    if path.exists():
-        registry = _read_registry(path)
-    else:
-        registry = {"version": REGISTRY_VERSION, "runtimes": {}}
-    runtimes = registry["runtimes"]
-    if runtime_id in runtimes:
-        raise PuffoV0RegistryError("runtime_id is already provisioned")
-    entry = _canonical_entry(runtime_id, agent_dir, workspace)
-    entry["config_digest"] = _digest(entry)
-    runtimes[runtime_id] = entry
-    _write_registry(path, registry)
+    with _registry_mutation_lock(path):
+        if path.exists():
+            registry = _read_registry(path)
+        else:
+            registry = {"version": REGISTRY_VERSION, "runtimes": {}}
+        runtimes = registry["runtimes"]
+        if runtime_id in runtimes:
+            raise PuffoV0RegistryError("runtime_id is already provisioned")
+        entry = _canonical_entry(runtime_id, agent_dir, workspace)
+        entry["config_digest"] = _digest(entry)
+        runtimes[runtime_id] = entry
+        _write_registry(path, registry)
     return PuffoV0Runtime(runtime_id, agent_dir, workspace, entry["config_digest"])
 
 
@@ -136,14 +205,16 @@ def revoke_runtime(runtime_id: str, *, registry_path: Path | None = None) -> Non
     """Mark a provisioned profile identity unavailable for future ACP spawns."""
 
     runtime_id = _valid_runtime_id(runtime_id)
-    registry = _read_registry(registry_path or default_registry_path())
-    entry = registry["runtimes"].get(runtime_id)
-    if not isinstance(entry, dict):
-        raise PuffoV0RegistryError("runtime_id is not provisioned")
-    entry["status"] = "revoked"
-    canonical = {key: value for key, value in entry.items() if key != "config_digest"}
-    entry["config_digest"] = _digest(canonical)
-    _write_registry(registry_path or default_registry_path(), registry)
+    path = registry_path or default_registry_path()
+    with _registry_mutation_lock(path):
+        registry = _read_registry(path)
+        entry = registry["runtimes"].get(runtime_id)
+        if not isinstance(entry, dict):
+            raise PuffoV0RegistryError("runtime_id is not provisioned")
+        entry["status"] = "revoked"
+        canonical = {key: value for key, value in entry.items() if key != "config_digest"}
+        entry["config_digest"] = _digest(canonical)
+        _write_registry(path, registry)
 
 
 def resolve_runtime(
@@ -152,6 +223,7 @@ def resolve_runtime(
     """Resolve one active runtime id into an immutable local spawn specification."""
 
     runtime_id = _valid_runtime_id(runtime_id)
+    _require_posix_registry_security()
     registry = _read_registry(registry_path or default_registry_path())
     entry = registry["runtimes"].get(runtime_id)
     if not isinstance(entry, dict):

--- a/src/lingtai/adapters/acp/puffo_v0.py
+++ b/src/lingtai/adapters/acp/puffo_v0.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import os
 import re
+import stat
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -99,6 +100,80 @@ def _secure_registry_directory(path: Path) -> None:
         ) from exc
 
 
+def _secure_registry_file(path: Path) -> bool:
+    """Harden an existing registry artifact; return false when it is absent."""
+
+    _require_posix_registry_security()
+    try:
+        mode = path.lstat().st_mode
+    except FileNotFoundError:
+        return False
+    except OSError as exc:
+        raise PuffoV0RegistryError("puffo-v0 runtime registry is unavailable or invalid") from exc
+    if not stat.S_ISREG(mode):
+        raise PuffoV0RegistryError("puffo-v0 runtime registry has an invalid file type")
+    try:
+        os.chmod(path, 0o600)
+    except OSError as exc:
+        raise PuffoV0RegistryError("puffo-v0 runtime registry could not be secured") from exc
+    return True
+
+
+def _revocation_log_path(path: Path) -> Path:
+    """Return the append-only, owner-only tombstone log beside a registry."""
+
+    return path.with_name(f".{path.name}.revocations.jsonl")
+
+
+def _read_revoked_runtime_ids(path: Path) -> frozenset[str]:
+    """Read monotonic revocation tombstones, rejecting malformed local state."""
+
+    tombstones = _revocation_log_path(path)
+    if not _secure_registry_file(tombstones):
+        return frozenset()
+    try:
+        lines = tombstones.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeError) as exc:
+        raise PuffoV0RegistryError("puffo-v0 revocation log is unavailable or invalid") from exc
+    revoked: set[str] = set()
+    for line in lines:
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise PuffoV0RegistryError("puffo-v0 revocation log is unavailable or invalid") from exc
+        if not isinstance(entry, dict) or set(entry) != {"runtime_id"}:
+            raise PuffoV0RegistryError("puffo-v0 revocation log is unavailable or invalid")
+        revoked.add(_valid_runtime_id(entry["runtime_id"]))
+    return frozenset(revoked)
+
+
+def _append_revocation_tombstone(path: Path, runtime_id: str) -> None:
+    """Persist a terminal revocation before the mutable registry is updated."""
+
+    _secure_registry_directory(path.parent)
+    tombstones = _revocation_log_path(path)
+    descriptor: int | None = None
+    try:
+        flags = os.O_APPEND | os.O_CREAT | os.O_WRONLY
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(tombstones, flags, 0o600)
+        os.fchmod(descriptor, 0o600)
+        payload = (json.dumps({"runtime_id": runtime_id}, sort_keys=True) + "\n").encode("utf-8")
+        offset = 0
+        while offset < len(payload):
+            written = os.write(descriptor, payload[offset:])
+            if written == 0:
+                raise OSError("short write to puffo-v0 revocation log")
+            offset += written
+        os.fsync(descriptor)
+    except OSError as exc:
+        raise PuffoV0RegistryError("puffo-v0 revocation log could not be written") from exc
+    finally:
+        if descriptor is not None:
+            with suppress(OSError):
+                os.close(descriptor)
+
+
 @contextmanager
 def _registry_mutation_lock(path: Path) -> Iterator[None]:
     """Serialize one registry read-modify-write across local processes."""
@@ -131,6 +206,7 @@ def _registry_mutation_lock(path: Path) -> Iterator[None]:
 
 
 def _read_registry(path: Path) -> dict[str, Any]:
+    _secure_registry_file(path)
     try:
         raw = path.read_text(encoding="utf-8")
         data = json.loads(raw)
@@ -187,6 +263,9 @@ def provision_runtime(
         raise PuffoV0RegistryError("agent_dir must contain init.json")
     path = registry_path or default_registry_path()
     with _registry_mutation_lock(path):
+        revoked_runtime_ids = _read_revoked_runtime_ids(path)
+        if runtime_id in revoked_runtime_ids:
+            raise PuffoV0RegistryError("runtime_id is revoked and cannot be provisioned again")
         if path.exists():
             registry = _read_registry(path)
         else:
@@ -211,6 +290,8 @@ def revoke_runtime(runtime_id: str, *, registry_path: Path | None = None) -> Non
         entry = registry["runtimes"].get(runtime_id)
         if not isinstance(entry, dict):
             raise PuffoV0RegistryError("runtime_id is not provisioned")
+        if runtime_id not in _read_revoked_runtime_ids(path):
+            _append_revocation_tombstone(path, runtime_id)
         entry["status"] = "revoked"
         canonical = {key: value for key, value in entry.items() if key != "config_digest"}
         entry["config_digest"] = _digest(canonical)
@@ -223,8 +304,11 @@ def resolve_runtime(
     """Resolve one active runtime id into an immutable local spawn specification."""
 
     runtime_id = _valid_runtime_id(runtime_id)
-    _require_posix_registry_security()
-    registry = _read_registry(registry_path or default_registry_path())
+    path = registry_path or default_registry_path()
+    _secure_registry_directory(path.parent)
+    if runtime_id in _read_revoked_runtime_ids(path):
+        raise PuffoV0RegistryError("runtime registry entry is inactive or does not match puffo-v0")
+    registry = _read_registry(path)
     entry = registry["runtimes"].get(runtime_id)
     if not isinstance(entry, dict):
         raise PuffoV0RegistryError("runtime_id is not provisioned")

--- a/src/lingtai/adapters/acp/puffo_v0.py
+++ b/src/lingtai/adapters/acp/puffo_v0.py
@@ -14,7 +14,8 @@ from typing import Any, Iterator
 
 
 PROFILE_NAME = "puffo-v0"
-REGISTRY_VERSION = 1
+REGISTRY_VERSION = 2
+REVOCATION_LOG_REQUIRED = "required"
 FORCED_DISABLED_CAPABILITIES = frozenset({"avatar", "daemon", "mcp"})
 _RUNTIME_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9_-]{0,127}\Z")
 
@@ -125,12 +126,36 @@ def _revocation_log_path(path: Path) -> Path:
     return path.with_name(f".{path.name}.revocations.jsonl")
 
 
+def _initialize_revocation_log(path: Path) -> None:
+    """Create the mandatory empty tombstone log before first registry write."""
+
+    _secure_registry_directory(path.parent)
+    tombstones = _revocation_log_path(path)
+    descriptor: int | None = None
+    try:
+        flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(tombstones, flags, 0o600)
+        os.fchmod(descriptor, 0o600)
+        os.fsync(descriptor)
+    except FileExistsError as exc:
+        raise PuffoV0RegistryError(
+            "puffo-v0 registry initialization found an unexpected revocation log"
+        ) from exc
+    except OSError as exc:
+        raise PuffoV0RegistryError("puffo-v0 revocation log could not be initialized") from exc
+    finally:
+        if descriptor is not None:
+            with suppress(OSError):
+                os.close(descriptor)
+
+
 def _read_revoked_runtime_ids(path: Path) -> frozenset[str]:
     """Read monotonic revocation tombstones, rejecting malformed local state."""
 
     tombstones = _revocation_log_path(path)
     if not _secure_registry_file(tombstones):
-        return frozenset()
+        raise PuffoV0RegistryError("puffo-v0 revocation log is unavailable or invalid")
     try:
         lines = tombstones.read_text(encoding="utf-8").splitlines()
     except (OSError, UnicodeError) as exc:
@@ -154,7 +179,7 @@ def _append_revocation_tombstone(path: Path, runtime_id: str) -> None:
     tombstones = _revocation_log_path(path)
     descriptor: int | None = None
     try:
-        flags = os.O_APPEND | os.O_CREAT | os.O_WRONLY
+        flags = os.O_APPEND | os.O_WRONLY
         flags |= getattr(os, "O_NOFOLLOW", 0)
         descriptor = os.open(tombstones, flags, 0o600)
         os.fchmod(descriptor, 0o600)
@@ -212,9 +237,13 @@ def _read_registry(path: Path) -> dict[str, Any]:
         data = json.loads(raw)
     except (OSError, UnicodeError, json.JSONDecodeError) as exc:
         raise PuffoV0RegistryError("puffo-v0 runtime registry is unavailable or invalid") from exc
-    if not isinstance(data, dict) or set(data) != {"runtimes", "version"}:
+    if not isinstance(data, dict) or set(data) != {"revocation_log", "runtimes", "version"}:
         raise PuffoV0RegistryError("puffo-v0 runtime registry has an invalid shape")
-    if data["version"] != REGISTRY_VERSION or not isinstance(data["runtimes"], dict):
+    if (
+        data["version"] != REGISTRY_VERSION
+        or data["revocation_log"] != REVOCATION_LOG_REQUIRED
+        or not isinstance(data["runtimes"], dict)
+    ):
         raise PuffoV0RegistryError("puffo-v0 runtime registry has an unsupported version")
     return data
 
@@ -263,13 +292,19 @@ def provision_runtime(
         raise PuffoV0RegistryError("agent_dir must contain init.json")
     path = registry_path or default_registry_path()
     with _registry_mutation_lock(path):
-        revoked_runtime_ids = _read_revoked_runtime_ids(path)
-        if runtime_id in revoked_runtime_ids:
-            raise PuffoV0RegistryError("runtime_id is revoked and cannot be provisioned again")
         if path.exists():
+            revoked_runtime_ids = _read_revoked_runtime_ids(path)
             registry = _read_registry(path)
         else:
-            registry = {"version": REGISTRY_VERSION, "runtimes": {}}
+            _initialize_revocation_log(path)
+            revoked_runtime_ids = frozenset()
+            registry = {
+                "revocation_log": REVOCATION_LOG_REQUIRED,
+                "version": REGISTRY_VERSION,
+                "runtimes": {},
+            }
+        if runtime_id in revoked_runtime_ids:
+            raise PuffoV0RegistryError("runtime_id is revoked and cannot be provisioned again")
         runtimes = registry["runtimes"]
         if runtime_id in runtimes:
             raise PuffoV0RegistryError("runtime_id is already provisioned")

--- a/src/lingtai/adapters/acp/server.py
+++ b/src/lingtai/adapters/acp/server.py
@@ -244,7 +244,15 @@ class AcpStdioServer:
     _OUTBOUND_QUEUE_BATCHES = 64
     _PERMISSION_TIMEOUT_SECONDS = 60.0
 
-    def __init__(self, agent, input_stream: TextIO, output_stream: TextIO):
+    def __init__(
+        self,
+        agent,
+        input_stream: TextIO,
+        output_stream: TextIO,
+        *,
+        fixed_execution_workspace: ExecutionWorkspace | None = None,
+        allow_session_mcp: bool = True,
+    ):
         self._agent = agent
         self._input = input_stream
         self._output = output_stream
@@ -253,6 +261,8 @@ class AcpStdioServer:
         self._session_id: str | None = None
         self._session_pending = False
         self._execution_workspace: ExecutionWorkspace | None = None
+        self._fixed_execution_workspace = fixed_execution_workspace
+        self._allow_session_mcp = allow_session_mcp
         self._session_mcp_lease = None
         self._active: _ActivePrompt | None = None
         self._closing = False
@@ -541,7 +551,21 @@ class AcpStdioServer:
             raise _RpcError(INVALID_PARAMS, "cwd must exist") from exc
         if not resolved_cwd.is_dir():
             raise _RpcError(INVALID_PARAMS, "cwd must be a directory")
-        configs = self._stdio_mcp_configs(mcp_servers)
+        if self._fixed_execution_workspace is not None:
+            if resolved_cwd != self._fixed_execution_workspace.root:
+                raise _RpcError(
+                    INVALID_PARAMS,
+                    "cwd must match the profile's fixed execution workspace",
+                )
+        if not self._allow_session_mcp:
+            if mcp_servers != []:
+                raise _RpcError(
+                    INVALID_PARAMS,
+                    "mcpServers must be an empty array for this profile",
+                )
+            configs: tuple[StdioMCPServerConfig, ...] = ()
+        else:
+            configs = self._stdio_mcp_configs(mcp_servers)
         additional_directories = params.get("additionalDirectories")
         if additional_directories not in (None, []):
             raise _RpcError(
@@ -567,7 +591,7 @@ class AcpStdioServer:
             except Exception as exc:
                 raise _RpcError(INTERNAL_ERROR, "session MCP startup failed") from exc
 
-            workspace = ExecutionWorkspace(resolved_cwd)
+            workspace = self._fixed_execution_workspace or ExecutionWorkspace(resolved_cwd)
             with self._state_lock:
                 if self._closing:
                     raise _RpcError(UNSUPPORTED, "adapter is closing")

--- a/src/lingtai/agent.py
+++ b/src/lingtai/agent.py
@@ -214,12 +214,14 @@ class Agent(BaseAgent):
         plugins: list[str] | None = None,
         combo_name: str | None = None,
         disable: list[str] | None = None,
+        _forced_disable: frozenset[str] | None = None,
         _from_init_boot: bool = False,
         **kwargs: Any,
     ):
         # Private CLI composition sentinel. It is set before BaseAgent invokes
         # the overridable mandatory-official boot hook below.
         self._from_init_boot = _from_init_boot
+        self._forced_disable = frozenset(_forced_disable or ())
 
         # Default karma authority for the primary agent (本我)
         kwargs.setdefault("admin", {"karma": True})
@@ -401,7 +403,10 @@ class Agent(BaseAgent):
         # unless explicitly disabled via `disable=[...]` or `"name": null` in
         # the capabilities dict. init.json kwargs override default kwargs.
         from lingtai.tools.registry import apply_core_defaults
-        capabilities = apply_core_defaults(capabilities, disable=disable)
+        capabilities = apply_core_defaults(
+            capabilities,
+            disable=[*(disable or []), *self._forced_disable],
+        )
 
         # Track for avatar replay
         self._capabilities: list[tuple[str, dict]] = []
@@ -1018,6 +1023,10 @@ class Agent(BaseAgent):
         helper consults this dict on ``system(action="refresh")`` to detect
         and re-spawn MCPs whose subprocess died (issue #34).
         """
+        if "mcp" in self._forced_disable:
+            self._mcp_init_specs = {}
+            return
+
         import json
         import sys
 
@@ -2309,7 +2318,7 @@ class Agent(BaseAgent):
             if v is None:
                 normalized[n] = None  # type: ignore[assignment]
 
-        disable_list = m.get("disable") or []
+        disable_list = [*(m.get("disable") or []), *self._forced_disable]
         capabilities = apply_core_defaults(normalized, disable=disable_list)
 
         # Register declared Agent Plugins BEFORE capability setup, next to addon

--- a/src/lingtai/cli.py
+++ b/src/lingtai/cli.py
@@ -123,7 +123,12 @@ def build_llm_service(data: dict, working_dir: Path) -> LLMService:
     )
 
 
-def build_agent(data: dict, working_dir: Path) -> Agent:
+def build_agent(
+    data: dict,
+    working_dir: Path,
+    *,
+    _forced_disable: frozenset[str] | None = None,
+) -> Agent:
     """Construct Agent from validated init data.
 
     Creates a minimal Agent (LLMService + working_dir + mail_service),
@@ -170,6 +175,7 @@ def build_agent(data: dict, working_dir: Path) -> Agent:
             ensure_ascii=False,
         ),
         streaming=m.get("streaming", False),
+        _forced_disable=_forced_disable,
         _from_init_boot=True,
     )
 
@@ -548,6 +554,8 @@ def main() -> None:
     add_daemon_parser(sub)
     from lingtai.cli_acp import add_acp_parser
     add_acp_parser(sub)
+    from lingtai.cli_puffo_v0 import add_puffo_v0_parser
+    add_puffo_v0_parser(sub)
     from lingtai.cli_project import add_project_parser
     add_project_parser(sub)
 
@@ -621,6 +629,10 @@ def main() -> None:
         from lingtai.cli_acp import handle_acp_command
 
         handle_acp_command(args)
+    elif args.command == "puffo-v0":
+        from lingtai.cli_puffo_v0 import handle_puffo_v0_command
+
+        handle_puffo_v0_command(args)
     elif args.command == "project":
         from lingtai.cli_project import handle_project_command
 

--- a/src/lingtai/cli_acp.py
+++ b/src/lingtai/cli_acp.py
@@ -65,6 +65,7 @@ def run_acp(
     output_stream: TextIO | None = None,
     fixed_execution_workspace=None,
     forced_disable: frozenset[str] | None = None,
+    puffo_runtime=None,
 ) -> None:
     """Compose one Agent and the local ACP stdio driving adapter.
 
@@ -105,6 +106,15 @@ def run_acp(
         from lingtai.kernel.logging import setup_logging
         from lingtai.venv_resolve import resolve_venv
 
+        if puffo_runtime is not None:
+            from lingtai.adapters.acp.puffo_v0 import resolve_runtime
+            from lingtai.kernel.execution_workspace import ExecutionWorkspace
+
+            verified_runtime = resolve_runtime(puffo_runtime.runtime_id)
+            if verified_runtime != puffo_runtime:
+                raise RuntimeError("puffo-v0 runtime binding changed before ACP startup")
+            agent_dir = verified_runtime.agent_dir
+            fixed_execution_workspace = ExecutionWorkspace(verified_runtime.workspace)
         _check_duplicate_process(agent_dir)
         _clean_signal_files(agent_dir)
         setup_logging(
@@ -197,6 +207,7 @@ def handle_acp_command(args) -> None:
         runtime.agent_dir,
         fixed_execution_workspace=ExecutionWorkspace(runtime.workspace),
         forced_disable=FORCED_DISABLED_CAPABILITIES,
+        puffo_runtime=runtime,
     )
 
 

--- a/src/lingtai/cli_acp.py
+++ b/src/lingtai/cli_acp.py
@@ -12,11 +12,20 @@ def add_acp_parser(subparsers) -> None:
         "acp",
         help="Serve one existing LingTai agent over local ACP v1 stdio",
     )
-    parser.add_argument(
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument(
         "--agent-dir",
         type=Path,
-        required=True,
         help="Existing agent working directory containing init.json",
+    )
+    source.add_argument(
+        "--runtime-id",
+        help="Opaque operator-provisioned Puffo runtime id (requires --profile puffo-v0)",
+    )
+    parser.add_argument(
+        "--profile",
+        choices=("puffo-v0",),
+        help="Constrained locally provisioned ACP launch profile",
     )
 
 
@@ -54,6 +63,8 @@ def run_acp(
     *,
     input_stream: TextIO | None = None,
     output_stream: TextIO | None = None,
+    fixed_execution_workspace=None,
+    forced_disable: frozenset[str] | None = None,
 ) -> None:
     """Compose one Agent and the local ACP stdio driving adapter.
 
@@ -106,10 +117,22 @@ def run_acp(
         os.environ["LINGTAI_RUNTIME_VENV"] = str(venv_dir)
         data["venv_path"] = str(venv_dir)
 
-        agent = build_agent(data, agent_dir)
+        if forced_disable:
+            agent = build_agent(data, agent_dir, _forced_disable=forced_disable)
+        else:
+            agent = build_agent(data, agent_dir)
         agent._venv_path = str(venv_dir)
         agent.start()
-        server = AcpStdioServer(agent, wire_in, wire_out)
+        if fixed_execution_workspace is None and not forced_disable:
+            server = AcpStdioServer(agent, wire_in, wire_out)
+        else:
+            server = AcpStdioServer(
+                agent,
+                wire_in,
+                wire_out,
+                fixed_execution_workspace=fixed_execution_workspace,
+                allow_session_mcp=not bool(forced_disable and "mcp" in forced_disable),
+            )
         try:
             server.serve()
         except (BrokenPipeError, OSError, UnicodeError, KeyboardInterrupt):
@@ -138,11 +161,43 @@ def run_acp(
 
 
 def handle_acp_command(args) -> None:
-    agent_dir = args.agent_dir.resolve()
-    if not agent_dir.is_dir():
-        print(f"error: {agent_dir} is not a directory", file=sys.stderr)
+    if args.profile is None:
+        if args.runtime_id is not None:
+            print("error: --runtime-id requires --profile puffo-v0", file=sys.stderr)
+            raise SystemExit(1)
+        agent_dir = args.agent_dir.resolve()
+        if not agent_dir.is_dir():
+            print(f"error: {agent_dir} is not a directory", file=sys.stderr)
+            raise SystemExit(1)
+        run_acp(agent_dir)
+        return
+
+    if args.profile == "puffo-v0" and args.agent_dir is not None:
+        print(
+            "error: puffo-v0 does not accept --agent-dir; use --runtime-id",
+            file=sys.stderr,
+        )
         raise SystemExit(1)
-    run_acp(agent_dir)
+    if args.profile != "puffo-v0" or args.runtime_id is None:
+        print("error: puffo-v0 requires --runtime-id", file=sys.stderr)
+        raise SystemExit(1)
+    from lingtai.adapters.acp.puffo_v0 import (
+        FORCED_DISABLED_CAPABILITIES,
+        PuffoV0RegistryError,
+        resolve_runtime,
+    )
+    from lingtai.kernel.execution_workspace import ExecutionWorkspace
+
+    try:
+        runtime = resolve_runtime(args.runtime_id)
+    except PuffoV0RegistryError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        raise SystemExit(1) from None
+    run_acp(
+        runtime.agent_dir,
+        fixed_execution_workspace=ExecutionWorkspace(runtime.workspace),
+        forced_disable=FORCED_DISABLED_CAPABILITIES,
+    )
 
 
 __all__ = ["add_acp_parser", "handle_acp_command", "run_acp"]

--- a/src/lingtai/cli_puffo_v0.py
+++ b/src/lingtai/cli_puffo_v0.py
@@ -46,7 +46,7 @@ def handle_puffo_v0_command(args: argparse.Namespace) -> None:
                 "runtime_id": runtime.runtime_id,
                 "agent_dir": str(runtime.agent_dir),
                 "workspace": str(runtime.workspace),
-                "config_digest": runtime.config_digest,
+                "entry_digest": runtime.entry_digest,
             }
         elif args.puffo_v0_command == "revoke":
             revoke_runtime(args.runtime_id)

--- a/src/lingtai/cli_puffo_v0.py
+++ b/src/lingtai/cli_puffo_v0.py
@@ -1,0 +1,65 @@
+"""Local operator control plane for the constrained Puffo ACP profile."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from lingtai.adapters.acp.puffo_v0 import (
+    PuffoV0RegistryError,
+    provision_runtime,
+    revoke_runtime,
+)
+
+
+def add_puffo_v0_parser(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> None:
+    parser = subparsers.add_parser(
+        "puffo-v0",
+        help="Provision or revoke locally managed Puffo ACP runtimes",
+    )
+    commands = parser.add_subparsers(dest="puffo_v0_command", required=True)
+    provision = commands.add_parser(
+        "provision",
+        help="Bind one existing persistent agent identity to an opaque runtime id",
+    )
+    provision.add_argument("--runtime-id", required=True)
+    provision.add_argument("--agent-dir", type=Path, required=True)
+    provision.add_argument("--workspace", type=Path, required=True)
+    provision.add_argument("--json", action="store_true", dest="as_json")
+    revoke = commands.add_parser(
+        "revoke",
+        help="Prevent future puffo-v0 ACP spawns for one runtime id",
+    )
+    revoke.add_argument("--runtime-id", required=True)
+    revoke.add_argument("--json", action="store_true", dest="as_json")
+
+
+def handle_puffo_v0_command(args: argparse.Namespace) -> None:
+    try:
+        if args.puffo_v0_command == "provision":
+            runtime = provision_runtime(args.runtime_id, args.agent_dir, args.workspace)
+            payload = {
+                "status": "provisioned",
+                "runtime_id": runtime.runtime_id,
+                "agent_dir": str(runtime.agent_dir),
+                "workspace": str(runtime.workspace),
+                "config_digest": runtime.config_digest,
+            }
+        elif args.puffo_v0_command == "revoke":
+            revoke_runtime(args.runtime_id)
+            payload = {"status": "revoked", "runtime_id": args.runtime_id}
+        else:
+            raise SystemExit(2)
+    except PuffoV0RegistryError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        raise SystemExit(1) from None
+    if args.as_json:
+        print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+    else:
+        print(f"puffo-v0 runtime {payload['runtime_id']} {payload['status']}.")
+
+
+__all__ = ["add_puffo_v0_parser", "handle_puffo_v0_command"]

--- a/tests/ANATOMY.md
+++ b/tests/ANATOMY.md
@@ -41,6 +41,7 @@ related_files:
   - tests/opencode
   - tests/test_activate_preset.py
   - tests/test_acp_stdio.py
+  - tests/test_puffo_v0_profile.py
   - tests/test_execution_workspace.py
   - tests/test_turn_events.py
   - tests/test_turn_permissions.py

--- a/tests/test_puffo_v0_profile.py
+++ b/tests/test_puffo_v0_profile.py
@@ -107,10 +107,77 @@ def test_registry_rejects_tampering_and_revoked_runtime(tmp_path):
     with pytest.raises(PuffoV0RegistryError, match="does not match"):
         resolve_runtime("opaque-id", registry_path=registry)
 
-    provision_runtime("active-id", agent_dir, workspace, registry_path=registry)
+    other_agent_dir = tmp_path / "other-identity"
+    other_agent_dir.mkdir()
+    (other_agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    other_workspace = tmp_path / "other-workspace"
+    other_workspace.mkdir()
+    provision_runtime("active-id", other_agent_dir, other_workspace, registry_path=registry)
     revoke_runtime("active-id", registry_path=registry)
     with pytest.raises(PuffoV0RegistryError, match="inactive"):
         resolve_runtime("active-id", registry_path=registry)
+
+
+def test_runtime_binding_rejects_symlink_retargeting_of_identity_and_workspace(tmp_path):
+    agent_dir = tmp_path / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    registry = tmp_path / "registry.json"
+    provision_runtime("runtime-a", agent_dir, workspace, registry_path=registry)
+
+    replacement_agent = tmp_path / "replacement-agent"
+    replacement_agent.mkdir()
+    (replacement_agent / "init.json").write_text("{}", encoding="utf-8")
+    replacement_workspace = tmp_path / "replacement-workspace"
+    replacement_workspace.mkdir()
+    agent_dir.rename(tmp_path / "original-agent")
+    workspace.rename(tmp_path / "original-workspace")
+    agent_dir.symlink_to(replacement_agent, target_is_directory=True)
+    workspace.symlink_to(replacement_workspace, target_is_directory=True)
+
+    with pytest.raises(PuffoV0RegistryError, match="binding no longer matches"):
+        resolve_runtime("runtime-a", registry_path=registry)
+
+
+def test_runtime_binding_rejects_replaced_directory_at_the_same_canonical_path(tmp_path):
+    agent_dir = tmp_path / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    registry = tmp_path / "registry.json"
+    provision_runtime("runtime-a", agent_dir, workspace, registry_path=registry)
+
+    agent_dir.rename(tmp_path / "original-agent")
+    workspace.rename(tmp_path / "original-workspace")
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace.mkdir()
+
+    with pytest.raises(PuffoV0RegistryError, match="binding no longer matches"):
+        resolve_runtime("runtime-a", registry_path=registry)
+
+
+def test_active_runtime_bindings_require_dedicated_identity_and_workspace(tmp_path):
+    agent_dir = tmp_path / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    other_agent_dir = tmp_path / "other-identity"
+    other_agent_dir.mkdir()
+    (other_agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    other_workspace = tmp_path / "other-workspace"
+    other_workspace.mkdir()
+    registry = tmp_path / "registry.json"
+    provision_runtime("runtime-a", agent_dir, workspace, registry_path=registry)
+
+    with pytest.raises(PuffoV0RegistryError, match="agent_dir is already bound"):
+        provision_runtime("runtime-b", agent_dir, other_workspace, registry_path=registry)
+    with pytest.raises(PuffoV0RegistryError, match="workspace is already bound"):
+        provision_runtime("runtime-c", other_agent_dir, workspace, registry_path=registry)
 
 
 def test_registry_mutations_are_linearized_so_revoke_cannot_be_resurrected(
@@ -124,6 +191,11 @@ def test_registry_mutations_are_linearized_so_revoke_cannot_be_resurrected(
     (agent_dir / "init.json").write_text("{}", encoding="utf-8")
     workspace = tmp_path / "workspace"
     workspace.mkdir()
+    agent_dir_b = tmp_path / "identity-b"
+    agent_dir_b.mkdir()
+    (agent_dir_b / "init.json").write_text("{}", encoding="utf-8")
+    workspace_b = tmp_path / "workspace-b"
+    workspace_b.mkdir()
     registry = tmp_path / "registry.json"
     provision_runtime("runtime-a", agent_dir, workspace, registry_path=registry)
 
@@ -146,7 +218,7 @@ def test_registry_mutations_are_linearized_so_revoke_cannot_be_resurrected(
 
     def provision() -> None:
         try:
-            provision_runtime("runtime-b", agent_dir, workspace, registry_path=registry)
+            provision_runtime("runtime-b", agent_dir_b, workspace_b, registry_path=registry)
         except BaseException as exc:  # pragma: no cover - surfaced below
             failures.append(exc)
 
@@ -226,6 +298,11 @@ def test_registry_mutation_lock_blocks_a_second_process(tmp_path):
     (agent_dir / "init.json").write_text("{}", encoding="utf-8")
     workspace = tmp_path / "workspace"
     workspace.mkdir()
+    agent_dir_b = tmp_path / "identity-b"
+    agent_dir_b.mkdir()
+    (agent_dir_b / "init.json").write_text("{}", encoding="utf-8")
+    workspace_b = tmp_path / "workspace-b"
+    workspace_b.mkdir()
     registry = tmp_path / "registry.json"
     provision_runtime("runtime-a", agent_dir, workspace, registry_path=registry)
 
@@ -233,7 +310,7 @@ def test_registry_mutation_lock_blocks_a_second_process(tmp_path):
     provisioned = context.Event()
 
     def provision_in_child() -> None:
-        provision_runtime("runtime-b", agent_dir, workspace, registry_path=registry)
+        provision_runtime("runtime-b", agent_dir_b, workspace_b, registry_path=registry)
         provisioned.set()
 
     with puffo_v0._registry_mutation_lock(registry):
@@ -319,13 +396,14 @@ def test_profile_session_rejects_remote_workspace_and_mcp_inputs(tmp_path):
 
 def test_profile_cli_resolves_an_opaque_id_before_composing_acp(monkeypatch, tmp_path):
     import lingtai.cli_acp as cli_acp
-    from lingtai.adapters.acp.puffo_v0 import PuffoV0Runtime
+    from lingtai.adapters.acp.puffo_v0 import DirectoryBinding, PuffoV0Runtime
 
     agent_dir = tmp_path / "identity"
     agent_dir.mkdir()
     workspace = tmp_path / "workspace"
     workspace.mkdir()
-    runtime = PuffoV0Runtime("runtime-1", agent_dir, workspace, "digest")
+    binding = DirectoryBinding(device=1, inode=2, owner=3, group=4)
+    runtime = PuffoV0Runtime("runtime-1", agent_dir, workspace, "digest", binding, binding)
     observed = {}
     monkeypatch.setattr(cli_acp, "resolve_runtime", lambda _id: runtime, raising=False)
     # The handler imports from the profile module after parser validation.
@@ -337,6 +415,7 @@ def test_profile_cli_resolves_an_opaque_id_before_composing_acp(monkeypatch, tmp
     assert observed["directory"] == agent_dir
     assert observed["fixed_execution_workspace"].root == workspace
     assert observed["forced_disable"] == FORCED_DISABLED_CAPABILITIES
+    assert observed["puffo_runtime"] == runtime
 
 
 def test_profile_cli_rejects_agent_dir_instead_of_ignoring_it(capsys):

--- a/tests/test_puffo_v0_profile.py
+++ b/tests/test_puffo_v0_profile.py
@@ -1,0 +1,217 @@
+"""Conformance tests for the constrained, registry-backed Puffo ACP profile."""
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from lingtai.adapters.acp.puffo_v0 import (
+    FORCED_DISABLED_CAPABILITIES,
+    PuffoV0RegistryError,
+    provision_runtime,
+    resolve_runtime,
+    revoke_runtime,
+)
+from lingtai.adapters.acp.server import AcpStdioServer, INVALID_PARAMS
+from lingtai.agent import Agent
+from lingtai.kernel.execution_workspace import ExecutionWorkspace
+from lingtai.kernel.config import AgentConfig
+from tests._service_helpers import make_gemini_mock_service as make_mock_service
+from tests.test_deep_refresh import _make_init
+
+
+class _Agent:
+    def __init__(self):
+        self._shutdown = None
+
+
+def _frames(output: io.StringIO) -> list[dict]:
+    return [json.loads(line) for line in output.getvalue().splitlines()]
+
+
+def _wait_for_frames(output: io.StringIO, count: int) -> list[dict]:
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        frames = _frames(output)
+        if len(frames) >= count:
+            return frames
+        time.sleep(0.01)
+    raise AssertionError(f"timed out waiting for {count} frames")
+
+
+def _new_profile_server(workspace: Path) -> tuple[AcpStdioServer, io.StringIO]:
+    output = io.StringIO()
+    return (
+        AcpStdioServer(
+            _Agent(),
+            io.StringIO(),
+            output,
+            fixed_execution_workspace=ExecutionWorkspace(workspace),
+            allow_session_mcp=False,
+        ),
+        output,
+    )
+
+
+def _request(server: AcpStdioServer, request_id: int, method: str, params: dict) -> None:
+    server._dispatch({
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "method": method,
+        "params": params,
+    })
+
+
+def test_provisioned_runtime_resolves_only_the_canonical_local_paths(tmp_path):
+    agent_dir = tmp_path / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    registry = tmp_path / "registry.json"
+
+    provisioned = provision_runtime(
+        "puffo-agent-7", agent_dir, workspace, registry_path=registry
+    )
+    resolved = resolve_runtime("puffo-agent-7", registry_path=registry)
+
+    assert resolved == provisioned
+    stored = json.loads(registry.read_text(encoding="utf-8"))
+    entry = stored["runtimes"]["puffo-agent-7"]
+    assert entry["mcp_servers"] == []
+    assert entry["disabled_capabilities"] == sorted(FORCED_DISABLED_CAPABILITIES)
+
+
+def test_registry_rejects_tampering_and_revoked_runtime(tmp_path):
+    agent_dir = tmp_path / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    registry = tmp_path / "registry.json"
+    provision_runtime("opaque-id", agent_dir, workspace, registry_path=registry)
+
+    data = json.loads(registry.read_text(encoding="utf-8"))
+    data["runtimes"]["opaque-id"]["workspace"] = str(tmp_path)
+    registry.write_text(json.dumps(data), encoding="utf-8")
+    with pytest.raises(PuffoV0RegistryError, match="does not match"):
+        resolve_runtime("opaque-id", registry_path=registry)
+
+    provision_runtime("active-id", agent_dir, workspace, registry_path=registry)
+    revoke_runtime("active-id", registry_path=registry)
+    with pytest.raises(PuffoV0RegistryError, match="inactive"):
+        resolve_runtime("active-id", registry_path=registry)
+
+
+def test_profile_session_rejects_remote_workspace_and_mcp_inputs(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    other = tmp_path / "other"
+    other.mkdir()
+    server, output = _new_profile_server(workspace)
+    _request(server, 1, "initialize", {"protocolVersion": 1})
+
+    _request(server, 2, "session/new", {"cwd": str(other), "mcpServers": []})
+    _request(server, 3, "session/new", {
+        "cwd": str(workspace),
+        "mcpServers": [{"name": "unsafe", "command": "/bin/echo", "args": [], "env": []}],
+    })
+
+    frames = _wait_for_frames(output, 3)
+    assert frames[1]["error"]["code"] == INVALID_PARAMS
+    assert frames[1]["error"]["message"] == "cwd must match the profile's fixed execution workspace"
+    assert frames[2]["error"]["code"] == INVALID_PARAMS
+    assert frames[2]["error"]["message"] == "mcpServers must be an empty array for this profile"
+    server.close()
+
+
+def test_profile_cli_resolves_an_opaque_id_before_composing_acp(monkeypatch, tmp_path):
+    import lingtai.cli_acp as cli_acp
+    from lingtai.adapters.acp.puffo_v0 import PuffoV0Runtime
+
+    agent_dir = tmp_path / "identity"
+    agent_dir.mkdir()
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    runtime = PuffoV0Runtime("runtime-1", agent_dir, workspace, "digest")
+    observed = {}
+    monkeypatch.setattr(cli_acp, "resolve_runtime", lambda _id: runtime, raising=False)
+    # The handler imports from the profile module after parser validation.
+    monkeypatch.setattr("lingtai.adapters.acp.puffo_v0.resolve_runtime", lambda _id: runtime)
+    monkeypatch.setattr(cli_acp, "run_acp", lambda directory, **kwargs: observed.update(directory=directory, **kwargs))
+
+    cli_acp.handle_acp_command(SimpleNamespace(profile="puffo-v0", runtime_id="runtime-1", agent_dir=None))
+
+    assert observed["directory"] == agent_dir
+    assert observed["fixed_execution_workspace"].root == workspace
+    assert observed["forced_disable"] == FORCED_DISABLED_CAPABILITIES
+
+
+def test_profile_cli_rejects_agent_dir_instead_of_ignoring_it(capsys):
+    import lingtai.cli_acp as cli_acp
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_acp.handle_acp_command(
+            SimpleNamespace(profile="puffo-v0", runtime_id=None, agent_dir=Path("/tmp"))
+        )
+    assert exc_info.value.code == 1
+    assert "puffo-v0 does not accept --agent-dir; use --runtime-id" in capsys.readouterr().err
+
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    cli_acp.add_acp_parser(subparsers)
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args([
+            "acp", "--profile", "puffo-v0", "--agent-dir", "/tmp",
+            "--runtime-id", "opaque-id",
+        ])
+    assert exc_info.value.code == 2
+
+
+def test_forced_profile_capability_denials_override_agent_defaults(tmp_path):
+    agent = Agent(
+        service=make_mock_service(),
+        agent_name="profile-test",
+        working_dir=tmp_path / "identity",
+        _forced_disable=FORCED_DISABLED_CAPABILITIES,
+    )
+    try:
+        registered = {name for name, _ in agent._capabilities}
+        assert FORCED_DISABLED_CAPABILITIES.isdisjoint(registered)
+        assert agent._mcp_init_specs == {}
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_forced_profile_capability_denials_survive_init_refresh(tmp_path):
+    (tmp_path / "init.json").write_text(
+        json.dumps(_make_init(capabilities={"avatar": {}, "daemon": {}, "mcp": {}})),
+        encoding="utf-8",
+    )
+    service = MagicMock()
+    service.provider = "openai"
+    service.model = "gpt-4o"
+    service._base_url = None
+    agent = Agent(
+        service,
+        agent_name="profile-refresh",
+        working_dir=tmp_path,
+        config=AgentConfig(),
+        _forced_disable=FORCED_DISABLED_CAPABILITIES,
+        _from_init_boot=True,
+    )
+    agent._from_init_boot = False
+    try:
+        agent._setup_from_init()
+        agent._setup_from_init()
+        registered = {name for name, _ in agent._capabilities}
+        assert FORCED_DISABLED_CAPABILITIES.isdisjoint(registered)
+        assert agent._mcp_init_specs == {}
+    finally:
+        agent.stop(timeout=1.0)

--- a/tests/test_puffo_v0_profile.py
+++ b/tests/test_puffo_v0_profile.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 import argparse
 import io
 import json
+import multiprocessing
+import os
+import stat
+import threading
 import time
 from pathlib import Path
 from types import SimpleNamespace
@@ -107,6 +111,132 @@ def test_registry_rejects_tampering_and_revoked_runtime(tmp_path):
     revoke_runtime("active-id", registry_path=registry)
     with pytest.raises(PuffoV0RegistryError, match="inactive"):
         resolve_runtime("active-id", registry_path=registry)
+
+
+def test_registry_mutations_are_linearized_so_revoke_cannot_be_resurrected(
+    monkeypatch, tmp_path
+):
+    """A stale provision snapshot must never overwrite a completed revoke."""
+    import lingtai.adapters.acp.puffo_v0 as puffo_v0
+
+    agent_dir = tmp_path / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    registry = tmp_path / "registry.json"
+    provision_runtime("runtime-a", agent_dir, workspace, registry_path=registry)
+
+    original_write = puffo_v0._write_registry
+    provision_waiting = threading.Event()
+    release_provision = threading.Event()
+    revoke_write_seen = threading.Event()
+    failures: list[BaseException] = []
+
+    def controlled_write(path, data):
+        entry_a = data["runtimes"].get("runtime-a", {})
+        if "runtime-b" in data["runtimes"] and entry_a.get("status") == "active":
+            provision_waiting.set()
+            assert release_provision.wait(timeout=5)
+        if entry_a.get("status") == "revoked":
+            revoke_write_seen.set()
+        original_write(path, data)
+
+    monkeypatch.setattr(puffo_v0, "_write_registry", controlled_write)
+
+    def provision() -> None:
+        try:
+            provision_runtime("runtime-b", agent_dir, workspace, registry_path=registry)
+        except BaseException as exc:  # pragma: no cover - surfaced below
+            failures.append(exc)
+
+    def revoke() -> None:
+        try:
+            revoke_runtime("runtime-a", registry_path=registry)
+        except BaseException as exc:  # pragma: no cover - surfaced below
+            failures.append(exc)
+
+    provision_thread = threading.Thread(target=provision)
+    provision_thread.start()
+    assert provision_waiting.wait(timeout=5)
+    revoke_thread = threading.Thread(target=revoke)
+    revoke_thread.start()
+
+    # Without a mutation lock, revoke writes while provision is paused and the
+    # stale provision snapshot subsequently resurrects runtime-a.  With the
+    # lock, revoke cannot reach its write until provision releases the lock.
+    revoke_write_seen.wait(timeout=0.2)
+    release_provision.set()
+    provision_thread.join(timeout=5)
+    revoke_thread.join(timeout=5)
+    assert not provision_thread.is_alive()
+    assert not revoke_thread.is_alive()
+    assert not failures
+
+    data = json.loads(registry.read_text(encoding="utf-8"))
+    assert data["runtimes"]["runtime-a"]["status"] == "revoked"
+    assert data["runtimes"]["runtime-b"]["status"] == "active"
+
+
+@pytest.mark.skipif(os.name != "posix", reason="puffo-v0 registry is POSIX-only")
+def test_registry_mutation_lock_blocks_a_second_process(tmp_path):
+    import lingtai.adapters.acp.puffo_v0 as puffo_v0
+
+    agent_dir = tmp_path / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    registry = tmp_path / "registry.json"
+    provision_runtime("runtime-a", agent_dir, workspace, registry_path=registry)
+
+    context = multiprocessing.get_context("fork")
+    provisioned = context.Event()
+
+    def provision_in_child() -> None:
+        provision_runtime("runtime-b", agent_dir, workspace, registry_path=registry)
+        provisioned.set()
+
+    with puffo_v0._registry_mutation_lock(registry):
+        child = context.Process(target=provision_in_child)
+        child.start()
+        assert not provisioned.wait(timeout=0.2)
+    child.join(timeout=5)
+    assert child.exitcode == 0
+    assert provisioned.is_set()
+    assert resolve_runtime("runtime-b", registry_path=registry).runtime_id == "runtime-b"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX file modes are not meaningful on Windows")
+def test_registry_directory_and_files_are_owner_only_even_with_a_permissive_umask(
+    monkeypatch, tmp_path
+):
+    import lingtai.adapters.acp.puffo_v0 as puffo_v0
+
+    agent_dir = tmp_path / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    registry = tmp_path / "private" / "registry.json"
+    observed: dict[str, int] = {}
+    original_replace = os.replace
+
+    def inspect_temporary(source, target):
+        observed["temporary"] = stat.S_IMODE(Path(source).stat().st_mode)
+        original_replace(source, target)
+
+    monkeypatch.setattr(puffo_v0.os, "replace", inspect_temporary)
+    previous_umask = os.umask(0)
+    try:
+        provision_runtime("runtime-a", agent_dir, workspace, registry_path=registry)
+    finally:
+        os.umask(previous_umask)
+
+    assert stat.S_IMODE(registry.parent.stat().st_mode) == 0o700
+    assert observed["temporary"] == 0o600
+    assert stat.S_IMODE(registry.stat().st_mode) == 0o600
+    assert stat.S_IMODE(registry.with_name(".registry.json.lock").stat().st_mode) == 0o600
 
 
 def test_profile_session_rejects_remote_workspace_and_mcp_inputs(tmp_path):

--- a/tests/test_puffo_v0_profile.py
+++ b/tests/test_puffo_v0_profile.py
@@ -178,6 +178,24 @@ def test_registry_mutations_are_linearized_so_revoke_cannot_be_resurrected(
     assert data["runtimes"]["runtime-b"]["status"] == "active"
 
 
+def test_revocation_tombstone_denies_a_stale_active_registry_snapshot(tmp_path):
+    """The main registry cannot reactivate an id once its tombstone is written."""
+    agent_dir = tmp_path / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    registry = tmp_path / "registry.json"
+    provision_runtime("runtime-a", agent_dir, workspace, registry_path=registry)
+    stale_active_snapshot = registry.read_text(encoding="utf-8")
+
+    revoke_runtime("runtime-a", registry_path=registry)
+    registry.write_text(stale_active_snapshot, encoding="utf-8")
+
+    with pytest.raises(PuffoV0RegistryError, match="inactive"):
+        resolve_runtime("runtime-a", registry_path=registry)
+
+
 @pytest.mark.skipif(os.name != "posix", reason="puffo-v0 registry is POSIX-only")
 def test_registry_mutation_lock_blocks_a_second_process(tmp_path):
     import lingtai.adapters.acp.puffo_v0 as puffo_v0
@@ -237,6 +255,23 @@ def test_registry_directory_and_files_are_owner_only_even_with_a_permissive_umas
     assert observed["temporary"] == 0o600
     assert stat.S_IMODE(registry.stat().st_mode) == 0o600
     assert stat.S_IMODE(registry.with_name(".registry.json.lock").stat().st_mode) == 0o600
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX file modes are not meaningful on Windows")
+def test_resolve_tightens_legacy_registry_file_and_directory_modes(tmp_path):
+    agent_dir = tmp_path / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    registry = tmp_path / "legacy" / "registry.json"
+    provision_runtime("runtime-a", agent_dir, workspace, registry_path=registry)
+    registry.parent.chmod(0o755)
+    registry.chmod(0o644)
+
+    assert resolve_runtime("runtime-a", registry_path=registry).runtime_id == "runtime-a"
+    assert stat.S_IMODE(registry.parent.stat().st_mode) == 0o700
+    assert stat.S_IMODE(registry.stat().st_mode) == 0o600
 
 
 def test_profile_session_rejects_remote_workspace_and_mcp_inputs(tmp_path):

--- a/tests/test_puffo_v0_profile.py
+++ b/tests/test_puffo_v0_profile.py
@@ -196,6 +196,27 @@ def test_revocation_tombstone_denies_a_stale_active_registry_snapshot(tmp_path):
         resolve_runtime("runtime-a", registry_path=registry)
 
 
+def test_missing_required_tombstone_log_fails_closed(tmp_path):
+    import lingtai.adapters.acp.puffo_v0 as puffo_v0
+
+    agent_dir = tmp_path / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    registry = tmp_path / "registry.json"
+    provision_runtime("runtime-a", agent_dir, workspace, registry_path=registry)
+    stale_active_snapshot = registry.read_text(encoding="utf-8")
+    revoke_runtime("runtime-a", registry_path=registry)
+    puffo_v0._revocation_log_path(registry).unlink()
+    registry.write_text(stale_active_snapshot, encoding="utf-8")
+
+    with pytest.raises(PuffoV0RegistryError, match="revocation log is unavailable"):
+        resolve_runtime("runtime-a", registry_path=registry)
+    with pytest.raises(PuffoV0RegistryError, match="revocation log is unavailable"):
+        provision_runtime("runtime-b", agent_dir, workspace, registry_path=registry)
+
+
 @pytest.mark.skipif(os.name != "posix", reason="puffo-v0 registry is POSIX-only")
 def test_registry_mutation_lock_blocks_a_second_process(tmp_path):
     import lingtai.adapters.acp.puffo_v0 as puffo_v0


### PR DESCRIPTION
## Scope: foundation / PR1

This PR is a foundation for the future spawned-ACP Puffo Phase A profile. It does **not** claim that the complete restricted Phase A contract is implemented.

It establishes a local, registry-backed second gate for a pre-provisioned persistent LingTai identity and fixed workspace:

- Opaque runtime IDs select a local registry binding; the public profile command rejects direct `--agent-dir` input.
- The binding records canonical paths and POSIX device/inode/owner/group identity. Resolve rejects symlink retargeting, path drift, and replacement at the same path; it is checked again immediately before Agent construction.
- One active runtime owns one agent directory and one workspace; duplicates are rejected under the registry mutation lock.
- Profile sessions enforce the registered workspace and `mcpServers: []`; the existing composition disables `avatar`, `daemon`, and `mcp` across refresh.
- Registry mutation is cross-process serialized; revocation uses a mandatory append-only tombstone log and owner-only POSIX artifacts. Windows fails closed pending an ACL-backed implementation.

`entry_digest` is deliberately named for what it is: integrity of the registry entry. It is **not** an effective security configuration digest.

## Explicitly not delivered here

The review correctly identified the following as required before this can be called the complete Phase A restricted profile. They are not represented as done by this PR:

- A versioned effective security-config digest for `init.json` / presets, executable, argv, environment, addon/plugin policy, ingress policy, and action policy.
- A typed positive capability/action allowlist with unknown-deny semantics; the current three capability disables are not a complete action policy.
- Central authenticated ACP/Puffo-only turn admission and suppression of non-ACP turn producers.
- Metadata-only ACP permission-decision audit and verified process-group or Job Object containment with a descendant-shutdown test.
- An atomic resolve-to-spawn launch claim. This PR revalidates immediately before Agent construction, but same-OS-principal mutation after that check remains outside its threat model.

## Security / lifecycle boundary

- `puffo-v0` is a controlled entrypoint, not same-OS-principal isolation.
- Only future profile spawns are denied after revoke; existing sessions are not terminated.
- v1/v2 registries have no implicit migration: missing or mismatched revocation history fails closed.
- The required first gate remains in Puffo: it must derive a validated launch plan from authorized route and operator configuration before emitting only this profile command plus opaque runtime ID. OpenCode is not a valid Puffo identity-binding entrypoint.

## Historical-permission window

Earlier revisions could create a registry with umask-derived permissions, for example `0644` under umask `022`, exposing canonical identity and workspace paths to other local users while that file existed. This PR tightens existing artifacts on load and creates new artifacts owner-only; it closes continued exposure, not any read that may already have occurred. Whether such an artifact existed or was read on a particular host is **unassessed**; any impact assessment is an operator decision.

## Validation

- `python -m pytest -q tests/test_puffo_v0_profile.py tests/test_agent_capabilities.py tests/test_acp_stdio.py` — **93 passed**
- `git diff --check` — passed
- Generic docs governance is collection-style: candidate and `main` report the same five pre-existing violations; changed Markdown adds none under that rule set.
- Architecture-document suite: candidate and `main` are both **2 passed / 2 failed**, with the same failures. The suite is not green, but this PR introduces no failure visible to that suite.

The binding/uniqueness regressions cover symlink retargeting, same-path directory replacement, and duplicate active identity/workspace bindings.