### PR TITLE
feat(context): expose owned settings and env parity

### DIFF
--- a/ENVIRONMENT_VARIABLES.md
+++ b/ENVIRONMENT_VARIABLES.md
@@ -3,8 +3,8 @@ name: environment-variable-registry
 description: >
   Canonical registry for environment variables consumed by LingTai source,
   bundled MCPs, adapters, daemon composition, and focused tests.
-version: 1.8.0
-last_changed_at: "2026-08-29"
+version: 1.9.0
+last_changed_at: "2026-08-30"
 related_files:
 - ANATOMY.md
 - CONTRACT.md
@@ -31,6 +31,8 @@ related_files:
 - src/lingtai/prompts/ANATOMY.md
 - src/lingtai/services/ANATOMY.md
 - src/lingtai/tools/ANATOMY.md
+- src/lingtai/tools/context/ANATOMY.md
+- src/lingtai/tools/context/CONTRACT.md
 - src/lingtai/tools/bash/ANATOMY.md
 - src/lingtai/tools/daemon/ANATOMY.md
 - src/lingtai/tools/daemon/CONTRACT.md
@@ -71,7 +73,7 @@ reports, prompts, or this registry.
 | `LINGTAI_ACTIVE_STUCK_THRESHOLD_S` | `600` seconds | Finite numeric seconds; values below `30` clamp to `30` | ACTIVE no-progress watchdog | When the watchdog evaluates a turn | Missing, non-numeric, or non-finite values fall back to `600` | `src/lingtai/kernel/base_agent/lifecycle.py` | Watchdog tuning can affect availability; it grants no capability |
 | `LINGTAI_AGENT_ALIVE_THRESHOLD_SEC` | `10` seconds | Positive finite numeric seconds; shared TUI/Portal/kernel process environment | Heartbeat freshness for non-human agent presence, session status, and peer liveness; it does **not** control the separate ACTIVE-no-progress watchdog | Kernel resolves it when `lingtai.kernel.config` loads (restart/reload the participating process after a change); TUI and Portal resolve it on each liveness check | Missing, blank, non-numeric, non-finite, zero, or negative values fall back to `10` | `src/lingtai/kernel/config.py`, `src/lingtai/kernel/agent_presence/__init__.py` | Availability/liveness tuning only; it grants no authority and does not alter lifecycle state or ACTIVE-stuck semantics |
 | `LINGTAI_TOOL_PROSE_SECTION_ENABLED` | unset and off | `1`/`true`/`yes`/`on` (case-insensitive, surrounding whitespace ignored); anything else, including unset and empty, is off | The resident `## tools` prose walkthrough in every composed system prompt, and the top-level tool description on every provider wire | Every prompt rebuild and every provider payload build; no restart, so an `env_file` flip applies at the next refresh | Unrecognized values are treated as off | `src/lingtai/kernel/config.py`, `src/lingtai/kernel/base_agent/tools.py`, `src/lingtai/kernel/llm/base.py` | Context-size control only; it grants no capability and removes no tool. Off (default): the `## tools` section is not rendered and each tool's full prose rides on its tool-calling schema description. On: the historical two-surface behavior is restored — the section carries the prose and wires carry the `WIRE_TOOL_DESCRIPTION` pointer at it. Nested parameter/property descriptions are never affected in either state |
-| `LINGTAI_SYSTEM_PROMPT_PRESSURE_RATIO` | `0.4` | Finite float strictly greater than `0` and less than `1` | Main-agent and daemon metadata snapshots | Every metadata snapshot through the shared renderer | Missing, blank, non-numeric, non-finite, zero, negative, or `>=1` values fall back to `0.4` | `src/lingtai/kernel/config.py`, `src/lingtai/kernel/meta_block.py` | Advisory metadata only; never authorizes access or exposes prompt text |
+| `LINGTAI_SYSTEM_PROMPT_PRESSURE_RATIO` | `0.4` | Finite float strictly greater than `0` and less than `1` | Main-agent and daemon metadata snapshots | Every metadata snapshot through the shared renderer | Missing, blank, non-numeric, non-finite, zero, negative, or `>=1` values fall back to `0.4` | Runtime parser/consumers: `src/lingtai/kernel/config.py`, `src/lingtai/kernel/meta_block.py`; Context settings provider/manual: `src/lingtai/tools/context/settings.py`, `context-manual#system-prompt-pressure-ratio` | Read-only advisory metadata: Context settings never mutates process environment; the value never authorizes access or exposes prompt text |
 | `LINGTAI_SESSION_STATS_REFRESH_SECONDS` | `5` seconds | Finite positive number of seconds; one process | Agent Record (`system/agent_record.json`) refresh throttle | Each of the three existing `.status.json` write hooks (`_save_chat_history`, the ACTIVE no-progress watchdog, the heartbeat tick); no restart | Missing, blank, non-numeric, non-finite, zero, or negative values fall back to `5` | `src/lingtai/kernel/session_stats/__init__.py` | Refresh-cadence tuning only; never authorizes access or changes what fields are published |
 | `LINGTAI_SESSION_STATS_DAEMON_LIMIT` | `1000` | Positive integer; one Agent Record's daemon aggregation | Bound on how many newest-mtime `<run_dir>/session_stats.json` daemon self-records `kernel.session_stats.aggregate_daemon_records` reads into one Agent Record | Every Agent Record refresh | Missing, blank, non-integer, zero, or negative values fall back to `1000` | `src/lingtai/kernel/session_stats/__init__.py` | Aggregation-scope control only; a daemon whose self-record falls outside the bound is simply excluded from the aggregate, never faked as zero |
 | `LINGTAI_RISKY_ACTION_GATE` | unset and off unless `<workdir>/.security/gate_config.json` exists | `1`/`true`/`yes`/`on` enables the fail-closed gate without an owner document; a present owner document enables it independently | Risky file-write and shell-command authorization gate | Each gate-config load; no restart for direct process-environment changes | Unrecognized environment values are off; a present malformed owner document fails the guarded operation closed | `system` catch-all — `src/lingtai/kernel/risky_action_gate.py` | Authorization boundary; SHOW exposes only the effective enabled boolean and never the allowlists, roots, hosts, scripts, or pending path |

--- a/src/lingtai/tools/context/ANATOMY.md
+++ b/src/lingtai/tools/context/ANATOMY.md
@@ -17,9 +17,12 @@ related_files:
   - src/lingtai/tools/system/summarize.py
   - src/lingtai/tools/context/__init__.py
   - tests/test_context_declared_tool_plugin.py
+  - tests/test_context_settings.py
   - src/lingtai/tools/context/_molt.py
   - src/lingtai/tools/context/_session_journal.py
   - src/lingtai/tools/context/_snapshots.py
+  - src/lingtai/tools/context/settings.py
+  - ENVIRONMENT_VARIABLES.md
   - src/lingtai/agent.py
   - src/lingtai/kernel/base_agent/prompt.py
   - src/lingtai/tools/context/glossary-en.md
@@ -35,7 +38,7 @@ maintenance: |
 # tools/context
 
 Context lifecycle family with exact public actions
-`molt | summarize | rebuild | manual`. `rebuild` is the sole active full
+`molt | summarize | rebuild | settings | manual`. `rebuild` is the sole active full
 reconstruction operation; refresh and molt invoke the same internal contract as
 passive lifecycle scenarios.
 
@@ -43,7 +46,8 @@ passive lifecycle scenarios.
 
 - `__init__.py`
   - module-level `DECLARATION` owns Context identity, ordered operational
-    actions, strict schemas, and the packaged `context-manual`;
+    actions, the settings opt-in, strict schemas, and the packaged
+    `context-manual`;
   - `_bind(host)` composes the public family from only `host.workdir` and
     `host.context_runtime`; `setup`/`boot` supply the registrar wiring while
     `handle` is direct-caller compatibility only;
@@ -54,7 +58,8 @@ passive lifecycle scenarios.
     private summary engine, handles reconstruction failures as result dicts, and
     marks successful engine results `prompt_reconstructed: true`;
   - `_CHILD_SPECS`, `_build_children`, `_FAMILY`, `get_schema`, `handle` provide
-    single-registry schema/dispatch and isolate `_tc_id` to molt;
+    single-registry schema/dispatch, inject the provider-backed `settings`
+    child, and isolate `_tc_id` to molt;
   - manual adaptation resolves `context-manual` once after dispatch.
 - `../system/summarize.py` — private history-summary engine. It records pending
   marker replacements, marks the applied set done, persists history, and only
@@ -66,6 +71,10 @@ passive lifecycle scenarios.
   post-molt notification publishing.
 - `_session_journal.py` — fail-closed journal-path/frontmatter gate.
 - `_snapshots.py` — atomic pre-molt snapshots and retrospective persistence.
+- `settings.py` — builds the seven-row `SettingsProvider` from two live Context
+  readers, the canonical prompt-pressure resolver, and four kernel constants;
+  its narrow runtime-adapter extension carries that read-only provider beside
+  the three existing lifecycle callbacks (`settings.py:1-131`).
 - `agent.py`
   - `_reload_prompt_sections` is the authoritative all-source composer and
     reuses private `_lingtai_load`/`_pad_load`;
@@ -111,3 +120,12 @@ and current tool/meta sections.
 `summarize` never reconstructs. `rebuild` always composes before history
 mutation and provider request. `molt` retains refusal-before-shed and its distinct
 archive/count/replay effects. No retired root or action is an alias.
+
+Settings inventory is read-only. `manifest.context_limit` and
+`manifest.summarize_notification_threshold` remain authored composition applied
+by refresh; `LINGTAI_SYSTEM_PROMPT_PRESSURE_RATIO` remains a live process input;
+the pressure ladder remains kernel-fixed. The provider owns no persistence or
+process-environment mutation and projects no session-journal/history/prompt
+content.
+Legacy `manifest.molt_notice`, `molt_pressure`, `molt_urgency`, and `molt_prompt`
+remain recognized-and-ignored compatibility input, not adjustable settings.

--- a/src/lingtai/tools/context/CONTRACT.md
+++ b/src/lingtai/tools/context/CONTRACT.md
@@ -1,12 +1,14 @@
 ---
 name: context-contract
 tool: context
-contract_version: 6
+contract_version: 7
 related_files:
   - src/lingtai/tools/context/BEHAVIORS.md
   - src/lingtai/tools/context/__init__.py
   - src/lingtai/tools/context/_molt.py
   - src/lingtai/tools/context/_session_journal.py
+  - src/lingtai/tools/context/settings.py
+  - ENVIRONMENT_VARIABLES.md
   - src/lingtai/tools/context/ANATOMY.md
   - src/lingtai/agent.py
   - src/lingtai/kernel/base_agent/prompt.py
@@ -24,12 +26,14 @@ related_files:
   - tests/test_tool_family_context_migration.py
   - tests/test_deep_refresh.py
   - tests/test_context_declared_tool_plugin.py
+  - tests/test_context_settings.py
 maintenance: |
   Keep related paths real and the paired Anatomy reciprocal. Update schemas,
   model prose, manuals, results, lifecycle wiring, private summary engine, and
-  focused evidence together. Version 6 packages the established context-manual with its owner and recuts the
-  unchanged public surface through the declared host-plugin contract;
-  `context_runtime` is the only new host port and delegates existing engines.
+  focused evidence together. Version 7 opts Context into the bounded settings
+  action without changing its lifecycle engines or persistence; version 6
+  packaged the established context-manual with its owner and recut the public
+  surface through the declared host-plugin contract.
 ---
 
 # Context capability contract
@@ -43,12 +47,16 @@ Guarded by: [K003](../../kernel/BEHAVIORS.md#behavior-k003)
 - `molt` — shed conversation history while preserving durable stores;
 - `summarize` — record compact replacements in local runtime history only;
 - `rebuild` — the **one active full context reconstruction operation**;
+- `settings` — show effective Context policy through the read-only five-field
+  projection;
 - `manual` — return `context-manual` without a lifecycle operation.
 
 The implementation is an official declared host plugin: its static
-`DECLARATION` owns the identity, actions, schemas, and `context-manual`; its
-binder receives only `workdir` and `context_runtime`, whose three narrow
-operations delegate the existing live molt/summarize/rebuild engines. The package
+`DECLARATION` owns the identity, actions, settings opt-in, schemas, and
+`context-manual`; its
+binder receives only `workdir` and `context_runtime`; its three narrow lifecycle
+operations delegate the existing live molt/summarize/rebuild engines, and its
+owner adapter supplies the read-only settings provider. The package
 manual under `tools/context/manual/` is the sole canonical source and is installed
 at the longstanding `context-manual` path. Any same-name collision fails loudly.
 No OLD
@@ -76,11 +84,39 @@ Schema and dispatch derive from one child registry.
 | `molt` | required `summary`, `session_journal_path`, nullable `keep_tool_calls`, `keep_last` | preserved molt receipt/errors and refusal-before-shed gates |
 | `summarize` | required nonempty `items` | record-only marker/result; no prompt composition or provider rebuild |
 | `rebuild` | optional nullable `items`; bare `{}` is valid | summary-engine rebuild result plus `prompt_reconstructed: true`; LTP-shaped reconstruction/no-session errors |
+| `settings` | strict `{}` | seven ordered rows containing exactly `key`, `current`, `default`, `configurable`, `comment`; one fixed bounded whole-action failure on unavailable/malformed/unserializable provider output |
 | `manual` | strict `{}` | flat manual result |
 
-Unknown actions and branch/root shape errors fail before handler I/O. `_tc_id` is
+`settings` is inserted immediately before `manual` only through the declaration's
+generic opt-in seam. Unknown actions and branch/root shape errors fail before handler I/O. `_tc_id` is
 stripped from the closed root and reaches `molt` only. No retired Pad/LingTai or
 system-summarize spelling is accepted.
+
+## Settings inventory and authority
+
+Guarded by: [T011](../tool_family/BEHAVIORS.md#behavior-t011)
+
+The provider returns exactly these ordered key/comment pairs:
+
+| Key | Exact manual pointer |
+|---|---|
+| `context_limit` | `context-manual#context-limit` |
+| `summarize_notification_threshold` | `context-manual#summarize-notification-threshold` |
+| `system_prompt_pressure_ratio` | `context-manual#system-prompt-pressure-ratio` |
+| `pressure_high_ratio` | `context-manual#pressure-high-ratio` |
+| `forced_rebuild_ratio` | `context-manual#forced-rebuild-ratio` |
+| `pressure_warn_after_rounds` | `context-manual#pressure-warn-after-rounds` |
+| `recovery_target_ratio` | `context-manual#recovery-target-ratio` |
+
+The first three rows are configurable only through the authorized procedures at
+those exact manual targets; the four kernel constants are not configurable. The
+SHOW action itself never writes config, process environment, or runtime state.
+All seven are non-sensitive public scalars; session paths, history, prompt text,
+provider identity, and credentials are absent. A provider raises when either
+live runtime value is unavailable, so no partial or placeholder row is returned.
+The generic action owns the fixed failure and 65,536-byte complete-response
+bound. Accepted values, precedence, canonical keys, apply timing, authorization,
+and change/verification procedures live only in `context-manual`.
 
 ## Full reconstruction ordering
 
@@ -149,10 +185,15 @@ Focused verification:
 ```bash
 python -m pytest -q tests/test_context_ownership_redesign.py \
   tests/test_tool_family_context_migration.py tests/test_deep_refresh.py \
-  tests/test_pad_lingtai_split.py tests/test_context_declared_tool_plugin.py
+  tests/test_pad_lingtai_split.py tests/test_context_declared_tool_plugin.py \
+  tests/test_context_settings.py
 ```
 
 Evidence pins public action sets and strict retirement; file and append no-hot-
 load; bare zero-pending reconstruction; compose-before-summary-before-provider
 ordering (including provider replay observing the new prompt); all canonical
 durable sources; one shared refresh/molt hook; manual strictness; provider-wire parity; and existing molt refusal/lifecycle semantics.
+The settings evidence additionally pins exact five-field rows and manual targets,
+live current/default/configurable values, strict empty input, whole-action
+unavailable-current failure, absence of sensitive material, and ordinary rebuild
+non-regression.

--- a/src/lingtai/tools/context/__init__.py
+++ b/src/lingtai/tools/context/__init__.py
@@ -1,12 +1,13 @@
 """Context intrinsic — the department that owns the agent's context.
 
 An LTP v2 family (``../CONTRACT.md``): one model-facing root ``context`` with
-four fixed canonical action children, each owning its own strict ``input``
+five fixed canonical action children, each owning its own strict ``input``
 object::
 
     molt      -> shed the conversation, keep the durable stores
     summarize -> record compact replacements in runtime history (record-only)
     rebuild   -> recompose the full prompt, apply summaries, replay provider context
+    settings  -> show Context policy through the read-only five-field projection
     manual    -> return the installed context-manual skill
 
 This package replaces the former ``psyche`` family, which mixed two unrelated
@@ -74,6 +75,10 @@ from ..tool_family.manual import MANUAL_INPUT_SCHEMA, build_manual_child
 # The summarize/rebuild engine remains private implementation. The official
 # plugin binds only the narrow context-runtime port that invokes it.
 from ..system.summarize import _summarize as _summarize_engine
+from .settings import (
+    ContextRuntimeSettingsAdapter,
+    build_context_settings_provider,
+)
 
 # ---------------------------------------------------------------------------
 # Canonical child input schemas — one strict, closed object per action.
@@ -290,8 +295,8 @@ def _build_family(
 
     ``None`` builds only the import-time schema family. A real host contributes
     two earned capabilities: a read-only workdir for the installed manual and a
-    ContextRuntimePort with exactly ``molt``, ``summarize``, and ``rebuild``.
-    No child closes over, receives, or reaches for the Agent.
+    ContextRuntimePort with ``molt``, ``summarize``, ``rebuild``, and the
+    owner-bound read-only settings provider. No child receives the Agent.
     """
     if host is None:
         def _unused(_input: Mapping[str, Any]) -> dict:
@@ -308,7 +313,7 @@ def _build_family(
             for name, schema, _handler in _CHILD_SPECS
         ]
         children.append(ChildTool("manual", MANUAL_INPUT_SCHEMA, _unused, title="manual input"))
-        return ToolFamily(DECLARATION.name, children)
+        return ToolFamily(DECLARATION.name, children, settings_provider=tuple)
 
     runtime = host.context_runtime
     extra = dict(envelope or {})
@@ -339,7 +344,11 @@ def _build_family(
     # The manual reads the installed copy from the workdir port. Its destination
     # is declaration-owned, so package/manual/ and runtime mount cannot drift.
     children.append(build_manual_child(host.workdir, DECLARATION.manual))
-    return ToolFamily(DECLARATION.name, children)
+    return ToolFamily(
+        DECLARATION.name,
+        children,
+        settings_provider=runtime.settings,
+    )
 
 # ---------------------------------------------------------------------------
 # Schema / description
@@ -361,6 +370,8 @@ _ACTION_ENUM_DESCRIPTION = (
     'pending/new summaries, then replay provider context with the new prompt and '
     'history. Bare input is valid even with zero pending summaries. Prefer one '
     'tactical rebuild; do not loop rebuild.\n'
+    'settings: show effective Context limits and pressure policy through the '
+    'read-only five-field projection; procedures live at each comment target.\n'
     'manual: return the installed context-manual skill without performing any '
     'context operation.\n'
     'Your name is not here: use system(action=\'name_set\'|\'name_nickname\').'
@@ -368,7 +379,7 @@ _ACTION_ENUM_DESCRIPTION = (
 
 
 def get_description(lang: str = "en") -> str:
-    return 'Your context: shed it, compact it, rebuild it. One tool, four actions, each with its own strict input object: context(action=..., input={...}, reasoning=\'why\'). molt: 凝蜕 — shed the conversation, keep the durable stores; requires a written session journal. summarize: record compact replacements for bulky prior tool results (records only, does NOT rebuild). rebuild: re-read and recompose every canonical prompt source, then apply pending/new summaries, then replay provider context with the new prompt/history; bare input is valid even with zero pending summaries. manual: return the installed context-manual skill. Your name lives on system(action=\'name_set\'|\'name_nickname\'); your 灵台 and pad are lingtai(...) and pad(...). Note the two levels: the ACTION named summarize is this domain operation, while the optional ROOT summarize boolean is the unrelated result-presentation control — leave it false here (results are small), and call manual with summarize=false so the exact molt procedure is not summarized away.'
+    return 'Your context: shed it, compact it, rebuild it. One tool, five actions, each with its own strict input object: context(action=..., input={...}, reasoning=\'why\'). molt: 凝蜕 — shed the conversation, keep the durable stores; requires a written session journal. summarize: record compact replacements for bulky prior tool results (records only, does NOT rebuild). rebuild: re-read and recompose every canonical prompt source, then apply pending/new summaries, then replay provider context with the new prompt/history; bare input is valid even with zero pending summaries. settings: show effective Context limits and pressure policies through a read-only five-field projection whose comment targets teach real change procedures. manual: return the installed context-manual skill. Your name lives on system(action=\'name_set\'|\'name_nickname\'); your 灵台 and pad are lingtai(...) and pad(...). Note the two levels: the ACTION named summarize is this domain operation, while the optional ROOT summarize boolean is the unrelated result-presentation control — leave it false here (results are small), and call manual with summarize=false so the exact molt procedure is not summarized away.'
 
 
 def get_schema(lang: str = "en") -> dict:
@@ -451,6 +462,7 @@ DECLARATION = ToolPluginDeclaration(
     binder=_bind,
     requires=("workdir", "context_runtime"),
     glossary_package=__package__,
+    settings=True,
 )
 
 #: Import-time schema-only composition catches a bad child registry before any
@@ -458,7 +470,7 @@ DECLARATION = ToolPluginDeclaration(
 #: every official bind.
 _FAMILY = _build_family(None)
 
-#: Public order comes only from the declaration (operational actions + manual).
+#: Public order comes only from the declaration (operations + settings + manual).
 ACTION_ORDER: tuple[str, ...] = DECLARATION.public_actions
 _MANUAL_SKILL_NAME = DECLARATION.manual
 
@@ -467,11 +479,9 @@ def _runtime_port(agent):
     """Compose the production ContextRuntimePort from narrow bound callbacks.
 
     This is composition wiring, not a plugin API: each callback preserves the
-    existing live-Agent engine intact while the bound family receives only the
-    adapter's three operation methods.
+    existing live-Agent engine intact while the bound family receives the
+    adapter's three operation methods and its read-only settings provider.
     """
-    from lingtai.adapters.tool_plugin_host import AgentContextRuntimeAdapter
-
     def invoke(action: str, args: dict) -> dict:
         # Look up at call time: Context's narrow focused tests can replace one
         # implementation operation without bypassing the declared host route.
@@ -480,19 +490,37 @@ def _runtime_port(agent):
                 return operation(agent, args)
         raise AssertionError(f"unknown Context runtime action: {action}")
 
-    return AgentContextRuntimeAdapter(
+    def read_context_limit() -> object:
+        configured = getattr(agent._config, "context_limit", None)
+        if configured is not None:
+            return configured
+        chat = getattr(agent, "_chat", None)
+        live = chat.context_window() if chat is not None else None
+        if type(live) is int and live > 0:
+            return live
+        return getattr(agent.service, "_context_window", None)
+
+    def read_summarize_notification_threshold() -> object:
+        return agent._summarize_notification_threshold
+
+    settings_provider = build_context_settings_provider(
+        read_context_limit,
+        read_summarize_notification_threshold,
+    )
+
+    return ContextRuntimeSettingsAdapter(
         molt=lambda args: invoke("molt", args),
         summarize=lambda args: invoke("summarize", args),
         rebuild=lambda args: invoke("rebuild", args),
+        settings=settings_provider,
     )
 
 
 def _build_children(agent, envelope: Mapping[str, Any] | None = None) -> list[ChildTool]:
-    """Compatibility child-list view for direct in-process family tests.
+    """Child-list view of the bound declaration for focused in-process tests.
 
     Normal Agent dispatch never uses this view; it is the declared family bound
-    to the same production adapters, returned as children for legacy callers
-    that construct their own ``ToolFamily`` around Context.
+    to the same production adapters, including its injected settings child.
     """
     from lingtai.adapters.tool_plugin_host import AgentWorkdirAdapter
 

--- a/src/lingtai/tools/context/manual/SKILL.md
+++ b/src/lingtai/tools/context/manual/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: context-manual
 description: |
-  Router and operational guide for the context tool: molt, summarize/rebuild, session journaling, and post-wipe recovery. Read it when molting, compacting or rebuilding provider context, tending the four durable stores, or waking from a system-performed wipe. Routes consequential handoffs to assets/molt-template.md and the summarize/rebuild procedure to reference/summarize-manual.
-version: 2.1.1
-last_changed_at: "2026-08-29T00:00:00Z"
+description: |
+  Router and operational guide for the context tool: molt, summarize/rebuild, settings inventory, session journaling, and post-wipe recovery. Read it when molting, compacting or rebuilding provider context, inspecting context policy, tending the four durable stores, or waking from a system-performed wipe. Routes consequential handoffs to assets/molt-template.md and the summarize/rebuild procedure to reference/summarize-manual.
+version: 2.2.0
+last_changed_at: "2026-08-30"
 related_files:
 - src/lingtai/tools/context/__init__.py
 - src/lingtai/tools/context/_molt.py
 - src/lingtai/tools/context/_session_journal.py
+- src/lingtai/tools/context/settings.py
 - src/lingtai/tools/system/summarize.py
 - src/lingtai/agent.py
 - src/lingtai/tools/psyche/CONTRACT.md
+- ENVIRONMENT_VARIABLES.md
+- tests/test_context_settings.py
 maintenance: |
   This package is the canonical Context manual source and runtime-installed owner.
   Update it when the tool/capability behavior changes.
@@ -18,7 +22,10 @@ maintenance: |
 
 # Context Manual
 
-This manual is the router for `context` operations — `molt`, `summarize`, and `rebuild`. Keep routine guidance here; load the supporting asset or reference only when you need the full scaffold or the detailed summarize/rebuild procedure.
+This manual is the router for `context` operations — `molt`, `summarize`,
+`rebuild`, and settings inventory. Keep routine guidance here; load the
+supporting asset or reference only when you need the full scaffold or the
+detailed summarize/rebuild procedure.
 
 ## Reference catalog
 
@@ -31,6 +38,120 @@ This manual is the router for `context` operations — `molt`, `summarize`, and 
 `context(action="rebuild", ...)` is the **one active full reconstruction operation**: recompose every canonical prompt source → apply pending summaries → provider replay. The tool description and the `rebuild` schema carry the exact contract, including that bare `{}` is valid.
 
 The fact that is only here: **generic durable mutations do not hot-load.** Write with `file.write`/`file.edit`, then rebuild when the change must apply now — that is the only mutation path for all four durable stores (no per-store append, info, or reload action). Passive refresh and molt invoke the same internal reconstruction contract with their own lifecycle effects. Do not loop rebuild.
+
+## Settings inventory
+
+Call `context(action="settings", input={}, reasoning="inspect Context policy")`
+to perform the read-only SHOW. Its input is exactly `{}` and each success row is
+exactly `key`, `current`, `default`, `configurable`, and `comment`. There is no
+set/reset/mutation form. `configurable: true` means an authorized procedure
+below exists outside this action; use a second SHOW to verify its effect. A
+failed or malformed current-value read fails the complete action instead of
+returning partial or unavailable rows.
+
+These seven scalars are not sensitive, so their values are not redacted.
+Session-journal paths, summaries, histories, prompt text, provider identity,
+credentials, accepted values, source, precedence, and procedures are never
+projected. The sections named by `comment` own those details.
+
+## Context limit
+
+- **Meaning and accepted values:** the effective main-session context-token
+  ceiling. `manifest.context_limit` accepts a positive integer; null or omission
+  selects the active provider/model window. The projected meaningful fallback
+  default is `272000`.
+- **Source and precedence:** a non-null effective `AgentConfig.context_limit`
+  wins; otherwise SHOW reads the live chat/provider context window.
+- **Canonical key and timing:** live-agent `init.json` uses
+  `manifest.context_limit`; a preset source uses
+  `manifest.llm.context_limit` and materializes it for activation. A change
+  applies on System refresh (or normal relaunch), not inside SHOW.
+- **Authorization and procedure:** this is a public scalar but configuration
+  editing is operator/owner work. Use the existing File or Shell procedure to
+  edit the authorized `init.json` or preset, validate the document, then call
+  `system(action="refresh", input={"reason": "apply context limit", "preset":
+  null, "revert_preset": null}, reasoning="apply the authorized change")`.
+  Re-run SHOW and confirm `current`.
+
+## Summarize notification threshold
+
+- **Meaning and accepted values:** character threshold for the large-result
+  summarize hint. It accepts a non-negative integer; `0` disables the hint.
+  The default is `3000`.
+- **Source and precedence:** the effective authored manifest value wins;
+  missing or invalid resolved input uses `3000`.
+- **Canonical key and timing:** `manifest.summarize_notification_threshold` in
+  the live `init.json` (or the corresponding manifest in an authorized preset),
+  applied by System refresh or relaunch.
+- **Authorization and procedure:** this public scalar is owner-configurable.
+  Edit the authorized manifest with the existing File or Shell procedure,
+  validate it, perform the same System refresh call shown under
+  [Context limit](#context-limit), then verify `current` with a second SHOW.
+
+## System prompt pressure ratio
+
+- **Meaning and accepted values:** advisory ratio at which rendered system
+  prompt size is reported as pressure. It accepts a finite float strictly
+  greater than `0` and less than `1`; the default is `0.4`.
+- **Source and precedence:** a valid live process value wins; missing, blank,
+  non-numeric, non-finite, non-positive, or `>=1` values fall back to `0.4`.
+- **Canonical key and timing:** environment variable
+  `LINGTAI_SYSTEM_PROMPT_PRESSURE_RATIO`, read for every main-agent and daemon
+  metadata snapshot. SHOW never writes `os.environ`.
+- **Authorization and procedure:** this public scalar is launcher/operator
+  configurable. Set it in the authorized launcher environment, or edit the
+  workdir environment file selected by `manifest.env_file` and run the System
+  refresh procedure so that file is reloaded. A direct launcher change requires
+  relaunch. Verify the effective `current` with a second SHOW.
+
+## Pressure high ratio
+
+- **Meaning and accepted values:** inclusive sustained-high context-pressure
+  boundary. Its only accepted runtime value and default are the kernel constant
+  `0.85`.
+- **Source, key, and timing:** kernel source is authoritative; there is no
+  environment or config key. A different code release would load on full
+  relaunch.
+- **Authorization and procedure:** the scalar is public but
+  `configurable: false`; there is no owner setting procedure. Changing kernel
+  source/release policy is product development, not a SHOW mutation path.
+
+## Forced rebuild ratio
+
+- **Meaning and accepted values:** inclusive hard boundary for one forced
+  provider-context rebuild per continuous overflow episode. Its only accepted
+  runtime value and default are the kernel constant `1.0`.
+- **Source, key, and timing:** kernel source is authoritative; there is no
+  environment or config key. A different code release would load on full
+  relaunch.
+- **Authorization and procedure:** the scalar is public but
+  `configurable: false`; no owner setting procedure exists.
+
+## Pressure warn after rounds
+
+- **Meaning and accepted values:** consecutive fresh high-context rounds before
+  the sustained molt reminder appears. Its only accepted runtime value and
+  default are the kernel integer constant `3`.
+- **Source, key, and timing:** kernel source is authoritative; there is no
+  environment or config key. A different code release would load on full
+  relaunch.
+- **Authorization and procedure:** the scalar is public but
+  `configurable: false`; no owner setting procedure exists.
+
+## Recovery target ratio
+
+- **Meaning and accepted values:** target below which summarize/rebuild counts
+  as recovery from context pressure. Its only accepted runtime value and default
+  are the kernel constant `0.75`.
+- **Source, key, and timing:** kernel source is authoritative; there is no
+  environment or config key. A different code release would load on full
+  relaunch.
+- **Authorization and procedure:** the scalar is public but
+  `configurable: false`; no owner setting procedure exists.
+
+Legacy `manifest.molt_notice`, `molt_pressure`, `molt_urgency`, and
+`molt_prompt` remain recognized-and-ignored compatibility input. They are not
+settings aliases or hidden ways to change these policies.
 
 ## Asset catalog
 
@@ -128,8 +249,8 @@ context(
 ```
 
 Every `context` call uses this one envelope: a single `action`, that action's
-own strict `input` object, and a root `reasoning`. The four actions are `molt`,
-`summarize`, `rebuild`, and `manual`. Leave the root `summarize` **boolean**
+own strict `input` object, and a root `reasoning`. The five actions are `molt`,
+`summarize`, `rebuild`, `settings`, and `manual`. Leave the root `summarize` **boolean**
 false: `context` results are small (short-result profile), and summarizing a
 `manual` call would drop the exact procedure you called it for.
 

--- a/src/lingtai/tools/context/settings.py
+++ b/src/lingtai/tools/context/settings.py
@@ -1,0 +1,131 @@
+"""Context-owned provider for read-only five-field settings discovery."""
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from lingtai.adapters.tool_plugin_host import AgentContextRuntimeAdapter
+from lingtai.kernel.base_agent.messaging import (
+    DEFAULT_SUMMARIZE_NOTIFICATION_THRESHOLD,
+)
+from lingtai.kernel.config import (
+    CONTEXT_PRESSURE_FORCED_REBUILD_RATIO,
+    CONTEXT_PRESSURE_HIGH_RATIO,
+    CONTEXT_PRESSURE_RECOVERY_TARGET,
+    CONTEXT_PRESSURE_WARN_AFTER_ROUNDS,
+    DEFAULT_SYSTEM_PROMPT_PRESSURE_RATIO,
+    system_prompt_pressure_ratio,
+)
+from lingtai.llm.service import CONSERVATIVE_CONTEXT_WINDOW
+from lingtai.tools.tool_family import SettingRow, SettingsProvider
+
+
+_ValueReader = Callable[[], object]
+
+
+def _positive_integer(value: object, key: str) -> int:
+    if type(value) is not int or value <= 0:
+        raise RuntimeError(f"current {key} is unavailable")
+    return value
+
+
+def _nonnegative_integer(value: object, key: str) -> int:
+    if type(value) is not int or value < 0:
+        raise RuntimeError(f"current {key} is unavailable")
+    return value
+
+
+def build_context_settings_provider(
+    read_context_limit: _ValueReader,
+    read_summarize_notification_threshold: _ValueReader,
+) -> SettingsProvider:
+    """Build the fresh provider bound to this Context runtime's live readers."""
+    if not callable(read_context_limit) or not callable(
+        read_summarize_notification_threshold
+    ):
+        raise TypeError("Context settings readers must be callable")
+
+    def provide() -> tuple[SettingRow, ...]:
+        context_limit = _positive_integer(read_context_limit(), "context_limit")
+        summarize_threshold = _nonnegative_integer(
+            read_summarize_notification_threshold(),
+            "summarize_notification_threshold",
+        )
+        return (
+            SettingRow(
+                "context_limit",
+                context_limit,
+                CONSERVATIVE_CONTEXT_WINDOW,
+                True,
+                "context-manual#context-limit",
+            ),
+            SettingRow(
+                "summarize_notification_threshold",
+                summarize_threshold,
+                DEFAULT_SUMMARIZE_NOTIFICATION_THRESHOLD,
+                True,
+                "context-manual#summarize-notification-threshold",
+            ),
+            SettingRow(
+                "system_prompt_pressure_ratio",
+                system_prompt_pressure_ratio(),
+                DEFAULT_SYSTEM_PROMPT_PRESSURE_RATIO,
+                True,
+                "context-manual#system-prompt-pressure-ratio",
+            ),
+            SettingRow(
+                "pressure_high_ratio",
+                CONTEXT_PRESSURE_HIGH_RATIO,
+                CONTEXT_PRESSURE_HIGH_RATIO,
+                False,
+                "context-manual#pressure-high-ratio",
+            ),
+            SettingRow(
+                "forced_rebuild_ratio",
+                CONTEXT_PRESSURE_FORCED_REBUILD_RATIO,
+                CONTEXT_PRESSURE_FORCED_REBUILD_RATIO,
+                False,
+                "context-manual#forced-rebuild-ratio",
+            ),
+            SettingRow(
+                "pressure_warn_after_rounds",
+                CONTEXT_PRESSURE_WARN_AFTER_ROUNDS,
+                CONTEXT_PRESSURE_WARN_AFTER_ROUNDS,
+                False,
+                "context-manual#pressure-warn-after-rounds",
+            ),
+            SettingRow(
+                "recovery_target_ratio",
+                CONTEXT_PRESSURE_RECOVERY_TARGET,
+                CONTEXT_PRESSURE_RECOVERY_TARGET,
+                False,
+                "context-manual#recovery-target-ratio",
+            ),
+        )
+
+    return provide
+
+
+class ContextRuntimeSettingsAdapter(AgentContextRuntimeAdapter):
+    """Existing Context lifecycle adapter plus its read-only row provider."""
+
+    __slots__ = ("_settings",)
+
+    def __init__(
+        self,
+        *,
+        molt: Callable[[dict], dict],
+        summarize: Callable[[dict], dict],
+        rebuild: Callable[[dict], dict],
+        settings: SettingsProvider,
+    ) -> None:
+        super().__init__(molt=molt, summarize=summarize, rebuild=rebuild)
+        self._settings = settings
+
+    def settings(self):
+        return self._settings()
+
+
+__all__ = [
+    "ContextRuntimeSettingsAdapter",
+    "build_context_settings_provider",
+]

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -226,6 +226,7 @@ def test_context_schema_exposes_the_exact_action_surface():
     assert SCHEMA["properties"]["action"]["enum"] == [
         "molt",
         "summarize", "rebuild",
+        "settings",
         "manual",
     ]
 

--- a/tests/test_context_declared_tool_plugin.py
+++ b/tests/test_context_declared_tool_plugin.py
@@ -56,7 +56,10 @@ def test_unallowlisted_same_name_manual_collision_fails_loudly(tmp_path, monkeyp
 def test_context_declaration_is_static_and_derives_its_public_surface():
     assert DECLARATION.name == "context"
     assert DECLARATION.actions == ("molt", "summarize", "rebuild")
-    assert DECLARATION.public_actions == ("molt", "summarize", "rebuild", "manual")
+    assert DECLARATION.public_actions == (
+        "molt", "summarize", "rebuild", "settings", "manual",
+    )
+    assert DECLARATION.settings is True
     assert DECLARATION.requires == ("workdir", "context_runtime")
     assert get_schema()["properties"]["action"]["enum"] == list(DECLARATION.public_actions)
 

--- a/tests/test_context_ownership_redesign.py
+++ b/tests/test_context_ownership_redesign.py
@@ -37,7 +37,9 @@ def test_public_action_sets_are_the_locked_inventories():
     assert psyche_tool.ACTION_ORDER == (
         "pad", "lingtai", "knowledge", "skills", "settings", "manual",
     )
-    assert _actions(context_tool) == ["molt", "summarize", "rebuild", "manual"]
+    assert _actions(context_tool) == [
+        "molt", "summarize", "rebuild", "settings", "manual",
+    ]
 
 
 def test_retired_actions_are_rejected_without_aliases(tmp_path):

--- a/tests/test_context_settings.py
+++ b/tests/test_context_settings.py
@@ -1,0 +1,184 @@
+"""Focused evidence for Context's five-field settings opt-in."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from lingtai.agent import Agent
+from lingtai.kernel.llm.interface import ChatInterface
+from lingtai.tools import context as context_tool
+from lingtai.tools.context import ACTION_ORDER, DECLARATION, get_schema
+from lingtai.tools.context.settings import build_context_settings_provider
+from lingtai.tools.tool_family import ChildTool, ToolFamily
+from tests._service_helpers import make_gemini_mock_service
+
+
+_EMPTY = {
+    "type": "object",
+    "properties": {},
+    "required": [],
+    "additionalProperties": False,
+}
+_COMMENTS = {
+    "context_limit": "context-manual#context-limit",
+    "summarize_notification_threshold": (
+        "context-manual#summarize-notification-threshold"
+    ),
+    "system_prompt_pressure_ratio": (
+        "context-manual#system-prompt-pressure-ratio"
+    ),
+    "pressure_high_ratio": "context-manual#pressure-high-ratio",
+    "forced_rebuild_ratio": "context-manual#forced-rebuild-ratio",
+    "pressure_warn_after_rounds": "context-manual#pressure-warn-after-rounds",
+    "recovery_target_ratio": "context-manual#recovery-target-ratio",
+}
+
+
+@pytest.fixture
+def context_agent(tmp_path):
+    service = make_gemini_mock_service()
+    service._context_window = 272_000
+    agent = Agent(
+        service=service,
+        agent_name="context-settings",
+        working_dir=tmp_path / "agent",
+        capabilities={},
+    )
+    try:
+        yield agent
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def _settings(agent, action_input) -> dict:
+    return agent._tool_handlers["context"](
+        {"action": "settings", "input": action_input, "reasoning": "test"}
+    )
+
+
+def _rows(agent) -> dict[str, dict]:
+    return {row["key"]: row for row in _settings(agent, {})["settings"]}
+
+
+def test_context_is_the_only_family_opted_in_here():
+    assert DECLARATION.settings is True
+    assert DECLARATION.actions == ("molt", "summarize", "rebuild")
+    assert DECLARATION.public_actions == (
+        "molt",
+        "summarize",
+        "rebuild",
+        "settings",
+        "manual",
+    )
+    assert ACTION_ORDER == DECLARATION.public_actions
+    assert get_schema()["properties"]["action"]["enum"] == list(ACTION_ORDER)
+
+
+def test_exact_five_field_inventory_and_manual_targets(context_agent, monkeypatch):
+    monkeypatch.delenv("LINGTAI_SYSTEM_PROMPT_PRESSURE_RATIO", raising=False)
+    expected = {
+        "context_limit": (272_000, 272_000, True),
+        "summarize_notification_threshold": (3000, 3000, True),
+        "system_prompt_pressure_ratio": (0.4, 0.4, True),
+        "pressure_high_ratio": (0.85, 0.85, False),
+        "forced_rebuild_ratio": (1.0, 1.0, False),
+        "pressure_warn_after_rounds": (3, 3, False),
+        "recovery_target_ratio": (0.75, 0.75, False),
+    }
+    result = _settings(context_agent, {})
+    assert result == {
+        "settings": [
+            {
+                "key": key,
+                "current": current,
+                "default": default,
+                "configurable": configurable,
+                "comment": _COMMENTS[key],
+            }
+            for key, (current, default, configurable) in expected.items()
+        ]
+    }
+    assert all(set(row) == {
+        "key", "current", "default", "configurable", "comment",
+    } for row in result["settings"])
+    assert "<redacted>" not in repr(result)  # These seven scalars are non-sensitive.
+
+    manual = (
+        context_agent.working_dir
+        / ".library/intrinsic/capabilities/context-manual/SKILL.md"
+    ).read_text(encoding="utf-8")
+    headings = {
+        "context-manual#" + heading.lower().replace(" ", "-"): heading
+        for heading in (
+            "Context limit",
+            "Summarize notification threshold",
+            "System prompt pressure ratio",
+            "Pressure high ratio",
+            "Forced rebuild ratio",
+            "Pressure warn after rounds",
+            "Recovery target ratio",
+        )
+    }
+    assert headings.keys() == set(_COMMENTS.values())
+    assert all(f"## {heading}" in manual for heading in headings.values())
+
+
+def test_live_runtime_and_environment_values_are_read_fresh(context_agent, monkeypatch):
+    context_agent._config.context_limit = 64_000
+    context_agent._summarize_notification_threshold = 0
+    monkeypatch.setenv("LINGTAI_SYSTEM_PROMPT_PRESSURE_RATIO", "0.625")
+    rows = _rows(context_agent)
+    assert rows["context_limit"]["current"] == 64_000
+    assert rows["summarize_notification_threshold"]["current"] == 0
+    assert rows["system_prompt_pressure_ratio"]["current"] == 0.625
+
+    monkeypatch.setenv("LINGTAI_SYSTEM_PROMPT_PRESSURE_RATIO", "invalid")
+    assert _rows(context_agent)["system_prompt_pressure_ratio"]["current"] == 0.4
+
+
+def test_strict_empty_input_and_unavailable_current_fail_as_one_action(context_agent):
+    for value in (None, [], {"set": "context_limit"}):
+        assert _settings(context_agent, value)["status"] == "failed"
+
+    unavailable = build_context_settings_provider(lambda: 0, lambda: 3000)
+    family = ToolFamily(
+        "context-probe",
+        [ChildTool("manual", _EMPTY, lambda _value: {})],
+        settings_provider=unavailable,
+    )
+    assert family.handle(
+        {"action": "settings", "input": {}, "reasoning": "test"}
+    ) == {
+        "status": "failed",
+        "error_code": "SETTINGS_UNAVAILABLE",
+        "message": "settings inventory is unavailable",
+    }
+
+
+def test_rebuild_dispatch_is_unchanged_by_settings_opt_in(tmp_path):
+    class Chat:
+        def __init__(self):
+            self.interface = ChatInterface()
+            self.rebuilds = 0
+
+        def request_history_rebuild(self, reason=""):
+            self.rebuilds += 1
+            return True
+
+    subject = SimpleNamespace(
+        _working_dir=tmp_path,
+        _tool_handlers={},
+        _config=SimpleNamespace(context_limit=None),
+        _summarize_notification_threshold=3000,
+        _chat=Chat(),
+        _log=lambda *_args, **_kwargs: None,
+    )
+    reconstructions = []
+    subject._reconstruct_context = lambda: reconstructions.append("reconstructed")
+
+    result = context_tool.handle(subject, {"action": "rebuild", "input": {}})
+    assert result["status"] == "ok"
+    assert result["prompt_reconstructed"] is True
+    assert reconstructions == ["reconstructed"]
+    assert subject._chat.rebuilds == 1

--- a/tests/test_pad_lingtai_split.py
+++ b/tests/test_pad_lingtai_split.py
@@ -43,7 +43,9 @@ def test_neither_package_registers_a_public_root():
 
 
 def test_context_inventory_still_carries_no_pad_or_lingtai_aliases():
-    assert context_tool.ACTION_ORDER == ("molt", "summarize", "rebuild", "manual")
+    assert context_tool.ACTION_ORDER == (
+        "molt", "summarize", "rebuild", "settings", "manual",
+    )
     actions = context_tool.get_schema()["properties"]["action"]["enum"]
     for retired in (
         "pad_edit", "pad_load", "pad_append", "lingtai_update", "lingtai_load",

--- a/tests/test_tool_family_context_migration.py
+++ b/tests/test_tool_family_context_migration.py
@@ -83,7 +83,7 @@ def _molt_input(journal_path, summary="briefing", **over):
 
 
 def test_one_public_context_root_with_the_exact_action_inventory():
-    """The four actions, in the exact public order, and nothing else.
+    """The five actions, in the exact public order, and nothing else.
 
     `molt` is the lifecycle operation carried over from `psyche.context_molt`;
     `summarize`/`rebuild` are the explicit pair that replaced the former
@@ -94,9 +94,10 @@ def test_one_public_context_root_with_the_exact_action_inventory():
         "molt",                    # shed the conversation
         "summarize",               # record only
         "rebuild",                 # apply pending summaries
+        "settings",                # read-only Context policy inventory
         "manual",                  # root manual (family-owned)
     ]
-    assert len(ACTION_ORDER) == 4
+    assert len(ACTION_ORDER) == 5
 
 
 def test_context_is_registered_exactly_once_as_an_intrinsic():
@@ -160,13 +161,19 @@ def test_schema_and_dispatch_come_from_one_registry():
     """A child cannot be schema-advertised but dispatch-rejected."""
     schema = get_schema("en")
     advertised = list(schema["properties"]["action"]["enum"])
-    branch_titles = [b["title"] for b in schema["properties"]["input"]["oneOf"]]
+    branch_titles = [b["title"] for b in schema["properties"]["input"]["anyOf"]]
     correlated = [
         c["if"]["properties"]["action"]["const"] for c in schema["allOf"]
     ]
     assert advertised == list(ACTION_ORDER)
     assert correlated == advertised
-    assert branch_titles == [f"{name} input" for name in advertised]
+    assert branch_titles == [
+        "molt input",
+        "summarize input",
+        "rebuild input",
+        "settings inventory input",
+        "manual input",
+    ]
 
 
 def test_each_action_advertises_only_its_own_input():
@@ -188,6 +195,7 @@ def test_each_action_advertises_only_its_own_input():
     }
     assert props["summarize"] == {"items"}
     assert props["rebuild"] == {"items"}
+    assert props["settings"] == set()
     assert props["manual"] == set()
     # Naming left for ``system``; no context action advertises ``content``.
     assert not any("content" in fields for fields in props.values())
@@ -640,14 +648,15 @@ def test_kernel_detects_the_migrated_molt_call_shape():
 
 
 def test_manual_child_returns_the_canonical_result_unwrapped(tmp_path):
-    """`ToolFamily.handle()` returns the reserved child's result verbatim."""
+    """The reserved manual child still owns its canonical unwrapped result."""
     from lingtai.tools.context import _build_children
-    from lingtai.tools.tool_family import ToolFamily
 
     agent = _agent(tmp_path)
     try:
-        family = ToolFamily("psyche", _build_children(agent))
-        raw = family.handle({"action": "manual", "input": {}})
+        manual = next(
+            child for child in _build_children(agent) if child.name == "manual"
+        )
+        raw = manual.handler({})
         # Canonical ManualTool shape — full body + host-local path, no flatten.
         assert raw["content"][0]["text"]
         assert raw["structuredContent"]["manual_path"]
@@ -729,7 +738,7 @@ def test_one_context_root_survives_both_wires_with_action_input_correlation(tmp_
 
         chat = _build_tools(context_schemas)[0]["function"]["parameters"]
         responses = _build_responses_tools(context_schemas)[0]["parameters"]
-        for wire, combinator in ((chat, "oneOf"), (responses, "anyOf")):
+        for wire, combinator in ((chat, "anyOf"), (responses, "anyOf")):
             assert set(wire["properties"]) == {
                 "action", "input", "reasoning", "summarize",
             }
@@ -740,7 +749,11 @@ def test_one_context_root_survives_both_wires_with_action_input_correlation(tmp_
             assert wire["properties"]["action"]["enum"] == list(ACTION_ORDER)
             branches = wire["properties"]["input"][combinator]
             assert [b["title"] for b in branches] == [
-                f"{a} input" for a in ACTION_ORDER
+                "molt input",
+                "summarize input",
+                "rebuild input",
+                "settings inventory input",
+                "manual input",
             ]
             assert len(wire["allOf"]) == len(ACTION_ORDER)
             molt = next(
@@ -839,7 +852,7 @@ def test_rebuild_items_stays_optional_on_both_provider_wires(tmp_path):
         schemas = [s for s in _build_tool_schemas(live) if s.name == "context"]
         chat = _build_tools(schemas)[0]["function"]["parameters"]
         responses = _build_responses_tools(schemas)[0]["parameters"]
-        for wire, combinator in ((chat, "oneOf"), (responses, "anyOf")):
+        for wire, combinator in ((chat, "anyOf"), (responses, "anyOf")):
             branches = {
                 b["title"]: b for b in wire["properties"]["input"][combinator]
             }

--- a/tests/test_tool_settings_contract.py
+++ b/tests/test_tool_settings_contract.py
@@ -147,10 +147,10 @@ def test_public_export_and_exact_production_opt_ins():
         name: importlib.import_module(f"lingtai.tools.{modules.get(name, name)}").DECLARATION
         for name in OFFICIAL_TOOL_PLUGIN_NAMES
     }
-    expected_official = {"avatar", "daemon", "email", "file", "mcp", "notification", "plugin", "shell", "soul", "system", "task_card", "vision", "web"}
+    expected_official = {"avatar", "context", "daemon", "email", "file", "mcp", "notification", "plugin", "shell", "soul", "system", "task_card", "vision", "web"}
     assert {name for name, item in declarations.items() if item.settings} == expected_official
     assert expected_curated | expected_official == {
-        "avatar", "cloud_mail", "daemon", "email", "feishu", "file", "imap", "mcp", "notification", "plugin", "shell", "soul", "system", "task_card", "telegram", "vision", "web", "wechat", "whatsapp"
+        "avatar", "cloud_mail", "context", "daemon", "email", "feishu", "file", "imap", "mcp", "notification", "plugin", "shell", "soul", "system", "task_card", "telegram", "vision", "web", "wechat", "whatsapp"
     }
     for name, item in declarations.items():
         assert ("settings" in item.public_actions) is (name in expected_official)


### PR DESCRIPTION
## Summary

- rebase the `context` owner directly onto merged five-field foundation `2418bd89`
- opt only this owner into read-only `settings`
- successful rows expose exactly `key`, `current`, `default`, `configurable`, and owner-manual `comment`
- keep meaning, accepted values, source/precedence, config/env key, apply timing, and the real change procedure in the exact owner manual section
- keep all mutation in existing authorized owner procedures; this action has no set/reset path

## Independent owner scope

- one owner PR; no stacking on another owner
- exact resulting surface: **13 files changed, 610 insertions(+), 61 deletions(-)**
- owner provider/manual/docs/tests only, plus the owner-specific transition expectation in the shared synthetic contract test

## Validation

- owner validation: {"failing": ["required generic: 10 passed, 1 failed because exact-main asserts all official families settings=False"], "passing": ["context owner: 92 passed, 1 inherited deselected", "refresh/pressure: 72 passed", "prompt-pressure: 17 passed, 185 deselected", "touched docs: 4 checked, 0 failures", "py_compile and git diff --check"]}
- shared five-field/owner transition contract: **11 passed**
- `git diff --check`: pass

## Status

This PR remains **Draft**. No merge, live refresh, release/deploy, operator config/auth change, deletion, or cleanup is included.

Telegram: @lingtaidev3bot | Nickname: 澄一

Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
