### PR TITLE
feat(avatar): expose five-field settings inventory

### DIFF
--- a/src/lingtai/intrinsic_skills/system-manual/reference/tool-plugin-settings/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/tool-plugin-settings/SKILL.md
@@ -4,8 +4,8 @@ description: >
   Developer reference for opting one tool family into bounded, read-only
   settings discovery without changing other families.
 tags: [lingtai, system-manual, tool-family, settings]
-version: 4.0.1
-last_changed_at: 2026-08-28T00:00:00Z
+version: 4.0.2
+last_changed_at: 2026-08-29T00:00:00Z
 related_files:
   - src/lingtai/kernel/tool_plugin/__init__.py
   - src/lingtai/tools/tool_family/ANATOMY.md
@@ -22,9 +22,9 @@ maintenance: |
 ---
 # ToolFamily settings SHOW reference
 
-Use this for one bounded family-owner change at a time. System is currently the
-only production family opted in; every later owner remains opted out until its
-own vertical change.
+Use this for one bounded family-owner change at a time. Production families opt
+in only through their own reviewed vertical change; no owner document or
+another family's opt-in enables them implicitly.
 
 ## Opt in
 

--- a/src/lingtai/tools/avatar/ANATOMY.md
+++ b/src/lingtai/tools/avatar/ANATOMY.md
@@ -7,6 +7,7 @@ related_files:
   - src/lingtai/tools/avatar/BEHAVIORS.md
   - src/lingtai/tools/avatar/__init__.py
   - src/lingtai/tools/avatar/_launcher.py
+  - src/lingtai/tools/avatar/settings.py
   - src/lingtai/tools/avatar/CONTRACT.md
   - src/lingtai/kernel/tool_plugin/ANATOMY.md
   - src/lingtai/kernel/tool_plugin/CONTRACT.md
@@ -47,11 +48,14 @@ independent life — its existence does not depend on yours.
 
 ## Components
 
-- `avatar/__init__.py` — static official `DECLARATION`, local manual child,
-  validation, preparation, boot policy, ledger, rules, schemas, and registrar
-  setup. The core class is `AvatarManager`.
+- `avatar/__init__.py` — static official `DECLARATION`, settings binding, local
+  manual child, validation, preparation, boot policy, ledger, rules, schemas,
+  and registrar setup. The core class is `AvatarManager`.
 - `avatar/_launcher.py` — immutable launch request/receipt and the avatar-local
   opaque-handle Port.
+- `avatar/settings.py` — the no-I/O `AvatarSettingsProvider` and the constants
+  shared with Avatar's runtime validation/default/lifecycle consumers. It owns
+  no store, environment reader, runtime object, or writer.
 
 ## Public API
 
@@ -62,6 +66,7 @@ family (`src/lingtai/tools/CONTRACT.md`) whose actions are canonical children:
 |------|------|-------------|
 | `spawn` | `name`, `type`, `comment`, `dry_run`, `confirm` | Spawn a new avatar agent (shallow or deep). `dry_run` previews only; `confirm` acknowledges the mission-quality gate. |
 | `rules` | `rules_content` | Set rules content and distribute via `.rules` signal files to self + all descendants. Karma-gated. |
+| `settings` | `{}` | Return 16 immutable Avatar defaults, validation constraints, and lifecycle policies as exact five-field rows. |
 | `manual` | *(empty)* | Read-only: returns the exact `manual/SKILL.md` body plus its host-local `manual_path`. No spawn or rules I/O. |
 
 The model-facing root is exactly `action` + `input` + required `reasoning` +
@@ -93,10 +98,11 @@ unknown-action error string.
 ```
 avatar/__init__.py
   ├── _SPAWN/_RULES_INPUT_SCHEMA    — canonical strict operational inputs
-  ├── DECLARATION                   — static official identity, actions, manual,
-  │                                    and exact `(workdir, avatar_parent)` grant
+  ├── DECLARATION                   — static official identity, actions,
+  │                                    settings/manual reservations, and exact
+  │                                    `(workdir, avatar_parent)` grant
   ├── _CHILD_SPECS / _build_family  — declaration-derived public listing plus
-  │                                    the package-local reserved manual child
+  │                                    generic settings and local manual children
   ├── _bind()                       — pure host composition → BoundToolPlugin
   ├── AvatarManager.__init__        — narrow host + per-instance ToolFamily
   ├── handle()                      — envelope entry: captures root _reasoning,
@@ -108,6 +114,8 @@ avatar/__init__.py
   ├── _strip_nulls()                — nullable-optional → absent
   ├── _manual_payload()             — plugin-owned local `manual/SKILL.md`
   │                                    result; no manager/host mutation
+  ├── settings.AvatarSettingsProvider — fresh immutable SettingRow values;
+  │                                    no parent state or configuration I/O
   │
   │  Spawn pipeline:
   ├── _spawn()                      — validates name, checks liveness, prepares working dir, launches process
@@ -135,6 +143,12 @@ avatar/__init__.py
 - **Local manual:** `manual` is the declaration-appended reserved child but
   remains package-local: it returns `manual/SKILL.md` and performs no host or
   manager I/O.
+- **Settings are SHOW-only:** declaration opt-in injects `settings` immediately
+  before `manual`. The provider returns only
+  `key/current/default/configurable/comment`, with every Avatar row fixed and
+  non-configurable. Avatar owns no settings file, environment peer, provider
+  cache, writer, or set/reset operation; parent identity, runtime/venv/auth,
+  handoff, and invocation/session state are omitted rather than sampled.
 - **Name validation:** Avatar names must match `^[\w-]+$` (Unicode-aware), max 64 chars, no dots or path separators. The name doubles as the working directory basename.
 - **Path scope:** The avatar's working directory must be a direct sibling of the parent's (same parent directory). Resolved path is checked against the network root to prevent escape.
 - **No identity inheritance:** Avatars get no name (`agent_name` is set to the avatar name), no admin privileges, no comment, no brief, no addons (IMAP/Telegram). The inherited `lingtai` seed is blanked; the first turn still arrives via a separate `.prompt` signal file.
@@ -162,8 +176,9 @@ avatar/__init__.py
   routes `DECLARATION` through `register_agent_tool_plugins`; the kernel checks
   the reserved `avatar` name, grants only `workdir`/`avatar_parent`, binds the
   manager, and mounts the issued transaction. `AvatarManager` internally
-  dispatches `spawn`/`rules`/the declaration-owned local `manual` child through
-  `ToolFamily`. `avatar` is on the kernel's `_LTP_V2_MIGRATED_FAMILIES` allowlist
+  dispatches `spawn`/`rules`, the generic declaration-bound `settings` child,
+  and the declaration-owned local `manual` child through `ToolFamily`. `avatar`
+  is on the kernel's `_LTP_V2_MIGRATED_FAMILIES` allowlist
   (`src/lingtai/kernel/tool_result_summary.py`), so the root `summarize` boolean
   it advertises is actually honored by the single central summarizer. The daemon
   capability blacklists `avatar` to prevent avatar-in-daemon recursion and rules

--- a/src/lingtai/tools/avatar/BEHAVIORS.md
+++ b/src/lingtai/tools/avatar/BEHAVIORS.md
@@ -9,18 +9,20 @@ related_files:
   - src/lingtai/tools/avatar/ANATOMY.md
   - src/lingtai/tools/avatar/__init__.py
   - src/lingtai/tools/avatar/_launcher.py
+  - src/lingtai/tools/avatar/settings.py
+  - tests/test_tool_family_avatar_migration.py
 maintenance: |
   Created during the every-contract-needs-behaviors sweep. Keep this file
   reciprocal with CONTRACT.md and ANATOMY.md (tridirectional loop): when an
-  avatar spawn/rules/manual behavior clause changes, update the guarding LABT
-  here in the same change.
+  avatar spawn/rules/settings/manual behavior clause changes, update the
+  guarding LABT here in the same change.
 ---
 # Avatar Capability Behavior Tests
 
 Self-contained agent behavior tasks guarding the observable behavior clauses of
 `src/lingtai/tools/avatar/CONTRACT.md` (spawn mission gate, name grammar, rules
-admin gate, manual no-I/O). Pinned pytest commands must run from the repo root
-with the project's Python.
+admin gate, five-field settings SHOW, manual no-I/O). Pinned pytest commands
+must run from the repo root with the project's Python.
 
 ## Behavior AV001 — spawn enforces the name grammar and the mission-quality gate, and rules requires admin privilege
 
@@ -43,3 +45,28 @@ with the project's Python.
 
 ### Pass / Fail
 Pass when the suites pass and the gate observations hold. Fail on a malformed name spawning, on a weak mission spawning without confirmation, or on `rules` executing without admin karma; record the evidence trail in the task report.
+
+## Behavior AV002 — settings shows only immutable Avatar owner policy
+
+- **id**: AV002
+- **title**: settings shows only immutable Avatar owner policy
+- **guards**: `avatar-contract` § `avatar` — `action="settings"`
+- **runner**: any LingTai agent with `shell` and `file` access to this repository
+- **prerequisites**: a clean checkout of `<repo>` and no live avatar spawned by the probe
+- **estimate**: ≈ 10 minutes
+
+### Steps
+1. From `<repo>`, run `python -m pytest tests/test_tool_family_avatar_migration.py tests/test_tool_settings_contract.py -q` and capture the outcome.
+2. Call `avatar(action="settings", input={}, reasoning="inventory policy")`; inspect action order, all row fields and values, and every manual pointer.
+3. Call settings with a set-shaped non-empty input and with a failing injected provider; inspect the parent directory and environment key used by the probe.
+
+### Expected evidence
+- [ ] Step 1: both suites pass, including a real Agent construction and complete system-prompt build, exact `{system, avatar}` opt-in ownership, and the 65,536-byte generic bound.
+- [ ] Step 2: `settings` appears once immediately before `manual`; all 16 rows contain only `key/current/default/configurable/comment`, are `configurable:false`, and reach the three Avatar-manual anchors. Parent identity, runtime/venv/auth, handoff, ignored arguments, and invocation/session state are absent.
+- [ ] Step 3: non-empty input is rejected; provider failure returns only the fixed `SETTINGS_UNAVAILABLE` result; neither path creates a settings file, process, ledger, rules signal, privilege change, environment mutation, or partial row list.
+
+### Pass / Fail
+Pass when SHOW is exact, fresh, bounded, source-backed, read-only, and omits all
+private/non-setting state. Fail if an environment shadow changes current policy,
+a private or partial row appears, a mutation form is accepted, or existing
+spawn/rules behavior changes.

--- a/src/lingtai/tools/avatar/CONTRACT.md
+++ b/src/lingtai/tools/avatar/CONTRACT.md
@@ -1,10 +1,12 @@
 ---
 name: avatar-contract
 tool: avatar
-contract_version: 4
+contract_version: 5
 related_files:
+  - src/lingtai/tools/avatar/BEHAVIORS.md
   - src/lingtai/tools/avatar/__init__.py
   - src/lingtai/tools/avatar/_launcher.py
+  - src/lingtai/tools/avatar/settings.py
   - src/lingtai/kernel/tool_plugin/CONTRACT.md
   - src/lingtai/kernel/tool_plugin/ANATOMY.md
   - src/lingtai/adapters/tool_plugin_host.py
@@ -28,7 +30,8 @@ maintenance: |
 
 `avatar` spawns independent peer agents (分身) as fully detached processes, and
 distributes shared rules across the avatar subtree. It registers **one** public
-tool, `avatar`, dispatched by an `action` enum (`spawn` | `rules` | `manual`).
+tool, `avatar`, dispatched by an `action` enum (`spawn` | `rules` | `settings`
+| `manual`).
 The implementation lives in `src/lingtai/tools/avatar/`; the code is the source
 of truth.
 
@@ -80,8 +83,18 @@ choice, not a contract requirement: per that package's "Implementation
 independence" rule, avatar could hand-write an equivalent `handle()` without
 changing any promise in this file.
 
+**contract_version 5** (additive): Avatar opts into the generic read-only
+`settings` action. It appears once immediately before `manual` and returns 16
+immutable call-default, validation, and lifecycle rows with exactly
+`key/current/default/configurable/comment`. All rows are
+`configurable:false`; Avatar gains no file, environment source, writer, or
+set/reset action. Parent identity, runtime/venv/auth, handoff, and
+invocation/session facts remain outside the inventory. Provider/JSON/size
+failure stays whole-inventory and bounded by the generic contract.
+
 ## Routing Card
-Guarded by: [AV001](BEHAVIORS.md#behavior-av001)
+Guarded by: [AV001](BEHAVIORS.md#behavior-av001),
+[AV002](BEHAVIORS.md#behavior-av002)
 
 
 **Use this when:**
@@ -106,11 +119,12 @@ storage; detached-process launch -> §Cross-platform invariants.
   whose root property set is exactly `action`, `input`, `reasoning`, and
   `summarize`, with `additionalProperties: false` and
   `required: ["action", "input", "reasoning"]`. `action` is the enum
-  (`spawn` | `rules` | `manual`) — schema-required, the same convention as
+  (`spawn` | `rules` | `settings` | `manual`) — schema-required, the same convention as
   `knowledge`, `mcp`, `skills`, `notification`, `system`, `soul`, and `daemon`.
   Each action's own strict, closed `input` schema is exposed to the model
   before invocation two ways, both generated from the one child registry: an
-  `input.oneOf` disclosure branch per action, and one root `allOf`/`if`/`then`
+  `input.anyOf` disclosure branch per action (required because `settings` and
+  `manual` both have strict empty input), and one root `allOf`/`if`/`then`
   condition per action correlating that action's `const` with that exact input
   shape. Dispatch re-validates independently and is always authoritative.
 - Action-specific required inputs (`name` for spawn, `rules_content` for rules)
@@ -122,6 +136,8 @@ storage; detached-process launch -> §Cross-platform invariants.
 - `action="rules"` writes a `.rules` signal to the caller and every descendant
   so each agent refreshes its own `system/rules.md`-derived prompt. It carries
   its own admin gate, independent of `spawn` — spawning never requires admin.
+- `action="settings"` calls the Avatar-owned provider for immutable defaults,
+  constraints, and lifecycle policy. It has no mutation or configuration I/O.
 - `action="manual"` is read-only: it returns the exact packaged
   `src/lingtai/tools/avatar/manual/SKILL.md` body plus its host-local
   `manual_path`, and performs no filesystem mutation (no spawn, no ledger
@@ -146,11 +162,12 @@ any-admin-value authorization decision for `rules`. `AvatarManager` never holds
 or accepts a whole Agent. The registrar still owns reservation, activation, and
 mounting; `setup(agent)` is composition wiring only.
 
-The declaration owns operational `spawn`/`rules`; it appends the reserved
-`manual` slot. Avatar owns that child directly so its longstanding local-manual
-contract remains unchanged: `manual` returns the packaged `manual/SKILL.md`
-body and its package-local path, never an installed intrinsic copy and never a
-manager/host side effect.
+The declaration owns operational `spawn`/`rules`; generic composition inserts
+the opted-in `settings` slot immediately before the reserved `manual` slot.
+Avatar owns the manual child directly so its longstanding local-manual contract
+remains unchanged: `manual` returns the packaged `manual/SKILL.md` body and its
+package-local path, never an installed intrinsic copy and never a manager/host
+side effect.
 
 ## Tool surface
 
@@ -160,7 +177,7 @@ Every call is `avatar(action=..., input={...}, reasoning="...", summarize?=bool)
 
 | Root field | Required | Meaning |
 |---|---|---|
-| `action` | yes | One of `spawn` \| `rules` \| `manual`. No default. |
+| `action` | yes | One of `spawn` \| `rules` \| `settings` \| `manual`. No default. |
 | `input` | yes | The selected action's own strict, closed object. |
 | `reasoning` | yes | Cross-cutting rationale. For `spawn` this **is** the mission brief and becomes the avatar's first prompt. Never an `input` property. |
 | `summarize` | no | Root-only result post-processing control, absent/false by default. Never action input, never reaches a handler. |
@@ -200,6 +217,31 @@ and before any write.
 caller. This gate applies only to `rules`; `spawn` never checks admin. The
 family must not hide this stronger action behind a weaker family posture.
 
+### `avatar` — `action="settings"`
+
+Input is exactly `{}`. Success is exactly `{"settings": [...]}`, with 16 rows
+in the owner-defined stable order. Every row has exactly five fields, in order:
+`key`, `current`, `default`, `configurable`, `comment`. The comments point to
+stable `avatar-manual#...` sections that own meaning, source, precedence,
+accepted values, timing, and the only valid change procedure. No source,
+precedence, sensitivity, diagnostic, or writer metadata is projected.
+
+The inventory contains only the pre-existing immutable spawn call defaults,
+validation constraints, boot observation values, preset/environment/lifetime
+policy, and cleared newborn-admin policy. Each fixed code value is both fresh
+effective `current` and truthful `default`, and each row is
+`configurable:false`. Per-call spawn inputs vary only one invocation. Avatar
+owns no `settings/avatar.json`, action settings file, `LINGTAI_AVATAR_*`
+environment peer, or alternate source.
+
+Parent identity, runtime/venv/auth, handoff values, ignored capability
+arguments, and invocation/session state are not settings and MUST NOT be read
+or returned. A non-empty input fails before the provider runs. Provider,
+malformed-row, non-JSON, or response-size failure produces the generic fixed
+bounded no-row failure; no partial inventory or exception detail is exposed.
+SHOW performs no filesystem, process, launcher, ledger, rules, privilege,
+configuration, or environment mutation.
+
 ### `avatar` — `action="manual"`
 
 Strict empty `input` (`{}`); any field is rejected. Performs no spawn or rules
@@ -214,9 +256,9 @@ nested inside another action's result envelope and never double-wrapped.
 
 ### Invalid or missing `action`
 
-An `action` value outside `spawn`/`rules`/`manual` — including an entirely
+An `action` value outside `spawn`/`rules`/`settings`/`manual` — including an entirely
 omitted `action` key — returns
-`{error: "unknown action: <repr>, only 'spawn', 'rules', or 'manual' is supported"}`
+`{error: "unknown action: <repr>, only 'spawn', 'rules', 'settings', or 'manual' is supported"}`
 (for the omitted case, `<repr>` is `''`) without touching the filesystem, the
 ledger, `.rules`, or launching any process. There is no default action: a
 `name`- or `rules_content`-shaped payload with `action` omitted still fails
@@ -293,7 +335,7 @@ live descendant.
   `venv_python` from the avatar's `init.json` → global runtime. The
   `lingtai.tools → lingtai` import edge is allowed only inside setup/handlers.
 - Boot verification polls for the avatar's `.agent.heartbeat` handshake file (up
-  to `_BOOT_WAIT_SECS = 5.0s`, 0.1s interval). If the child exits first, spawn
+  to the owner-declared 5.0s window, 0.1s interval). If the child exits first, spawn
   is `failed` and a bounded stderr tail is returned; if neither happens in the
   window, boot is `slow` and a warning is attached.
 
@@ -311,12 +353,13 @@ live descendant.
 | Unsafe / duplicate avatar names are rejected | `src/lingtai/tools/avatar/__init__.py` | `tests/test_layers_avatar.py::test_spawn_rejects_unsafe_name`, `::test_spawn_duplicate_name_error` |
 | Shallow spawn does not copy identity files | `src/lingtai/tools/avatar/__init__.py` | `tests/test_layers_avatar.py::test_spawn_does_not_copy_identity_files` |
 | `action="rules"` requires admin and non-empty content; `spawn` does not inherit that gate | `src/lingtai/tools/avatar/__init__.py` | `tests/test_avatar_rules.py::test_rules_requires_admin`, `::test_rules_requires_content`; `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_spawn_does_not_inherit_rules_permission_gate` |
+| `action="settings"` is immediately before `manual`, returns the exact 16 five-field fixed-policy rows, points to owner-manual anchors, excludes private/runtime/auth/handoff state, accepts no writer input or environment peer, and fails as one bounded result | `src/lingtai/tools/avatar/settings.py`, `src/lingtai/tools/avatar/__init__.py` | `tests/test_tool_family_avatar_migration.py::test_avatar_settings_inventory_is_exact_fresh_and_excludes_private_state`, `::test_avatar_settings_is_show_only_and_has_no_environment_peer`, `::test_avatar_settings_provider_failure_is_one_bounded_result`; `tests/test_tool_settings_contract.py` |
 | Rules are distributed recursively to descendants (cycle-safe) | `src/lingtai/tools/avatar/__init__.py` | `tests/test_avatar_rules.py::test_rules_distributes_recursively`, `::test_rules_root_not_duplicated_via_cycle` |
 | Spawning distributes existing rules to the newborn | `src/lingtai/tools/avatar/__init__.py` | `tests/test_avatar_rules.py::test_spawn_distributes_existing_rules`, `::test_spawn_deep_clone_also_gets_rules_signal` |
 | `_prepare_deep` refuses a non-sibling destination | `src/lingtai/tools/avatar/__init__.py` | `tests/test_layers_avatar.py::test_prepare_deep_refuses_non_sibling_dst` |
 | `action="manual"` returns the exact packaged manual body and mutates nothing | `src/lingtai/tools/avatar/__init__.py` | `tests/test_tool_family_avatar_migration.py::test_avatar_manager_uses_only_granted_ports_for_local_manual_and_rules`, `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_manual_returns_exact_body_and_performs_no_mutation` |
 | Invalid `action` fails deterministically without touching other actions | `src/lingtai/tools/avatar/__init__.py` | `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_invalid_action_fails_deterministically`, `::test_spawn_missing_name_fails_without_affecting_other_actions` |
-| `action` is schema-required (root `required: ["action", "input", "reasoning"]`) and runtime-required — a missing `action` never defaults to `spawn`, `rules`, or `manual`, regardless of which action's fields are present, and mutates nothing | `src/lingtai/tools/avatar/__init__.py` | `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_missing_action_fails_deterministically_regardless_of_payload_shape`; `tests/test_avatar_rules.py::TestAvatarRulesAction::test_explicit_spawn_action_required` |
+| `action` is schema-required (root `required: ["action", "input", "reasoning"]`) and runtime-required — a missing `action` never defaults to `spawn`, `rules`, `settings`, or `manual`, regardless of which action's fields are present, and mutates nothing | `src/lingtai/tools/avatar/__init__.py` | `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_missing_action_fails_deterministically_regardless_of_payload_shape`; `tests/test_avatar_rules.py::TestAvatarRulesAction::test_explicit_spawn_action_required` |
 | The daemon blacklists the canonical `avatar` name (not the retired two-tool names) | `src/lingtai/tools/daemon/__init__.py` | `tests/test_daemon.py::test_build_tool_surface_blacklist`, `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_daemon_excludes_avatar_from_child_surface` |
 
 ## Verification matrix
@@ -331,6 +374,7 @@ live descendant.
 | Omitted `action` never defaults to spawn | `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_missing_action_fails_deterministically_regardless_of_payload_shape` | Call `avatar(input={"name": "x", "confirm": true}, reasoning="...")` with no `action`, confirm error + no spawned process | A model omitting `action` could accidentally spawn an untracked process |
 | Rules propagate to the whole subtree | `tests/test_avatar_rules.py::test_rules_distributes_recursively` | Set rules on a root, confirm `.rules` on each descendant | Descendants run stale/ungoverned rules |
 | `manual` action is read-only | `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_manual_returns_exact_body_and_performs_no_mutation` | Call `avatar(action="manual", input={}, reasoning="...")`, confirm no new files | A "manual" call could accidentally spawn or mutate rules |
+| Settings SHOW is exact, fresh, bounded, read-only, and excludes private state | `tests/test_tool_family_avatar_migration.py` settings tests plus `tests/test_tool_settings_contract.py` | Call settings with `{}` and a set-shaped input; inspect exact fields/order/manual targets and no source mutation | A writer, stale result, partial inventory, or host-state leak could drift from the owner contract |
 
 Run before merging avatar changes:
 
@@ -338,7 +382,7 @@ Run before merging avatar changes:
 python -m pytest tests/test_avatar_launcher.py tests/test_layers_avatar.py \
   tests/test_avatar_rules.py tests/test_avatar_preset_inheritance.py \
   tests/test_avatar_timezone_inheritance.py \
-  tests/test_tool_family_avatar_migration.py -q
+  tests/test_tool_family_avatar_migration.py tests/test_tool_settings_contract.py -q
 ```
 
 ## Schema and glossary ownership

--- a/src/lingtai/tools/avatar/__init__.py
+++ b/src/lingtai/tools/avatar/__init__.py
@@ -20,6 +20,7 @@ Usage (LTP v2 envelope — one action, one strict child input):
     # avatar(action="spawn", input={"name": "researcher"}, reasoning="...")
     # avatar(action="spawn", input={"name": "clone", "type": "deep"}, reasoning="...")
     # avatar(action="rules", input={"rules_content": "..."}, reasoning="...")
+    # avatar(action="settings", input={}, reasoning="...")
     # avatar(action="manual", input={}, reasoning="...")
 
 The spawn mission brief is root ``reasoning`` (normalized to ``_reasoning`` by
@@ -44,9 +45,24 @@ from typing import TYPE_CHECKING, Any, Mapping
 from lingtai.kernel.agent_presence import observe_alive as _presence_observe_alive
 from lingtai.kernel.i18n import t
 from lingtai.kernel.tool_plugin import BoundToolPlugin, ToolPluginDeclaration
-from ..tool_family import ChildTool, ToolFamily
+from ..tool_family import ChildTool, SettingsProvider, ToolFamily
 from ..tool_family.manual import MANUAL_INPUT_SCHEMA
 from ._launcher import AvatarLaunchReceipt, AvatarLaunchRequest, AvatarLauncherPort
+from .settings import (
+    AVATAR_NAME_MAX_CHARACTERS,
+    AVATAR_NAME_MIN_CHARACTERS,
+    BOOT_POLL_INTERVAL_SECONDS,
+    BOOT_STDERR_TAIL_BYTES,
+    BOOT_WAIT_SECONDS,
+    MISSION_MIN_CHARACTERS,
+    MISSION_PLACEHOLDER_PREFIXES,
+    SPAWN_COMMENT_DEFAULT,
+    SPAWN_CONFIRM_DEFAULT,
+    SPAWN_DRY_RUN_DEFAULT,
+    SPAWN_TYPE_DEFAULT,
+    SPAWN_TYPES,
+    AvatarSettingsProvider,
+)
 
 
 def _is_alive(working_dir) -> bool:
@@ -67,16 +83,6 @@ def _is_alive(working_dir) -> bool:
 # control chars, no dots. The structural chars are what make this dangerous;
 # the script itself is the agent's choice.
 _AVATAR_NAME_RE = re.compile(r"^[\w-]+$")  # \w is Unicode-aware in Py3 re
-_AVATAR_NAME_MAX_LEN = 64
-
-# Mission quality gate — minimum length below which we treat the mission as a
-# probable accidental spawn unless the caller explicitly confirms.
-_MISSION_MIN_CHARS = 20
-
-# Suspicious tokens that indicate a debug/test placeholder mission. Compared
-# case-insensitively against the trimmed mission (full match) and against the
-# first whitespace-delimited token (prefix match like "test something").
-_MISSION_SUSPICIOUS = {"test", "debug", "check", "tmp", "temp", "foo", "bar"}
 
 
 def _mission_looks_unsafe(mission: str) -> tuple[bool, str]:
@@ -89,11 +95,11 @@ def _mission_looks_unsafe(mission: str) -> tuple[bool, str]:
     trimmed = (mission or "").strip()
     if not trimmed:
         return True, "mission is empty"
-    if len(trimmed) < _MISSION_MIN_CHARS:
+    if len(trimmed) < MISSION_MIN_CHARACTERS:
         return True, f"mission is very short ({len(trimmed)} chars)"
     lower = trimmed.lower()
-    if lower in _MISSION_SUSPICIOUS or lower.startswith(
-        tuple(f"{w} " for w in _MISSION_SUSPICIOUS)
+    if lower in MISSION_PLACEHOLDER_PREFIXES or lower.startswith(
+        tuple(f"{word} " for word in MISSION_PLACEHOLDER_PREFIXES)
     ):
         return True, "mission looks like a debug/test placeholder"
     return False, ""
@@ -126,7 +132,7 @@ _SPAWN_INPUT_SCHEMA: dict[str, Any] = {
         },
         "type": {
             "type": ["string", "null"],
-            "enum": ["shallow", "deep", None],
+            "enum": [*SPAWN_TYPES, None],
             "description": (
                 "'shallow' (default): blank slate — init.json only. 'deep': "
                 "full copy of character, pad, and codex. Null for the default."
@@ -184,12 +190,15 @@ _DECLARED_CHILD_SPECS: tuple[tuple[str, dict[str, Any]], ...] = (
 
 _DESCRIPTION = (
     "Spawn an independent agent (他我), set network rules for descendants, "
-    "or read the avatar manual. Requires an explicit action — no default. "
+    "inventory Avatar settings, or read the avatar manual. Requires an "
+    "explicit action — no default. "
     "avatar(action='spawn', input={'name': 'researcher', ...}, "
     "reasoning='<the avatar's mission>'): inherits init.json, boots on "
     "default preset; your reasoning becomes the avatar's first prompt. "
     "avatar(action='rules', input={'rules_content': '...'}, reasoning='...'): "
     "distribute rules to self + all descendants (requires karma). "
+    "avatar(action='settings', input={}, reasoning='...'): show immutable "
+    "defaults, constraints, and lifecycle policy. "
     "avatar(action='manual', input={}, reasoning='...'): return the "
     "avatar-manual skill body. See avatar-manual skill for full guidance."
 )
@@ -220,7 +229,11 @@ def _unused(_input: Mapping[str, Any]) -> dict[str, Any]:
     raise AssertionError("the module-level schema-only ToolFamily never dispatches")
 
 
-def _build_family(handlers: Mapping[str, Any] | None = None) -> ToolFamily:
+def _build_family(
+    handlers: Mapping[str, Any] | None = None,
+    *,
+    settings_provider: SettingsProvider | None = None,
+) -> ToolFamily:
     """Compose Avatar's declared actions plus its local, reserved manual child."""
     action_handlers = (
         {name: _unused for name, _ in _DECLARED_CHILD_SPECS}
@@ -241,6 +254,11 @@ def _build_family(handlers: Mapping[str, Any] | None = None) -> ToolFamily:
                 title="manual input",
             ),
         ],
+        settings_provider=(
+            settings_provider
+            if settings_provider is not None
+            else AvatarSettingsProvider()
+        ),
     )
 
 
@@ -269,13 +287,13 @@ DECLARATION = ToolPluginDeclaration(
     binder=_bind,
     requires=("workdir", "avatar_parent"),
     glossary_package=__package__,
+    settings=True,
 )
 
 # Kept as the compatibility-visible complete action/spec registry, but derived
 # from the declaration so schema-only and host-bound families cannot drift.
-_CHILD_SPECS: tuple[tuple[str, dict[str, Any]], ...] = (
-    *_DECLARED_CHILD_SPECS,
-    ("manual", DECLARATION.manual_input_schema),
+_CHILD_SPECS: tuple[tuple[str, Mapping[str, Any]], ...] = tuple(
+    DECLARATION.public_input_schemas().items()
 )
 _SUPPORTED_ACTIONS_PHRASE = (
     "".join(f"{action!r}, " for action in DECLARATION.public_actions[:-1])
@@ -312,10 +330,12 @@ class AvatarManager:
         self._launcher = launcher
         # The spawn mission brief reaches ``_spawn`` out-of-band via
         # ``self._pending_reasoning``, set by ``handle()`` (see ``handle``).
-        self._family = _build_family({
-            "spawn": self._dispatch_spawn,
-            "rules": self._dispatch_rules,
-        })
+        self._family = _build_family(
+            {
+                "spawn": self._dispatch_spawn,
+                "rules": self._dispatch_rules,
+            }
+        )
         self._pending_reasoning: str | None = None
 
     # ------------------------------------------------------------------
@@ -396,14 +416,14 @@ class AvatarManager:
         newborn's first prompt and gates the mission-quality check."""
         parent_working_dir = self._host.workdir.path
         peer_name = args.get("name")
-        avatar_type = args.get("type", "shallow")
-        dry_run = bool(args.get("dry_run", False))
-        confirm = bool(args.get("confirm", False))
+        avatar_type = args.get("type", SPAWN_TYPE_DEFAULT)
+        dry_run = bool(args.get("dry_run", SPAWN_DRY_RUN_DEFAULT))
+        confirm = bool(args.get("confirm", SPAWN_CONFIRM_DEFAULT))
 
         if peer_name is None:
             return {"error": "name is required — pick a true name (真名) for the 他我 (e.g. 'researcher', '学者')"}
 
-        if avatar_type not in ("shallow", "deep"):
+        if avatar_type not in SPAWN_TYPES:
             return {"error": "type must be 'shallow' or 'deep'"}
 
         # Name doubles as working-dir basename. Enforce a safe, single-segment
@@ -412,17 +432,18 @@ class AvatarManager:
         # from the ledger and mail-routing layer).
         if (
             not isinstance(peer_name, str)
-            or not peer_name
+            or len(peer_name) < AVATAR_NAME_MIN_CHARACTERS
             or peer_name in (".", "..")
             or peer_name.startswith(".")
-            or len(peer_name) > _AVATAR_NAME_MAX_LEN
+            or len(peer_name) > AVATAR_NAME_MAX_CHARACTERS
             or not _AVATAR_NAME_RE.match(peer_name)
         ):
             return {
                 "error": (
                     f"Invalid avatar name '{peer_name}': must be a bare directory "
                     f"name — letters (any script), digits, underscore, or hyphen; "
-                    f"no slashes, dots, spaces, or leading '.'; 1-{_AVATAR_NAME_MAX_LEN} chars."
+                    f"no slashes, dots, spaces, or leading '.'; "
+                    f"{AVATAR_NAME_MIN_CHARACTERS}-{AVATAR_NAME_MAX_CHARACTERS} chars."
                 )
             }
 
@@ -497,7 +518,7 @@ class AvatarManager:
                     "mission_chars": len(preview_mission),
                     "mission_unsafe": unsafe,
                     "mission_reason": reason if unsafe else "",
-                    "comment": args.get("comment", ""),
+                    "comment": args.get("comment", SPAWN_COMMENT_DEFAULT),
                 },
                 "message": "Dry run — no process spawned, no files written.",
             }
@@ -571,7 +592,7 @@ class AvatarManager:
             first_prompt = f"{parent_prompt}\n\n{reasoning.strip()}"
 
         # Write avatar's init.json (modified copy of parent's).
-        avatar_comment = args.get("comment", "")
+        avatar_comment = args.get("comment", SPAWN_COMMENT_DEFAULT)
         avatar_init = self._make_avatar_init(
             parent_init, peer_name, comment=avatar_comment,
             parent_working_dir=parent_working_dir,
@@ -676,8 +697,11 @@ class AvatarManager:
                 stderr_tail = ""
                 try:
                     raw = stderr_path.read_bytes()
-                    if len(raw) > 2000:
-                        raw = b"...[truncated]...\n" + raw[-2000:]
+                    if len(raw) > BOOT_STDERR_TAIL_BYTES:
+                        raw = (
+                            b"...[truncated]...\n"
+                            + raw[-BOOT_STDERR_TAIL_BYTES:]
+                        )
                     stderr_tail = raw.decode("utf-8", errors="replace").strip()
                 except OSError:
                     pass
@@ -839,8 +863,8 @@ class AvatarManager:
     # Boot verification — how long to wait for the child to write .agent.heartbeat
     # before we conclude it crashed. Healthy boots finish well under 2s on local
     # disk; 5s is generous enough for slow systems to still pass.
-    _BOOT_WAIT_SECS = 5.0
-    _BOOT_POLL_INTERVAL = 0.1
+    _BOOT_WAIT_SECS = BOOT_WAIT_SECONDS
+    _BOOT_POLL_INTERVAL = BOOT_POLL_INTERVAL_SECONDS
 
     def _launch(self, working_dir: Path) -> tuple[AvatarLaunchReceipt, Path]:
         """Launch `lingtai-agent run <dir>` as a fully detached process.

--- a/src/lingtai/tools/avatar/glossary-wen.md
+++ b/src/lingtai/tools/avatar/glossary-wen.md
@@ -16,7 +16,7 @@ maintenance: |
 **名相对照**
 
 - `avatar`：唯一公开之器，以 `action` 分遣，每遣各有严整自专之 `input`。详见 avatar-manual 技。
-- `action`：必填，无默认。`spawn`（化出独立他我，承 init.json，以默认预设启）｜`rules`（设网法以布一切后嗣，需 karma）｜`manual`（只读，还 avatar 手册全文及其 `manual_path`）。
+- `action`：必填，无默认。`spawn`（化出独立他我，承 init.json，以默认预设启）｜`rules`（设网法以布一切后嗣，需 karma）｜`settings`（唯读，以五栏列 Avatar 之定默认与策）｜`manual`（只读，还 avatar 手册全文及其 `manual_path`）。
 - `input`：必填，乃所遣一动作自专之严封之器。他遣分支之名，未及动手之先即斥。
 - `reasoning`：必填，居根，非动作之入。`action=spawn` 时即任务之书，为他我第一言。
 - `summarize`：可选，居根之布尔，默然为否。惟司果之后治，终不入动作之实。

--- a/src/lingtai/tools/avatar/glossary-zh.md
+++ b/src/lingtai/tools/avatar/glossary-zh.md
@@ -16,7 +16,7 @@ maintenance: |
 **术语对照**
 
 - `avatar`：唯一公开工具，以 `action` 分派，每个动作各有严格独立的 `input`。详见 avatar-manual 技能。
-- `action`：必填，无默认值。`spawn`（化出独立他我，继承 init.json，用默认预设启动）｜`rules`（设置网络法则并分发给所有后代，需 karma）｜`manual`（只读，返回 avatar 手册全文及其 `manual_path`）。
+- `action`：必填，无默认值。`spawn`（化出独立他我，继承 init.json，用默认预设启动）｜`rules`（设置网络法则并分发给所有后代，需 karma）｜`settings`（只读，以五字段列出 Avatar 的固定默认值与策略）｜`manual`（只读，返回 avatar 手册全文及其 `manual_path`）。
 - `input`：必填，为所选 `action` 独有之严格封闭对象。属于他动作分支之字段一律在任何写入前拒斥。
 - `reasoning`：必填，根层字段，非动作输入。`action=spawn` 时即为任务书，成为他我第一道提示。
 - `summarize`：可选，根层布尔，默认为否。仅作结果后处理之开关，永不传入动作实现。

--- a/src/lingtai/tools/avatar/manual/SKILL.md
+++ b/src/lingtai/tools/avatar/manual/SKILL.md
@@ -2,10 +2,11 @@
 name: avatar-manual
 description: |
   Complete operational guide for the avatar tool — spawning, managing, and communicating with 他我 (alter-ego agents). Read this when: you are about to spawn an avatar; an avatar you spawned goes quiet; you need to decide between avatar, daemon, or bash; or you are an avatar and need to know how to escalate to your parent. Covers spawn types, naming rules, discipline, escalation protocol, and the parent_prompt contract.
-version: 1.1.0
-last_changed_at: 2026-07-27T00:00:00Z
+version: 1.2.0
+last_changed_at: 2026-08-29T00:00:00Z
 related_files:
 - src/lingtai/tools/avatar/__init__.py
+- src/lingtai/tools/avatar/settings.py
 - src/lingtai/tools/avatar/ANATOMY.md
 - src/lingtai/tools/avatar/CONTRACT.md
 - src/lingtai/tools/CONTRACT.md
@@ -17,25 +18,29 @@ maintenance: |
 
 ## 0. How to Call `avatar`
 
-One tool, three actions, each with its own strict `input` object:
+One tool, four actions, each with its own strict `input` object:
 
 ```
 avatar(action="spawn",  input={"name": "researcher"},        reasoning="<mission briefing>")
 avatar(action="spawn",  input={"name": "clone", "type": "deep"}, reasoning="<mission briefing>")
 avatar(action="rules",  input={"rules_content": "..."},      reasoning="why these rules")
+avatar(action="settings", input={},                           reasoning="inventory Avatar policy")
 avatar(action="manual", input={},                            reasoning="load avatar guidance")
 ```
 
 - `action` is **required** — there is no default. Omitting it never spawns.
 - `input` is **required** and closed. `spawn` owns `name`, `type`, `comment`,
-  `dry_run`, `confirm`; `rules` owns `rules_content`; `manual` takes `{}`.
+  `dry_run`, `confirm`; `rules` owns `rules_content`; `settings` and `manual`
+  each take only `{}`.
   Putting one action's field in another's `input` is rejected before anything
   happens — no process, no ledger entry, no `.rules` write.
 - `reasoning` is **required** and lives at the root, never inside `input`. For
   `spawn` it *is* the mission briefing (see §4).
 
 **Settings:** `avatar` has no settings file at either the family or action
-level. There is nothing to configure on disk.
+level and reads no `LINGTAI_AVATAR_*` environment variable. The read-only
+`settings` action inventories the immutable defaults and owner policy below; it
+does not make them mutable.
 
 **`summarize` (short-result profile).** Every action here returns a small
 result — a spawn receipt, a distribution list, or a manual body you asked for
@@ -43,6 +48,60 @@ verbatim. `summarize` is available but normally unnecessary: leave it false.
 Keep it false for `manual` in particular, so exact procedure and constraints
 are not summarized away, and for `spawn`, whose receipt carries the address,
 `agent_name`, and `pid` you need exactly.
+
+### Settings inventory
+
+`avatar(action="settings", input={}, reasoning="...")` is SHOW-only. Success
+is exactly `{"settings": [...]}`. Every row contains exactly, and in order,
+`key`, `current`, `default`, `configurable`, and `comment`. The 16 rows are the
+immutable call defaults, validation constraints, and lifecycle policy described
+in the next three sections. Each is `configurable:false`, and its fixed code
+fallback is both the fresh effective `current` and truthful `default`.
+
+The action accepts no set/reset form and never creates a settings file, launches
+an avatar, changes rules or authorization, writes the spawn ledger, or mutates
+the process environment. Avatar has no owner file, environment peer, or source
+precedence for these rows. Parent identity, runtime/venv data, authorization,
+handoff values, and per-invocation/session state are not settings and are not
+read or returned. A provider or JSON-safety failure makes the complete
+inventory unavailable with no partial rows or exception text; the generic
+boundary caps the complete response at 65,536 UTF-8 bytes.
+
+There is no runtime change procedure. To change one of these policies, revise
+the owning Avatar source and this manual through normal review, run the Avatar
+and shared settings suites, then relaunch. Call SHOW again after relaunch to
+verify the effective policy. A per-call `spawn` input varies only that one
+invocation and never changes a row.
+
+### Spawn call defaults
+
+When the corresponding nullable input is absent or `null`, `spawn` uses
+`spawn.type.default="shallow"`, `spawn.comment.default=""`,
+`spawn.dry_run.default=false`, and `spawn.confirm.default=false`. A single call
+may supply `type` (`shallow` or `deep`), `comment` (string), `dry_run` (boolean),
+or `confirm` (boolean). Those inputs have no precedence beyond that invocation;
+the next SHOW reports the same fixed defaults. Permanent changes follow the
+review-and-relaunch procedure under Settings inventory.
+
+### Spawn validation policy
+
+The fixed accepted spawn types are `spawn.type.allowed=["shallow","deep"]`.
+Names must contain 1–64 characters. Missions under 20 characters trigger the
+confirmation gate, as do missions equal to or beginning with the placeholder
+tokens `bar`, `check`, `debug`, `foo`, `temp`, `test`, and `tmp`. These package
+constants are the only source; there is no config/environment key or runtime
+precedence. Permanent changes follow the review-and-relaunch procedure above.
+
+### Spawn lifecycle policy
+
+Avatar observes boot for 5.0 seconds, polls every 0.1 seconds, and retains at
+most the final 2,000 bytes of child stderr on early exit. It always selects the
+parent's default preset, inherits the launcher process environment without
+showing it, launches a detached independent life, and clears newborn admin.
+These seven rows are fixed package/launcher policy with no file, environment
+peer, or runtime precedence. A slow observation releases the parent-side handle
+without terminating the detached child. Permanent changes require owner-source
+and launcher review, the focused tests, and relaunch as described above.
 
 ## 1. What Is an Avatar
 

--- a/src/lingtai/tools/avatar/settings.py
+++ b/src/lingtai/tools/avatar/settings.py
@@ -1,0 +1,162 @@
+"""Avatar-owned immutable policy for read-only settings discovery."""
+from __future__ import annotations
+
+from ..tool_family import SettingRow
+
+SPAWN_TYPES = ("shallow", "deep")
+SPAWN_TYPE_DEFAULT = "shallow"
+SPAWN_COMMENT_DEFAULT = ""
+SPAWN_DRY_RUN_DEFAULT = False
+SPAWN_CONFIRM_DEFAULT = False
+
+AVATAR_NAME_MIN_CHARACTERS = 1
+AVATAR_NAME_MAX_CHARACTERS = 64
+MISSION_MIN_CHARACTERS = 20
+MISSION_PLACEHOLDER_PREFIXES = frozenset(
+    {"test", "debug", "check", "tmp", "temp", "foo", "bar"}
+)
+
+BOOT_WAIT_SECONDS = 5.0
+BOOT_POLL_INTERVAL_SECONDS = 0.1
+BOOT_STDERR_TAIL_BYTES = 2_000
+
+_CALL_DEFAULTS = "avatar-manual#spawn-call-defaults"
+_VALIDATION_POLICY = "avatar-manual#spawn-validation-policy"
+_LIFECYCLE_POLICY = "avatar-manual#spawn-lifecycle-policy"
+
+
+class AvatarSettingsProvider:
+    """Return fresh effective Avatar defaults and immutable owner policy."""
+
+    def __call__(self) -> tuple[SettingRow, ...]:
+        return (
+            SettingRow(
+                "spawn.type.default",
+                SPAWN_TYPE_DEFAULT,
+                SPAWN_TYPE_DEFAULT,
+                False,
+                _CALL_DEFAULTS,
+            ),
+            SettingRow(
+                "spawn.type.allowed",
+                list(SPAWN_TYPES),
+                list(SPAWN_TYPES),
+                False,
+                _VALIDATION_POLICY,
+            ),
+            SettingRow(
+                "spawn.comment.default",
+                SPAWN_COMMENT_DEFAULT,
+                SPAWN_COMMENT_DEFAULT,
+                False,
+                _CALL_DEFAULTS,
+            ),
+            SettingRow(
+                "spawn.dry_run.default",
+                SPAWN_DRY_RUN_DEFAULT,
+                SPAWN_DRY_RUN_DEFAULT,
+                False,
+                _CALL_DEFAULTS,
+            ),
+            SettingRow(
+                "spawn.confirm.default",
+                SPAWN_CONFIRM_DEFAULT,
+                SPAWN_CONFIRM_DEFAULT,
+                False,
+                _CALL_DEFAULTS,
+            ),
+            SettingRow(
+                "spawn.name.minimum_characters",
+                AVATAR_NAME_MIN_CHARACTERS,
+                AVATAR_NAME_MIN_CHARACTERS,
+                False,
+                _VALIDATION_POLICY,
+            ),
+            SettingRow(
+                "spawn.name.maximum_characters",
+                AVATAR_NAME_MAX_CHARACTERS,
+                AVATAR_NAME_MAX_CHARACTERS,
+                False,
+                _VALIDATION_POLICY,
+            ),
+            SettingRow(
+                "spawn.mission.minimum_characters",
+                MISSION_MIN_CHARACTERS,
+                MISSION_MIN_CHARACTERS,
+                False,
+                _VALIDATION_POLICY,
+            ),
+            SettingRow(
+                "spawn.mission.placeholder_prefixes",
+                sorted(MISSION_PLACEHOLDER_PREFIXES),
+                sorted(MISSION_PLACEHOLDER_PREFIXES),
+                False,
+                _VALIDATION_POLICY,
+            ),
+            SettingRow(
+                "spawn.boot.wait_seconds",
+                BOOT_WAIT_SECONDS,
+                BOOT_WAIT_SECONDS,
+                False,
+                _LIFECYCLE_POLICY,
+            ),
+            SettingRow(
+                "spawn.boot.poll_interval_seconds",
+                BOOT_POLL_INTERVAL_SECONDS,
+                BOOT_POLL_INTERVAL_SECONDS,
+                False,
+                _LIFECYCLE_POLICY,
+            ),
+            SettingRow(
+                "spawn.boot.stderr_tail_bytes",
+                BOOT_STDERR_TAIL_BYTES,
+                BOOT_STDERR_TAIL_BYTES,
+                False,
+                _LIFECYCLE_POLICY,
+            ),
+            SettingRow(
+                "spawn.preset_policy",
+                "parent-default",
+                "parent-default",
+                False,
+                _LIFECYCLE_POLICY,
+            ),
+            SettingRow(
+                "spawn.environment_policy",
+                "inherit-launcher-process",
+                "inherit-launcher-process",
+                False,
+                _LIFECYCLE_POLICY,
+            ),
+            SettingRow(
+                "spawn.lifecycle_policy",
+                "detached-independent",
+                "detached-independent",
+                False,
+                _LIFECYCLE_POLICY,
+            ),
+            SettingRow(
+                "spawn.admin_inheritance",
+                "none",
+                "none",
+                False,
+                _LIFECYCLE_POLICY,
+            ),
+        )
+
+
+__all__ = [
+    "AvatarSettingsProvider",
+    "AVATAR_NAME_MAX_CHARACTERS",
+    "AVATAR_NAME_MIN_CHARACTERS",
+    "BOOT_POLL_INTERVAL_SECONDS",
+    "BOOT_STDERR_TAIL_BYTES",
+    "BOOT_WAIT_SECONDS",
+    "MISSION_MIN_CHARACTERS",
+    "MISSION_PLACEHOLDER_PREFIXES",
+    "SPAWN_COMMENT_DEFAULT",
+    "SPAWN_CONFIRM_DEFAULT",
+    "SPAWN_DRY_RUN_DEFAULT",
+    "SPAWN_TYPE_DEFAULT",
+    "SPAWN_TYPES",
+]

--- a/src/lingtai/tools/tool_family/ANATOMY.md
+++ b/src/lingtai/tools/tool_family/ANATOMY.md
@@ -18,6 +18,7 @@ related_files:
   - src/lingtai/tools/plugin/ANATOMY.md
   - src/lingtai/tools/knowledge/ANATOMY.md
   - src/lingtai/tools/avatar/ANATOMY.md
+  - src/lingtai/tools/avatar/settings.py
   - src/lingtai/tools/soul/ANATOMY.md
   - src/lingtai/tools/skills/ANATOMY.md
   - src/lingtai/tools/psyche/ANATOMY.md
@@ -189,10 +190,11 @@ pre-migration unknown-action result.
 `avatar/__init__.py` ([`../avatar/ANATOMY.md`](../avatar/ANATOMY.md)) is the
 sixth real consumer, and shows partial adoption is conforming: it reuses
 `ChildTool`/`ToolFamily` and the exported `MANUAL_INPUT_SCHEMA` for
-`spawn`/`rules`/`manual` schema composition and dispatch — deriving both its
-schema-only and handler-bound child listings from one `_CHILD_SPECS`
-`(action, schema)` source via its own `_build_family`, so they cannot drift
-apart — but supplies its **own** `manual` handler rather than
+`spawn`/`rules`/`settings`/`manual` schema composition and dispatch. Its
+declaration opts into the generic settings child with the no-I/O provider from
+`avatar/settings.py`, while its operational actions remain one
+`_DECLARED_CHILD_SPECS` source and its public listing derives from the
+declaration. It supplies its **own** `manual` handler rather than
 `manual.build_manual_child`, because its manual ships inside its own package
 instead of the agent's installed `.library` catalog. `ToolFamily.handle()`
 returns that child's own canonical flat result verbatim — no double wrap, and

--- a/src/lingtai/tools/tool_family/BEHAVIORS.md
+++ b/src/lingtai/tools/tool_family/BEHAVIORS.md
@@ -13,6 +13,7 @@ related_files:
   - src/lingtai/intrinsic_skills/system-manual/reference/tool-plugin-settings/SKILL.md
   - src/lingtai/tools/file/CONTRACT.md
   - src/lingtai/tools/avatar/CONTRACT.md
+  - src/lingtai/tools/avatar/settings.py
   - src/lingtai/tools/psyche/CONTRACT.md
   - src/lingtai/tools/mcp/CONTRACT.md
   - src/lingtai/tools/email/CONTRACT.md
@@ -39,7 +40,7 @@ LABT v1. These are self-contained agent-executable behavioral tests for the
 families built on the generic `src/lingtai/tools/tool_family/` infrastructure.
 They prove the *observable* promises of the family contracts this package
 serves: the `file` read/write/edit surface and its fail-closed envelope, the
-`avatar` spawn/rules/manual migration envelope, the reserved `manual` child's
+`avatar` spawn/rules/settings/manual migration envelope, the reserved `manual` child's
 canonical result contract (no double wrap), the `psyche` five-domain manual
 router (pad + lingtai + knowledge + skills = psyche), `mcp` identity
 discovery with secret-safe projection, and `email` abs-mode reply routing with
@@ -265,8 +266,9 @@ tree untouched.
       created (names must match `^[\w-]+$`, be ≤64 chars, with no dot, slash,
       or leading `.`).
 - [ ] Step 5 returns exactly `{"error": "unknown action: 'bogus', only
-      'spawn', 'rules', or 'manual' is supported"}` and `{"error": "unknown
-      action: '', only 'spawn', 'rules', or 'manual' is supported"}` for the
+      'spawn', 'rules', 'settings', or 'manual' is supported"}` and `{"error":
+      "unknown action: '', only 'spawn', 'rules', 'settings', or 'manual' is
+      supported"}` for the
       omitted case — no spawn, no ledger, no process.
 - [ ] Step 6: the cross-action key fails with `{"status": "failed",
       "error_code": "INVALID_ARGUMENT", "message": "unsupported avatar input
@@ -646,7 +648,7 @@ new snapshot/summary/session state.
 
 - [ ] Opt-in/order, exact input, exact five-field success, private redaction,
       manual `comment` route, fixed whole-action failures, incremental bounding,
-      exports, and production opt-out pass.
+      exports, and exact production opt-in ownership pass.
 
 ### Pass / Fail
 

--- a/src/lingtai/tools/tool_family/CONTRACT.md
+++ b/src/lingtai/tools/tool_family/CONTRACT.md
@@ -20,6 +20,7 @@ related_files:
   - src/lingtai/tools/plugin/__init__.py
   - src/lingtai/tools/avatar/CONTRACT.md
   - src/lingtai/tools/avatar/__init__.py
+  - src/lingtai/tools/avatar/settings.py
   - src/lingtai/tools/soul/CONTRACT.md
   - src/lingtai/tools/soul/__init__.py
   - src/lingtai/tools/skills/CONTRACT.md
@@ -287,7 +288,9 @@ knowledge's exact pre-migration unknown-action result.
 contract (after `file` and `vision`, which adopt this package per
 `../CONTRACT.md` without a dedicated Adapter paragraph here):
 `AvatarManager.__init__` builds a per-instance `ToolFamily` with
-`spawn`/`rules`/`manual` handlers bound to that instance, and
+`spawn`/`rules` handlers bound to that instance, the generic `settings` child
+bound to the static no-I/O `AvatarSettingsProvider`, and Avatar's local
+`manual` handler. `settings` is injected immediately before `manual`, and
 `AvatarManager.handle()` calls `self._family.handle(args)`. It is a deliberate
 **partial** adoption, which this package permits: `avatar` reuses `ChildTool`
 and `ToolFamily` but *not* `build_manual_child`, because its manual ships inside

--- a/tests/test_avatar_rules.py
+++ b/tests/test_avatar_rules.py
@@ -344,7 +344,10 @@ class TestAvatarRulesAction:
             # Omitted action must fail deterministically and spawn nothing.
             omitted = mgr.handle({"name": "child", "confirm": True})
             assert "error" in omitted
-            assert omitted["error"] == "unknown action: '', only 'spawn', 'rules', or 'manual' is supported"
+            assert omitted["error"] == (
+                "unknown action: '', only 'spawn', 'rules', 'settings', "
+                "or 'manual' is supported"
+            )
             launch.assert_not_called()
             assert not (parent_dir.parent / "child").exists()
 

--- a/tests/test_layers_avatar.py
+++ b/tests/test_layers_avatar.py
@@ -295,13 +295,13 @@ class TestMissionQualityGate:
         """The dry_run/confirm gates stay model-visible after the LTP v2 migration.
 
         Under the action-separated envelope they live inside the ``spawn``
-        branch of ``input.oneOf`` (and ``rules_content`` inside the ``rules``
+        branch of ``input.anyOf`` (and ``rules_content`` inside the ``rules``
         branch) rather than at the root, but they must still be declared with
         their gate types so the model can actually reach them.
         """
         from lingtai.tools.avatar import get_schema
         sch = get_schema("en")
-        branches = {b["title"]: b for b in sch["properties"]["input"]["oneOf"]}
+        branches = {b["title"]: b for b in sch["properties"]["input"]["anyOf"]}
         spawn_props = branches["spawn input"]["properties"]
         assert "dry_run" in spawn_props
         assert spawn_props["dry_run"]["type"] == ["boolean", "null"]
@@ -309,7 +309,9 @@ class TestMissionQualityGate:
         assert spawn_props["confirm"]["type"] == ["boolean", "null"]
         assert "rules_content" in branches["rules input"]["properties"]
         assert sch["required"] == ["action", "input", "reasoning"]
-        assert sch["properties"]["action"]["enum"] == ["spawn", "rules", "manual"]
+        assert sch["properties"]["action"]["enum"] == [
+            "spawn", "rules", "settings", "manual"
+        ]
 
     def test_description_points_to_avatar_manual_after_prompt_compaction(self):
         """The terse tool description should route safety guidance to the manual.
@@ -317,7 +319,7 @@ class TestMissionQualityGate:
         Prompt-token compaction moved verbose WARNING copy out of the always-on
         tool description and into avatar-manual. The safety contract now lives
         in the schema gates (dry_run/confirm, now inside the spawn branch of
-        ``input.oneOf``) plus the manual pointer, not in a long description
+        ``input.anyOf``) plus the manual pointer, not in a long description
         string.
         """
         from lingtai.tools.avatar import get_description, get_schema
@@ -326,7 +328,7 @@ class TestMissionQualityGate:
         assert "avatar-manual" in desc
         assert "WARNING" not in desc
         spawn_props = {
-            b["title"]: b for b in schema["properties"]["input"]["oneOf"]
+            b["title"]: b for b in schema["properties"]["input"]["anyOf"]
         }["spawn input"]["properties"]
         assert "confirm" in spawn_props
         assert "dry_run" in spawn_props
@@ -394,7 +396,7 @@ class TestUnifiedAvatarTool:
         Pre-migration the schema was a plain object with every action's fields
         merged at the root and no top-level combinators. It is now the
         action-separated envelope: four root fields, three of them required,
-        closed to anything else, with one ``input.oneOf`` branch per action.
+        closed to anything else, with one ``input.anyOf`` branch per action.
         """
         from lingtai.tools.avatar import get_schema
         sch = get_schema("en")
@@ -403,8 +405,10 @@ class TestUnifiedAvatarTool:
         assert sch["required"] == ["action", "input", "reasoning"]
         assert sch["additionalProperties"] is False
         assert sch["properties"]["action"]["type"] == "string"
-        assert sch["properties"]["action"]["enum"] == ["spawn", "rules", "manual"]
-        assert len(sch["properties"]["input"]["oneOf"]) == 3
+        assert sch["properties"]["action"]["enum"] == [
+            "spawn", "rules", "settings", "manual"
+        ]
+        assert len(sch["properties"]["input"]["anyOf"]) == 4
 
     def test_spawn_dispatch_preserves_behavior_and_reasoning(self, tmp_path, fake_avatar_launch):
         """action='spawn' preserves outputs and _reasoning → first-prompt propagation."""
@@ -500,7 +504,10 @@ class TestUnifiedAvatarTool:
                         working_dir=tmp_path / "test", capabilities=["avatar"],
                         admin={"karma": True})
         mgr = parent.get_capability("avatar")
-        expected_error = "unknown action: '', only 'spawn', 'rules', or 'manual' is supported"
+        expected_error = (
+            "unknown action: '', only 'spawn', 'rules', 'settings', "
+            "or 'manual' is supported"
+        )
 
         # Payload shaped like a valid rules call, but action omitted.
         rules_shaped = mgr.handle({"rules_content": "Be concise."})

--- a/tests/test_tool_family_avatar_migration.py
+++ b/tests/test_tool_family_avatar_migration.py
@@ -10,6 +10,20 @@ from lingtai.kernel.tool_plugin import OFFICIAL_TOOL_PLUGIN_NAMES, ToolPluginHos
 from lingtai.tools import avatar
 from lingtai.tools.avatar import AvatarManager
 from lingtai.tools.avatar._launcher import AvatarLaunchReceipt
+from lingtai.tools.avatar.settings import (
+    AVATAR_NAME_MAX_CHARACTERS,
+    AVATAR_NAME_MIN_CHARACTERS,
+    BOOT_POLL_INTERVAL_SECONDS,
+    BOOT_STDERR_TAIL_BYTES,
+    BOOT_WAIT_SECONDS,
+    MISSION_MIN_CHARACTERS,
+    MISSION_PLACEHOLDER_PREFIXES,
+    SPAWN_COMMENT_DEFAULT,
+    SPAWN_CONFIRM_DEFAULT,
+    SPAWN_DRY_RUN_DEFAULT,
+    SPAWN_TYPE_DEFAULT,
+    SPAWN_TYPES,
+)
 
 
 class _Workdir:
@@ -59,13 +73,225 @@ def test_avatar_declaration_is_static_and_matches_its_composed_public_surface():
 
     assert declaration.name == "avatar"
     assert declaration.actions == ("spawn", "rules")
-    assert declaration.public_actions == ("spawn", "rules", "manual")
+    assert declaration.public_actions == ("spawn", "rules", "settings", "manual")
+    assert declaration.settings is True
     assert declaration.requires == ("workdir", "avatar_parent")
     assert declaration.name in OFFICIAL_TOOL_PLUGIN_NAMES
     assert avatar.get_schema()["properties"]["action"]["enum"] == list(
         declaration.public_actions
     )
     assert dict(avatar._CHILD_SPECS)["manual"] is declaration.manual_input_schema
+
+
+def test_avatar_settings_inventory_is_exact_fresh_and_excludes_private_state(
+    tmp_path,
+):
+    parent_dir = _parent_dir(tmp_path)
+    private_parent = "private-parent-identity"
+    private_runtime = "/private/runtime/location"
+    host = ToolPluginHost.grant(
+        avatar.DECLARATION,
+        {
+            "workdir": _Workdir(parent_dir),
+            "avatar_parent": _AvatarParent(
+                name=private_parent,
+                venv_path=private_runtime,
+                rules=True,
+            ),
+        },
+    )
+    manager = AvatarManager(host, launcher=_Launcher())
+
+    result = manager(
+        {"action": "settings", "input": {}, "reasoning": "inventory policy"}
+    )
+
+    def row(key, current, default, comment):
+        return {
+            "key": key,
+            "current": current,
+            "default": default,
+            "configurable": False,
+            "comment": comment,
+        }
+
+    call_defaults = "avatar-manual#spawn-call-defaults"
+    validation = "avatar-manual#spawn-validation-policy"
+    lifecycle = "avatar-manual#spawn-lifecycle-policy"
+    expected_rows = [
+        row(
+            "spawn.type.default",
+            SPAWN_TYPE_DEFAULT,
+            SPAWN_TYPE_DEFAULT,
+            call_defaults,
+        ),
+        row("spawn.type.allowed", list(SPAWN_TYPES), list(SPAWN_TYPES), validation),
+        row(
+            "spawn.comment.default",
+            SPAWN_COMMENT_DEFAULT,
+            SPAWN_COMMENT_DEFAULT,
+            call_defaults,
+        ),
+        row(
+            "spawn.dry_run.default",
+            SPAWN_DRY_RUN_DEFAULT,
+            SPAWN_DRY_RUN_DEFAULT,
+            call_defaults,
+        ),
+        row(
+            "spawn.confirm.default",
+            SPAWN_CONFIRM_DEFAULT,
+            SPAWN_CONFIRM_DEFAULT,
+            call_defaults,
+        ),
+        row(
+            "spawn.name.minimum_characters",
+            AVATAR_NAME_MIN_CHARACTERS,
+            AVATAR_NAME_MIN_CHARACTERS,
+            validation,
+        ),
+        row(
+            "spawn.name.maximum_characters",
+            AVATAR_NAME_MAX_CHARACTERS,
+            AVATAR_NAME_MAX_CHARACTERS,
+            validation,
+        ),
+        row(
+            "spawn.mission.minimum_characters",
+            MISSION_MIN_CHARACTERS,
+            MISSION_MIN_CHARACTERS,
+            validation,
+        ),
+        row(
+            "spawn.mission.placeholder_prefixes",
+            sorted(MISSION_PLACEHOLDER_PREFIXES),
+            sorted(MISSION_PLACEHOLDER_PREFIXES),
+            validation,
+        ),
+        row(
+            "spawn.boot.wait_seconds",
+            BOOT_WAIT_SECONDS,
+            BOOT_WAIT_SECONDS,
+            lifecycle,
+        ),
+        row(
+            "spawn.boot.poll_interval_seconds",
+            BOOT_POLL_INTERVAL_SECONDS,
+            BOOT_POLL_INTERVAL_SECONDS,
+            lifecycle,
+        ),
+        row(
+            "spawn.boot.stderr_tail_bytes",
+            BOOT_STDERR_TAIL_BYTES,
+            BOOT_STDERR_TAIL_BYTES,
+            lifecycle,
+        ),
+        row("spawn.preset_policy", "parent-default", "parent-default", lifecycle),
+        row(
+            "spawn.environment_policy",
+            "inherit-launcher-process",
+            "inherit-launcher-process",
+            lifecycle,
+        ),
+        row(
+            "spawn.lifecycle_policy",
+            "detached-independent",
+            "detached-independent",
+            lifecycle,
+        ),
+        row("spawn.admin_inheritance", "none", "none", lifecycle),
+    ]
+
+    assert result == {"settings": expected_rows}
+    assert all(
+        list(item) == ["key", "current", "default", "configurable", "comment"]
+        for item in result["settings"]
+    )
+    assert len({item["key"] for item in result["settings"]}) == len(expected_rows)
+    forbidden_keys = {
+        "rules.authorization_policy",
+        "rules.authorized",
+        "spawn.parent_identity",
+        "runtime.venv_path",
+        "configuration.capability_arguments",
+    }
+    assert forbidden_keys.isdisjoint(item["key"] for item in result["settings"])
+    assert private_parent not in repr(result)
+    assert private_runtime not in repr(result)
+
+    result["settings"][1]["current"].append("mutated-display-copy")
+    fresh = manager({"action": "settings", "input": {}})
+    assert fresh == {"settings": expected_rows}
+
+    manual = (Path(avatar.__file__).parent / "manual" / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    headings = {
+        call_defaults: "Spawn call defaults",
+        validation: "Spawn validation policy",
+        lifecycle: "Spawn lifecycle policy",
+    }
+    for comment in {item["comment"] for item in fresh["settings"]}:
+        assert f"### {headings[comment]}" in manual
+
+
+def test_avatar_settings_is_show_only_and_has_no_environment_peer(
+    tmp_path,
+    monkeypatch,
+):
+    parent_dir = _parent_dir(tmp_path)
+    manager = AvatarManager(_host(parent_dir), launcher=_Launcher())
+    monkeypatch.setenv("LINGTAI_AVATAR_BOOT_WAIT_SECONDS", "99")
+    before = {
+        path.relative_to(parent_dir): path.read_bytes()
+        for path in parent_dir.rglob("*")
+        if path.is_file()
+    }
+
+    shown = manager({"action": "settings", "input": {}})
+    rejected = [
+        manager({"action": "settings", "input": value})
+        for value in (
+            {"set": "spawn.type.default", "value": "deep"},
+            {"reset": "spawn.boot.wait_seconds"},
+            {"extra": True},
+        )
+    ]
+
+    rows = {item["key"]: item for item in shown["settings"]}
+    assert rows["spawn.boot.wait_seconds"]["current"] == BOOT_WAIT_SECONDS
+    assert all(
+        result
+        == {
+            "status": "failed",
+            "error_code": "INVALID_ARGUMENT",
+            "message": "unsupported avatar input field",
+        }
+        for result in rejected
+    )
+    after = {
+        path.relative_to(parent_dir): path.read_bytes()
+        for path in parent_dir.rglob("*")
+        if path.is_file()
+    }
+    assert after == before
+    assert not (parent_dir / "settings").exists()
+
+
+def test_avatar_settings_provider_failure_is_one_bounded_result():
+    def unavailable():
+        raise RuntimeError("private provider detail")
+
+    family = avatar._build_family(
+        {"spawn": lambda _input: {}, "rules": lambda _input: {}},
+        settings_provider=unavailable,
+    )
+
+    assert family.handle({"action": "settings", "input": {}}) == {
+        "status": "failed",
+        "error_code": "SETTINGS_UNAVAILABLE",
+        "message": "settings inventory is unavailable",
+    }
 
 
 def test_avatar_manager_uses_only_granted_ports_for_local_manual_and_rules(tmp_path):
@@ -143,6 +369,7 @@ def test_agent_mounts_avatar_only_through_the_official_registrar(tmp_path):
         assert [schema.name for schema in agent._tool_schemas].count("avatar") == 1
         assert agent.get_capability("avatar") is agent._tool_handlers["avatar"]
         assert isinstance(agent.get_capability("avatar"), AvatarManager)
+        assert agent._build_system_prompt()
     finally:
         agent.stop(timeout=1.0)
 

--- a/tests/test_tool_settings_contract.py
+++ b/tests/test_tool_settings_contract.py
@@ -138,7 +138,7 @@ def test_public_export_and_only_this_owner_opts_in():
         name: importlib.import_module(f"lingtai.tools.{modules.get(name, name)}").DECLARATION
         for name in OFFICIAL_TOOL_PLUGIN_NAMES
     }
-    expected_official = {'system'}
+    expected_official = {"avatar", "system"}
     assert {name for name, item in declarations.items() if item.settings} == expected_official
     for name, item in declarations.items():
         assert ("settings" in item.public_actions) is (name in expected_official)
@@ -155,7 +155,7 @@ def test_parent_contract_states_declaration_provider_opt_in_not_owner_file():
     ).read_text(encoding="utf-8")
     contract = (repo / "src/lingtai/tools/CONTRACT.md").read_text(encoding="utf-8")
 
-    assert "System is currently the\nonly production family opted in" in manual
+    assert "Production families opt\nin only through their own reviewed vertical" in manual
     assert "declaration opt-in\n   plus this bound provider" in manual
     assert "may be absent" in manual
     assert "ToolPluginDeclaration(settings=True)" in contract


### PR DESCRIPTION
## Final revised candidate

This Draft is the independent **Avatar** owner implementation on exact merged foundation `1b25fd09069314b531cdb55aa08c533e037eea89`. It does not stack on another owner PR.

- exact candidate commit: `49ffa3565bb1f598c11461ae363aff82226860cc`
- exact parent: `1b25fd09069314b531cdb55aa08c533e037eea89`
- stable reviewed patch id: `b1dc5f8f10ea35be9cfc45a7102ffafcdb45ef19`
- resulting owner diff: **16 files changed, 674 insertions(+), 99 deletions(-)**
- one owner commit, canonical `Huang Zesen <hzsbazinga@outlook.com>` identity, clean worktree, and no tracked deletions

## Behavior

- opts only `avatar` into the generic read-only `settings` action
- successful rows expose exactly `key`, `current`, `default`, `configurable`, and owner-manual `comment`
- preserves owner-specific source, precedence, sensitivity/redaction, apply timing, and change authority in the owning manual
- adds no generic writer, `set`, `reset`, mutation receipt, or central settings registry; actual changes remain in existing authorized owner procedures

## Validation

- Parent affected-suite differential classification was accepted with **zero candidate-unique failures**; any nonzero nodes reproduced on the clean frozen foundation.
- Final parent affected modules: **102 passed**.
- The latest owner-patch static review has **no open P0 or P1 finding**.
- the committed patch has the same stable patch id as the final owner-specific reviewed input; authoritative input SHA-256: `b0a898623c391f04cdeab25ffe92b46820d6ceda65b33ea6834096a51df2d2df`
- `git diff --check`: pass

## Draft boundary and next gate

This remains **Draft**. It is not merge authorization. After all 19 owner Drafts are updated, the exact commits will be combined only in an isolated aggregate runtime for behavioral acceptance of every public `settings` action and one non-side-effecting existing action per tool. No merge, release, deploy, unrelated live refresh, operator config/auth mutation, deletion, or cleanup is included here.

Telegram: @lingtaidev3bot | Nickname: 澄一

Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
