### PR TITLE
feat(task-card): expose owned settings and env parity

### DIFF
--- a/src/lingtai/tools/task_card/ANATOMY.md
+++ b/src/lingtai/tools/task_card/ANATOMY.md
@@ -17,6 +17,7 @@ related_files:
   - src/lingtai/adapters/tool_plugin_host.py
   - tests/test_task_card_controller.py
   - tests/test_task_card_notifications.py
+  - tests/test_tool_settings_contract.py
   - tests/test_tool_plugin_declaration.py
   - tests/test_telegram_toolfamily_ltpv2.py
   - tests/test_telegram_task_card_programmable.py
@@ -38,12 +39,12 @@ The intrinsic `task_card` capability owns one agent-local declarative artifact
 plus its persisted agent-wide configuration, both under `<workdir>/taskcard/`,
 and nothing else. It is producer-first and channel-neutral: it runs a
 renderer, writes `taskcard/taskcard.md`, and writes `taskcard/status` as exact
-`active` or `inactive`, reading `taskcard/taskcard.json` to resolve each new
-watch's cadence/ceiling defaults. An active watch persists a resume descriptor
-at `taskcard/watch.json` so a `refresh`/molt/agent-stop can rehydrate the same
-watch on the next boot; `stop` pauses a watch and preserves the last
-body; `remove` is the terminal lifecycle action that also retires any active
-watch and deletes the body, so a caller never needs to reach around this
+`active` or `inactive`, reading five numeric `taskcard/taskcard.json` policies
+at their existing application seams. An active watch persists a resume
+descriptor at `taskcard/watch.json` so a `refresh`/molt/agent-stop can
+rehydrate the same watch on the next boot; `stop` pauses a watch and preserves
+the last body; `remove` is the terminal lifecycle action that also retires any
+active watch and deletes the body, so a caller never needs to reach around this
 capability with a filesystem delete. It does not own Telegram, Feishu, portals,
 chat IDs, retry policy against a transport, or any resident message state.
 It is the twelfth declared official host-plugin slice: `DECLARATION` is static
@@ -63,11 +64,13 @@ Normative promises live in [`CONTRACT.md`](CONTRACT.md).
 
 ## Components
 
-- `__init__.py` — the full capability owner: static `DECLARATION`,
+- `__init__.py` — the full capability owner: static `DECLARATION` plus its
+  read-only five-row settings provider,
   declaration-derived schema/description/manual family, one-watch lifecycle,
   renderer execution, atomic file writes, typed error/recovered/limit
   notifications (`TaskCardNotificationsAdapter` and its event forms), persisted
-  config loading/validation (`TaskCardManager._load_config`), the one-way
+  config loading/validation (`TaskCardManager._load_config` and
+  `TaskCardManager.settings_rows`), the one-way
   legacy-config migration (`TaskCardManager._migrate_legacy_config`), and the
   `setup(agent)` composition call into the official registrar.
 - `manual/SKILL.md` — the progressive-disclosure manual for renderer authors
@@ -84,6 +87,9 @@ Normative promises live in [`CONTRACT.md`](CONTRACT.md).
   notification port in its typed event view before dispatch; the host-side
   `AgentTaskCardNotificationsAdapter` in `lingtai.adapters.tool_plugin_host`
   pins source/channel/priority/idempotency/extras behind those operations.
+- The declaration/provider opt-in injects `settings` exactly once immediately
+  before `manual`; the retained manager resolves fresh owner facts without
+  creating or changing the owner document.
 - `lifecycle._stop` calls `shutdown_for_agent_stop()` so a stopping agent
   writes `inactive`, joins the watch thread best-effort, and re-persists the
   watch descriptor with its carried refresh budget for the next boot.
@@ -112,9 +118,11 @@ Normative promises live in [`CONTRACT.md`](CONTRACT.md).
 - `<workdir>/taskcard/status` — exact `active` or `inactive`
 - `<workdir>/taskcard/taskcard.md` — the full rendered body
 - `<workdir>/taskcard/taskcard.json` — persisted agent-wide config
-  (`interval_s`/`timeout_s`/`max_refreshes`); read fresh on every `start`,
-  written only by the one-way legacy migration (never by any model-facing
-  action)
+  (`interval_s`/`timeout_s`/`max_refreshes`/`reminder_turns`/
+  `max_body_chars`); read at each field's existing runtime application seam,
+  written by the capability only during the one-way legacy migration (never by
+  a model-facing action). Settings SHOW reads or previews those same effective
+  values without invoking the writer.
 - `<workdir>/taskcard/watch.json` — persisted active-watch descriptor
   (`watch_id`/`renderer_path`/`interval_s`/`timeout_s`/`max_refreshes`/
   `refreshes_used`/`started_at`); written on `start` and re-written on
@@ -145,3 +153,7 @@ Normative promises live in [`CONTRACT.md`](CONTRACT.md).
   it is gated on `taskcard/taskcard.json` not yet existing (never on its
   content), so this capability never carries an ongoing runtime dependence on
   Telegram or any other consumer for its own policy.
+- Settings inventory projects only those five public numeric policies.
+  Renderer/workdir paths, body/status/watch contents, notification state, and
+  unknown owner-document fields remain operational or sensitive state outside
+  the projection.

--- a/src/lingtai/tools/task_card/BEHAVIORS.md
+++ b/src/lingtai/tools/task_card/BEHAVIORS.md
@@ -1,6 +1,6 @@
 ---
 name: task-card-behavior-tests
-behavior_version: 1
+behavior_version: 2
 labt_version: 2
 contract: CONTRACT.md
 anatomy: ANATOMY.md
@@ -11,7 +11,9 @@ related_files:
   - src/lingtai/adapters/tool_plugin_host.py
   - src/lingtai/kernel/tool_plugin/__init__.py
   - src/lingtai/mcp_servers/task_card/resident.py
+  - tests/test_task_card_controller.py
   - tests/test_task_card_notifications.py
+  - tests/test_tool_settings_contract.py
 maintenance: |
   Created during the every-contract-needs-behaviors sweep. Keep this file
   reciprocal with CONTRACT.md and ANATOMY.md (tridirectional loop): when a
@@ -22,8 +24,8 @@ maintenance: |
 
 Self-contained agent behavior tasks guarding the observable behavior clauses of
 `src/lingtai/tools/task_card/CONTRACT.md` (start writes body then exact active,
-second start fails closed, stop/remove semantics, watch persistence, and the
-typed notification boundary). Pinned
+second start fails closed, stop/remove semantics, watch persistence, the
+read-only settings provider, and the typed notification boundary). Pinned
 pytest commands must run from the repo root with the project's Python.
 
 ## Behavior TK001 — start writes the body atomically before exact active, and a second start fails closed
@@ -71,3 +73,27 @@ Pass when the suites pass and the ordering/idempotency observations hold. Fail o
 
 ### Pass / Fail
 Pass when the typed suite passes, all three event forms retain their exact wire parity, and every foreign-field/source/channel attempt fails before publication at both boundaries. Fail if a caller can choose a source/channel, inject arbitrary publisher metadata, reach a generic publisher through the granted port, or alter the established event identity.
+
+## Behavior TK003 — settings SHOW stays exact, read-only, and owner-bounded
+
+- **id**: TK003
+- **title**: settings SHOW stays exact, read-only, and owner-bounded
+- **guards**: `intrinsic-task-card` § Behavior rule 15
+- **runner**: any LingTai agent with `shell` access to this repository
+- **prerequisites**: a clean checkout of `<repo>` and the focused Task Card fixtures
+- **estimate**: ≈ 10 minutes
+
+### Steps
+1. From `<repo>`, run `PYTHONDONTWRITEBYTECODE=1 python -m pytest -q -p no:cacheprovider tests/test_task_card_controller.py tests/test_tool_settings_contract.py` and capture every outcome.
+2. Inspect the five rows and verify exact key order, fresh current/default values, configurable flags, five-field-only projection, and exact owner-manual anchors.
+3. Change valid and invalid owner-document fields, preview a customized legacy ceiling before migration, force the provider to fail, and attempt a nonempty settings input.
+4. Verify SHOW creates or changes no owner document, returns no partial inventory on failure, omits paths/body/watch/unknown fields, and leaves ordinary Task Card lifecycle behavior unchanged.
+
+### Expected evidence
+- [ ] Step 1: the owner and generic settings suites pass with the exact cumulative production opt-in set.
+- [ ] Step 2: every row is exactly `key`/`current`/`default`/`configurable`/`comment`, and every comment names a real Task Card manual heading.
+- [ ] Step 3: current values follow the runtime's owner-document validation and built-in fallback, while a pre-migration custom legacy ceiling is previewed without a write; invalid input and unavailable truth fail closed.
+- [ ] Step 4: no write, migration, operational-state leak, partial row, or ordinary lifecycle change is observed.
+
+### Pass / Fail
+Pass when the five rows remain exact and truthful, change procedures stay outside SHOW, failure is bounded and whole-action, and existing Task Card behavior is unchanged. Fail on an extra field, stale value, writer, path/body leak, missing manual target, unrelated owner opt-in, or lifecycle regression.

--- a/src/lingtai/tools/task_card/CONTRACT.md
+++ b/src/lingtai/tools/task_card/CONTRACT.md
@@ -1,6 +1,6 @@
 ---
 name: intrinsic-task-card
-contract_version: 4
+contract_version: 5
 root_contract: CONTRACT.md
 related_files:
   - src/lingtai/tools/task_card/ANATOMY.md
@@ -20,6 +20,7 @@ related_files:
   - tests/test_task_card_controller.py
   - tests/test_task_card_notifications.py
   - tests/test_task_card_proactivity.py
+  - tests/test_tool_settings_contract.py
   - tests/test_tool_plugin_declaration.py
   - tests/test_telegram_toolfamily_ltpv2.py
   - tests/test_telegram_task_card_programmable.py
@@ -77,25 +78,29 @@ declarative artifact and one active watch per agent.
    without creating, mutating, or importing watch state.
 8. Missing, invalid, or inactive producer state is outside this contract.
    Consumers decide what those states mean.
-9. `taskcard/taskcard.json` holds optional `interval_s`, `timeout_s`, and
-   `max_refreshes` fields. Built-in defaults are `interval_s: 5`, `timeout_s:
-   10` (one renderer execution, not the watch's total lifetime), and
-   `max_refreshes: 2000`; a configured value overrides the built-in default for
-   its own field only. `start` resolves each of the three fields independently:
+9. `taskcard/taskcard.json` holds optional `interval_s`, `timeout_s`,
+   `max_refreshes`, `reminder_turns`, and `max_body_chars` fields. Built-in
+   defaults are respectively `5`, `10` (one renderer execution, not the
+   watch's total lifetime), `2000`, `10`, and `2000`. A valid configured value
+   overrides the built-in default for its own field only. `start` resolves each
+   of the first three fields independently:
    an omitted field uses the configured (or built-in) default; an explicit
    `timeout_s`/`max_refreshes` is a safety ceiling request and is silently
    `min`-clamped to the configured ceiling (it may lower, never exceed, that
    ceiling); an explicit `interval_s` has no ceiling at all — only the
    pre-existing absolute floor of 1 second applies, so a slower/safer explicit
    cadence is always honored even when it configures above the default.
+   `reminder_turns` is read on each completed text turn and `max_body_chars` on
+   each body publication.
 10. Config validation is strict and per-field: `interval_s`/`timeout_s` must be
     a non-boolean finite number at or above their floor (1 and 0.1 respectively)
-    and `max_refreshes` must be a non-boolean positive `int`; an invalid or
+    and `max_refreshes`/`reminder_turns` must be non-boolean positive integers;
+    `max_body_chars` must be a non-boolean integer at least 100. An invalid or
     missing field falls back to its own built-in default without discarding
     valid sibling fields, and a config file that fails to parse as a JSON
-    object falls back to all built-in defaults. No malformed input can produce
-    a larger effective ceiling or a faster effective floor than the built-in
-    defaults allow.
+    object contributes no owner value. No malformed input can produce a larger
+    effective ceiling or a faster effective floor than the built-in defaults
+    allow.
 11. The first time `start` resolves configuration and finds no
     `taskcard/taskcard.json`, it performs a one-way migration: if
     `telegram/taskcard.json` (the retired Telegram-owned reverse-channel
@@ -156,6 +161,24 @@ declarative artifact and one active watch per agent.
     body and lets the updater thread retry, matching live-watch error
     semantics.
 
+15. The read-only settings boundary is guarded by
+    [TK003](BEHAVIORS.md#behavior-tk003). The declaration opts in with
+    `settings=True`, and the retained manager supplies exactly five rows in
+    declared owner order: `interval_s`, `timeout_s`, `max_refreshes`,
+    `reminder_turns`, and `max_body_chars`. Every successful row has exactly
+    `key`, `current`, `default`, `configurable`, and `comment`, and each comment
+    names the corresponding stable section in `task_card-manual`. Current
+    values are resolved fresh through the same per-field validation as the
+    runtime; before the intrinsic document exists, `max_refreshes` may preview
+    the genuine one-time legacy migration value without writing it. All five
+    numeric policies are configurable through the existing owner document,
+    outside SHOW. `settings` accepts only exact `input={}`, is inserted
+    immediately before `manual`, and has no set/reset/mutation form. If current
+    truth is unavailable or any row is malformed, unserializable, or too large,
+    the complete bounded action fails with no partial rows. Paths, body/status/
+    watch contents, notification state, source metadata, and unknown owner
+    fields are never projected.
+
 ## Notification boundary [TK002](BEHAVIORS.md#behavior-tk002)
 
 The producer owns notification policy and constructs one of three immutable
@@ -181,7 +204,8 @@ remain the two separate operations `submit_reminder(turns)` and
 ## Port
 
 Public LTP-v2 family root `task_card` with actions `start`, `inspect`, `retry`,
-`stop`, `remove`, and `manual`. It is the static official
+`stop`, `remove`, `settings`, and `manual`, with `settings` inserted immediately
+before `manual` by the generic declaration seam. It is the static official
 `ToolPluginDeclaration` for the reserved `task_card` name. Its binder receives
 only `workdir`, `shutdown`, `task_card_lifecycle`, and
 `task_card_notifications`: filesystem/manual paths, cooperative watch stop,
@@ -216,8 +240,9 @@ itself; the kernel registrar binds, activates (resume), and mounts it.
   `start` and agent shutdown (carried refresh budget); unlink on
   `stop`/`remove`/refresh exhaustion (tolerating an already-missing file).
 - Filesystem config reader: plain read of `taskcard/taskcard.json` (no fsync;
-  read-only in the steady state) plus the one-way legacy-migration writer
-  described in Behavior rule 11.
+  read-only in the steady state), the read-only settings projection, and the
+  one-way legacy-migration writer described in Behavior rule 11. SHOW never
+  invokes that writer.
 - Consumer examples only: `TelegramManager` and `FeishuManager` read the
   artifact and project it; that consuming behavior is not part of this
   producer contract.
@@ -253,6 +278,17 @@ itself; the kernel registrar binds, activates (resume), and mounts it.
     boundary; source/channel/foreign-field injection is rejected at both, and
     the emitted wire forms retain the established error/recovered/limit
     source, idempotency, priority, and bounded-extra parity.
+12. `settings` appears exactly once immediately before `manual`; it is absent
+    from the declared operational action tuple and is injected only because the
+    declaration and manager-backed provider both opt in.
+13. Settings SHOW performs no write or migration and reuses the runtime's
+    owner-document validation. Real changes remain external File/Shell edits
+    described by the owner manual and require a second SHOW for verification.
+14. Settings rows omit renderer/workdir paths, body/status/watch contents,
+    notification state, source metadata, and unknown document fields.
+15. Exact empty input, whole-inventory failure, private redaction, JSON safety,
+    and the complete 65,536-byte response bound follow the generic ToolFamily
+    settings contract; Task Card adds no writer or control plane.
 
 ## Tests
 
@@ -278,7 +314,12 @@ itself; the kernel registrar binds, activates (resume), and mounts it.
   later successful tick; corrupt/empty/stale descriptors being cleared;
   partial and exhausted budgets being carried; and stop/remove/exhaust
   clearing the descriptor so a deliberately stopped watch is never
-  resurrected.
+  resurrected. It also covers the exact ordered Task Card settings inventory,
+  fresh effective file/default and legacy-preview truth, strict input, manual
+  anchors, whole-action failure, projection exclusions, and no mutation.
+- `tests/test_tool_settings_contract.py` proves exact cumulative production
+  opt-in, private redaction, JSON-safe whole-inventory failure, and the
+  65,536-byte complete-response bound.
 - `tests/test_telegram_toolfamily_ltpv2.py` covers the strict public family
   schema plus intrinsic refresh-limit behavior.
 - `tests/test_telegram_task_card_programmable.py` covers Telegram's read-only

--- a/src/lingtai/tools/task_card/__init__.py
+++ b/src/lingtai/tools/task_card/__init__.py
@@ -34,7 +34,7 @@ from lingtai.kernel import notifications
 from lingtai.kernel._fsutil import atomic_write_json, read_json
 from lingtai.kernel.tool_plugin import BoundToolPlugin, ToolPluginDeclaration
 
-from ..tool_family import ChildTool, ToolFamily
+from ..tool_family import ChildTool, SettingRow, ToolFamily
 from ..tool_family.manual import MANUAL_INPUT_SCHEMA, build_manual_child
 
 if TYPE_CHECKING:
@@ -295,14 +295,14 @@ _DESCRIPTION = (
     "and current. Restart a new watch when one expires mid-task. Use stop to "
     "pause a watch while preserving its last body, and remove once the work is "
     "completed, cancelled, or abandoned so the artifact cannot mislead a consumer "
-    "as stale. Actions: start, inspect, retry, stop, remove, manual."
+    "as stale. Actions: start, inspect, retry, stop, remove, settings, manual."
 )
 
 _ACTION_DESCRIPTION = (
     "Declarative Task Card action. start keeps one renderer watch writing the "
     "agent-local taskcard/status and taskcard/taskcard.md files; inspect, retry, "
     "and stop read or control that one artifact; remove is the terminal lifecycle "
-    "cleanup; manual explains the full contract."
+    "cleanup; settings shows current owner policy; manual explains the full contract."
 )
 
 
@@ -1175,6 +1175,10 @@ class TaskCardManager:
         """
         if not self._config_path.is_file():
             return self._migrate_legacy_config()
+        return self._read_owner_config()
+
+    def _read_owner_config(self) -> _Config:
+        """Read the intrinsic owner document with the runtime's per-field fallbacks."""
         try:
             data = read_json(self._config_path, expect=dict)
         except (OSError, ValueError, TypeError):
@@ -1185,6 +1189,72 @@ class TaskCardManager:
             self._config_max_refreshes(data.get("max_refreshes")),
             self._config_reminder_turns(data.get("reminder_turns")),
             self._config_max_body_chars(data.get("max_body_chars")),
+        )
+
+    def _legacy_config(self) -> _Config:
+        """Resolve the one-time legacy ceiling without writing intrinsic state."""
+        try:
+            legacy = read_json(self._legacy_config_path, expect=dict)
+        except (OSError, ValueError, TypeError):
+            legacy = None
+        legacy_max = legacy.get("max_refreshes") if legacy is not None else None
+        if (
+            type(legacy_max) is not int
+            or legacy_max <= 0
+            or legacy_max == _LEGACY_UNTOUCHED_MAX_REFRESHES
+        ):
+            return _BUILTIN_CONFIG
+        return _Config(
+            _DEFAULT_INTERVAL_S,
+            _DEFAULT_TIMEOUT_S,
+            legacy_max,
+            _DEFAULT_REMINDER_TURNS,
+            _MAX_BODY_CHARS,
+        )
+
+    def settings_rows(self) -> tuple[SettingRow, ...]:
+        """Return fresh five-field owner facts without triggering migration."""
+        config = (
+            self._read_owner_config()
+            if self._config_path.is_file()
+            else self._legacy_config()
+        )
+        return (
+            SettingRow(
+                "interval_s",
+                config.interval_s,
+                _DEFAULT_INTERVAL_S,
+                True,
+                "task_card-manual#interval-s",
+            ),
+            SettingRow(
+                "timeout_s",
+                config.timeout_s,
+                _DEFAULT_TIMEOUT_S,
+                True,
+                "task_card-manual#timeout-s",
+            ),
+            SettingRow(
+                "max_refreshes",
+                config.max_refreshes,
+                _DEFAULT_MAX_REFRESHES,
+                True,
+                "task_card-manual#max-refreshes",
+            ),
+            SettingRow(
+                "reminder_turns",
+                config.reminder_turns,
+                _DEFAULT_REMINDER_TURNS,
+                True,
+                "task_card-manual#reminder-turns",
+            ),
+            SettingRow(
+                "max_body_chars",
+                config.max_body_chars,
+                _MAX_BODY_CHARS,
+                True,
+                "task_card-manual#max-body-chars",
+            ),
         )
 
     def _migrate_legacy_config(self) -> _Config:
@@ -1210,25 +1280,7 @@ class TaskCardManager:
         again for this agent, so a later change to the Telegram-owned file
         cannot alter intrinsic policy.
         """
-        try:
-            legacy = read_json(self._legacy_config_path, expect=dict)
-        except (OSError, ValueError, TypeError):
-            legacy = None
-        legacy_max = legacy.get("max_refreshes") if legacy is not None else None
-        if (
-            type(legacy_max) is not int
-            or legacy_max <= 0
-            or legacy_max == _LEGACY_UNTOUCHED_MAX_REFRESHES
-        ):
-            resolved = _BUILTIN_CONFIG
-        else:
-            resolved = _Config(
-                _DEFAULT_INTERVAL_S,
-                _DEFAULT_TIMEOUT_S,
-                legacy_max,
-                _DEFAULT_REMINDER_TURNS,
-                _MAX_BODY_CHARS,
-            )
+        resolved = self._legacy_config()
         try:
             atomic_write_json(
                 self._config_path,
@@ -1362,6 +1414,7 @@ def _build_family(
             ),
             manual_child,
         ],
+        settings_provider=manager.settings_rows if manager is not None else tuple,
     )
 
 
@@ -1404,6 +1457,7 @@ DECLARATION = ToolPluginDeclaration(
     # Every requirement is exercised by the current lifecycle: workdir-owned
     # artifacts/manual, shutdown polling, the retained manager, and its notices.
     requires=("workdir", "shutdown", "task_card_lifecycle", "task_card_notifications"),
+    settings=True,
 )
 
 # Retain the producer's existing notification channel, derived from the one

--- a/src/lingtai/tools/task_card/manual/SKILL.md
+++ b/src/lingtai/tools/task_card/manual/SKILL.md
@@ -3,7 +3,7 @@ name: task_card-manual
 description: >
   Manual for the intrinsic `task_card` capability: the declarative Task Card
   artifact, its renderer watch lifecycle, and the one-card-per-agent contract.
-last_changed_at: 2026-08-01T00:00:00Z
+last_changed_at: 2026-08-29T00:00:00Z
 related_files:
 - src/lingtai/tools/task_card/__init__.py
 - src/lingtai/tools/task_card/ANATOMY.md
@@ -11,10 +11,10 @@ related_files:
 - src/lingtai/kernel/tool_plugin/CONTRACT.md
 maintenance: |
   Keep this manual aligned with the intrinsic task_card capability's actual
-  action surface, the exact taskcard/status and taskcard/taskcard.md file
-  contract, and the one-card-per-agent lifecycle. Update it with the paired
-  Anatomy/Contract whenever the renderer contract, file paths, or stop/order
-  semantics change.
+  action/settings surface, the exact taskcard/status and taskcard/taskcard.md
+  file contract, and the one-card-per-agent lifecycle. Update it with the
+  paired Anatomy/Contract whenever the renderer contract, settings, file paths,
+  or stop/order semantics change.
 ---
 
 # task_card manual
@@ -50,7 +50,8 @@ a stale descriptor (renderer gone, budget exhausted, corrupt file) is cleared
 on boot and leaves the card `inactive` rather than silently resurrecting a
 dead watch.
 
-Actions are `start`, `inspect`, `retry`, `stop`, `remove`, and `manual`.
+Actions are `start`, `inspect`, `retry`, `stop`, `remove`, `settings`, and
+`manual`. The declaration inserts `settings` immediately before `manual`.
 
 ## Call shape and packaged manual
 
@@ -62,6 +63,78 @@ installed `capabilities/task_card/SKILL.md` through the granted workdir port;
 it does not enter the watch manager or require a whole Agent. The declaration
 also fixes the public action inventory, so the schema, dispatch family, and
 manual cannot silently drift.
+
+## Settings
+
+Call `settings` with exact `input={}` to SHOW the five numeric policies owned
+by `taskcard/taskcard.json`. Every row contains only `key`, `current`,
+`default`, `configurable`, and `comment`; the comment points back to one exact
+section below for meaning, source, validation, application timing, and change
+procedure.
+
+SHOW is read-only. It never creates or changes `taskcard/taskcard.json`, never
+runs the one-time migration, and has no set/reset form. A `configurable: true`
+row means an authorized owner may create the JSON object when absent or edit it
+with File or Shell outside SHOW, preserving all other fields; it does not grant
+that authority. After an authorized change, call `settings(input={})` again to
+verify the fresh effective value. An invalid or missing field falls back
+independently to its built-in default. If effective truth is unavailable, the
+whole inventory fails with no partial rows or raw exception detail.
+
+### interval-s
+
+- Meaning: default polling cadence in seconds for a newly started or resumed
+  watch. An explicit `start.interval_s` replaces it, subject to the same
+  one-second floor.
+- Source/default: valid `taskcard/taskcard.json` `interval_s`, otherwise `5`.
+  It must be a non-boolean finite number at least `1`.
+- Application/change: read for each `start` and persisted-watch resume; an
+  already-running watch keeps its captured cadence. An authorized owner edits
+  only `interval_s` in the owner document, preserves sibling fields, then
+  verifies with a second SHOW.
+
+### timeout-s
+
+- Meaning: per-render execution ceiling in seconds for a newly started or
+  resumed watch. An explicit `start.timeout_s` may lower but never raise it.
+- Source/default: valid `taskcard/taskcard.json` `timeout_s`, otherwise `10`.
+  It must be a non-boolean finite number at least `0.1`.
+- Application/change: read for each `start` and persisted-watch resume; an
+  already-running watch keeps its captured ceiling. An authorized owner edits
+  only `timeout_s`, preserves sibling fields, then verifies with a second SHOW.
+
+### max-refreshes
+
+- Meaning: refresh ceiling for a newly started or resumed watch. An explicit
+  `start.max_refreshes` may lower but never raise it.
+- Source/default: valid positive integer `taskcard/taskcard.json`
+  `max_refreshes`, otherwise `2000`. Before the intrinsic document exists, a
+  genuinely customized positive legacy Telegram ceiling is the effective
+  one-time migration preview; the untouched legacy default `1000` is ignored.
+- Application/change: read for each `start` and persisted-watch resume; an
+  existing watch keeps its captured budget. SHOW previews the migration result
+  without writing it. An authorized owner edits only `max_refreshes`, preserves
+  sibling fields, then verifies with a second SHOW.
+
+### reminder-turns
+
+- Meaning: completed text turns between absent-or-stale Task Card reminders.
+- Source/default: valid positive integer `taskcard/taskcard.json`
+  `reminder_turns`, otherwise `10`.
+- Application/change: read on every completed text turn. An authorized owner
+  edits only `reminder_turns`, preserves sibling fields, then verifies with a
+  second SHOW.
+
+### max-body-chars
+
+- Meaning: maximum rendered Task Card body accepted by the producer;
+  oversized bodies are refused rather than truncated.
+- Source/default: integer `taskcard/taskcard.json` `max_body_chars` at least
+  `100`, otherwise `2000`.
+- Application/change: read on every body publication. An authorized owner
+  edits only `max_body_chars`, preserves sibling fields, then verifies with a
+  second SHOW. Body content, renderer paths, and unrelated document fields are
+  never settings rows.
 
 ## Typed notification boundary
 

--- a/tests/test_intrinsic_manual_actions.py
+++ b/tests/test_intrinsic_manual_actions.py
@@ -302,7 +302,7 @@ def test_manual_schemas_preserve_runtime_checks_for_ordinary_file_calls(
     assert len(vision_schema["properties"]["input"]["oneOf"]) == 4
     task_card_schema = task_card_tool.get_schema()
     assert task_card_schema["required"] == ["action", "input", "reasoning"]
-    assert len(task_card_schema["properties"]["input"]["oneOf"]) == 6
+    assert len(task_card_schema["properties"]["input"]["anyOf"]) == 7
     # ``shell`` is migrated to the same LTP v2 envelope, with four children.
     shell_schema = shell_tool.get_schema()
     assert shell_schema["required"] == ["action", "input", "reasoning"]
@@ -352,7 +352,10 @@ def test_shipped_task_card_manuals_only_document_intrinsic_file_contract() -> No
         assert "taskcard/status" in body, name
         assert "taskcard/taskcard.md" in body, name
         assert "nonempty" in lowered, name
-        for action in ("start", "inspect", "retry", "stop", "remove", "manual"):
+        actions = ("start", "inspect", "retry", "stop", "remove", "manual")
+        if name == "intrinsic":
+            actions = (*actions[:-1], "settings", "manual")
+        for action in actions:
             assert action in lowered, (name, action)
         for forbidden in forbidden_active_contracts:
             assert forbidden not in lowered, (name, forbidden)

--- a/tests/test_task_card_controller.py
+++ b/tests/test_task_card_controller.py
@@ -775,6 +775,155 @@ def test_config_paths_are_exact_and_agent_local(agent, manager):
     assert manager._legacy_config_path == agent._working_dir / "telegram" / "taskcard.json"
 
 
+_SETTING_DEFAULTS = {
+    "interval_s": 5.0,
+    "timeout_s": 10.0,
+    "max_refreshes": 2000,
+    "reminder_turns": 10,
+    "max_body_chars": 2000,
+}
+_SETTING_COMMENTS = {
+    key: f"task_card-manual#{key.replace('_', '-')}" for key in _SETTING_DEFAULTS
+}
+
+
+def _show_settings(manager: TaskCardManager, input_: dict | None = None) -> dict:
+    return manager.handle(
+        {
+            "action": "settings",
+            "input": {} if input_ is None else input_,
+            "reasoning": "inspect Task Card owner policy",
+        }
+    )
+
+
+def test_settings_inventory_is_exact_ordered_and_read_only_by_default(agent, manager):
+    assert DECLARATION.settings is True
+    assert DECLARATION.public_actions == (
+        "start",
+        "inspect",
+        "retry",
+        "stop",
+        "remove",
+        "settings",
+        "manual",
+    )
+    schema = get_schema()
+    settings_index = DECLARATION.public_actions.index("settings")
+    assert schema["properties"]["input"]["anyOf"][settings_index] == {
+        "title": "settings inventory input",
+        "type": "object",
+        "properties": {},
+        "required": [],
+        "additionalProperties": False,
+    }
+
+    assert _show_settings(manager) == {
+        "settings": [
+            {
+                "key": key,
+                "current": value,
+                "default": value,
+                "configurable": True,
+                "comment": _SETTING_COMMENTS[key],
+            }
+            for key, value in _SETTING_DEFAULTS.items()
+        ]
+    }
+    assert not manager._config_path.exists(), "SHOW must not trigger migration"
+
+    manual = (
+        Path(__file__).parents[1]
+        / "src/lingtai/tools/task_card/manual/SKILL.md"
+    ).read_text(encoding="utf-8")
+    for pointer in _SETTING_COMMENTS.values():
+        manual_name, anchor = pointer.split("#", 1)
+        assert manual_name == "task_card-manual"
+        assert f"### {anchor}\n" in manual
+
+
+def test_settings_current_is_fresh_effective_owner_truth_without_unknown_field_leak(
+    agent, manager
+):
+    secret = "private-task-card-owner-field"
+    path = _write_config(
+        agent,
+        {
+            "interval_s": 7,
+            "timeout_s": 2,
+            "max_refreshes": 11,
+            "reminder_turns": 4,
+            "max_body_chars": 150,
+            "credential_path": secret,
+        },
+    )
+    original = path.read_bytes()
+    first = _show_settings(manager)
+    assert [row["current"] for row in first["settings"]] == [7.0, 2.0, 11, 4, 150]
+    assert path.read_bytes() == original
+    assert secret not in json.dumps(first)
+    assert all(list(row) == [
+        "key", "current", "default", "configurable", "comment"
+    ] for row in first["settings"])
+
+    path.write_text(
+        json.dumps(
+            {
+                "interval_s": 9,
+                "timeout_s": 0.01,
+                "max_refreshes": 12,
+                "reminder_turns": 0,
+                "max_body_chars": 99,
+            }
+        ),
+        encoding="utf-8",
+    )
+    second_bytes = path.read_bytes()
+    second = _show_settings(manager)
+    assert [row["current"] for row in second["settings"]] == [
+        9.0,
+        10.0,
+        12,
+        10,
+        2000,
+    ]
+    assert path.read_bytes() == second_bytes
+
+
+def test_settings_previews_legacy_ceiling_and_rejects_mutation_input_without_writing(
+    agent, manager
+):
+    legacy = _write_legacy_telegram_config(
+        agent, {"taskcard": True, "normal_rows": 1, "max_refreshes": 37}
+    )
+    legacy_bytes = legacy.read_bytes()
+
+    rows = {row["key"]: row["current"] for row in _show_settings(manager)["settings"]}
+    assert rows == {**_SETTING_DEFAULTS, "max_refreshes": 37}
+    assert not manager._config_path.exists()
+    assert legacy.read_bytes() == legacy_bytes
+
+    assert _show_settings(manager, {"set": "max_refreshes"}) == {
+        "status": "failed",
+        "error_code": "INVALID_ARGUMENT",
+        "message": "unsupported task_card input field",
+    }
+    assert not manager._config_path.exists()
+    assert legacy.read_bytes() == legacy_bytes
+
+
+def test_settings_provider_failure_is_one_fixed_no_row_result(manager, monkeypatch):
+    def unavailable():
+        raise OSError("private owner read detail")
+
+    monkeypatch.setattr(manager, "settings_rows", unavailable)
+    assert _show_settings(manager) == {
+        "status": "failed",
+        "error_code": "SETTINGS_UNAVAILABLE",
+        "message": "settings inventory is unavailable",
+    }
+
+
 def test_load_config_defaults_to_5_10_2000_when_no_config_file_exists(agent, manager):
     config = manager._load_config()
     assert config.interval_s == 5.0

--- a/tests/test_telegram_toolfamily_ltpv2.py
+++ b/tests/test_telegram_toolfamily_ltpv2.py
@@ -193,15 +193,20 @@ def test_taskcard_refresh_setting_positive_value_round_trips(tmp_path):
 def test_intrinsic_task_card_schema_is_a_strict_ltp_v2_family():
     schema = task_card_schema()
     names = schema["properties"]["action"]["enum"]
-    branches = schema["properties"]["input"]["oneOf"]
+    branches = schema["properties"]["input"]["anyOf"]
 
     assert schema["required"] == ["action", "input", "reasoning"]
     assert set(schema["properties"]) == {"action", "input", "reasoning", "summarize"}
     assert schema["additionalProperties"] is False
-    assert names == ["start", "inspect", "retry", "stop", "remove", "manual"]
+    assert names == [
+        "start", "inspect", "retry", "stop", "remove", "settings", "manual"
+    ]
     assert len(schema["allOf"]) == len(names) == len(branches)
     for action, branch, condition in zip(names, branches, schema["allOf"]):
-        assert branch["title"] == f"{action} input"
+        expected_title = (
+            "settings inventory input" if action == "settings" else f"{action} input"
+        )
+        assert branch["title"] == expected_title
         assert condition["if"]["properties"]["action"]["const"] == action
 
 

--- a/tests/test_tool_plugin_declaration.py
+++ b/tests/test_tool_plugin_declaration.py
@@ -246,12 +246,24 @@ def test_official_task_card_mount_keeps_the_current_agent_lifecycle(task_card_ag
     assert not hasattr(manager, "_agent")
     handler = task_card_agent._tool_handlers["task_card"]
     assert handler.__self__ is manager
+    settings = handler({"action": "settings", "input": {}, "reasoning": "inspect"})
+    assert [row["key"] for row in settings["settings"]] == [
+        "interval_s", "timeout_s", "max_refreshes", "reminder_turns", "max_body_chars"
+    ]
+    assert not manager._config_path.exists()
     manual = handler({"action": "manual", "input": {}, "reasoning": "guidance"})
     assert manual["status"] == "ok"
     assert manual["content"][0]["text"]
     assert manual["structuredContent"]["manual_path"].endswith(
         "capabilities/task_card/SKILL.md"
     )
+    task_card_agent.start()
+    prompt = task_card_agent._build_system_prompt()
+    batches = task_card_agent._build_system_prompt_batches()
+    schemas = task_card_agent._build_tool_schemas()
+    assert isinstance(prompt, str) and prompt
+    assert batches and all(isinstance(batch, str) for batch in batches)
+    assert "task_card" in {schema.name for schema in schemas}
 
 
 def test_official_task_card_manager_holds_only_the_native_notification_operations(

--- a/tests/test_tool_settings_contract.py
+++ b/tests/test_tool_settings_contract.py
@@ -138,7 +138,7 @@ def test_public_export_and_only_this_owner_opts_in():
         name: importlib.import_module(f"lingtai.tools.{modules.get(name, name)}").DECLARATION
         for name in OFFICIAL_TOOL_PLUGIN_NAMES
     }
-    expected_official = {"avatar", "plugin", "system"}
+    expected_official = {"avatar", "plugin", "system", "task_card"}
     assert {name for name, item in declarations.items() if item.settings} == expected_official
     for name, item in declarations.items():
         assert ("settings" in item.public_actions) is (name in expected_official)


### PR DESCRIPTION
## Sequential merge candidate

This is the independent **Task Card** owner implementation rebased onto exact cumulative main `d95258e510654734fa581406ffeb72c9f6c0d41b` during Jason's authorized one-PR-at-a-time merge flow.

- exact candidate commit: `3caa6a250a1cdaa46b15aec10a6ba251b4332045`
- exact parent: `d95258e510654734fa581406ffeb72c9f6c0d41b`
- rebased whole-patch stable id: `013efb2c67331c5498666df5d77572459a5afb06`
- resulting owner diff: **10 files changed, 437 insertions(+), 62 deletions(-)**
- one owner commit, canonical `Huang Zesen <hzsbazinga@outlook.com>` identity, clean worktree, and no tracked deletions

## Behavior

- adds the read-only `settings` action with exactly five rows: `interval_s`, `timeout_s`, `max_refreshes`, `reminder_turns`, and `max_body_chars`
- defaults are `5.0`, `10.0`, `2000`, `10`, and `2000`; all five are configurable through the existing agent-local `taskcard/taskcard.json` owner document
- there is no environment-variable peer; invalid/missing owner-file fields fall back independently to built-in defaults
- preserves the existing start/inspect/retry/stop/remove/manual behavior and adds no generic set/reset writer

## Rebase preservation

#1524 and #1525 advanced main. The isolated rebase preserved all eight ordinary Task Card paths byte-for-byte from the reviewed owner head. The shared settings manual is byte-identical to current main. The shared settings contract changes only the owner set from `{avatar, plugin, system}` to `{avatar, plugin, system, task_card}`. The auto-merged declaration test retains both Plugin's public-actions assertion and Task Card's five-key settings assertion.

## Validation

- exact rebased changed-test surface: **124 passed**
- live `task_card.settings`: five exact five-field rows with current values equal to defaults
- live pre-existing `task_card.inspect` against watch `tc_20`: watching, valid body, no error
- original owner-patch static review had no open P0 or P1 finding
- `git diff --check`: pass

## Merge boundary

Jason TG12190 authorized the sequential merge flow. This PR is handled individually: exact-head guarded squash merge only after its settings/env/default/runtime report. No release, deploy, live refresh, unrelated config/auth mutation, deletion, cleanup, or source-branch deletion is included.

Telegram: @lingtaidev3bot | Nickname: 澄一

Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
