### PR TITLE
feat(email): add five-field settings discovery

### DIFF
--- a/src/lingtai/adapters/posix/ANATOMY.md
+++ b/src/lingtai/adapters/posix/ANATOMY.md
@@ -92,7 +92,10 @@ co-located owning ANATOMY.md files.
   (`src/lingtai/adapters/posix/event_journal.py:47-48`).
 - `PosixFilesystemMailAdapter` implements `MailTransportPort` by delivering
   messages as files into a recipient's inbox and polling its own inbox plus
-  subscribed pseudo-agent outboxes (`src/lingtai/adapters/posix/mail.py:34-69`).
+  subscribed pseudo-agent outboxes. Its adapter-only
+  `pseudo_agent_subscriptions` property returns the effective paths resolved
+  once at construction for Email's fully redacted SHOW provider; it does not
+  widen the Core mail transport Port (`src/lingtai/adapters/posix/mail.py`).
 - `send()` handshakes, injects mailbox metadata, validates every attachment
   path up front, stages the full message (attachments + `message.json`) in a
   hidden `.<id>.staging` dir under the inbox, and publishes it with a single

--- a/src/lingtai/adapters/posix/mail.py
+++ b/src/lingtai/adapters/posix/mail.py
@@ -102,6 +102,11 @@ class PosixFilesystemMailAdapter(MailTransportPort):
         self._own_inbox_slice_entries = 200
         self._mail_poll_slow_seconds = 1.0
 
+    @property
+    def pseudo_agent_subscriptions(self) -> tuple[str, ...]:
+        """Return the effective constructor-time subscription snapshot."""
+        return tuple(str(path) for path in self._pseudo_agent_dirs)
+
     # ------------------------------------------------------------------
     # address
     # ------------------------------------------------------------------

--- a/src/lingtai/adapters/tool_plugin_host.py
+++ b/src/lingtai/adapters/tool_plugin_host.py
@@ -489,7 +489,7 @@ class AgentAvatarParentAdapter:
 
 
 class AgentEmailRuntimeAdapter:
-    """Email's narrow live-manager port over one call-time reader.
+    """Email's narrow live-manager and applied-settings read port.
 
     The adapter owns no Agent and never dispatches through an intrinsic or an
     official tool handler.  It validates the Email-owned action set before it
@@ -499,10 +499,15 @@ class AgentEmailRuntimeAdapter:
     without leaving an already-bound declared family stale.
     """
 
-    __slots__ = ("_read_manager",)
+    __slots__ = ("_read_manager", "_read_pseudo_agent_subscriptions")
 
-    def __init__(self, read_manager: Callable[[], Any]) -> None:
+    def __init__(
+        self,
+        read_manager: Callable[[], Any],
+        read_pseudo_agent_subscriptions: Callable[[], Any] | None = None,
+    ) -> None:
         self._read_manager = read_manager
+        self._read_pseudo_agent_subscriptions = read_pseudo_agent_subscriptions
 
     def handle_email(self, request: "EmailRuntimeRequest") -> "EmailResult":
         # Keep the action source of truth in Email's static declaration without
@@ -515,6 +520,18 @@ class AgentEmailRuntimeAdapter:
         if manager is None:
             return {"error": "Internal: email manager not initialized. boot() was not called."}
         return manager.handle({"action": request.action, **dict(request.input)})
+
+    def read_pseudo_agent_subscriptions(self) -> tuple[str, ...]:
+        """Read the mail adapter's effective, construction-time path snapshot."""
+        read = self._read_pseudo_agent_subscriptions
+        if read is None:
+            raise RuntimeError("Email pseudo-agent subscription snapshot is unavailable")
+        value = read()
+        if not isinstance(value, tuple) or not all(
+            isinstance(item, str) for item in value
+        ):
+            raise RuntimeError("Email pseudo-agent subscription snapshot is invalid")
+        return value
 
 
 class _DaemonPresetToolCollector:

--- a/src/lingtai/intrinsic_skills/system-manual/reference/settings-inventory/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/settings-inventory/SKILL.md
@@ -104,10 +104,9 @@ cross-cutting Agent/ToolExecutor result hints, not the Context ToolPlugin's
 public summarize action. Conversely, `manifest.pseudo_agent_subscriptions`
 belongs to the concrete Email ToolPlugin because CLI composition hands it
 directly to `PosixFilesystemMailAdapter`, which resolves the subscription
-paths. It is intentionally absent from System SHOW. A future Email-owner
-classification and coverage change must add its owner-local discovery row and
-fully redact both current and default path lists; this System repair does not
-edit Email implementation.
+paths. It is intentionally absent from System SHOW. The Email-owner inventory
+uses the generic sensitive-value seam to fully redact both current and default path lists;
+System neither duplicates that row nor exposes the paths.
 
 Authorized change procedure: after explicit owner/human authorization, edit
 the exact `init.json` field with the existing File or Shell capability. For a

--- a/src/lingtai/intrinsic_skills/system-manual/reference/substrate-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/substrate-manual/SKILL.md
@@ -6,9 +6,9 @@ description: >
   communication and memory layers, collaboration topology, MCP/addon ownership,
   and (§11) the canonical `init.json` composition and preset runtime model.
   Route via `system-manual` when it is unclear whether this is the right node.
-version: 1.5.0
+version: 1.5.1
 tags: [lingtai, system-manual, substrate, runtime, lifecycle, alarm, communication, memory, notifications, mcp, preset]
-last_changed_at: "2026-08-24T08:45:00Z"
+last_changed_at: "2026-08-29T00:00:00Z"
 related_files:
 - src/lingtai/intrinsic_skills/system-manual/SKILL.md
 - src/lingtai/prompts/substrate/substrate.md
@@ -356,10 +356,10 @@ policy does not read it. Agent `init.json` likewise does not own
 `snapshot_interval`, or `activeness`: old root keys are compatibility-known and
 ignored, while valid environment and `settings/system.json` v2 values override
 fixed defaults. Materialization and preset activation discard a preset context
-limit instead of handing it into init. Some runtime gaps
-(`pseudo_agent_subscriptions`, exact MCP reload/venv/prompt persistence detail)
-are open implementation questions, not resolved by this reference — do not
-infer a guarantee from a name alone.
+limit instead of handing it into init. Email's owner manual defines the exact
+`pseudo_agent_subscriptions` construction/relaunch lifecycle. Exact MCP reload,
+venv, and prompt-persistence details remain open implementation questions not
+resolved by this reference — do not infer a guarantee from a name alone.
 
 ### Preset identity and the two catalogs
 

--- a/src/lingtai/tools/email/ANATOMY.md
+++ b/src/lingtai/tools/email/ANATOMY.md
@@ -10,10 +10,13 @@ related_files:
   - src/lingtai/kernel/base_agent/__init__.py
   - src/lingtai/tools/email/manager.py
   - src/lingtai/tools/email/primitives.py
+  - src/lingtai/tools/email/settings.py
+  - src/lingtai/adapters/posix/mail.py
   - src/lingtai/tools/email/schema.py
   - src/lingtai/tools/email/_family_schema.py
   - src/lingtai/kernel/tool_plugin/ANATOMY.md
   - tests/test_email_official_tool_plugin.py
+  - tests/test_email_settings.py
   - src/lingtai/tools/tool_family/ANATOMY.md
   - src/lingtai/tools/email/glossary-en.md
   - src/lingtai/tools/email/glossary-zh.md
@@ -37,9 +40,9 @@ Filesystem-based email system — mailbox I/O, composition, search, contacts, an
 ## Components
 
 - `__init__.py` — Package surface and the LTP v2 family boundary. Re-exports the full public API of the former monolithic `email.py` for backward compatibility: all primitives, schema functions, and `EmailManager`. Registers the `email` generic-dismiss guard at import because `.notification/email.json` mirrors durable unread state. Owns the family composition and the module-level intrinsic protocol:
-  - `_schema_only_family()` / `_FAMILY` — the module-level schema-only `ToolFamily`. Email is an *intrinsic* (module-level `get_schema()`/`handle(agent, args)`, no per-Agent manager object to hang a family off at import), so this one never dispatches; constructing it at import is still load-bearing as the registry's duplicate/reserved-`manual`-collision check.
+  - `_schema_only_family()` / `_FAMILY` — the module-level schema-only `ToolFamily`. Email is an *intrinsic* (module-level `get_schema()`/`handle(agent, args)`, no per-Agent manager object to hang a family off at import), so this one never dispatches; constructing it at import is still load-bearing as the registry's duplicate/reserved-child collision check and supplies the Email settings provider for schema composition.
   - `get_schema()` — the composed model-facing schema. Shadows the legacy flat `schema.get_schema` (re-exported as `get_flat_schema`) and replaces the generic composer's neutral `action` description with Email's own `ACTION_ENUM_DESCRIPTION`.
-  - `_build_family(agent)` — the per-call dispatching family. Every non-`manual` child re-enters `EmailManager.handle` with its unchanged historical flat shape; `manual` is `build_manual_child(agent, "email")`, registered directly and unwrapped.
+  - `_build_family(agent)` — the per-call dispatching family. Every operational child re-enters `EmailManager.handle` with its unchanged historical flat shape; the generic seam injects `settings` from the Email provider, and `manual` is `build_manual_child(agent, "email")`, registered directly and unwrapped.
   - `_strip_nulls()` — turns provider-sent explicit `null`s back into absent keys so the manager's `args.get(...)`/`in args` defaulting is preserved.
   - `_adapt_manual_result()` — Host/presentation-only flattening of the canonical ManualTool result to Email's pinned `{status, manual, manual_path}` public shape, strictly *after* dispatch.
   - `handle(agent, args)` — strips `_tc_id`, renders the reserved `unread` rejection before dispatch, delegates to the family, then adapts `manual` and restores Email's own unknown/absent-action results.
@@ -49,21 +52,25 @@ Filesystem-based email system — mailbox I/O, composition, search, contacts, an
     `DaemonEmailAgentShim` lacks an official tool surface and intentionally gets
     manager/hook boot only, preserving its task-scoped daemon-email MCP route.
   - `EmailRuntimeRequest` / `EmailRuntimePort` — Email-owned manager-facing
-    request and typed operation. `_build_bound_family(host)` consumes exactly
-    `host.email_runtime`; `_strip_nulls()` runs before request construction.
+    request, typed operation, and applied pseudo-subscription snapshot read.
+    `_build_bound_family(host)` consumes exactly `host.email_runtime`;
+    `_strip_nulls()` runs before request construction.
   - `DECLARATION` / `_bind(host)` — static official-plugin declaration and
     host-bound composition. It requires exactly `workdir`/`email_runtime`;
-    operational children consume only `EmailRuntimePort`, and the reserved
-    manual child uses only `host.workdir`. The official mount supplies the one
+    operational children and settings provider consume only `EmailRuntimePort`,
+    while the reserved manual child uses only `host.workdir`. The official mount supplies the one
     model-facing schema while the module remains available to kernel hook
     resolution.
   - `AgentEmailRuntimeAdapter` lives in the production host adapter module, not
-    this family. It retains only a manager reader, rejects foreign Email actions,
+    this family. It retains only manager/settings readers, rejects foreign Email actions,
     looks up the current `agent._email_manager` at call time, and calls its
     `handle({"action": request.action, **dict(request.input)})` exactly once.
     It never captures `_intrinsics` or routes through the official handler.
+    The settings read returns the POSIX adapter's actual construction snapshot.
 
-- `_family_schema.py` — Canonical per-action data for the composed schema: `ACTION_ORDER` (the single source for the `action` enum order, the `input.oneOf`/`allOf` branch order, and child registration order), one strict closed `input_schema` per action in `INPUT_SCHEMAS`, and `ACTION_ENUM_DESCRIPTION`. Holds no composition logic and imports `mode_field` from `primitives` and `MANUAL_INPUT_SCHEMA` from `tool_family.manual` rather than restating them.
+- `_family_schema.py` — Canonical operational/manual action data for the composed schema: `ACTION_ORDER`, one strict closed `input_schema` per action in `INPUT_SCHEMAS`, and `ACTION_ENUM_DESCRIPTION`. The generic declaration seam inserts `settings` before `manual`, changing the disclosed input union to `anyOf` without hand-authoring a settings child. This module holds no composition logic and imports `mode_field` from `primitives` and `MANUAL_INPUT_SCHEMA` from `tool_family.manual` rather than restating them.
+
+- `settings.py` — Email-owned read-only settings provider and single source for the fixed body, duplicate-loop, check-result, and unread-projection limits consumed by `manager.py`/`primitives.py`. `email_settings_rows()` adds the fully redacted `manifest.pseudo_agent_subscriptions` row from the effective mail-adapter construction snapshot. It raises when that snapshot is unavailable and defines no mutation type or handler.
 
 - `manual/SKILL.md` — the installed `email-manual` bundle the reserved `manual` child returns; `Agent._install_intrinsic_manuals()` copies it to `.library/intrinsic/capabilities/email/`.
 
@@ -113,7 +120,8 @@ Filesystem-based email system — mailbox I/O, composition, search, contacts, an
 - `_send(mode="abs")` embeds an explicit `_return_route` dict (`{"mode": "abs", "address": <sender abs workdir>, "sender_agent_id": <sender id>}`) into every dispatched payload AND the local `sent/{id}/message.json` record. This is the only safe return route across `.lingtai/` networks where short addresses can collide (issue #145). Recipients without the field — older messages — keep working through the existing absolute-`from` fallback in `_resolve_reply_target`.
 - `_mailman` runs as a daemon thread per recipient. It waits until `deliver_at`, then dispatches. The outbox entry is written synchronously before the thread starts.
 - `_mailman` with `skip_sent=True` (used by `_send`) deletes the outbox entry instead of moving it to `sent/`, because `_send` writes the `sent/` entry itself.
-- The model-facing root is one closed LTP v2 envelope (`action`, `input`, `reasoning`, `summarize`) over 14 internal children — one per public action — composed by the generic `ToolFamily` infra from the single `_family_schema.ACTION_ORDER`/`INPUT_SCHEMAS` registry. Children consume no model tool slots, so `email` still advertises exactly one tool. Because both the advertised schema and dispatch are generated from that one registry, an action cannot be advertised without being dispatchable. Cross-action `input` keys are rejected before any mailbox I/O — the property that matters most for a side-effecting family.
+- The model-facing root is one closed LTP v2 envelope (`action`, `input`, `reasoning`, `summarize`) over 15 internal children: thirteen unchanged operational actions, generic `settings` immediately before `manual`, and `manual`. Children consume no model tool slots, so `email` still advertises exactly one tool. The declaration opt-in and family provider drive advertised schema and dispatch. Cross-action `input` keys are rejected before any mailbox I/O.
+- `settings` is read-only and performs no mailbox I/O. Four public rows are installed-code limits; `manifest.pseudo_agent_subscriptions` is configurable through the existing init manifest but fully redacts current/default path lists. Every success row projects exactly `key`, `current`, `default`, `configurable`, and an exact `email-manual` section pointer in `comment`. Unavailable applied truth fails the whole action without partial rows. Mailbox/session paths, addresses, identities, contacts, content, attachments, and read state never enter this inventory.
 - The official manager-facing composition is domain-native: `EmailRuntimeRequest`
   is the only request shape accepted by `EmailRuntimePort`; `_strip_nulls()` runs
   before it is constructed. The host adapter rejects foreign actions before one

--- a/src/lingtai/tools/email/BEHAVIORS.md
+++ b/src/lingtai/tools/email/BEHAVIORS.md
@@ -9,7 +9,9 @@ related_files:
   - src/lingtai/tools/email/ANATOMY.md
   - src/lingtai/tools/email/__init__.py
   - src/lingtai/tools/email/manager.py
+  - src/lingtai/tools/email/settings.py
   - tests/test_email_official_tool_plugin.py
+  - tests/test_email_settings.py
 maintenance: |
   Created during the every-contract-needs-behaviors sweep. Keep this file
   reciprocal with CONTRACT.md and ANATOMY.md (tridirectional loop): when an
@@ -21,7 +23,8 @@ maintenance: |
 Self-contained agent behavior tasks guarding the observable behavior clauses of
 `src/lingtai/tools/email/CONTRACT.md` (closed LTP v2 envelope, validation
 before mailbox I/O, reserved `unread` rejection, exact receipts, typed
-manager-facing runtime, live manager replacement, and absence of dynamic Email capability state). Pinned
+manager-facing runtime, live manager replacement, five-field/redacted settings,
+and absence of dynamic Email capability state). Pinned
 pytest commands must run from the repo root with the project's Python.
 
 ## Behavior EM001 — envelope failures are rejected before any mailbox I/O, and send returns the exact sent receipt
@@ -88,3 +91,27 @@ Pass when the suite passes and the before-I/O rejection and exact receipt hold. 
 
 ### Pass / Fail
 Pass when all four steps hold and the official Email surface is mandatory by intrinsic/official registration rather than dynamic capability state. Fail on a generic/foreign operation reaching the manager, an Email capability/manifest row, a duplicate schema, a missing manager, or a non-package manual.
+
+## Behavior EM003 — settings inventory is exact, read-only, and private
+
+- **id**: EM003
+- **title**: settings inventory is exact, read-only, and private
+- **guards**: `email-contract` § Settings
+- **runner**: any LingTai agent with `shell` and `file` access to this repository
+- **prerequisites**: a clean checkout of `<repo>`; a scratch agent working directory `<scratch>`
+- **estimate**: ≈ 10 minutes
+
+### Steps
+1. From `<repo>`, run `PYTHONDONTWRITEBYTECODE=1 python -m pytest -q -p no:cacheprovider tests/test_email_settings.py`.
+2. Call `email(action="settings", input={}, reasoning="inventory Email policy")`; confirm four active public constants plus the redacted `manifest.pseudo_agent_subscriptions` row appear in exact order with exactly five fields.
+3. Follow every `comment` to its exact heading in `email-manual`; pass non-empty `input` and confirm refusal without mutation, then exercise the unavailable-source case and confirm one fixed whole-action failure with no rows.
+4. Confirm current/default subscription paths are both redacted, no mailbox/session/identity/content data appears, and an ordinary `contacts` call remains unchanged.
+
+### Expected evidence
+- [ ] Step 1 passes, including the operational-source and ordinary-action non-regressions.
+- [ ] Every row has exactly `key`, `current`, `default`, `configurable`, and `comment`; the four fixed rows are non-configurable and the subscription row is configurable.
+- [ ] Every comment names an existing owner-manual heading; the sensitive row redacts current/default through an unprojected private flag.
+- [ ] Missing applied truth fails the complete response with `SETTINGS_UNAVAILABLE`, and non-empty input cannot invoke a set/reset/mutation path or create persistence.
+
+### Pass / Fail
+Pass when exact five-field inventory, manual pointers, full redaction, whole-action failure, and no-I/O behavior all hold. Fail on any extra field, mutation API, partial unavailable row, path/domain-data leak, missing manual target, or operational regression.

--- a/src/lingtai/tools/email/CONTRACT.md
+++ b/src/lingtai/tools/email/CONTRACT.md
@@ -1,15 +1,17 @@
 ---
 name: email-contract
 tool: email
-contract_version: 2
+contract_version: 3
 related_files:
   - src/lingtai/tools/email/__init__.py
   - src/lingtai/adapters/tool_plugin_host.py
+  - src/lingtai/adapters/posix/mail.py
   - src/lingtai/tools/registry.py
   - src/lingtai/kernel/base_agent/__init__.py
   - src/lingtai/tools/email/_family_schema.py
   - src/lingtai/tools/email/schema.py
   - src/lingtai/tools/email/manager.py
+  - src/lingtai/tools/email/settings.py
   - src/lingtai/tools/email/ANATOMY.md
   - src/lingtai/tools/email/BEHAVIORS.md
   - src/lingtai/tools/email/manual/SKILL.md
@@ -20,13 +22,14 @@ related_files:
   - tests/test_tool_family_email_migration.py
   - tests/test_tool_family_email_wire_parity.py
   - tests/test_email_official_tool_plugin.py
+  - tests/test_email_settings.py
 maintenance: |
   Keep related_files as repo-relative paths to real files. If behavior and this
   contract disagree, the code is the source of truth — fix the contract in the
   same change and bump contract_version on breaking contract edits.
-  contract_version 2 records the LTP v2 / ToolFamily envelope migration: the
-  call shape moved to closed action/input/reasoning/summarize while the public
-  tool name, every action value, and every result shape stayed identical.
+  contract_version 3 adds Email's generic read-only settings inventory after
+  the LTP v2 / ToolFamily envelope migration. The public tool name and all
+  operational action/result shapes remain unchanged.
   Update this contract, the paired ANATOMY.md, the per-action schemas in
   _family_schema.py, and the kernel _LTP_V2_MIGRATED_FAMILIES allowlist
   together when the envelope or an action's input surface changes.
@@ -41,14 +44,14 @@ this one tool. The implementation lives in `src/lingtai/tools/email/`; the code 
 source of truth.
 
 ## Routing Card
-Guarded by: [EM001](BEHAVIORS.md#behavior-em001), [EM002](BEHAVIORS.md#behavior-em002)
+Guarded by: [EM001](BEHAVIORS.md#behavior-em001), [EM002](BEHAVIORS.md#behavior-em002), [EM003](BEHAVIORS.md#behavior-em003)
 
 
 **Use this when:**
 - You are editing the internal mailbox tool: send/check/read/reply/search/
   archive/delete or the contact book.
-- You are reviewing mailbox on-disk layout, unread digest republishing, or the
-  duplicate-send loop guard.
+- You are reviewing mailbox on-disk layout, unread digest republishing, the
+  duplicate-send loop guard, or Email's read-only settings inventory.
 - You need the ambiguous-reply (`#145`) return-route handling or the abs/peer
   send modes.
 
@@ -76,16 +79,17 @@ storage; abs/peer reply routing -> §Anchored claims.
 `email` is a migrated LTP v2 family (`src/lingtai/tools/CONTRACT.md`). The
 model-facing root is the closed envelope — exactly `action`, `input`,
 `reasoning`, and `summarize`, with `additionalProperties: false` and
-`required: [action, input, reasoning]`. The public tool name is unchanged, and
-so is every `action` value; only the call shape moved, from one open flat
-argument bag to one strict per-action `input` object.
+`required: [action, input, reasoning]`. The public tool name and all thirteen
+operational action values are unchanged. The generic opt-in seam adds only
+`settings`, immediately before the existing final `manual` action.
 
-Each action is one canonical internal child with its own closed
-`input_schema` (`src/lingtai/tools/email/_family_schema.py`); children consume
+Each operational/manual action is one canonical internal child with its own
+closed `input_schema` (`src/lingtai/tools/email/_family_schema.py`), and the
+generic seam supplies the closed settings child; children consume
 no model tool slots, so the family still advertises exactly one tool. The
 composed schema is built by the generic `ToolFamily` infra
-(`src/lingtai/tools/tool_family/`) from that one child registry, so the
-advertised `action` enum, the `input.oneOf` branches, the root `allOf`
+(`src/lingtai/tools/tool_family/`) from the declaration and provider, so the
+advertised `action` enum, the `input.anyOf` branches, the root `allOf`
 correlation, and dispatch cannot drift apart. `summarize` guidance profile:
 **bulky-result** for `check`, `read`, and `search` (mailbox listings and full
 bodies can be large); **short-result** for every other action, whose receipts
@@ -130,6 +134,7 @@ action's `input` properties — e.g. `email(action='read', input={'email_id':
 | `add_contact` | `address`, `name` | `note` | `{status: "added"/"updated", contact}` | `{error: "address is required"}`; `{error: "name is required"}` |
 | `remove_contact` | `address` | — | `{status: "removed", address}` | `{error: "address is required"}`; `{error: "Contact not found: ..."}` |
 | `edit_contact` | `address` | `name`, `note` | `{status: "updated", contact}` | `{error: "address is required"}`; `{error: "Contact not found: ..."}` |
+| `settings` | — (`input` is exactly `{}`) | — | `{"settings": [...]}` with exactly five fields per row | fixed whole-action failure when current truth/provider rows are unavailable or invalid |
 
 Missing/absent `action` returns `{error: "action is required"}`; an unrecognized
 action returns `{error: "Unknown email action: ..."}`. Both are Email's own
@@ -161,17 +166,54 @@ Envelope metadata never reaches an action implementation: `reasoning`,
 `base_agent._dispatch_tool` adds to every intrinsic's args) are all stripped at
 this family's own boundary.
 
+## Settings
+
+Email opts into the generic read-only settings action with the provider in
+`settings.py`. Success is only `{"settings": [...]}`. Every row contains
+exactly `key`, `current`, `default`, `configurable`, and `comment`; each
+`comment` points to the exact owner-manual heading for meaning, accepted
+values, source/precedence, configuration key, timing, sensitivity, and the
+authorized external change procedure.
+
+| Key | Current | Default | Configurable | Comment |
+|---|---:|---:|---|---|
+| `send.body_char_limit` | `50000` | `50000` | `false` | `email-manual#send-body-character-limit` |
+| `send.duplicate_free_passes` | `2` | `2` | `false` | `email-manual#duplicate-send-loop-guard` |
+| `check.result_token_limit` | `10000` | `10000` | `false` | `email-manual#check-result-token-limit` |
+| `unread.max_entries` | `10` | `10` | `false` | `email-manual#unread-notification-entry-limit` |
+| `manifest.pseudo_agent_subscriptions` | `<redacted>` | `<redacted>` | `true` | `email-manual#pseudo-agent-subscriptions` |
+
+The first four rows are installed-code facts consumed by Email operations.
+The fifth reads the actual paths resolved once by
+`PosixFilesystemMailAdapter` at construction. Its private sensitive flag fully
+redacts both current and meaningful default (`["../human"]`) and is never
+projected. If applied truth is unavailable or malformed, the provider raises
+and the complete action becomes the fixed generic `SETTINGS_UNAVAILABLE`
+failure with no partial rows or exception detail. Non-empty input is rejected;
+there is no set/reset/writer. The generic complete-response bound remains
+65,536 UTF-8 bytes.
+
+`manifest.pseudo_agent_subscriptions` is configurable only through that exact
+existing `init.json` manifest field. CLI composition supplies the absent-field
+default and constructs the mail adapter; ordinary refresh does not rebuild the
+adapter, so an authorized edit requires full relaunch. No Email environment or
+owner-file peer exists. Mailbox/session paths, addresses, identity, contacts,
+content, attachments, and read/archive state are excluded rather than merely
+redacted.
+
 ## Declared host plugin
 
 `email` is an official declared host plugin under
 [`src/lingtai/kernel/tool_plugin/CONTRACT.md`](../../kernel/tool_plugin/CONTRACT.md).
 Its module-level `DECLARATION` is static: it derives its thirteen operational
 actions and per-action schemas from the existing family registry, appends the
-reserved `manual` only through the declaration, and names the existing package
-manual destination `email`.
+generic reserved `settings` child through `settings=True`, appends `manual`
+only through the declaration, and names the existing package manual destination
+`email`.
 
-The Email package owns the manager-facing `EmailRuntimeRequest` value and
-`EmailRuntimePort.handle_email()` operation (`src/lingtai/tools/email/__init__.py`).
+The Email package owns the manager-facing `EmailRuntimeRequest` value plus
+`EmailRuntimePort.handle_email()` and the narrow applied-subscription read
+(`src/lingtai/tools/email/__init__.py`).
 Operational children receive one fixed action plus its validated input through
 that port; they never receive an Agent, a capability-name lookup, or a generic
 `dispatch(args)` vocabulary. Family normalization is `_strip_nulls()` before the
@@ -183,8 +225,8 @@ injected `official_plugin` in `src/lingtai/tools/registry.py`, so
 `BaseAgent._boot_official_intrinsics()` invokes `email.boot(agent)` on
 construction and refresh. That boot creates/replaces `EmailManager` first, then
 calls `register_agent_tool_plugins(..., extra_ports_for=...)`. Its sole extra
-port is `AgentEmailRuntimeAdapter(lambda: getattr(agent, "_email_manager",
-None))`. The adapter owns no Agent object: it rejects an undeclared action,
+port is `AgentEmailRuntimeAdapter` with call-time manager and mail-adapter
+snapshot readers. The adapter owns no Agent object: it rejects an undeclared action,
 looks up the current manager at invocation time, and calls exactly once with
 `{"action": request.action, **dict(request.input)}`. It never captures
 `agent._intrinsics` and never recurses through the official handler. Thus a
@@ -213,6 +255,10 @@ foreign-action rejection before manager invocation, normalization-before-request
 one real-Agent mount, canonical package manual, one model-facing schema, no
 capability/manifest row for null or disabled input, and call-time observation of
 a manager replacement after refresh.
+`tests/test_email_settings.py` proves exact row/order/field equality,
+source-backed constants, full subscription-list redaction, stable manual
+anchors, whole-inventory failure, strict SHOW-only input, the applied POSIX
+construction snapshot, and an unchanged ordinary contacts call.
 
 ## State & storage
 
@@ -267,7 +313,8 @@ mailbox/contacts.json                 — contact book (list of {address,name,no
 | Sender identity is carried on inbound mail and surfaced on read | `src/lingtai/tools/email/manager.py:_inject_identity` | `tests/test_email_identity.py` |
 | Abs-mode replies resolve via `_return_route`, guarding the `#145` ambiguous self-route | `src/lingtai/tools/email/manager.py:_resolve_reply_target` | `tests/test_email_abs_reply_route.py` |
 | The model-facing root is the closed LTP v2 envelope and nothing else | `src/lingtai/tools/email/__init__.py:get_schema` | `tests/test_tool_family_email_migration.py::test_root_is_the_closed_ltp_v2_envelope_and_nothing_else` |
-| All 14 public action values and their order are unchanged | `src/lingtai/tools/email/_family_schema.py:ACTION_ORDER` | `tests/test_tool_family_email_migration.py::test_public_action_values_and_order_are_unchanged` |
+| Thirteen operational action values remain pinned and generic `settings` is immediately before `manual` | `src/lingtai/tools/email/__init__.py:DECLARATION` | `tests/test_tool_family_email_migration.py::test_settings_is_the_only_added_public_action_and_order_is_pinned`, `tests/test_email_settings.py::test_declaration_opts_in_immediately_before_manual` |
+| Settings shares operational constants, projects five ordered fields, fully redacts subscriptions, and has no writer | `src/lingtai/tools/email/settings.py` | `tests/test_email_settings.py` |
 | One child registry drives both the advertised schema and dispatch | `src/lingtai/tools/email/__init__.py:_build_family` | `tests/test_tool_family_email_migration.py::test_one_canonical_child_registry_drives_schema_and_dispatch` |
 | A cross-action key is rejected before any mailbox I/O or delivery | `src/lingtai/tools/tool_family/__init__.py:ToolFamily.handle` | `tests/test_tool_family_email_migration.py::test_cross_action_key_is_rejected_before_any_mailbox_io`, `::test_send_fields_cannot_be_smuggled_through_a_read_call` |
 | Reserved `unread` keeps its exact rejection and is not a public child | `src/lingtai/tools/email/__init__.py:handle` | `tests/test_tool_family_email_migration.py::test_reserved_unread_keeps_its_exact_rejection_before_dispatch` |
@@ -291,12 +338,13 @@ mailbox/contacts.json                 — contact book (list of {address,name,no
 | Cross-action smuggle rejected before side effects | `tests/test_tool_family_email_migration.py::test_send_fields_cannot_be_smuggled_through_a_read_call` | Call `read` with `address`/`message` in `input` | Mail could leave the agent via a read-shaped call |
 | Email manager requests use the typed domain port and reject foreign actions | `tests/test_email_official_tool_plugin.py::test_email_runtime_port_is_domain_specific_and_rejects_foreign_action` | Bind the runtime adapter and inspect its request | A generic dispatcher leaks unrelated capability vocabulary |
 | Official Email mount creates no dynamic capability or persisted manifest row | `tests/test_email_official_tool_plugin.py::test_official_email_mount_keeps_real_agent_runtime_and_package_manual`, `::test_email_opt_out_forms_keep_one_official_surface_on_construction_and_refresh` | Inspect `_capabilities` and `_build_manifest()` after construction and refresh | Avatar replay/identity state gains a false Email capability |
+| Settings is read-only and private state stays absent/redacted | `tests/test_email_settings.py` | Call SHOW and follow every `comment` into `email-manual` | Local paths or Email domain data leak, or output grows beyond five fields |
 | `email.boot` runs exactly once per construction and per refresh | `tests/test_email_official_tool_plugin.py::test_email_official_boot_runs_exactly_once_per_construction_and_refresh` | Count official boots, Email registrar calls, and `EmailManager` constructions per phase | A second boot silently repeats manager/grant/bind/mount work behind one final surface |
 
 Run before merging email changes:
 
 ```bash
-python -m pytest tests/test_layers_email.py tests/test_email_identity.py tests/test_email_abs_reply_route.py tests/test_system_dismiss.py tests/test_tool_family_email_migration.py tests/test_tool_family_email_wire_parity.py tests/test_email_official_tool_plugin.py -q
+PYTHONDONTWRITEBYTECODE=1 python -m pytest -q -p no:cacheprovider tests/test_layers_email.py tests/test_email_identity.py tests/test_email_abs_reply_route.py tests/test_system_dismiss.py tests/test_tool_family_email_migration.py tests/test_tool_family_email_wire_parity.py tests/test_email_official_tool_plugin.py tests/test_email_settings.py
 ```
 
 ## Schema and glossary ownership

--- a/src/lingtai/tools/email/__init__.py
+++ b/src/lingtai/tools/email/__init__.py
@@ -7,9 +7,10 @@ The tool is an LTP v2 family (``../CONTRACT.md``): the model-facing root is
 the closed ``action`` + ``input`` + ``reasoning`` + ``summarize`` envelope,
 and each action's arguments live in its own strict ``input`` object composed
 by the generic ``ToolFamily`` infra (``lingtai.tools.tool_family``) from the
-per-action schemas in :mod:`._family_schema`. The public tool name stays
-``email`` and every ``action`` value is unchanged; only the call envelope
-moved. ``EmailManager.handle``'s historical flat argument shape is retained
+per-action schemas in :mod:`._family_schema`. The public tool name and thirteen
+operational action values stay unchanged; the generic opt-in inserts only
+``settings`` before ``manual``. ``EmailManager.handle``'s historical flat
+argument shape is retained
 unchanged as a purely *internal* interface — the same seam ``shell`` kept for
 its ``ShellManager`` (``tools/CONTRACT.md`` "Relationship to current
 runtime") — and :func:`handle` translates the envelope into it.
@@ -17,6 +18,7 @@ runtime") — and :func:`handle` translates the envelope into it.
 Sub-modules:
     primitives.py     — Mailbox I/O, ID generation, read tracking, delivery, display.
     _family_schema.py — Canonical per-action ``input`` schemas + action order.
+    settings.py       — Read-only Email settings rows and policy constants.
     schema.py         — Legacy flat schema/description (internal manager shape).
     manager.py        — EmailManager class (the core filesystem manager).
 
@@ -82,6 +84,9 @@ class EmailRuntimePort(Protocol):
     def handle_email(self, request: EmailRuntimeRequest) -> EmailResult:
         """Execute one Email action without exposing an Agent or generic lookup."""
 
+    def read_pseudo_agent_subscriptions(self) -> tuple[str, ...]:
+        """Read the effective mail-adapter construction snapshot."""
+
 
 # --- Re-exports from sub-modules for backward compatibility ---
 
@@ -126,6 +131,7 @@ from ._family_schema import ACTION_ENUM_DESCRIPTION, ACTION_ORDER, INPUT_SCHEMAS
 
 # Manager
 from .manager import EmailManager  # noqa: F401
+from .settings import email_settings_rows
 
 
 # ---------------------------------------------------------------------------
@@ -159,8 +165,8 @@ def _schema_only_family() -> ToolFamily:
     import time. The real handlers need an ``agent``, which only arrives per
     call, so :func:`handle` builds a per-call family with bound handlers and
     this module-level one never dispatches. Constructing it at import time is
-    still load-bearing: it proves the fixed fourteen-child registry has no
-    duplicate and no reserved-name collision on ``manual``
+    still load-bearing: it proves the fixed fifteen-child public registry has
+    no duplicate or reserved-name collision
     (``ToolFamilyError`` raises here, at import, rather than shipping
     silently).
     """
@@ -173,8 +179,9 @@ def _schema_only_family() -> ToolFamily:
         DECLARATION.name,
         [
             ChildTool(action, schemas[action], _unused, title=f"{action} input")
-            for action in DECLARATION.public_actions
+            for action in (*DECLARATION.actions, "manual")
         ],
+        settings_provider=email_settings_rows,
     )
 
 
@@ -307,6 +314,9 @@ def _build_bound_family(host: "ToolPluginHost") -> ToolFamily:
             ],
             build_manual_child(host.workdir, DECLARATION.manual),
         ],
+        settings_provider=lambda: email_settings_rows(
+            runtime.read_pseudo_agent_subscriptions
+        ),
     )
 
 
@@ -354,6 +364,7 @@ DECLARATION = ToolPluginDeclaration(
     # only by the package-owned manual child.
     requires=("workdir", "email_runtime"),
     glossary_package=__package__,
+    settings=True,
 )
 
 
@@ -404,7 +415,20 @@ def _build_family(agent) -> ToolFamily:
         for action in DECLARATION.actions
     ]
     children.append(build_manual_child(agent, DECLARATION.manual))
-    return ToolFamily(DECLARATION.name, children)
+
+    def _read_pseudo_agent_subscriptions() -> tuple[str, ...]:
+        service = getattr(agent, "_mail_service", None)
+        if service is None:
+            raise RuntimeError("Email mail service is unavailable")
+        return service.pseudo_agent_subscriptions
+
+    return ToolFamily(
+        DECLARATION.name,
+        children,
+        settings_provider=lambda: email_settings_rows(
+            _read_pseudo_agent_subscriptions
+        ),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -492,7 +516,11 @@ def boot(agent) -> None:
         extra_ports_for=lambda declaration: (
             {
                 "email_runtime": AgentEmailRuntimeAdapter(
-                    lambda: getattr(agent, "_email_manager", None)
+                    lambda: getattr(agent, "_email_manager", None),
+                    lambda: getattr(
+                        getattr(agent, "_mail_service", None),
+                        "pseudo_agent_subscriptions",
+                    ),
                 )
             }
             if declaration is DECLARATION

--- a/src/lingtai/tools/email/_family_schema.py
+++ b/src/lingtai/tools/email/_family_schema.py
@@ -1,7 +1,8 @@
 """Schema data — canonical per-action ``input`` schemas for the ``email`` family.
 
-This module holds only data: one strict, closed ``input_schema`` per public
-``email`` action (:data:`INPUT_SCHEMAS`), the canonical action order
+This module holds only data: one strict, closed ``input_schema`` per
+operational/manual ``email`` action (:data:`INPUT_SCHEMAS`), the canonical
+pre-settings action order
 (:data:`ACTION_ORDER`), and the canonical English action prose
 (:data:`ACTION_ENUM_DESCRIPTION`).  ``__init__.py`` composes these into the
 public model-facing schema via the generic ``ToolFamily`` infra
@@ -18,9 +19,11 @@ exactly what each file is for.
 
 Field descriptions are reused verbatim from ``schema.py``'s flat properties
 wherever the field is the same field, so the migration changes the envelope
-and not the prose the model reads.  ``ACTION_ORDER`` is the single source for
-the ``action`` enum order, the ``input.oneOf``/``allOf`` branch order, and the
-child registration order in ``__init__.py`` — one list, not three.
+and not the prose the model reads. ``ACTION_ORDER`` owns the operational/manual
+order and child registration order in ``__init__.py``. The generic declaration
+opt-in inserts ``settings`` immediately before ``manual`` and consequently
+composes the public ``input.anyOf``/``allOf`` order without adding a
+hand-authored schema here.
 
 Optional fields are declared in the provider-compatible nullable
 representation (``"type": [..., "null"]`` plus membership in ``required``) per
@@ -38,9 +41,9 @@ from typing import Any
 from .primitives import mode_field
 from ..tool_family.manual import MANUAL_INPUT_SCHEMA
 
-# The canonical public action order. Identical to the pre-migration flat
-# ``schema.py`` ``action`` enum, in the same order, including the reserved
-# family-owned ``manual`` last.
+# The canonical operational/manual action order. Identical to the pre-settings
+# flat ``schema.py`` ``action`` enum, including family-owned ``manual`` last;
+# the generic declaration seam inserts ``settings`` immediately before it.
 ACTION_ORDER: tuple[str, ...] = (
     "send", "check", "read", "dismiss", "reply", "reply_all",
     "search", "archive", "delete",
@@ -382,7 +385,7 @@ _EDIT_CONTACT_INPUT_SCHEMA: dict[str, Any] = {
     "additionalProperties": False,
 }
 
-#: One strict ``input_schema`` per public action. The reserved ``manual``
+#: One strict ``input_schema`` per operational/manual action. The reserved ``manual``
 #: child references the exported canonical ``MANUAL_INPUT_SCHEMA`` literal
 #: rather than restating it (``tool_family/CONTRACT.md``: families MUST NOT
 #: restate it locally), so the schema-only family composed here and the real
@@ -423,7 +426,8 @@ ACTION_ENUM_DESCRIPTION = (
     "notification. reply: reply to email (requires email_id, message). "
     "reply_all: reply to all recipients. search: regex search mailbox. "
     "archive/delete: move/remove from inbox or archive. "
-    "contacts/add_contact/remove_contact/edit_contact manage contacts. manual "
+    "contacts/add_contact/remove_contact/edit_contact manage contacts. "
+    "settings shows read-only Email policy/source truth. manual "
     "returns the installed email-manual skill without reading or changing "
     "mailbox state."
 )

--- a/src/lingtai/tools/email/manager.py
+++ b/src/lingtai/tools/email/manager.py
@@ -20,7 +20,6 @@ from lingtai.kernel.time_veil import scrub_time_fields
 from lingtai.kernel.token_counter import count_tokens
 
 from .primitives import (
-    EMAIL_BODY_CHAR_LIMIT,
     _coerce_address_list,
     _email_time,
     _is_self_send,
@@ -39,6 +38,11 @@ from .primitives import (
     _save_read_ids,
     _sent_dir,
 )
+from .settings import (
+    EMAIL_BODY_CHAR_LIMIT,
+    EMAIL_CHECK_RESULT_TOKEN_LIMIT,
+    EMAIL_DUPLICATE_FREE_PASSES,
+)
 
 if TYPE_CHECKING:
     from lingtai.kernel.base_agent import BaseAgent
@@ -51,7 +55,7 @@ class EmailManager:
         self._agent = agent
         # Track consecutive identical sends per recipient to block loops.
         self._last_sent: dict[str, tuple[str, int]] = {}
-        self._dup_free_passes = 2  # allow this many identical sends
+        self._dup_free_passes = EMAIL_DUPLICATE_FREE_PASSES
 
     @property
     def _mailbox_path(self) -> Path:
@@ -403,8 +407,12 @@ class EmailManager:
 
         result = {"status": "ok", "total": total, "showing": len(summaries), "emails": summaries}
         tokens = count_tokens(json.dumps(result, ensure_ascii=False))
-        if tokens > 10_000:
-            while summaries and count_tokens(json.dumps(result, ensure_ascii=False)) > 10_000:
+        if tokens > EMAIL_CHECK_RESULT_TOKEN_LIMIT:
+            while (
+                summaries
+                and count_tokens(json.dumps(result, ensure_ascii=False))
+                > EMAIL_CHECK_RESULT_TOKEN_LIMIT
+            ):
                 summaries.pop()
                 result["emails"] = summaries
                 result["showing"] = len(summaries)

--- a/src/lingtai/tools/email/manual/SKILL.md
+++ b/src/lingtai/tools/email/manual/SKILL.md
@@ -3,20 +3,22 @@ name: email-manual
 description: >
   Operational guide for the `email` tool — LingTai email protocol within your
   `.lingtai/` network. Covers send/check/read/dismiss/reply/reply_all/search/
-  archive/delete/contacts, reply discipline, bare-path addressing (`human`,
+  archive/delete/contacts/settings, reply discipline, bare-path addressing (`human`,
   `mimo-1`) and `peer`/`abs` modes, self-send notes that survive molt, delayed
   self-send time capsules, the full-body persistent notification contract, and
   the 50,000-char send cap. INTERNAL only — real internet email is `mcp-manual`;
   recurring schedules are `shell-manual`. Calls use the LTP v2
   action/input/reasoning envelope.
-version: 1.1.0
+version: 1.2.1
 tags: [capabilities, email, communication]
-last_changed_at: "2026-07-27T00:00:00Z"
+last_changed_at: "2026-08-29T00:00:00Z"
 related_files:
 - src/lingtai/tools/email/__init__.py
 - src/lingtai/tools/email/_family_schema.py
 - src/lingtai/tools/email/manager.py
 - src/lingtai/tools/email/primitives.py
+- src/lingtai/tools/email/settings.py
+- src/lingtai/adapters/posix/mail.py
 - src/lingtai/tools/email/ANATOMY.md
 - src/lingtai/tools/email/CONTRACT.md
 maintenance: |
@@ -56,14 +58,112 @@ schema:
 `summarize=true` is reasonable when you only need the gist. Leave it false
 when you need exact IDs, addresses, or verbatim body text, because you will
 act on those literally. Every other action (`send`, `dismiss`, `reply`,
-`reply_all`, `archive`, `delete`, the four contact verbs) is
+`reply_all`, `archive`, `delete`, the four contact verbs, `settings`) is
 **short-result**: its receipt is small and meant to be read exactly, so leave
 `summarize` false. Call `manual` itself with `summarize=false` so procedure
 and constraints are not summarized away.
 
-**Settings:** `email` supports no settings file at either level — there is no
-`settings/email.json` and no `settings/email.<action>.json`. Its behavior is
-governed by this manual and the tool's own defaults.
+**Settings:** `email(action="settings", input={}, reasoning="inventory Email policy")`
+is SHOW-only and returns exactly five fields per row: `key`, `current`,
+`default`, `configurable`, and an exact section pointer in `comment`. It has no
+set/reset or other mutation input. Read the [settings reference](#settings-reference)
+below for source, precedence, accepted values, timing, sensitivity, and the
+actual owner procedure. A second SHOW verifies the effective snapshot after an
+authorized external change and full relaunch.
+
+## Settings reference
+
+Email supports no owner settings file or environment peer: there is no
+`settings/email.json`, no `settings/email.<action>.json`, and no
+`LINGTAI_EMAIL_*`. Four installed policy limits are public and
+non-configurable. The pseudo-agent subscription list is the one configurable
+row, owned by the existing launcher manifest path. Mailbox/session paths,
+addresses, identities, contacts, messages, attachments, and read/archive state
+are private runtime or domain data, not settings, and never appear.
+
+`LINGTAI_AGENT_ALIVE_THRESHOLD_SEC` remains kernel liveness policy and
+`LINGTAI_NOTIFICATION_MAX_CHARS` remains Notification presentation policy;
+Email does not claim either environment variable. Per-call `send`/`check`
+options are action input rather than persisted settings. The legacy
+200-character digest-renderer prose is discarded by the live full-body
+notification publisher, so it is not an effective Email setting.
+
+### Send body character limit
+
+- Key: `send.body_char_limit`; current and meaningful default: integer `50000`.
+- Meaning: maximum accepted internal-email body length, in Unicode characters;
+  an oversize `send` is refused before delivery.
+- Accepted configuration values: none. The installed integer constant in
+  `email/settings.py` is consumed directly by send and unread-notification code.
+- Source and precedence: installed code only. Canonical environment variable
+  and config key: none. It is public, not sensitive.
+- Application timing and authorized change procedure: `configurable` is false.
+  Only a reviewed product-code/package change followed by a full agent relaunch
+  can change it; SHOW never writes. Re-run SHOW after relaunch.
+
+### Duplicate send loop guard
+
+- Key: `send.duplicate_free_passes`; current and meaningful default: integer
+  `2`.
+- Meaning: number of consecutive identical sends allowed per recipient before
+  Email blocks the next duplicate as a loop.
+- Accepted configuration values: none. The installed constant in
+  `email/settings.py` initializes each `EmailManager`.
+- Source and precedence: installed code only. Canonical environment variable
+  and config key: none. It is public, not sensitive.
+- Application timing and authorized change procedure: `configurable` is false.
+  Only a reviewed code/package change plus full relaunch changes it; verify with
+  a second SHOW.
+
+### Check result token limit
+
+- Key: `check.result_token_limit`; current and meaningful default: integer
+  `10000`.
+- Meaning: token budget for one `check` result; Email removes summaries until
+  the serialized response fits.
+- Accepted configuration values: none. The installed constant in
+  `email/settings.py` is consumed directly by `EmailManager._check`.
+- Source and precedence: installed code only. Canonical environment variable
+  and config key: none. It is public, not sensitive.
+- Application timing and authorized change procedure: `configurable` is false.
+  Only a reviewed code/package change plus full relaunch changes it; verify with
+  a second SHOW.
+
+### Unread notification entry limit
+
+- Key: `unread.max_entries`; current and meaningful default: integer `10`.
+- Meaning: maximum number of newest unread message entries projected into one
+  Email notification mirror; the total unread count remains exact.
+- Accepted configuration values: none. The installed constant in
+  `email/settings.py` supplies the unread-renderer defaults.
+- Source and precedence: installed code only. Canonical environment variable
+  and config key: none. It is public, not sensitive.
+- Application timing and authorized change procedure: `configurable` is false.
+  Only a reviewed code/package change plus full relaunch changes it; verify with
+  a second SHOW.
+
+### Pseudo-agent subscriptions
+
+- Key: `manifest.pseudo_agent_subscriptions`; current and default are always
+  `<redacted>`. Both are path lists and are fully redacted by construction.
+- Meaning: pseudo-agent directories whose outboxes the POSIX mail adapter polls
+  in addition to its own inbox. SHOW reads the adapter's effective list after
+  those paths were resolved once against the agent workdir at construction.
+- Accepted values: a JSON list of path strings. An empty list disables these
+  subscriptions. The launcher's meaningful default when the field is absent is
+  `["../human"]`. The init schema checks that the outer value is a list; an
+  element that cannot be interpreted as a path fails mail-adapter construction
+  instead of being silently ignored.
+- Source and precedence: only `init.json` key
+  `manifest.pseudo_agent_subscriptions`; there is no environment or owner-file
+  peer. The raw configured/resolved lists are sensitive local routing data and
+  must not be copied from logs or inferred from SHOW.
+- Application timing and authorized change procedure: `configurable` is true.
+  After explicit owner/human authorization, edit that exact `init.json` field
+  with the existing File or Shell capability, then perform a full agent
+  relaunch. Ordinary refresh does not reconstruct the mail adapter and cannot
+  apply this field. Call SHOW again after relaunch; it confirms availability
+  and redaction, never the raw paths.
 
 ## 1. What is internal email
 
@@ -162,6 +262,8 @@ When you mention the sender in a reply body or in a summary you give the human, 
 | `add_contact`     | Add or upsert by `address`                                         | `address`, `name`, optional `note`                 |
 | `remove_contact`  | Remove by `address`                                                | `address`                                          |
 | `edit_contact`    | Update fields                                                      | `address`, plus the fields to change               |
+| `settings`        | SHOW Email policy/source truth; no mutation input exists           | —                                                  |
+| `manual`          | Return this installed Email manual                                 | —                                                  |
 
 ### `read` vs `dismiss` — when to use which
 

--- a/src/lingtai/tools/email/primitives.py
+++ b/src/lingtai/tools/email/primitives.py
@@ -19,11 +19,7 @@ from lingtai.kernel.i18n import t
 # ``__init__``) so existing ``lingtai.tools.email._new_mailbox_id`` importers still work.
 from lingtai.kernel.services.mail import _new_mailbox_id  # noqa: F401
 
-
-# Internal email bodies are injected in full into the persistent notification
-# lane.  Keep the sending boundary large but finite so notification rendering
-# never has to truncate ordinary unread mail.
-EMAIL_BODY_CHAR_LIMIT = 50_000
+from .settings import EMAIL_BODY_CHAR_LIMIT, EMAIL_UNREAD_MAX_ENTRIES
 
 
 def mode_field(lang: str = "en") -> dict:
@@ -336,7 +332,12 @@ def _email_time(e: dict) -> str:
 # Unread digest rendering
 # ---------------------------------------------------------------------------
 
-def _unread_notification_context(agent, *, max_entries: int = 10, preview_chars: int = 500) -> tuple[list[dict], list[str]]:
+def _unread_notification_context(
+    agent,
+    *,
+    max_entries: int = EMAIL_UNREAD_MAX_ENTRIES,
+    preview_chars: int = 500,
+) -> tuple[list[dict], list[str]]:
     """Return full unread email bodies for notification persistence.
 
     Internal email is capped at send time (``EMAIL_BODY_CHAR_LIMIT``), so the
@@ -403,7 +404,12 @@ def _unread_notification_context(agent, *, max_entries: int = 10, preview_chars:
     return emails, email_ids
 
 
-def _render_unread_digest(agent, *, max_entries: int = 10, preview_chars: int = 200) -> tuple[str, int, str | None]:
+def _render_unread_digest(
+    agent,
+    *,
+    max_entries: int = EMAIL_UNREAD_MAX_ENTRIES,
+    preview_chars: int = 200,
+) -> tuple[str, int, str | None]:
     """Compute and render the current unread mail digest.
 
     Returns ``(body, count, newest_received_at)``:

--- a/src/lingtai/tools/email/settings.py
+++ b/src/lingtai/tools/email/settings.py
@@ -1,0 +1,71 @@
+"""Source-backed display rows for Email's read-only settings action."""
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+
+from ..tool_family import SettingRow
+
+# Installed-code policies. Operational consumers import these constants so
+# SHOW cannot drift from the values that actually govern Email behavior.
+EMAIL_BODY_CHAR_LIMIT = 50_000
+EMAIL_DUPLICATE_FREE_PASSES = 2
+EMAIL_CHECK_RESULT_TOKEN_LIMIT = 10_000
+EMAIL_UNREAD_MAX_ENTRIES = 10
+
+
+_FIXED_ROWS = (
+    SettingRow(
+        "send.body_char_limit",
+        EMAIL_BODY_CHAR_LIMIT,
+        EMAIL_BODY_CHAR_LIMIT,
+        False,
+        "email-manual#send-body-character-limit",
+    ),
+    SettingRow(
+        "send.duplicate_free_passes",
+        EMAIL_DUPLICATE_FREE_PASSES,
+        EMAIL_DUPLICATE_FREE_PASSES,
+        False,
+        "email-manual#duplicate-send-loop-guard",
+    ),
+    SettingRow(
+        "check.result_token_limit",
+        EMAIL_CHECK_RESULT_TOKEN_LIMIT,
+        EMAIL_CHECK_RESULT_TOKEN_LIMIT,
+        False,
+        "email-manual#check-result-token-limit",
+    ),
+    SettingRow(
+        "unread.max_entries",
+        EMAIL_UNREAD_MAX_ENTRIES,
+        EMAIL_UNREAD_MAX_ENTRIES,
+        False,
+        "email-manual#unread-notification-entry-limit",
+    ),
+)
+
+
+def email_settings_rows(
+    read_pseudo_agent_subscriptions: Callable[[], Sequence[str]] | None = None,
+) -> tuple[SettingRow, ...]:
+    """Return Email's effective construction snapshot or fail as one inventory."""
+    if read_pseudo_agent_subscriptions is None:
+        raise RuntimeError("Email pseudo-agent subscription snapshot is unavailable")
+    subscriptions = read_pseudo_agent_subscriptions()
+    if isinstance(subscriptions, (str, bytes)) or not isinstance(
+        subscriptions, Sequence
+    ):
+        raise RuntimeError("Email pseudo-agent subscription snapshot is invalid")
+    if not all(isinstance(item, str) for item in subscriptions):
+        raise RuntimeError("Email pseudo-agent subscription snapshot is invalid")
+    return (
+        *_FIXED_ROWS,
+        SettingRow(
+            "manifest.pseudo_agent_subscriptions",
+            list(subscriptions),
+            ["../human"],
+            True,
+            "email-manual#pseudo-agent-subscriptions",
+            _sensitive=True,
+        ),
+    )

--- a/src/lingtai/tools/system/CONTRACT.md
+++ b/src/lingtai/tools/system/CONTRACT.md
@@ -159,8 +159,8 @@ verification live only in the manual section named by `comment`. Legacy
 The owner-local classification explicitly excludes settings assigned to Soul,
 Shell, Daemon, Notification, Email, File, Vision, Web, Task Card,
 Plugin/Psyche, MCP, and curated-addon ToolPlugins. In particular,
-`manifest.pseudo_agent_subscriptions` is Email-owned and is reserved for a
-future Email owner-local row that fully redacts its path lists; System does not
+`manifest.pseudo_agent_subscriptions` is Email-owned and is projected only by
+Email's owner-local row, which fully redacts both path lists; System does not
 project it. Psyche owns the live root `pad` / `pad_file` prompt inputs, so they
 are concrete-owner exclusions rather than inert compatibility fields. Daemon's
 manager-pool variable is a registered concrete-owner setting; its manager token

--- a/src/lingtai/tools/system/settings.py
+++ b/src/lingtai/tools/system/settings.py
@@ -215,8 +215,8 @@ SYSTEM_INIT_CONCRETE_TOOL_EXCLUSIONS = frozenset(
         "/lingtai_file",
         "/manifest/capabilities",
         "/manifest/plugins",
-        # Email owns these mail-adapter subscription paths. Its eventual
-        # owner-local discovery row must fully redact the path list.
+        # Email owns these mail-adapter subscription paths. Its owner-local
+        # discovery row fully redacts both current and default path lists.
         "/manifest/pseudo_agent_subscriptions",
         "/manifest/soul",
     }

--- a/tests/test_email_official_tool_plugin.py
+++ b/tests/test_email_official_tool_plugin.py
@@ -6,15 +6,22 @@ import json
 import pytest
 
 from lingtai.agent import Agent
+from lingtai.adapters.posix.mail import PosixFilesystemMailAdapter
 from tests._service_helpers import make_gemini_mock_service
 
 
 @pytest.fixture
 def email_agent(tmp_path):
+    workdir = tmp_path / "agent"
+    mail_service = PosixFilesystemMailAdapter(
+        workdir,
+        pseudo_agent_subscriptions=["../private-email-settings-marker"],
+    )
     agent = Agent(
         service=make_gemini_mock_service(),
         agent_name="email-official-plugin",
-        working_dir=tmp_path / "agent",
+        working_dir=workdir,
+        mail_service=mail_service,
         capabilities={},
     )
     try:
@@ -88,6 +95,8 @@ def test_email_runtime_port_is_domain_specific_and_rejects_foreign_action():
     with pytest.raises(ValueError, match="unsupported Email runtime action"):
         adapter.handle_email(EmailRuntimeRequest("mcp", {}))
     assert manager.calls == [{"action": "check", "folder": "inbox"}]
+    with pytest.raises(RuntimeError, match="snapshot is unavailable"):
+        adapter.read_pseudo_agent_subscriptions()
 
 
 def test_email_bound_family_normalizes_before_typed_runtime_and_preserves_results(
@@ -190,6 +199,19 @@ def test_official_email_mount_keeps_real_agent_runtime_and_package_manual(email_
     assert handler({"action": "check", "input": {}, "reasoning": "inspect"}) == {
         "status": "ok", "total": 0, "showing": 0, "emails": []
     }
+
+    settings = handler(
+        {"action": "settings", "input": {}, "reasoning": "inventory policy"}
+    )
+    pseudo_row = settings["settings"][-1]
+    assert pseudo_row == {
+        "key": "manifest.pseudo_agent_subscriptions",
+        "current": "<redacted>",
+        "default": "<redacted>",
+        "configurable": True,
+        "comment": "email-manual#pseudo-agent-subscriptions",
+    }
+    assert "private-email-settings-marker" not in repr(settings)
 
     manual = handler({"action": "manual", "input": {}, "reasoning": "procedure"})
     assert manual["status"] == "ok"

--- a/tests/test_email_settings.py
+++ b/tests/test_email_settings.py
@@ -1,0 +1,179 @@
+"""Focused owner proofs for Email's five-field settings inventory."""
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from lingtai.tools import email as email_tool
+from lingtai.tools.email import manager, primitives
+from lingtai.tools.email.settings import (
+    EMAIL_BODY_CHAR_LIMIT,
+    EMAIL_CHECK_RESULT_TOKEN_LIMIT,
+    EMAIL_DUPLICATE_FREE_PASSES,
+    EMAIL_UNREAD_MAX_ENTRIES,
+)
+
+
+class _Runtime:
+    def __init__(self, subscriptions=("/private/applied-subscription",)) -> None:
+        self.calls = []
+        self.subscriptions = subscriptions
+
+    def handle_email(self, request):
+        self.calls.append(request)
+        return {"status": "ok", "contacts": []}
+
+    def read_pseudo_agent_subscriptions(self):
+        if isinstance(self.subscriptions, Exception):
+            raise self.subscriptions
+        return self.subscriptions
+
+
+def _family(runtime: _Runtime):
+    host = SimpleNamespace(workdir=Path("unused-manual-workdir"), email_runtime=runtime)
+    return email_tool._build_bound_family(host)
+
+
+def _settings(family, action_input):
+    return family.handle(
+        {"action": "settings", "input": action_input, "reasoning": "audit"}
+    )
+
+
+def test_declaration_opts_in_immediately_before_manual():
+    public = (*email_tool.DECLARATION.actions, "settings", "manual")
+    assert email_tool.DECLARATION.settings is True
+    assert email_tool.DECLARATION.public_actions == public
+    assert tuple(email_tool.get_schema()["properties"]["action"]["enum"]) == public
+
+
+def test_inventory_is_exact_source_backed_and_fully_redacts_path_lists():
+    private_marker = "/private/owner-address-and-content-marker"
+    runtime = _Runtime((private_marker,))
+
+    result = _settings(_family(runtime), {})
+
+    assert result == {
+        "settings": [
+            {
+                "key": "send.body_char_limit",
+                "current": EMAIL_BODY_CHAR_LIMIT,
+                "default": EMAIL_BODY_CHAR_LIMIT,
+                "configurable": False,
+                "comment": "email-manual#send-body-character-limit",
+            },
+            {
+                "key": "send.duplicate_free_passes",
+                "current": EMAIL_DUPLICATE_FREE_PASSES,
+                "default": EMAIL_DUPLICATE_FREE_PASSES,
+                "configurable": False,
+                "comment": "email-manual#duplicate-send-loop-guard",
+            },
+            {
+                "key": "check.result_token_limit",
+                "current": EMAIL_CHECK_RESULT_TOKEN_LIMIT,
+                "default": EMAIL_CHECK_RESULT_TOKEN_LIMIT,
+                "configurable": False,
+                "comment": "email-manual#check-result-token-limit",
+            },
+            {
+                "key": "unread.max_entries",
+                "current": EMAIL_UNREAD_MAX_ENTRIES,
+                "default": EMAIL_UNREAD_MAX_ENTRIES,
+                "configurable": False,
+                "comment": "email-manual#unread-notification-entry-limit",
+            },
+            {
+                "key": "manifest.pseudo_agent_subscriptions",
+                "current": "<redacted>",
+                "default": "<redacted>",
+                "configurable": True,
+                "comment": "email-manual#pseudo-agent-subscriptions",
+            },
+        ]
+    }
+    fields = ["key", "current", "default", "configurable", "comment"]
+    assert all(list(row) == fields for row in result["settings"])
+    assert private_marker not in repr(result)
+    assert "../human" not in repr(result)
+    assert "_sensitive" not in repr(result)
+    assert runtime.calls == []
+
+
+def test_every_comment_targets_its_exact_manual_heading():
+    comments = [row["comment"] for row in _settings(_family(_Runtime()), {})["settings"]]
+    manual = (Path(email_tool.__file__).with_name("manual") / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    expected = {
+        "email-manual#send-body-character-limit": "Send body character limit",
+        "email-manual#duplicate-send-loop-guard": "Duplicate send loop guard",
+        "email-manual#check-result-token-limit": "Check result token limit",
+        "email-manual#unread-notification-entry-limit": (
+            "Unread notification entry limit"
+        ),
+        "email-manual#pseudo-agent-subscriptions": "Pseudo-agent subscriptions",
+    }
+    assert comments == list(expected)
+    for comment, heading in expected.items():
+        assert comment.startswith("email-manual#")
+        assert f"### {heading}\n" in manual
+
+
+def test_unavailable_current_fails_whole_inventory_without_private_detail():
+    private_detail = "private unavailable-subscription detail"
+    runtime = _Runtime(RuntimeError(private_detail))
+
+    result = _settings(_family(runtime), {})
+
+    assert result == {
+        "status": "failed",
+        "error_code": "SETTINGS_UNAVAILABLE",
+        "message": "settings inventory is unavailable",
+    }
+    assert "settings" not in result
+    assert private_detail not in repr(result)
+    assert runtime.calls == []
+
+
+def test_settings_is_show_only_and_contacts_action_is_unchanged():
+    runtime = _Runtime()
+    family = _family(runtime)
+
+    refused = _settings(
+        family, {"set": "send.body_char_limit", "value": 1}
+    )
+    assert refused["status"] == "failed"
+    assert "settings" not in refused
+    assert runtime.calls == []
+
+    ordinary = family.handle(
+        {"action": "contacts", "input": {}, "reasoning": "ordinary call"}
+    )
+    assert ordinary == {"status": "ok", "contacts": []}
+    assert len(runtime.calls) == 1
+    assert runtime.calls[0].action == "contacts"
+    assert dict(runtime.calls[0].input) == {}
+
+
+def test_posix_source_is_the_applied_constructor_snapshot(tmp_path):
+    from lingtai.adapters.posix.mail import PosixFilesystemMailAdapter
+
+    configured = ["../private-pseudo-agent"]
+    service = PosixFilesystemMailAdapter(
+        tmp_path / "agent", pseudo_agent_subscriptions=configured
+    )
+    first = service.pseudo_agent_subscriptions
+    configured.append("../later-edit")
+
+    assert first == service.pseudo_agent_subscriptions
+    assert len(first) == 1
+    assert Path(first[0]).is_absolute()
+
+
+def test_operational_constants_are_the_inventory_constants():
+    assert primitives.EMAIL_BODY_CHAR_LIMIT == EMAIL_BODY_CHAR_LIMIT
+    assert primitives.EMAIL_UNREAD_MAX_ENTRIES == EMAIL_UNREAD_MAX_ENTRIES
+    assert manager.EMAIL_BODY_CHAR_LIMIT == EMAIL_BODY_CHAR_LIMIT
+    assert manager.EMAIL_DUPLICATE_FREE_PASSES == EMAIL_DUPLICATE_FREE_PASSES
+    assert manager.EMAIL_CHECK_RESULT_TOKEN_LIMIT == EMAIL_CHECK_RESULT_TOKEN_LIMIT

--- a/tests/test_system_declared_plugin.py
+++ b/tests/test_system_declared_plugin.py
@@ -2034,7 +2034,7 @@ def test_system_manual_contains_declared_ltp_and_budget_settings_contract():
         "llm.codex_tui_dir",
         "LINGTAI_TUI_DIR",
         "manifest.pseudo_agent_subscriptions",
-        "future Email-owner",
+        "Email-owner inventory",
         "fully redact both current and default path lists",
         "Psyche owns the live Pad prompt inputs",
         "resolve_env_checked",

--- a/tests/test_tool_family_email_migration.py
+++ b/tests/test_tool_family_email_migration.py
@@ -12,7 +12,8 @@ the already-migrated families are:
   disturb;
 * it keeps a **reserved non-public action** (``unread``) that is deliberately
   not a child and must keep its exact pre-migration rejection;
-* its 14 actions are by far the widest registry to migrate, so
+* its 13 operational actions plus reserved ``settings``/``manual`` children
+  form a wide registry, so
   ``action``-to-``input`` correlation and per-action key isolation carry more
   weight here than in a two-child family.
 
@@ -41,12 +42,13 @@ from tests._snapshot_helpers import (
 )
 from tests._workdir_lease_helpers import make_test_lease
 
-# The exact pre-migration public action list, restated here as a literal so a
-# silent edit to ACTION_ORDER cannot quietly redefine what this test asserts.
+# The operational/manual list stays pinned; the settings seam adds its reserved
+# child immediately before manual without editing ``ACTION_ORDER``.
 _PUBLIC_ACTIONS = [
     "send", "check", "read", "dismiss", "reply", "reply_all",
     "search", "archive", "delete",
     "contacts", "add_contact", "remove_contact", "edit_contact",
+    "settings",
     "manual",
 ]
 
@@ -107,9 +109,12 @@ def test_root_is_the_closed_ltp_v2_envelope_and_nothing_else():
         assert legacy not in schema["properties"]
 
 
-def test_public_action_values_and_order_are_unchanged():
+def test_settings_is_the_only_added_public_action_and_order_is_pinned():
     assert email_tool.get_schema()["properties"]["action"]["enum"] == _PUBLIC_ACTIONS
-    assert list(ACTION_ORDER) == _PUBLIC_ACTIONS
+    assert list(ACTION_ORDER) == [
+        action for action in _PUBLIC_ACTIONS if action != "settings"
+    ]
+    assert list(email_tool.DECLARATION.public_actions) == _PUBLIC_ACTIONS
 
 
 def test_reserved_unread_is_not_a_public_child_or_action():
@@ -123,17 +128,18 @@ def test_one_canonical_child_registry_drives_schema_and_dispatch(tmp_path):
     """The advertised actions and the dispatchable children are one list.
 
     This is the anti-drift proof the acceptance asks for: the ``action`` enum,
-    the ``input.oneOf`` branch order, the ``allOf`` condition order, and the
+    the ``input.anyOf`` branch order, the ``allOf`` condition order, and the
     real per-call dispatching family's ``child_names`` all come from
-    ``ACTION_ORDER``, so an action cannot be advertised without being
+    declaration plus settings provider, so an action cannot be advertised without being
     dispatchable (or vice versa).
     """
     schema = email_tool.get_schema()
     family = email_tool._build_family(_agent(tmp_path))
     assert list(family.child_names) == _PUBLIC_ACTIONS
     assert schema["properties"]["action"]["enum"] == list(family.child_names)
-    assert [b["title"] for b in schema["properties"]["input"]["oneOf"]] == [
-        f"{action} input" for action in family.child_names
+    assert [b["title"] for b in schema["properties"]["input"]["anyOf"]] == [
+        "settings inventory input" if action == "settings" else f"{action} input"
+        for action in family.child_names
     ]
     assert [
         c["if"]["properties"]["action"]["const"] for c in schema["allOf"]
@@ -145,7 +151,7 @@ def test_one_canonical_child_registry_drives_schema_and_dispatch(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("action", _PUBLIC_ACTIONS)
+@pytest.mark.parametrize("action", ACTION_ORDER)
 def test_every_action_input_schema_is_closed_and_self_describing(action):
     branch = INPUT_SCHEMAS[action]
     assert branch["type"] == "object"
@@ -161,7 +167,7 @@ def test_every_action_input_schema_is_closed_and_self_describing(action):
 def test_all_of_correlates_every_action_const_with_its_exact_branch_schema():
     schema = email_tool.get_schema()
     conditions = schema["allOf"]
-    branches = schema["properties"]["input"]["oneOf"]
+    branches = schema["properties"]["input"]["anyOf"]
     assert len(conditions) == len(branches) == len(_PUBLIC_ACTIONS)
     for condition, branch, action in zip(conditions, branches, _PUBLIC_ACTIONS):
         assert condition["if"]["properties"]["action"]["const"] == action
@@ -181,7 +187,7 @@ def test_manual_child_reuses_the_canonical_strict_empty_input_literal():
     byte-identical ``manual`` input.
     """
     assert INPUT_SCHEMAS["manual"] == MANUAL_INPUT_SCHEMA
-    branch = email_tool.get_schema()["properties"]["input"]["oneOf"][-1]
+    branch = email_tool.get_schema()["properties"]["input"]["anyOf"][-1]
     assert {k: v for k, v in branch.items() if k != "title"} == MANUAL_INPUT_SCHEMA
 
 
@@ -204,7 +210,7 @@ def test_action_specific_fields_live_only_in_their_own_branch():
         "name": {"add_contact", "edit_contact"},
     }
     for field, expected in owners.items():
-        actual = {a for a in _PUBLIC_ACTIONS if field in INPUT_SCHEMAS[a]["properties"]}
+        actual = {a for a in ACTION_ORDER if field in INPUT_SCHEMAS[a]["properties"]}
         assert actual == expected, field
 
 

--- a/tests/test_tool_family_email_wire_parity.py
+++ b/tests/test_tool_family_email_wire_parity.py
@@ -2,7 +2,7 @@
 
 The generic wire proof (``tests/test_tool_family_wire_parity.py``) covers the
 infrastructure using ``web``. This file is ``email``'s own: it proves the same
-seam holds for the widest child registry migrated so far (14 actions), through
+seam holds for Email's 15-child public registry, through
 a **real Agent startup** — so what is asserted is the schema the model actually
 receives after ``_build_tool_schemas`` composition, not a unit-level
 ``get_schema()`` dict.
@@ -21,6 +21,7 @@ _PUBLIC_ACTIONS = [
     "send", "check", "read", "dismiss", "reply", "reply_all",
     "search", "archive", "delete",
     "contacts", "add_contact", "remove_contact", "edit_contact",
+    "settings",
     "manual",
 ]
 
@@ -43,7 +44,7 @@ def _email_schema(tmp_path):
 
 
 def test_email_is_exactly_one_model_facing_tool(tmp_path):
-    """Children consume no model tool slots: 14 actions, one advertised tool."""
+    """Children consume no model tool slots: 15 actions, one advertised tool."""
     from lingtai.agent import Agent
     from tests._service_helpers import make_gemini_mock_service as make_mock_service
 
@@ -98,27 +99,24 @@ def test_action_input_all_of_correlation_survives_both_wires(tmp_path):
 
 
 def test_every_action_branch_is_disclosed_on_both_wires(tmp_path):
-    """All 14 branches reach the model on both routes, with closed inputs.
+    """All 15 branches reach the model on both routes, with closed inputs.
 
-    The two wires spell the discriminated union differently, and that
-    difference is the pre-existing OpenAI adapter's, not this migration's:
-    Chat Completions carries the composed ``input.oneOf`` through verbatim,
-    while ``_scrub_responses_schema`` rewrites it to ``anyOf`` for the
-    Responses route (identically for ``web``). This asserts the branch set and
-    their closedness on both, under whichever combinator that wire uses.
+    Settings opt-in makes the composed input union ``anyOf`` on both routes.
+    This asserts the branch set and their closedness on both wires.
     """
     email = _email_schema(tmp_path)
     chat = _build_tools([email])[0]["function"]["parameters"]
     responses = _build_responses_tools([email])[0]["parameters"]
 
-    assert "oneOf" in chat["properties"]["input"]
+    assert "anyOf" in chat["properties"]["input"]
     assert "anyOf" in responses["properties"]["input"]
 
     for params in (chat, responses):
         node = params["properties"]["input"]
-        branches = node.get("oneOf") or node["anyOf"]
+        branches = node["anyOf"]
         assert [b["title"] for b in branches] == [
-            f"{a} input" for a in _PUBLIC_ACTIONS
+            "settings inventory input" if a == "settings" else f"{a} input"
+            for a in _PUBLIC_ACTIONS
         ]
         for branch in branches:
             assert branch["additionalProperties"] is False

--- a/tests/test_tool_settings_contract.py
+++ b/tests/test_tool_settings_contract.py
@@ -147,10 +147,10 @@ def test_public_export_and_exact_production_opt_ins():
         name: importlib.import_module(f"lingtai.tools.{modules.get(name, name)}").DECLARATION
         for name in OFFICIAL_TOOL_PLUGIN_NAMES
     }
-    expected_official = {"avatar", "plugin", "system", "task_card"}
+    expected_official = {"avatar", "email", "plugin", "system", "task_card"}
     assert {name for name, item in declarations.items() if item.settings} == expected_official
     assert expected_curated | expected_official == {
-        "avatar", "cloud_mail", "feishu", "imap", "plugin", "system", "task_card", "whatsapp"
+        "avatar", "cloud_mail", "email", "feishu", "imap", "plugin", "system", "task_card", "whatsapp"
     }
     for name, item in declarations.items():
         assert ("settings" in item.public_actions) is (name in expected_official)


### PR DESCRIPTION
## Final sequential merge candidate

This Draft is the independent **Email** settings owner implementation rebased onto the exact cumulative main after Cloud Mail.

- exact candidate commit: `c5235fe7bc68941436b6023d0ba2155bc2820f95`
- exact parent: `3abb76a8eb9d82cf284a5fb850143b154de5d197`
- exact tree: `8512e959cbb753a187c00be5c4ff5e91b8401e9e`
- stable patch id: `5cfc34e2b2cd1cf580cee4774cf58998914bab27`
- resulting diff: **22 files changed, 647 insertions(+), 116 deletions(-)**
- one owner commit, canonical `Huang Zesen <hzsbazinga@outlook.com>` identity, clean worktree, and no tracked deletions
- all 21 non-conflict Email owner/test paths are byte-identical to the previously reviewed owner head; the shared settings manual remains byte-identical to cumulative main

## Behavior

- opts only `email` into the generic read-only `settings` action in this PR
- reports four immutable installed-code policies: body limit `50000`, duplicate-free passes `2`, check token limit `10000`, and unread notification entries `10`
- reports one configurable sensitive `manifest.pseudo_agent_subscriptions` row with both current/default fully redacted; semantic default remains `../human`
- Email has no `LINGTAI_EMAIL_*` settings environment variable and no settings file; the configurable owner is the exact agent `init.json` manifest field and requires a full relaunch, while the immutable policies require reviewed code/package change and relaunch
- adds no generic writer, `set`, `reset`, mutation receipt, or central settings registry; mailbox paths, contacts, messages, attachments, and read/archive state remain private runtime data rather than settings
- preserves cumulative curated owners `{cloud_mail, feishu, imap, whatsapp}` and official owners `{avatar, plugin, system, task_card}`, then adds only official `email`

## Validation

- complete changed-test surface plus environment/Anatomy validators: **324 passed / 2 exact-current-main baseline failures / 0 candidate-unique failures**
- both failures reproduce on clean `3abb76a8`: the Avatar fake negative-test literal and the pre-existing session-stats reciprocal-link gap
- all 21 non-conflict owner paths match old reviewed head `909634f5114105aae6d8bbbf0b90e01af9c341c3` byte-for-byte
- shared settings manual blob is exactly cumulative-main blob `e5e7f367f4d8eb2af83a96a672aa6860623d25a2`
- live Email acceptance: `email.settings` returned the exact five rows with the sensitive row redacted, and original non-side-effecting `email.contacts` returned `status=ok`
- `git diff --check`: pass

## Sequential merge boundary

Jason authorized the strict one-PR-at-a-time merge flow. This candidate is limited to Email and is ready for the exact-head report followed by the guarded squash merge of **#1531 only**. It does not authorize another owner PR, release, deploy, live runtime refresh, mailbox/contact/message mutation, operator config/auth mutation, deletion, or cleanup.

Telegram: @lingtaidev3bot | Nickname: 澄一

Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
