### PR TITLE
feat(mcp): expose five-field settings inventory

### DIFF
--- a/src/lingtai/kernel/tool_plugin/ANATOMY.md
+++ b/src/lingtai/kernel/tool_plugin/ANATOMY.md
@@ -189,7 +189,8 @@ is in [`BEHAVIORS.md`](BEHAVIORS.md).
   No adapter exposes an Agent or generic dispatcher; `agent_host_ports` and
   `register_agent_tool_plugins` construct the private registrar mount seam.
 - `src/lingtai/tools/mcp/__init__.py` — the current base reference slice.
-  Its static declaration binds the per-host family and protected prompt
+  Its static declaration opts into the reserved SHOW-only settings child and
+  binds the per-host family and protected prompt
   section; Avatar, Context, Daemon, Email, File, Plugin, Notification, Shell,
   Soul, System, Task Card, Vision, and Web are separately accepted vertical
   slices. The later-family target register is now empty; the reserved list is

--- a/src/lingtai/kernel/tool_plugin/BEHAVIORS.md
+++ b/src/lingtai/kernel/tool_plugin/BEHAVIORS.md
@@ -10,6 +10,7 @@ related_files:
   - src/lingtai/kernel/tool_plugin/__init__.py
   - src/lingtai/adapters/tool_plugin_host.py
   - src/lingtai/tools/mcp/__init__.py
+  - src/lingtai/tools/mcp/settings.py
   - src/lingtai/tools/avatar/__init__.py
   - src/lingtai/tools/context/__init__.py
   - src/lingtai/tools/daemon/__init__.py
@@ -92,7 +93,7 @@ environment (`uv venv --python 3.11 && uv pip install -e . pytest`, per
    PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -c "import sys; sys.path.insert(0, 'src'); from lingtai.tools.mcp import DECLARATION as mcp; from lingtai.tools.file import DECLARATION as file; print(mcp.name, mcp.actions, mcp.public_actions, mcp.requires); print(file.name, file.actions, file.public_actions, file.requires)"
    ```
 
-   Expect `mcp ('info',) ('info', 'manual') ('workdir', 'prompt_section')` and
+   Expect `mcp ('info',) ('info', 'settings', 'manual') ('workdir', 'prompt_section')` and
    `file ('read', 'write', 'edit', 'glob', 'grep') ('read', 'write', 'edit',
    'glob', 'grep', 'manual') ('workdir', 'file_io')`. No `Agent` was constructed;
    each reserved `manual` action is appended, not declared.
@@ -132,13 +133,13 @@ environment (`uv venv --python 3.11 && uv pip install -e . pytest`, per
    its typed `web_runtime` composition is not in existence yet — only
    `setup` composes and grants it.
 
-2. Prove the public model-facing surface is unchanged by the recut:
+2. Prove the public model-facing surface contains the bounded owner addition:
 
    ```bash
    PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -c "import sys; sys.path.insert(0, 'src'); from lingtai.tools.mcp import get_schema; s = get_schema(); print(sorted(s['properties']), s['properties']['action']['enum'], s['additionalProperties'])"
    ```
 
-   Expect `['action', 'input', 'reasoning', 'summarize'] ['info', 'manual']
+   Expect `['action', 'input', 'reasoning', 'summarize'] ['info', 'settings', 'manual']
    False`.
 
 3. Prove a declaration is granted exactly its `requires` and nothing more:
@@ -283,9 +284,9 @@ environment (`uv venv --python 3.11 && uv pip install -e . pytest`, per
 ### Expected evidence
 
 - [ ] Step 1: MCP and File `DECLARATION`s import and validate with no Agent;
-      `manual` is in each `public_actions` but not in either `actions`.
-- [ ] Step 2: the closed LTP root and the `["info", "manual"]` enum are
-      unchanged.
+      reserved children are in `public_actions` but not in `actions`.
+- [ ] Step 2: the closed LTP root and MCP's
+      `["info", "settings", "manual"]` enum are exact.
 - [ ] Step 3: only `requires` ports are granted; an ungranted port raises
       `AttributeError`; `tool_mount` is not grantable at all; a standard-table
       port such as `plugin_catalog` is unreachable for a declaration that did

--- a/src/lingtai/tools/ANATOMY.md
+++ b/src/lingtai/tools/ANATOMY.md
@@ -140,8 +140,8 @@ capability names and lazy adapters.
   (`src/lingtai/tools/tool_family/ANATOMY.md`).
 - `plugin/` — the `plugin` capability: the per-agent Agent Plugins
   (agent-plugins.org, v1.0.0) catalog and registration snapshot, structural twin
-  of `mcp` with the same tool/service split plus Plugin's reserved read-only
-  `settings` child (`info`/`settings`/`manual`)
+  of `mcp` with the same tool/service split; both independently opt into the
+  reserved read-only `settings` child (`info`/`settings`/`manual`)
   (`src/lingtai/tools/plugin/ANATOMY.md`, `src/lingtai/tools/plugin/CONTRACT.md`).
   A plugin *declared* in `init.json` `manifest.plugins` is registered at boot —
   its validated `skills/` are named in the protected `plugins` prompt field and

--- a/src/lingtai/tools/CONTRACT.md
+++ b/src/lingtai/tools/CONTRACT.md
@@ -716,12 +716,12 @@ take the canonical strict-empty `input`, and it supports no settings file (see
 `src/lingtai/tools/knowledge/CONTRACT.md`). It remains a signpost capability
 with no authoring, search, or edit action.
 
-`mcp` (`info | manual`) is the first family declared under
-`### Tool-to-MCP Plugin Contract`: that recut is internal only — the public
-tool name, both public action values, both strict-empty `input` branches, and
-every result shape including the tool-specific `mcp_manual` body key are
-unchanged, while the family now reaches the live Agent body through two granted
-host ports instead of the whole `Agent` (see
+`mcp` (`info | settings | manual`) is the first family declared under
+`### Tool-to-MCP Plugin Contract`: the reserved settings action is the sole
+additive surface and is bound to the owner's five-field SHOW provider; the
+public tool name and existing action result shapes including the tool-specific
+`mcp_manual` body key are unchanged, while the family reaches the live Agent
+body through two granted host ports instead of the whole `Agent` (see
 `src/lingtai/tools/mcp/CONTRACT.md`).
 
 `avatar` (`spawn | rules | manual`) is the second family declared under
@@ -956,10 +956,10 @@ unmigrated and keeps its existing schema and settings surface unchanged by
 this file.
 
 `mcp` is the second migrated family: public tool name `mcp`, actions `info |
-manual`, both taking the canonical strict-empty `input`. The migration changed
-its call envelope only — no action was added, removed, renamed, or given a new
-capability; it remains signpost-only and read-only, and external MCP
-registration (direct insertion into `mcp_registry.jsonl`) is untouched by it.
+settings | manual`, all taking the canonical strict-empty `input`. The bounded
+settings owner slice is SHOW-only; existing action behavior stays read-only and
+external MCP registration (direct insertion into `mcp_registry.jsonl`) is
+untouched by it.
 See `src/lingtai/tools/mcp/CONTRACT.md`.
 
 `plugin` is `mcp`'s deliberate twin and the only family born on this envelope

--- a/src/lingtai/tools/mcp/ANATOMY.md
+++ b/src/lingtai/tools/mcp/ANATOMY.md
@@ -4,6 +4,7 @@ related_files:
   - src/lingtai/ANATOMY.md
   - src/lingtai/tools/mcp/BEHAVIORS.md
   - src/lingtai/tools/mcp/__init__.py
+  - src/lingtai/tools/mcp/settings.py
   - src/lingtai/tools/mcp/plugin.json
   - src/lingtai/agent.py
   - src/lingtai/services/mcp_inbox.py
@@ -20,6 +21,7 @@ related_files:
   - src/lingtai/tools/plugin/ANATOMY.md
   - src/lingtai/mcp_servers/ANATOMY.md
   - tests/test_mcp_capability.py
+  - tests/test_mcp_settings.py
   - tests/test_mcp_inbox.py
   - tests/test_tool_family_mcp_migration_parity.py
   - src/lingtai/tools/mcp/glossary-en.md
@@ -44,9 +46,10 @@ maintenance: |
 # lingtai/tools/mcp + lingtai/services/mcp_* (split)
 
 MCP capability — per-agent registry of MCP (Model Context Protocol) servers.
-Pure presentation: reads the registry from disk, validates records, and renders
-it as XML into the system prompt. No tool writes; all registry mutations happen
-via file operations from the agent (`write`, `edit`).
+Pure presentation: reads the registry from disk, validates records, renders it
+as XML into the system prompt, and SHOWs the two MCP-owned init settings. No
+tool writes; all configuration/registry mutations happen via explicitly
+authorized file operations from the agent (`write`, `edit`).
 
 Also includes the **LICC v1 (LingTai Inbox Callback Contract)** — a
 filesystem-based inbox that lets out-of-process MCP servers push events into
@@ -56,7 +59,35 @@ The model-visible notification projection for LICC events is governed by `src/li
 
 ## Components
 
-- `mcp/__init__.py` — MCP tool surface (the tool slice, ~350 lines). One model-facing LTP v2 family: the public tool name stays `mcp` and the public actions stay `info`/`manual`, now carried in the canonical `action` + `input` + `reasoning` + `summarize` envelope composed by the generic `lingtai.tools.tool_family` infrastructure (`src/lingtai/tools/tool_family/ANATOMY.md`). `get_description` (`src/lingtai/tools/mcp/__init__.py:219`), `get_schema` (`src/lingtai/tools/mcp/__init__.py:223`) returns `ToolFamily.build_schema()` with the pre-migration signpost `action` description preserved verbatim, `_build_family` (`src/lingtai/tools/mcp/__init__.py:170`) is the single source of the two-child registry — called with `None` at import for the module-level schema-only family `_FAMILY` (`src/lingtai/tools/mcp/__init__.py:330`, built after the declaration it derives from), which fails loudly on a duplicate/reserved-name collision and never dispatches, and called with the granted `ToolPluginHost` from `_bind` (`src/lingtai/tools/mcp/__init__.py:233`) for the real dispatching family whose `manual` child comes straight from `tool_family.manual.build_manual_child`, handed only `host.workdir` and the manual destination read back out of `DECLARATION.manual`; both paths take their per-action `input` schemas from `DECLARATION` too — which holds the one `_EMPTY_INPUT` literal (`src/lingtai/tools/mcp/__init__.py:160`) re-exported from `tool_family.manual.MANUAL_INPUT_SCHEMA` — so the declared, advertised, and validated shapes cannot drift. `_reconcile` (`src/lingtai/tools/mcp/__init__.py:74`) backs the `info` child and reaches the live Agent body only through `host.workdir.path` and `host.prompt_section.write_protected_section`, `_flatten_manual_result` (`src/lingtai/tools/mcp/__init__.py:113`) is the Host-owned adapter that turns the manual child's canonical `content`/`structuredContent` result back into mcp's flat `mcp_manual` public shape strictly *after* dispatch (no double wrap), and `handle_mcp` (closed over inside `_bind`, `src/lingtai/tools/mcp/__init__.py:245`) owns mcp's exact pre-migration unknown-action envelope — including the missing-action empty-string default and unhashable `action` values (issue #513), routed by tuple membership against `child_names`, which compares by `==` and never hashes — before delegating to `ToolFamily.handle`. Both actions declare a strict-empty `input`, so any extra input field fails before the registry is re-read or the manual is loaded. The registry infra now lives in `src/lingtai/services/mcp_registry.py`: `validate_record` (`src/lingtai/services/mcp_registry.py:72`), `validate_registry_line` (`src/lingtai/services/mcp_registry.py:118`), `read_registry` (`src/lingtai/services/mcp_registry.py:139`), `read_identities` (`src/lingtai/services/mcp_registry.py:253`), `decompress_addons` (`src/lingtai/services/mcp_registry.py:316`), `_load_catalog` (`src/lingtai/services/mcp_registry.py:43`), `_build_registry_xml` (`src/lingtai/services/mcp_registry.py:419`). **Account-identity discovery** (`src/lingtai/services/mcp_registry.py:253`): `read_identities` reads each addon's non-secret identity document at `system/mcp_identities/<name>.json` (schema `lingtai.mcp.identity.v1`) and projects every account through the secret-safe allowlist `IDENTITY_SAFE_ACCOUNT_KEYS` (`src/lingtai/services/mcp_registry.py:211`) via `_project_account` (`src/lingtai/services/mcp_registry.py:242`). The tool-slice `_reconcile` attaches the projected identity to each `registered` entry (`_registered_entry`, `src/lingtai/tools/mcp/__init__.py:66`) and the registry XML builder renders it into the prompt XML (`_build_identity_xml`, `src/lingtai/services/mcp_registry.py:399`). The projection is an allowlist, not a passthrough — tokens/passwords/secrets/headers and any unrecognized field are dropped even if an on-disk identity file contains them, so the generic surface can never leak what a producer bug might persist. The prompt render further narrows to `_PROMPT_ACCOUNT_KEYS` (`src/lingtai/services/mcp_registry.py:394`), which excludes `last_verified_at`: that field, and the identity-level `<last_verified_at>` that used to precede the account list, are volatile re-verification timestamps that change on plain refresh and would otherwise break prompt-cache stability. `read_identities` and the `mcp(action="info")` diagnostic payload still surface `last_verified_at` — only the model-facing prompt XML omits it.
+- `mcp/__init__.py` — MCP tool surface. One model-facing LTP v2 family keeps
+  public name `mcp` and exposes exact actions `info`/`settings`/`manual` through
+  the canonical `action` + `input` + `reasoning` + `summarize` envelope.
+  `_build_family` is the one ordered owner-child source; generic composition
+  injects settings immediately before manual. `_reconcile` backs `info` through
+  only the workdir and protected prompt-section ports; `_flatten_manual_result`
+  preserves the existing flat manual result; the Host-owned wrapper keeps
+  malformed/unknown actions out of dispatch. All actions have strict-empty
+  input. Registry validation, JSONL I/O, addon decompression, identity
+  projection, and XML construction remain in
+  `src/lingtai/services/mcp_registry.py` (`validate_record`,
+  `validate_registry_line`, `read_registry`, `read_identities`,
+  `decompress_addons`, `_load_catalog`, `_build_registry_xml`); `info` behavior
+  is unchanged.
+- `mcp/settings.py` — `MCPSettingsProvider`, the read-only owner provider.
+  Every call runs the canonical init reader with boot/refresh preset callbacks,
+  then returns exactly `init.addons` and `init.mcp`. The latter is marked
+  sensitive so current and default are fully redacted by the generic SHOW
+  projector. Any source/shape failure rejects the whole inventory; no registry,
+  identity, curated private config/session, Task Card, agent identity, legacy
+  server file, or live-process state is consulted.
+- **Account-identity discovery** — `read_identities` reads each addon's
+  non-secret `system/mcp_identities/<name>.json` document and projects accounts
+  through `IDENTITY_SAFE_ACCOUNT_KEYS` via `_project_account`. `_reconcile`
+  attaches that allowlisted projection to an `info` entry, while
+  `_build_identity_xml` narrows the prompt rendering again through
+  `_PROMPT_ACCOUNT_KEYS`. Tokens, passwords, secrets, headers, and unknown
+  fields are dropped. Volatile `last_verified_at` remains available to
+  `read_identities`/`info` but stays out of prompt XML for cache stability.
 - `src/lingtai/services/mcp_inbox.py` — LICC v1 filesystem inbox poller (the **consumer** half). `validate_event` validates required `from`/`subject`/`body` fields; `_format_notification_summary` is **deprecated** legacy helper (retained for backward compat); `_extract_preview_meta` pulls optional IM/chat scalars (`conversation_ref`, `message_ref`, `platform`, and the additive per-update `event_id` used by the persistent lane for event-identity dedup/delivery) out of `event["metadata"]` when present as non-empty strings, each capped at `_PREVIEW_META_FIELD_CAP` (200 chars), and curated IM structured fields (`latest_incoming`, `recent_messages`, `referenced_messages` — the full reply target when it falls outside the last-20 window) after a bounded JSON-safe copy (a right-typed structured field that is unserializable or over the `_PREVIEW_STRUCTURED_META_JSON_CAP` is replaced by an explicit `licc_structured_omitted` marker carrying the reason and a read-action recovery hint, never silently dropped) — these feed the kernel builder for `_meta.agent_meta.notifications.persistent.mcp.<channel>` (currently Telegram, WeChat, Feishu, WhatsApp) and are then stripped from the model-visible ephemeral lane by the per-channel `meta_block.sanitize_*_notification_after_persistent` wrappers (move, not duplicate — Jason #6148); `_consume_event` returns `(wake, preview)` where `preview = {"from": sender, "subject": subject, "preview": body[:_PREVIEW_FIELD_CAP], "preview_truncated": bool, **extracted_meta}` — only the body snippet gets capped (sender/subject are bounded by upstream construction); `_dispatch_summary` publishes to `.notification/mcp.<mcp_name>.json` via `notifications.submit`, embedding full body snippets once in `data.previews` while keeping `instructions` to read/check guidance plus lightweight sender/subject/metadata routing context; `_scan_once` coalesces per MCP, threading the preview list through; `MCPInboxPoller` class drives the poll loop. Body snippet cap is `_PREVIEW_FIELD_CAP = 10000`. Defines the shared contract constants `LICC_VERSION` / `INBOX_DIRNAME` / `DEAD_DIRNAME` / `TMP_SUFFIX` / `EVENT_SUFFIX`.
 - `src/lingtai/services/mcp_licc.py` — LICC v1 client (the **producer** half). One public function, `push_inbox_event(sender, subject, body, *, metadata=None, wake=True, received_at=None, agent_dir=None, mcp_name=None, event_id=None) -> bool`, that an out-of-process MCP imports to drop one event into `<agent_dir>/.mcp_inbox/<mcp_name>/<event_id>.json`. Lightweight by design — importing it starts no threads and re-exports the contract constants (`LICC_VERSION`, `INBOX_DIRNAME`, `TMP_SUFFIX`, `EVENT_SUFFIX`) straight from `src/lingtai/services/mcp_inbox.py` so producer and consumer never drift. `agent_dir`/`mcp_name` default to env vars `LINGTAI_AGENT_DIR`/`LINGTAI_MCP_NAME` (kernel-injected per MCP); explicit params override for tests/advanced callers. Writes atomically: serialize → `<event_id>.json.tmp` → `flush`+`os.fsync` → `os.replace` onto the final `.json` (the poller ignores `.tmp`, so half-writes are never observed). `event_id` defaults to a fresh `uuid4().hex` (guarantees per-call uniqueness); explicit `mcp_name`/`event_id` path components are validated before use. The payload is checked with `validate_event` before writing, so the canonical producer does not intentionally emit dead-letterable events. Best-effort/silent: missing/invalid target, unsafe path component, invalid payload, or filesystem/serialization error → `False` (never raises into the MCP), with a terse, content-free log that never echoes `body`/`subject`/`metadata`.
 - **Declared host-plugin route** — `mcp` is the current base reference slice
@@ -83,36 +114,38 @@ requires exactly `workdir` and the earned `file_io` port; and Plugin's static
 own `prompt_section`, and the read-only `plugin_catalog` projection
 (`src/lingtai/kernel/tool_plugin/ANATOMY.md`,
 `src/lingtai/kernel/tool_plugin/CONTRACT.md`, LABTs TP001/TP002). `DECLARATION`
-(`src/lingtai/tools/mcp/__init__.py:308`) is a static `ToolPluginDeclaration`
-built at module import with no Agent in existence: `actions=("info",)` (the
-reserved `manual` is appended by the declaration, never declared), one
+is a static `ToolPluginDeclaration` built at module import with no Agent in
+existence: `actions=("info",)` and `settings=True` (the reserved `settings` and
+`manual` children are appended by the declaration), one
 strict-empty `input` schema per action, `manual="mcp"` naming the installed
 manual destination that `_build_family` reads back out of it (one literal, not
 two), and `requires=("workdir", "prompt_section")` — the two host ports this
-family actually consumes. `_bind` (`src/lingtai/tools/mcp/__init__.py:233`)
+family actually consumes. `_bind`
 composes the family and the `handle_mcp` wrapper and returns a `BoundToolPlugin`
 whose `activate` is the boot reconcile; it mounts nothing, and
 `ToolPluginDeclaration.bind` refuses it outright if the composed schema
 advertises an action inventory other than the declared `public_actions`. `setup`
-(`src/lingtai/tools/mcp/__init__.py:333`) is now only composition wiring: it
+is only composition wiring: it
 calls `lingtai.adapters.tool_plugin_host.register_agent_tool_plugins`, which
 reserves the official `mcp` name, grants the two ports, binds, activates, and
 mounts — in that order, so a name conflict is refused before the live tool
-surface is touched. The recut changed no public behavior: same tool name, same
-`["info", "manual"]` enum, same strict-empty inputs, same result shapes including
-the tool-specific `mcp_manual` body key (`tests/test_tool_family_mcp_migration_parity.py`,
-`tests/test_mcp_capability.py`, `tests/test_tool_plugin_declaration.py`).
+surface is touched. Settings is the sole additive public action; the tool name,
+existing strict-empty inputs, and existing result shapes including the
+tool-specific `mcp_manual` body key stay unchanged
+(`tests/test_tool_family_mcp_migration_parity.py`, `tests/test_mcp_capability.py`,
+`tests/test_mcp_settings.py`).
 - `mcp/plugin.json` + `mcp/skills/mcp-manual/` — the built-in Agent Plugins v1.0.0 documentation package. `Agent._install_intrinsic_manuals` validates this one-skill package through `services.plugin_registry.read_plugin` and mounts the skill as `intrinsic/capabilities/mcp/`; it does not register a plugin or an MCP server. The retained `mcp/manual/` tree is a source-layout compatibility copy, never the installed manual source.
 
 ## Public API
 
-The `mcp` tool exposes two signpost actions, called through the LTP v2 envelope
-`mcp(action=..., input={}, reasoning="...")` (both actions take a strict-empty
+The `mcp` tool exposes three read-only actions, called through the LTP v2 envelope
+`mcp(action=..., input={}, reasoning="...")` (all actions take a strict-empty
 `input`; `summarize` is the optional root presentation control):
 
 | Action | Description |
 |--------|-------------|
 | `info` | Re-read the MCP registry and return runtime health (registry contents, problems, registry path) without the manual body. Each `registered` entry may carry a non-secret `identity` block (account alias, provider username/id/display name, non-secret routing counts) read from `system/mcp_identities/<name>.json` when the addon has published one. |
+| `settings` | SHOW exactly the five-field `init.addons` and fully redacted `init.mcp` rows from a fresh canonical effective init composition. |
 | `manual` | Return the mcp-manual skill body on demand, with no registry read, rescan, or mutation. |
 
 ### LICC v1 Inbox Protocol

--- a/src/lingtai/tools/mcp/BEHAVIORS.md
+++ b/src/lingtai/tools/mcp/BEHAVIORS.md
@@ -8,6 +8,8 @@ related_files:
   - src/lingtai/tools/mcp/CONTRACT.md
   - src/lingtai/tools/mcp/ANATOMY.md
   - src/lingtai/tools/mcp/__init__.py
+  - src/lingtai/tools/mcp/settings.py
+  - tests/test_mcp_settings.py
   - src/lingtai/mcp_catalog.json
 maintenance: |
   Created during the every-contract-needs-behaviors sweep. Keep this file
@@ -18,7 +20,7 @@ maintenance: |
 # MCP Capability Behavior Tests
 
 Self-contained agent behavior tasks guarding the observable behavior clauses of
-`src/lingtai/tools/mcp/CONTRACT.md` (info/manual only, strict-empty input,
+`src/lingtai/tools/mcp/CONTRACT.md` (info/settings/manual, strict-empty input,
 identity surfaced only when present, degraded manual shape). Pinned pytest
 commands must run from the repo root with the project's Python.
 
@@ -32,14 +34,16 @@ commands must run from the repo root with the project's Python.
 - **estimate**: ≈ 15 minutes
 
 ### Steps
-1. From `<repo>`, run `python -m pytest tests/test_mcp_capability.py tests/test_mcp_skill_manuals.py -q` and capture the outcome.
+1. From `<repo>`, run `python -m pytest tests/test_mcp_settings.py tests/test_mcp_capability.py tests/test_mcp_skill_manuals.py -q` and capture the outcome.
 2. Call `mcp(action="info", input={}, reasoning="probe")` and record the result; confirm it reconciles the registry, re-injects prompt XML, and returns `{status, registry_path, registered_count, registered, problems}`.
 3. Call `mcp(action="info", input={"extra": 1}, reasoning="probe")` and confirm rejection happens before the registry is re-read or the manual is loaded.
+4. Call `mcp(action="settings", input={}, reasoning="probe")`; confirm exact row order `init.addons`, `init.mcp`, exact five-field order, and full current/default redaction for `init.mcp`. Confirm the init file bytes are unchanged.
 
 ### Expected evidence
 - [ ] Step 1: the mcp capability and skill-manual suites pass, pinning envelope validation, dispatch, and the canonical manual shape.
 - [ ] Step 2: `info` returns the health/registry result; each `registered` entry carries `identity` only when a matching identity record with non-empty `accounts` exists.
 - [ ] Step 3: any extra `input` key yields `INVALID_ARGUMENT` (`unsupported mcp input field`) before registry I/O; unknown actions render the exact Host-owned pre-migration envelope.
+- [ ] Step 4: settings is a bounded whole-inventory SHOW with no writer and no nested MCP projection.
 
 ### Pass / Fail
-Pass when the suites pass and the read-only/no-input observations hold. Fail on an accepted input field, on identity leaking without a matching record, or on a mutating `info`; record the evidence trail in the task report.
+Pass when the suites pass and the read-only/no-input observations hold. Fail on an accepted input field, identity or configuration leakage, a partial inventory, or mutation; record the evidence trail in the task report.

--- a/src/lingtai/tools/mcp/CONTRACT.md
+++ b/src/lingtai/tools/mcp/CONTRACT.md
@@ -4,12 +4,15 @@ tool: mcp
 contract_version: 1
 related_files:
   - src/lingtai/tools/mcp/__init__.py
+  - src/lingtai/tools/mcp/settings.py
   - src/lingtai/tools/mcp/plugin.json
   - src/lingtai/agent.py
   - src/lingtai/tools/mcp/ANATOMY.md
+  - src/lingtai/tools/mcp/BEHAVIORS.md
   - src/lingtai/kernel/tool_plugin/CONTRACT.md
   - src/lingtai/adapters/tool_plugin_host.py
   - tests/test_tool_plugin_declaration.py
+  - tests/test_mcp_settings.py
   - tests/test_mcp_builtin_plugin_package.py
   - src/lingtai/tools/mcp/skills/mcp-manual/SKILL.md
   - src/lingtai/services/mcp_registry.py
@@ -36,9 +39,10 @@ maintenance: |
 
 # MCP capability contract
 
-`mcp` is a SIGNPOST-ONLY, read-only tool: it renders the per-agent MCP server
-registry into the protected `mcp` system-prompt section and reports registry
-health. It does NOT register, activate, configure, or troubleshoot MCP servers —
+`mcp` is a read-only tool family: it renders the per-agent MCP server registry
+into the protected `mcp` system-prompt section, reports registry health, and
+SHOWs the two MCP-owned top-level init settings. It does NOT register, activate,
+configure, or troubleshoot MCP servers —
 all mutations happen by editing `mcp_registry.jsonl` with `write`/`edit`. The tool
 slice lives in `src/lingtai/tools/mcp/__init__.py`; the registry machinery it renders
 lives in `src/lingtai/services/mcp_registry.py` (imported lazily). The code is the
@@ -73,12 +77,11 @@ back-edge -> §Scope; the generic composition/dispatch infrastructure ->
 - Registered via `capabilities=["mcp"]` or via init.json.
 - Symmetric to `skills` / `knowledge`: a per-agent presentation capability with a
   protected prompt section.
-- Non-goals: this tool never writes the registry, never launches or configures a
-  server, and never troubleshoots one. It is purely `info` (re-render + health)
-  and `manual` (return the umbrella manual body). The LTP v2 family migration
-  changed the call envelope only — no action was added, removed, renamed, or
-  given a new capability, and external MCP registration remains entirely
-  outside this tool.
+- Non-goals: this tool never writes configuration or the registry, never
+  launches or configures a server, and never troubleshoots one. `info` keeps
+  its re-render + health behavior, `settings` is SHOW-only, and `manual` keeps
+  returning the umbrella manual body. External MCP registration remains
+  entirely outside this tool.
 - Ownership boundary: the module is the agent-callable tool slice only. The
   registry service is imported lazily inside `_reconcile` and the handlers, per
   the `lingtai.tools → lingtai` lazy-back-edge rule, as is the host adapter
@@ -88,32 +91,44 @@ back-edge -> §Scope; the generic composition/dispatch infrastructure ->
 
 `mcp` is an LTP v2 action-separated family (`src/lingtai/tools/CONTRACT.md`
 "Envelope") built on the generic `src/lingtai/tools/tool_family/`
-infrastructure. The public tool name stays `mcp` and the public action values
-stay `info` / `manual`. Exactly two read-only actions; the handler is
+infrastructure. The public tool name stays `mcp`; its public action values are
+exactly `info` / `settings` / `manual`, with settings immediately before the
+reserved manual child. Exactly three read-only actions; the handler is
 `handle_mcp`, which delegates envelope validation and dispatch to a per-Agent
 `ToolFamily`.
 
 **Envelope.** The model-facing schema is `get_schema()` =
-`ToolFamily.build_schema()` with the pre-migration signpost `action`
-description preserved verbatim. Root properties are exactly `action`, `input`,
+`ToolFamily.build_schema()` with the existing `info`/`manual` signpost meaning
+preserved and `settings` described additively. Root properties are exactly `action`, `input`,
 `reasoning`, and `summarize`; `required` is `[action, input, reasoning]` and the
 root is closed (`additionalProperties: false`). `reasoning` is required Host
 InvocationContext/audit metadata declared by the family itself, never action
 input. `summarize` is the optional root presentation control, validated as
-boolean and stripped before dispatch. Both actions take **no arguments**, so
-both share the one canonical strict-empty `input`
+boolean and stripped before dispatch. All actions take **no arguments**, so
+all use the canonical strict-empty `input`
 (`{type: object, properties: {}, additionalProperties: false}`) — the
 `MANUAL_INPUT_SCHEMA` literal exported by `tool_family.manual` and reused here
 as `_EMPTY_INPUT`, rather than hand-copied per action, so the schema-only and
 dispatching families cannot advertise different shapes. The root
 `allOf`/`if`/`then` correlates each `action` const with its own `input` branch,
-and `input.oneOf` discloses both branches with titles
-`info input` / `manual input`.
+and `input.anyOf` discloses all branches with titles
+`info input` / `settings inventory input` / `manual input`.
 
 | Action | Required inputs | Optional inputs | Success output | Error shapes |
 |---|---|---|---|---|
 | `info` | `action="info"`, `input={}`, `reasoning` | `summarize` | reconciles registry, re-injects prompt XML, returns `{status: "ok", registry_path, registered_count, registered: [{name, summary, identity?}], problems}` | see below |
+| `settings` | `action="settings"`, `input={}`, `reasoning` | `summarize` | `{settings: [{key, current, default, configurable, comment}, ...]}` for exactly `init.addons`, `init.mcp`; the latter row's current and default are fully redacted | fixed bounded no-row failures from the shared SHOW seam |
 | `manual` | `action="manual"`, `input={}`, `reasoning` | `summarize` | `{status: "ok", mcp_manual, manual_path}` | degraded shape below |
+
+**Settings ownership.** `MCPSettingsProvider` fresh-reads the same canonical
+materialized/resolved init composition used by boot and refresh. Row order is
+exactly `init.addons`, then `init.mcp`; both are configurable, with logical
+defaults `[]` and `{}`. `init.mcp` sets the private sensitive marker so both
+current and default become `<redacted>` before serialization. Registry/catalog
+contents, identity, curated-addon config/session data, Task Cards, agent
+identity, legacy `mcp/servers.json`, and live client/process state are excluded.
+Provider/read/row/serialization failure makes the whole inventory unavailable;
+the shared 65,536-byte bound never returns partial rows. No writer exists.
 
 Each `registered` entry is `{name, summary}` and carries `identity` only when a
 matching identity record with non-empty `accounts` exists. `manual` returns
@@ -130,8 +145,8 @@ dispatch returns, never inside a registered child. `manual` performs no registry
 read, rescan, or mutation.
 
 **Error shapes** (plain dicts):
-- Unknown action: `{"status": "error", "message": "unknown action: <action>, only 'info' or 'manual' is supported"}`. This exact envelope is Host-owned and predates the family migration, so `handle_mcp` renders it *before* delegating: it restores the pre-migration empty-string default for a missing `action` key and routes an unhashable `action` (`[]`, `{}` from invalid JSON — issue #513) here instead of into the generic dispatcher's dict lookup. An unknown action is rejected before any input validation or handler I/O.
-- Invalid envelope/input (from the generic dispatcher, canonical and unwrapped): `{"status": "failed", "error_code": "INVALID_ARGUMENT", "message": ...}` for a non-object `input` (`input must be an object`), an unknown root field (`unsupported mcp argument`), a non-boolean `summarize` (`summarize must be a boolean`), or any `input` key outside the selected action's strict-empty schema (`unsupported mcp input field`). Because both actions declare an empty `input`, any extra input field fails **before** the registry is re-read or the manual is loaded.
+- Unknown action: `{"status": "error", "message": "unknown action: <action>, only 'info', 'settings', or 'manual' is supported"}`. This envelope is Host-owned, so `handle_mcp` renders it *before* delegating: it preserves the empty-string default for a missing `action` key and routes an unhashable `action` (`[]`, `{}` from invalid JSON — issue #513) here instead of into the generic dispatcher's dict lookup. An unknown action is rejected before any input validation or handler I/O.
+- Invalid envelope/input (from the generic dispatcher, canonical and unwrapped): `{"status": "failed", "error_code": "INVALID_ARGUMENT", "message": ...}` for a non-object `input` (`input must be an object`), an unknown root field (`unsupported mcp argument`), a non-boolean `summarize` (`summarize must be a boolean`), or any `input` key outside the selected action's strict-empty schema (`unsupported mcp input field`). Because all actions declare an empty `input`, any extra input field fails **before** provider/registry/manual I/O.
 
 ## Declared host plugin
 
@@ -142,7 +157,8 @@ normative rules stay there.
 
 - **Static declaration.** `DECLARATION` is a module-level
   `ToolPluginDeclaration` built at import, before any `Agent` exists. It
-  declares `actions=("info",)` — the reserved `manual` is appended by the
+  declares `actions=("info",)` and `settings=True` — the reserved SHOW child
+  and `manual` are appended by the
   declaration and never declared as an operational action — one strict-empty
   `input` schema per action, `manual="mcp"` (the installed manual destination
   the reserved child reads), the canonical description, and
@@ -165,11 +181,11 @@ normative rules stay there.
   read and protected prompt render — is the separately declared `activate`
   step, which the kernel registrar runs after the name check and immediately
   before mounting. `setup(agent)` is composition wiring only.
-- **No public change.** The recut is internal. Tool name, the
-  `["info", "manual"]` action enum, both strict-empty `input` branches, the
-  closed root envelope, `info`'s health snapshot, and `manual`'s flat
-  `status`/`mcp_manual`/`manual_path` shape (including the degraded shape) are
-  all unchanged, as is the exact unknown-action error envelope.
+- **Bounded additive public change.** The only new public action is the generic
+  reserved `settings` child immediately before `manual`. Tool name, closed
+  root envelope, `info`'s health snapshot, and `manual`'s flat
+  `status`/`mcp_manual`/`manual_path` shape (including the degraded shape) stay
+  unchanged.
 - **No transport.** Nothing here spawns a process, opens a connection, or
   publishes a catalog record. The curated MCP server packages and
   `src/lingtai/mcp_catalog.json` remain a separate external-transport concern
@@ -189,6 +205,7 @@ The capability reads (never writes) the per-agent registry:
 
 ```text
 <agent>/mcp_registry.jsonl      # one JSON record per line, sibling to init.json
+<agent>/init.json               # canonical source for init.addons/init.mcp SHOW
 ```
 
 Writers of this file are OUTSIDE this tool: the agent (`write`/`edit`) and the
@@ -219,10 +236,11 @@ Do not change any of the following; documented for reviewers only.
 |---|---|---|
 | The capability renders the registry into the `mcp` prompt section | `src/lingtai/tools/mcp/__init__.py` (`_reconcile`) | `tests/test_mcp_capability.py::test_mcp_capability_renders_registry_into_prompt` |
 | `info` returns a health snapshot | `src/lingtai/tools/mcp/__init__.py` (`_reconcile`) | `tests/test_mcp_capability.py::test_mcp_show_action_returns_health_snapshot`, `tests/test_tool_family_mcp_migration_parity.py::test_info_returns_health_snapshot_without_manual_body` |
-| Unknown actions return a `{status: error}` dict | `src/lingtai/tools/mcp/__init__.py` (`handle_mcp`) | `tests/test_mcp_capability.py::test_mcp_show_unknown_action_returns_error`, `tests/test_tool_family_mcp_migration_parity.py::test_unknown_action_envelope_is_byte_identical_to_pre_migration` |
+| Unknown actions return a `{status: error}` dict | `src/lingtai/tools/mcp/__init__.py` (`handle_mcp`) | `tests/test_mcp_capability.py::test_mcp_show_unknown_action_returns_error`, `tests/test_tool_family_mcp_migration_parity.py::test_unknown_action_envelope_preserves_shape_with_current_actions` |
 | Public name/actions and the LTP v2 envelope are exact on both wires | `src/lingtai/tools/mcp/__init__.py` (`get_schema`) | `tests/test_tool_family_mcp_migration_parity.py::test_schema_exposes_exact_public_actions_and_envelope`, `::test_schema_survives_chat_and_responses_wires` |
-| Both actions declare a strict-empty `input`; extra input fails before handler I/O | `src/lingtai/tools/mcp/__init__.py` (`_EMPTY_INPUT`, `_build_family`) | `tests/test_tool_family_mcp_migration_parity.py::test_both_actions_declare_canonical_strict_empty_input`, `::test_extra_input_field_is_rejected_before_any_io`, `::test_schema_only_and_dispatching_families_declare_identical_children` |
+| All actions declare a strict-empty `input`; extra input fails before handler I/O | `src/lingtai/tools/mcp/__init__.py` (`_EMPTY_INPUT`, `_build_family`) | `tests/test_tool_family_mcp_migration_parity.py::test_all_actions_declare_canonical_strict_empty_input`, `::test_extra_input_field_is_rejected_before_any_io`, `::test_schema_only_and_dispatching_families_declare_identical_children` |
 | `manual` returns the exact body/path with no registry rescan and no double wrap | `src/lingtai/tools/mcp/__init__.py` (`_flatten_manual_result`) | `tests/test_tool_family_mcp_migration_parity.py::test_manual_returns_exact_body_and_path`, `::test_manual_performs_no_registry_rescan_or_mutation`, `::test_manual_result_is_not_double_wrapped` |
+| `settings` returns only the two MCP-owned rows, fully redacts `init.mcp`, and writes nothing | `src/lingtai/tools/mcp/settings.py` | `tests/test_mcp_settings.py` |
 | init.json `addons: [...]` triggers append-only decompression | `src/lingtai/services/mcp_registry.py` | `tests/test_mcp_capability.py::test_addons_list_triggers_decompression`, `::test_decompress_is_idempotent` |
 | Duplicate / invalid registry lines are dropped | `src/lingtai/services/mcp_registry.py` | `tests/test_mcp_capability.py::test_registry_drops_duplicates_by_name`, `::test_registry_drops_invalid_lines` |
 | `mcp` is declared statically, with a reserved official name and only two required host ports | `src/lingtai/tools/mcp/__init__.py` (`DECLARATION`) | `tests/test_tool_plugin_declaration.py::test_mcp_declaration_is_static_and_needs_no_agent`, `::test_mcp_is_reserved_and_declares_only_the_ports_it_consumes` |
@@ -237,15 +255,16 @@ Do not change any of the following; documented for reviewers only.
 | Registry renders into the prompt | `tests/test_mcp_capability.py::test_mcp_capability_renders_registry_into_prompt` | Add a registry line, inspect the `mcp` prompt section | Registered MCPs invisible to the model |
 | Tool is read-only (no mutation) | `tests/test_mcp_capability.py::test_mcp_show_action_returns_health_snapshot` | Call `info`, confirm `mcp_registry.jsonl` unchanged | Signpost promise violated; surprise mutations |
 | Unknown actions handled | `tests/test_mcp_capability.py::test_mcp_show_unknown_action_returns_error` | Call `mcp(action="foo")` | Silent mis-dispatch |
-| Public action count/values unchanged by the family migration | `tests/test_tool_family_mcp_migration_parity.py::test_real_agent_registers_exactly_one_public_mcp_tool` | Inspect the composed `mcp` schema's `action.enum` | Duplicate or renamed model-facing roots |
+| Public action order is exact | `tests/test_tool_family_mcp_migration_parity.py::test_real_agent_registers_exactly_one_public_mcp_tool` | Inspect the composed `mcp` schema's `action.enum` | Duplicate, misplaced, or renamed model-facing actions |
 | Invalid input fails before any registry/manual I/O | `tests/test_tool_family_mcp_migration_parity.py::test_extra_input_field_is_rejected_before_any_io` | Call `mcp` with a bogus `input` field, confirm no registry read | Signpost promise violated; wasted or surprising I/O |
+| Settings is five-field SHOW only | `tests/test_mcp_settings.py` | Call settings twice around an authorized init edit; verify ordered rows and redaction | Secret/config leakage or a hidden writer |
 | Addon decompression is idempotent | `tests/test_mcp_capability.py::test_decompress_is_idempotent` | Boot twice with the same `addons`, diff the registry | Duplicate registry growth |
 | Secrets never reach the prompt | `tests/test_mcp_identity_discovery.py::test_secret_fields_are_stripped_from_accounts` | Add an identity with a secret field, inspect `info` output | Credential leakage into the prompt |
 
 Run before merging:
 
 ```bash
-python -m pytest tests/test_mcp_capability.py tests/test_mcp_identity_discovery.py \
+python -m pytest tests/test_mcp_settings.py tests/test_mcp_capability.py tests/test_mcp_identity_discovery.py \
   tests/test_tool_family_mcp_migration_parity.py tests/test_signpost_tool_descriptions.py \
   tests/test_tool_plugin_declaration.py -q
 ```

--- a/src/lingtai/tools/mcp/__init__.py
+++ b/src/lingtai/tools/mcp/__init__.py
@@ -15,12 +15,15 @@ Symmetric to the ``knowledge`` / ``skills`` capabilities:
   section and reporting health while ``manual`` returns the manual body.
 
 Tool surface: ``info`` returns the current registry and a runtime health
-snapshot without the manual body; ``manual`` returns the umbrella manual body on
-demand. Both are action children of one LTP v2 ``ToolFamily`` (see
+snapshot without the manual body; ``settings`` shows the two MCP-owned
+top-level init settings; ``manual`` returns the umbrella manual body on demand.
+All three are action children of one LTP v2 ``ToolFamily`` (see
 ``lingtai/tools/CONTRACT.md`` "Envelope"): the public tool name stays ``mcp`` and
-the public action values stay ``info``/``manual``, now carried in the canonical
+the public action values are ``info``/``settings``/``manual``, carried in the
+canonical
 ``action`` + ``input`` + ``reasoning`` + ``summarize`` envelope with a strict
-empty ``input`` per action. Neither action's observable result changed.
+empty ``input`` per action. The existing actions' observable results are
+unchanged.
 
 Ownership: this module is the agent-callable *tool* slice only. The registry
 machinery it renders (validation, JSONL I/O, catalog load, identity projection,
@@ -38,7 +41,7 @@ longer receives the whole ``Agent``: :func:`_bind` gets a ``ToolPluginHost``
 granting exactly the two ports this capability actually consumes — ``workdir``
 (read the registry and the installed manual) and ``prompt_section`` (rewrite
 its own protected ``mcp`` section). Nothing about the public tool — name,
-``["info", "manual"]`` action enum, strict-empty inputs, result shapes
+``["info", "settings", "manual"]`` action enum, strict-empty inputs, result shapes
 including the tool-specific ``mcp_manual`` body key — changed with it.
 
 Usage: ``Agent(capabilities=["mcp"])`` or via init.json.
@@ -58,6 +61,7 @@ from lingtai.kernel.tool_plugin import BoundToolPlugin, ToolPluginDeclaration
 
 from ..tool_family import ChildTool, ToolFamily
 from ..tool_family.manual import MANUAL_INPUT_SCHEMA, build_manual_child
+from .settings import MCPSettingsProvider
 
 if TYPE_CHECKING:
     from lingtai.kernel.base_agent import BaseAgent
@@ -147,7 +151,8 @@ def _flatten_manual_result(mcp_result: dict) -> dict:
 _DESCRIPTION = (
     "SIGNPOST ONLY: this tool does not register, activate, configure, or "
     "troubleshoot MCP servers by itself. `info` only re-reads the registry and "
-    "returns registry health; `manual` returns the mcp-manual body. "
+    "returns registry health; `settings` shows MCP-owned configuration; "
+    "`manual` returns the mcp-manual body. "
     "Your per-agent MCP server registry. The <registered_mcp> catalog in your "
     "system prompt lists every MCP server currently registered. Before using "
     "this tool (registering, deregistering, updating, or troubleshooting MCP "
@@ -158,10 +163,9 @@ _DESCRIPTION = (
     "system(action=\"refresh\")."
 )
 
-# Both actions are signpost-only reads that take no arguments at all, so both
-# children share the one canonical strict-empty ``input`` — the same literal
-# the generic ``manual`` child registers, reused rather than hand-copied so the
-# schema-only and dispatching families cannot advertise different shapes.
+# The owner-defined action and reserved manual action take no arguments; the
+# injected settings child is strict-empty too. Reuse the manual literal for the
+# declared actions so schema-only and dispatching families cannot drift.
 # ``ToolFamily.build_schema`` deep-copies per child, and dispatch reads only
 # ``properties``, so one shared object is safe.
 _EMPTY_INPUT: dict[str, Any] = MANUAL_INPUT_SCHEMA
@@ -169,13 +173,14 @@ _EMPTY_INPUT: dict[str, Any] = MANUAL_INPUT_SCHEMA
 _ACTION_DESCRIPTION = (
     "info: signpost-only action; re-reads the registry and returns "
     "a runtime health snapshot (registry contents, problems, registry path) "
-    "without the manual body. manual: return only the mcp-manual skill body. "
-    "Neither action mutates MCP configuration."
+    "without the manual body. settings: show the MCP-owned init.addons and "
+    "fully redacted init.mcp configuration rows. manual: return only the "
+    "mcp-manual skill body. No action mutates MCP configuration."
 )
 
 
 def _build_family(host: "ToolPluginHost | None") -> ToolFamily:
-    """Build the two-child ``mcp`` family; the registry is declared exactly once.
+    """Build the three-child ``mcp`` family; the registry is declared exactly once.
 
     With a granted ``host``, children are bound to real handlers for dispatch.
     With ``None``, the module-level schema-only family is built: its handlers
@@ -220,6 +225,7 @@ def _build_family(host: "ToolPluginHost | None") -> ToolFamily:
             ChildTool("info", info_input, info_handler, title="info input"),
             manual_child,
         ],
+        settings_provider=MCPSettingsProvider(host.workdir.path if host else None),
     )
 
 
@@ -229,9 +235,8 @@ def get_description(lang: str = "en") -> str:
 
 def get_schema(lang: str = "en") -> dict:
     # Composed by the generic ToolFamily infra from each child's own canonical
-    # ``input_schema``. The public action enum stays exactly ``["info",
-    # "manual"]``; the pre-migration hand-written action description is
-    # preserved verbatim so the signpost promise the model reads is unchanged.
+    # ``input_schema``. The settings child is injected immediately before the
+    # reserved manual child by the generic family seam.
     schema = _FAMILY.build_schema()
     schema["properties"]["action"]["description"] = _ACTION_DESCRIPTION
     return schema
@@ -253,13 +258,13 @@ def _bind(host: "ToolPluginHost") -> BoundToolPlugin:
         # The generic ``ToolFamily`` dispatcher validates ``action``,
         # type-checks and strips root ``summarize``, rejects unknown root
         # fields, and rejects any ``input`` key outside the selected action's
-        # own declared schema — both actions declare a strict empty input, so
+        # own declared schema — all actions declare a strict empty input, so
         # any extra input field fails here, before ``_reconcile`` re-reads the
         # registry or the manual child touches the filesystem.
         #
-        # mcp's exact pre-migration unknown-action envelope is preserved here,
-        # in the Host layer, rather than by changing the generic dispatcher's
-        # own canonical error shape. Two pre-migration facts the generic
+        # mcp's existing unknown-action envelope mechanics stay in the Host
+        # layer rather than changing the generic dispatcher's canonical error
+        # shape. Two pre-migration facts the generic
         # dispatcher does not reproduce on its own are restored before
         # delegating, both proven by ``test_mcp_show_unknown_action_returns_error``:
         # a missing ``action`` key renders the empty-string default (not
@@ -272,9 +277,13 @@ def _bind(host: "ToolPluginHost") -> BoundToolPlugin:
         # exists ahead of the delegation below.
         action = args.get("action", "") if isinstance(args, Mapping) else ""
         if action not in family.child_names:
+            choices = ", ".join(repr(name) for name in family.child_names[:-1])
             return {
                 "status": "error",
-                "message": f"unknown action: {action!r}, only 'info' or 'manual' is supported",
+                "message": (
+                    f"unknown action: {action!r}, only {choices}, or "
+                    f"{family.child_names[-1]!r} is supported"
+                ),
             }
         result = family.handle(args)
         if action == "manual" and "content" in result:
@@ -320,6 +329,7 @@ DECLARATION = ToolPluginDeclaration(
     manual="mcp",
     description=_DESCRIPTION,
     binder=_bind,
+    settings=True,
     # Earned from this slice, not enumerated: ``workdir`` replaces the private
     # ``agent._working_dir`` read, ``prompt_section`` replaces the
     # ``agent.update_system_prompt("mcp", ..., protected=True)`` call. ``mcp``

--- a/src/lingtai/tools/mcp/glossary-wen.md
+++ b/src/lingtai/tools/mcp/glossary-wen.md
@@ -16,4 +16,4 @@ maintenance: |
 **名相对照**
 
 - `mcp`：原 locale catalog 未载 model-facing 本地名；召名、action 枚举之值与参名皆仍书上文 canonical English。
-- `action`、`input`、`reasoning`、`summarize`：LTP v2 封函四名，literal 不译；`info`、`manual` 二 action 之值亦仍书 canonical English。
+- `action`、`input`、`reasoning`、`summarize`：LTP v2 封函四名，literal 不译；`info`、`settings`、`manual` 三 action 之值亦仍书 canonical English。

--- a/src/lingtai/tools/mcp/glossary-zh.md
+++ b/src/lingtai/tools/mcp/glossary-zh.md
@@ -16,4 +16,4 @@ maintenance: |
 **术语对照**
 
 - `mcp`：原 locale catalog 未定义 model-facing 本地化别名；调用名、action 枚举值和参数名均保持上方 canonical English。
-- `action` / `input` / `reasoning` / `summarize`：LTP v2 信封四字段，字面量不本地化；`info`、`manual` 两个 action 取值同样保持 canonical English。
+- `action` / `input` / `reasoning` / `summarize`：LTP v2 信封四字段，字面量不本地化；`info`、`settings`、`manual` 三个 action 取值同样保持 canonical English。

--- a/src/lingtai/tools/mcp/manual/SKILL.md
+++ b/src/lingtai/tools/mcp/manual/SKILL.md
@@ -26,7 +26,8 @@ description: >
   and HTTP server config; where `mcp_registry.jsonl` lives and how to mutate
   it (`write`/`edit`/`bash` — the `mcp` capability itself is read-only); the
   `<homepage>` fallback doc field; and how `init.json`'s `addons:` list and
-  `mcp:` activation entries relate to the registry. Replaces the deprecated
+  `mcp:` activation entries relate to the registry; and the bounded,
+  read-only five-field settings inventory. Replaces the deprecated
   `lingtai-mcp` skill.
 
   Does NOT cover the protocol spec. `lingtai-kernel-anatomy
@@ -37,12 +38,14 @@ description: >
   callback contract and to `src/lingtai/services/mcp_registry.py` for
   validator internals. Read this for *what to do*, anatomy for *how it
   works*.
-version: 3.4.2
-last_changed_at: 2026-08-20T00:00:00Z
+version: 3.5.0
+last_changed_at: 2026-08-29T00:00:00Z
 related_files:
 - src/lingtai/tools/mcp/__init__.py
+- src/lingtai/tools/mcp/settings.py
 - src/lingtai/tools/mcp/ANATOMY.md
 - src/lingtai/tools/mcp/CONTRACT.md
+- tests/test_mcp_settings.py
 maintenance: |
   Tracks the routed source/resources it summarizes; update when the underlying capability or its sub-references change.
 ---
@@ -112,13 +115,14 @@ If neither path yields docs, fall back to the MCP's own runtime self-description
 
 ## Tool surface
 
-Two actions, called through the standard envelope
+Three actions, called through the standard envelope
 `mcp(action=..., input={}, reasoning="...")`. `action`, `input`, and `reasoning`
-are all required; neither action takes any arguments, so `input` is always the
+are all required; no action takes arguments, so `input` is always the
 empty object `{}` — passing any field inside it is rejected before the tool does
 anything. The optional root `summarize` boolean is presentation only.
 
 - `mcp(action="info", input={}, reasoning="...")` returns current registry contents and a runtime health snapshot (registry path, count, problems) without the manual body.
+- `mcp(action="settings", input={}, reasoning="...")` returns the bounded, read-only MCP configuration inventory described below.
 - `mcp(action="manual", input={}, reasoning="...")` returns this manual body on demand, without re-reading the registry.
 
 Every worked call in this manual and its `reference/` docs is written in this
@@ -145,6 +149,26 @@ Each `registered` entry may also carry a non-secret **`identity`** block, so you
 Identity comes from the addon-written, non-secret document at `system/mcp_identities/<name>.json` (schema `lingtai.mcp.identity.v1`), surfaced both here and as an `<identity>` block under the server in your `<registered_mcp>` prompt section. It is a **strict allowlist projection** — only non-secret identity fields (alias, provider username/id/display name, non-secret routing counts) are ever shown; tokens, passwords, app secrets, refresh/access tokens, headers, and any unrecognized field are dropped. The block appears only for servers that have published an identity file (currently the curated messaging addons: `telegram`, `feishu`, `wechat`, `whatsapp`); it is absent otherwise and reflects each account's last-cached state (no live network call). For richer per-account detail, the addon's own `accounts` action remains authoritative.
 
 All registry mutations happen via `write` / `edit` / `bash`. The `mcp` capability never writes to the registry.
+
+## Configuration settings
+
+`mcp(action="settings", input={}, reasoning="...")` is SHOW-only. Success is exactly
+`{"settings":[...]}`; every row has exactly `key`, `current`, `default`,
+`configurable`, and `comment`, in that order. The complete response is
+bounded to 65,536 UTF-8 bytes. A source/read/serialization failure returns one
+fixed no-row failure, never exception text or a partial inventory. This action
+has no set/reset form and writes no file.
+
+| Key | Meaning and source | Default | Configurable | Change and verify |
+|---|---|---|---|---|
+| `init.addons` | The fresh canonical effective top-level `addons` list read through the same init composition as boot/refresh. It is configuration truth, not the decompressed registry or live-client health. | `[]` | `true` | With explicit authorization, edit top-level `init.json` `addons`, call `system(action="refresh")`, then SHOW again and confirm the list. Decompression is append-only, so removing a name does not delete its registry row. |
+| `init.mcp` | The fresh canonical effective top-level `mcp` object. The entire nested object — both `current` and `default` — is always projected as `"<redacted>"`; no server name, command, argument, path, environment entry, or credential reference is exposed. | Logically `{}`; SHOW still renders `"<redacted>"`. | `true` | With explicit authorization, edit top-level `init.json` `mcp`, call `system(action="refresh")`, and use `info` plus the target addon's runtime action to verify behavior. SHOW remains redacted by design. A full relaunch is required when an already-healthy child must pick up a changed launch spec. |
+
+These rows exclude `mcp_registry.jsonl`, identity documents,
+`mcp/servers.json`, curated-addon private config/session files, Task Cards,
+agent identity, and live client/process state. Registry membership still gates
+top-level `init.mcp` activation; the legacy `mcp/servers.json` route remains
+a separate source and never changes either settings row.
 
 ## Runtime venv swap (latest-main owner rollout)
 

--- a/src/lingtai/tools/mcp/settings.py
+++ b/src/lingtai/tools/mcp/settings.py
@@ -1,0 +1,68 @@
+"""Read-only SHOW projection of MCP-owned top-level init settings."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from ..tool_family import SettingRow
+
+_MANUAL_ANCHOR = "mcp-manual#configuration-settings"
+
+
+class MCPSettingsProvider:
+    """Read the canonical effective init document afresh for each SHOW."""
+
+    def __init__(self, working_dir: Path | None) -> None:
+        self._working_dir = working_dir
+
+    def __call__(self) -> list[SettingRow]:
+        if self._working_dir is None:
+            raise RuntimeError("MCP settings require a bound working directory")
+
+        # Keep the tools -> lingtai back-edge lazy and reuse the same reader as
+        # boot/refresh.  A failed canonical read makes the whole inventory
+        # unavailable; no raw-file fallback or partial rows are projected.
+        from lingtai.agent import load_preset
+        from lingtai.init_reader import read_init, reader_callbacks
+
+        materialize, prepare = reader_callbacks(
+            self._working_dir,
+            load_preset=load_preset,
+        )
+        outcome = read_init(
+            self._working_dir,
+            materialize=materialize,
+            prepare=prepare,
+        )
+        data = outcome.data
+        if not outcome.ok or not isinstance(data, dict):
+            raise RuntimeError(
+                f"effective init configuration is unavailable at {outcome.stage or 'UNKNOWN'}"
+            )
+
+        addons: Any = data.get("addons", [])
+        mcp: Any = data.get("mcp", {})
+        if not isinstance(addons, list) or any(
+            not isinstance(addon, str) for addon in addons
+        ):
+            raise RuntimeError("effective init.addons is unavailable")
+        if not isinstance(mcp, dict):
+            raise RuntimeError("effective init.mcp is unavailable")
+
+        return [
+            SettingRow(
+                key="init.addons",
+                current=list(addons),
+                default=[],
+                configurable=True,
+                comment=_MANUAL_ANCHOR,
+            ),
+            SettingRow(
+                key="init.mcp",
+                current=mcp,
+                default={},
+                configurable=True,
+                comment=_MANUAL_ANCHOR,
+                _sensitive=True,
+            ),
+        ]

--- a/src/lingtai/tools/mcp/skills/mcp-manual/SKILL.md
+++ b/src/lingtai/tools/mcp/skills/mcp-manual/SKILL.md
@@ -26,7 +26,8 @@ description: >
   and HTTP server config; where `mcp_registry.jsonl` lives and how to mutate
   it (`write`/`edit`/`bash` — the `mcp` capability itself is read-only); the
   `<homepage>` fallback doc field; and how `init.json`'s `addons:` list and
-  `mcp:` activation entries relate to the registry. Replaces the deprecated
+  `mcp:` activation entries relate to the registry; and the bounded,
+  read-only five-field settings inventory. Replaces the deprecated
   `lingtai-mcp` skill.
 
   Does NOT cover the protocol spec. `lingtai-kernel-anatomy
@@ -37,12 +38,14 @@ description: >
   callback contract and to `src/lingtai/services/mcp_registry.py` for
   validator internals. Read this for *what to do*, anatomy for *how it
   works*.
-version: 3.4.2
-last_changed_at: 2026-08-20T00:00:00Z
+version: 3.5.0
+last_changed_at: 2026-08-29T00:00:00Z
 related_files:
 - src/lingtai/tools/mcp/__init__.py
+- src/lingtai/tools/mcp/settings.py
 - src/lingtai/tools/mcp/ANATOMY.md
 - src/lingtai/tools/mcp/CONTRACT.md
+- tests/test_mcp_settings.py
 maintenance: |
   Tracks the routed source/resources it summarizes; update when the underlying capability or its sub-references change.
 ---
@@ -112,13 +115,14 @@ If neither path yields docs, fall back to the MCP's own runtime self-description
 
 ## Tool surface
 
-Two actions, called through the standard envelope
+Three actions, called through the standard envelope
 `mcp(action=..., input={}, reasoning="...")`. `action`, `input`, and `reasoning`
-are all required; neither action takes any arguments, so `input` is always the
+are all required; no action takes arguments, so `input` is always the
 empty object `{}` — passing any field inside it is rejected before the tool does
 anything. The optional root `summarize` boolean is presentation only.
 
 - `mcp(action="info", input={}, reasoning="...")` returns current registry contents and a runtime health snapshot (registry path, count, problems) without the manual body.
+- `mcp(action="settings", input={}, reasoning="...")` returns the bounded, read-only MCP configuration inventory described below.
 - `mcp(action="manual", input={}, reasoning="...")` returns this manual body on demand, without re-reading the registry.
 
 Every worked call in this manual and its `reference/` docs is written in this
@@ -145,6 +149,26 @@ Each `registered` entry may also carry a non-secret **`identity`** block, so you
 Identity comes from the addon-written, non-secret document at `system/mcp_identities/<name>.json` (schema `lingtai.mcp.identity.v1`), surfaced both here and as an `<identity>` block under the server in your `<registered_mcp>` prompt section. It is a **strict allowlist projection** — only non-secret identity fields (alias, provider username/id/display name, non-secret routing counts) are ever shown; tokens, passwords, app secrets, refresh/access tokens, headers, and any unrecognized field are dropped. The block appears only for servers that have published an identity file (currently the curated messaging addons: `telegram`, `feishu`, `wechat`, `whatsapp`); it is absent otherwise and reflects each account's last-cached state (no live network call). For richer per-account detail, the addon's own `accounts` action remains authoritative.
 
 All registry mutations happen via `write` / `edit` / `bash`. The `mcp` capability never writes to the registry.
+
+## Configuration settings
+
+`mcp(action="settings", input={}, reasoning="...")` is SHOW-only. Success is exactly
+`{"settings":[...]}`; every row has exactly `key`, `current`, `default`,
+`configurable`, and `comment`, in that order. The complete response is
+bounded to 65,536 UTF-8 bytes. A source/read/serialization failure returns one
+fixed no-row failure, never exception text or a partial inventory. This action
+has no set/reset form and writes no file.
+
+| Key | Meaning and source | Default | Configurable | Change and verify |
+|---|---|---|---|---|
+| `init.addons` | The fresh canonical effective top-level `addons` list read through the same init composition as boot/refresh. It is configuration truth, not the decompressed registry or live-client health. | `[]` | `true` | With explicit authorization, edit top-level `init.json` `addons`, call `system(action="refresh")`, then SHOW again and confirm the list. Decompression is append-only, so removing a name does not delete its registry row. |
+| `init.mcp` | The fresh canonical effective top-level `mcp` object. The entire nested object — both `current` and `default` — is always projected as `"<redacted>"`; no server name, command, argument, path, environment entry, or credential reference is exposed. | Logically `{}`; SHOW still renders `"<redacted>"`. | `true` | With explicit authorization, edit top-level `init.json` `mcp`, call `system(action="refresh")`, and use `info` plus the target addon's runtime action to verify behavior. SHOW remains redacted by design. A full relaunch is required when an already-healthy child must pick up a changed launch spec. |
+
+These rows exclude `mcp_registry.jsonl`, identity documents,
+`mcp/servers.json`, curated-addon private config/session files, Task Cards,
+agent identity, and live client/process state. Registry membership still gates
+top-level `init.mcp` activation; the legacy `mcp/servers.json` route remains
+a separate source and never changes either settings row.
 
 ## Runtime venv swap (latest-main owner rollout)
 

--- a/tests/test_mcp_capability.py
+++ b/tests/test_mcp_capability.py
@@ -635,22 +635,22 @@ def test_mcp_show_unknown_action_returns_error(tmp_path):
     # (issue #513) and the ToolFamily migration.
     assert result == {
         "status": "error",
-        "message": "unknown action: 'register', only 'info' or 'manual' is supported",
+        "message": "unknown action: 'register', only 'info', 'settings', or 'manual' is supported",
     }
     # Missing action key renders the empty-string default, not None.
     assert handler({}) == {
         "status": "error",
-        "message": "unknown action: '', only 'info' or 'manual' is supported",
+        "message": "unknown action: '', only 'info', 'settings', or 'manual' is supported",
     }
     # Invalid JSON can make `action` unhashable (issue #513 blocker): the router
     # must render the unknown-action envelope, not raise TypeError.
     assert handler({"action": []}) == {
         "status": "error",
-        "message": "unknown action: [], only 'info' or 'manual' is supported",
+        "message": "unknown action: [], only 'info', 'settings', or 'manual' is supported",
     }
     assert handler({"action": {}}) == {
         "status": "error",
-        "message": "unknown action: {}, only 'info' or 'manual' is supported",
+        "message": "unknown action: {}, only 'info', 'settings', or 'manual' is supported",
     }
 
 

--- a/tests/test_mcp_settings.py
+++ b/tests/test_mcp_settings.py
@@ -1,0 +1,165 @@
+"""MCP-owned five-field settings inventory and source semantics."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from lingtai.tools.mcp import DECLARATION, _build_family, get_schema
+from lingtai.tools.mcp.settings import MCPSettingsProvider
+
+_REQUIRED = {
+    "manifest": {"llm": {"provider": "mock", "model": "mock-model"}},
+    "covenant": "operator contract",
+    "pad": "durable state",
+}
+_FIELDS = ["key", "current", "default", "configurable", "comment"]
+_ANCHOR = "mcp-manual#configuration-settings"
+
+
+def _write_init(workdir: Path, *, addons: list[str], marker: str) -> bytes:
+    raw = json.dumps({
+        **_REQUIRED,
+        "addons": addons,
+        "mcp": {
+            "private": {
+                "type": "stdio",
+                "command": "private-runner",
+                "env": {"PRIVATE_VALUE": marker},
+            },
+        },
+    }, indent=2).encode()
+    (workdir / "init.json").write_bytes(raw)
+    return raw
+
+
+def _family(workdir: Path):
+    host = SimpleNamespace(workdir=SimpleNamespace(path=workdir))
+    return _build_family(host)
+
+
+def _show(workdir: Path) -> dict:
+    return _family(workdir).handle({
+        "action": "settings",
+        "input": {},
+        "reasoning": "inspect MCP configuration",
+    })
+
+
+def test_declaration_and_schema_expose_settings_immediately_before_manual():
+    assert DECLARATION.settings is True
+    assert DECLARATION.public_actions == ("info", "settings", "manual")
+    assert get_schema()["properties"]["action"]["enum"] == [
+        "info", "settings", "manual",
+    ]
+    assert _build_family(None).child_names == DECLARATION.public_actions
+
+
+def test_settings_has_exact_rows_order_fields_and_fresh_effective_current(tmp_path):
+    first = _write_init(tmp_path, addons=["imap"], marker="first-hidden-marker")
+    result = _show(tmp_path)
+
+    assert list(result) == ["settings"]
+    assert [row["key"] for row in result["settings"]] == [
+        "init.addons", "init.mcp",
+    ]
+    assert [list(row) for row in result["settings"]] == [_FIELDS, _FIELDS]
+    assert result["settings"] == [
+        {
+            "key": "init.addons",
+            "current": ["imap"],
+            "default": [],
+            "configurable": True,
+            "comment": _ANCHOR,
+        },
+        {
+            "key": "init.mcp",
+            "current": "<redacted>",
+            "default": "<redacted>",
+            "configurable": True,
+            "comment": _ANCHOR,
+        },
+    ]
+    assert (tmp_path / "init.json").read_bytes() == first
+    assert "first-hidden-marker" not in repr(result)
+    assert "private-runner" not in repr(result)
+
+    second = _write_init(tmp_path, addons=["telegram"], marker="second-hidden-marker")
+    refreshed = _show(tmp_path)
+    assert refreshed["settings"][0]["current"] == ["telegram"]
+    assert refreshed["settings"][1]["current"] == "<redacted>"
+    assert (tmp_path / "init.json").read_bytes() == second
+    assert "second-hidden-marker" not in repr(refreshed)
+
+
+def test_sensitive_row_preserves_mapping_type_before_projection(tmp_path):
+    _write_init(tmp_path, addons=[], marker="never-project-this-marker")
+    rows = MCPSettingsProvider(tmp_path)()
+
+    assert [row.key for row in rows] == ["init.addons", "init.mcp"]
+    assert isinstance(rows[1].current, dict)
+    assert isinstance(rows[1].default, dict)
+    assert rows[1]._sensitive is True
+    assert "never-project-this-marker" not in repr(rows)
+
+
+def test_failed_canonical_read_is_one_fixed_whole_inventory_failure(tmp_path):
+    (tmp_path / "init.json").write_text("{not valid json", encoding="utf-8")
+    assert _show(tmp_path) == {
+        "status": "failed",
+        "error_code": "SETTINGS_UNAVAILABLE",
+        "message": "settings inventory is unavailable",
+    }
+
+
+def test_settings_is_strict_show_only_and_manual_anchor_exists_in_both_twins(tmp_path):
+    _write_init(tmp_path, addons=[], marker="private-marker")
+    family = _family(tmp_path)
+    for invalid in (None, [], {"set": True}):
+        result = family.handle({
+            "action": "settings",
+            "input": invalid,
+            "reasoning": "invalid mutation attempt",
+        })
+        assert result["status"] == "failed"
+
+    root = Path(__file__).parents[1]
+    packaged = root / "src/lingtai/tools/mcp/skills/mcp-manual/SKILL.md"
+    compatibility = root / "src/lingtai/tools/mcp/manual/SKILL.md"
+    assert packaged.read_bytes() == compatibility.read_bytes()
+    assert "## Configuration settings" in packaged.read_text(encoding="utf-8")
+
+
+def test_real_agent_starts_mounts_settings_and_builds_complete_prompt(tmp_path):
+    from lingtai.agent import Agent
+    from tests._service_helpers import make_gemini_mock_service
+
+    workdir = tmp_path / "agent"
+    workdir.mkdir()
+    _write_init(workdir, addons=[], marker="prompt-private-marker")
+    agent = Agent(
+        service=make_gemini_mock_service(),
+        agent_name="mcp-settings-real-agent",
+        working_dir=workdir,
+        capabilities={"mcp": {}},
+        addons=[],
+    )
+    try:
+        assert agent.official_tool_plugins["mcp"] is DECLARATION
+        schema = next(item for item in agent._tool_schemas if item.name == "mcp")
+        assert schema.parameters["properties"]["action"]["enum"] == [
+            "info", "settings", "manual",
+        ]
+        shown = agent._tool_handlers["mcp"]({
+            "action": "settings",
+            "input": {},
+            "reasoning": "verify mounted inventory",
+        })
+        assert [row["key"] for row in shown["settings"]] == [
+            "init.addons", "init.mcp",
+        ]
+        complete_prompt = agent._build_system_prompt()
+        assert isinstance(complete_prompt, str) and complete_prompt
+        assert "prompt-private-marker" not in complete_prompt
+    finally:
+        agent.stop(timeout=1.0)

--- a/tests/test_signpost_tool_descriptions.py
+++ b/tests/test_signpost_tool_descriptions.py
@@ -32,19 +32,21 @@ def test_mcp_description_and_actions_are_explicit_signposts() -> None:
     assert mcp_description().startswith("SIGNPOST ONLY:")
     assert "does not register, activate, configure, or troubleshoot MCP servers" in mcp_description()
     assert "`info` only re-reads the registry" in mcp_description()
+    assert "`settings` shows MCP-owned configuration" in mcp_description()
     assert "`manual` returns the mcp-manual body" in mcp_description()
     schema = mcp_schema()
     prop = schema["properties"]["action"]
-    # The ToolFamily migration keeps the public action values byte-identical
-    # and preserves the hand-written signpost action description verbatim.
-    assert prop["enum"] == ["info", "manual"]
+    # The bounded SHOW child is inserted before the reserved manual child.
+    assert prop["enum"] == ["info", "settings", "manual"]
     assert schema["required"] == ["action", "input", "reasoning"]
-    assert [b["title"] for b in schema["properties"]["input"]["oneOf"]] == [
+    assert [b["title"] for b in schema["properties"]["input"]["anyOf"]] == [
         "info input",
+        "settings inventory input",
         "manual input",
     ]
     action = prop["description"]
     assert "info: signpost-only action" in action
     assert "without the manual body" in action
+    assert "settings: show the MCP-owned init.addons" in action
     assert "manual: return only the mcp-manual skill body" in action
-    assert "Neither action mutates MCP configuration" in action
+    assert "No action mutates MCP configuration" in action

--- a/tests/test_tool_family_mcp_migration_parity.py
+++ b/tests/test_tool_family_mcp_migration_parity.py
@@ -1,7 +1,7 @@
 """Parity evidence for the `mcp` ToolFamily migration.
 
-`mcp` keeps its public tool name and its exact public action values
-(`info` / `manual`) while moving to the LTP v2 action-separated envelope
+`mcp` keeps its public tool name and adds its opted-in SHOW child between the
+existing `info` / `manual` actions in the LTP v2 action-separated envelope
 (`action` + `input` + `reasoning` + `summarize`) built on the generic
 `lingtai.tools.tool_family` infrastructure.
 
@@ -9,15 +9,14 @@ What these tests pin, beyond the pre-existing `tests/test_mcp_capability.py`
 and `tests/test_mcp_identity_discovery.py` behavior suites:
 
 - the composed schema's exact public surface and Chat/Responses wire parity;
-- that both actions declare a canonical strict-empty `input`, so any extra
+- that all actions declare a canonical strict-empty `input`, so any extra
   input field fails *before* the handler performs any I/O;
 - that `info` still only re-reads the registry (no manual body, no mutation);
 - that `manual` returns the exact manual body/path with no registry rescan or
   registry mutation, flattened back to mcp's own `mcp_manual` public shape
   with no double wrap;
-- that the unknown-action envelope is byte-identical to the pre-migration one,
-  including the two shapes the generic dispatcher does not reproduce on its
-  own (missing action, unhashable action).
+- that the unknown-action envelope keeps its established shape and malformed
+  action handling while listing the additive settings action.
 """
 from __future__ import annotations
 
@@ -31,7 +30,7 @@ from lingtai.services.mcp_registry import REGISTRY_FILENAME
 from lingtai.tools.mcp import get_schema
 from tests._service_helpers import make_gemini_mock_service as make_mock_service
 
-_UNKNOWN_ACTION_HINT = "only 'info' or 'manual' is supported"
+_UNKNOWN_ACTION_HINT = "only 'info', 'settings', or 'manual' is supported"
 
 
 @pytest.fixture
@@ -64,20 +63,21 @@ def test_schema_exposes_exact_public_actions_and_envelope():
     assert schema["type"] == "object"
     assert schema["additionalProperties"] is False
     assert set(schema["properties"]) == {"action", "input", "reasoning", "summarize"}
-    # Public name/actions are unchanged by the migration.
-    assert schema["properties"]["action"]["enum"] == ["info", "manual"]
+    assert schema["properties"]["action"]["enum"] == ["info", "settings", "manual"]
     # `reasoning` is required Host metadata declared by the family itself.
     assert schema["required"] == ["action", "input", "reasoning"]
     assert schema["properties"]["reasoning"]["type"] == "string"
     assert schema["properties"]["summarize"]["type"] == "boolean"
 
 
-def test_both_actions_declare_canonical_strict_empty_input():
+def test_all_actions_declare_canonical_strict_empty_input():
     from lingtai.tools.tool_family.manual import MANUAL_INPUT_SCHEMA
 
     schema = get_schema()
-    branches = schema["properties"]["input"]["oneOf"]
-    assert [b["title"] for b in branches] == ["info input", "manual input"]
+    branches = schema["properties"]["input"]["anyOf"]
+    assert [b["title"] for b in branches] == [
+        "info input", "settings inventory input", "manual input",
+    ]
     for branch in branches:
         assert branch["type"] == "object"
         assert branch["properties"] == {}
@@ -86,9 +86,7 @@ def test_both_actions_declare_canonical_strict_empty_input():
         # Root envelope fields never leak into a child input branch.
         for leaked in ("action", "reasoning", "_reasoning", "summarize"):
             assert leaked not in branch["properties"]
-    # Both children share the one canonical strict-empty literal that
-    # `build_manual_child` itself registers, so the schema-only family cannot
-    # advertise a shape the dispatching family does not validate against.
+    # Every public child uses the canonical strict-empty shape.
     for branch in branches:
         assert {k: v for k, v in branch.items() if k != "title"} == MANUAL_INPUT_SCHEMA
 
@@ -113,13 +111,13 @@ def test_schema_only_and_dispatching_families_declare_identical_children(mcp_age
 def test_schema_correlates_each_action_const_to_its_own_input():
     schema = get_schema()
     conditions = schema["allOf"]
-    assert len(conditions) == 2
+    assert len(conditions) == 3
     seen = {}
     for condition in conditions:
         action = condition["if"]["properties"]["action"]["const"]
         assert condition["if"]["required"] == ["action"]
         seen[action] = condition["then"]["properties"]["input"]
-    assert set(seen) == {"info", "manual"}
+    assert set(seen) == {"info", "settings", "manual"}
     for action_input in seen.values():
         assert action_input["additionalProperties"] is False
         assert action_input["properties"] == {}
@@ -133,13 +131,15 @@ def test_schema_survives_chat_and_responses_wires():
     chat = _build_tools([fn])[0]["function"]["parameters"]
     responses = _build_responses_tools([fn])[0]["parameters"]
 
-    for wire, combinator in ((chat, "oneOf"), (responses, "anyOf")):
+    for wire in (chat, responses):
         assert wire["required"] == ["action", "input", "reasoning"]
         assert wire["additionalProperties"] is False
         assert set(wire["properties"]) == {"action", "input", "reasoning", "summarize"}
-        assert wire["properties"]["action"]["enum"] == ["info", "manual"]
-        branches = wire["properties"]["input"][combinator]
-        assert [b["title"] for b in branches] == ["info input", "manual input"]
+        assert wire["properties"]["action"]["enum"] == ["info", "settings", "manual"]
+        branches = wire["properties"]["input"]["anyOf"]
+        assert [b["title"] for b in branches] == [
+            "info input", "settings inventory input", "manual input",
+        ]
 
 
 def test_real_agent_registers_exactly_one_public_mcp_tool(mcp_agent):
@@ -149,7 +149,7 @@ def test_real_agent_registers_exactly_one_public_mcp_tool(mcp_agent):
     schemas = [s for s in _build_tool_schemas(agent) if s.name == "mcp"]
     assert len(schemas) == 1
     params = schemas[0].parameters
-    assert params["properties"]["action"]["enum"] == ["info", "manual"]
+    assert params["properties"]["action"]["enum"] == ["info", "settings", "manual"]
     assert params["required"] == ["action", "input", "reasoning"]
 
 
@@ -281,7 +281,7 @@ def test_manual_reports_degraded_when_manual_missing(mcp_agent):
 # Envelope enforcement: fail before handler I/O
 # ---------------------------------------------------------------------------
 
-@pytest.mark.parametrize("action", ["info", "manual"])
+@pytest.mark.parametrize("action", ["info", "settings", "manual"])
 def test_extra_input_field_is_rejected_before_any_io(mcp_agent, monkeypatch, action):
     import lingtai.services.mcp_registry as registry_service
     import lingtai.tools.tool_family.manual as manual_child_module
@@ -410,7 +410,7 @@ def test_mcp_error_results_are_never_summarized():
 # Unknown action parity
 # ---------------------------------------------------------------------------
 
-def test_unknown_action_envelope_is_byte_identical_to_pre_migration(mcp_agent):
+def test_unknown_action_envelope_preserves_shape_with_current_actions(mcp_agent):
     agent, _ = mcp_agent
     handler = _handler(agent)
 

--- a/tests/test_tool_plugin_declaration.py
+++ b/tests/test_tool_plugin_declaration.py
@@ -119,7 +119,7 @@ def test_all_fourteen_official_families_mount_exactly_once_together(tmp_path):
 
 
 def test_official_mcp_mount_uses_controlled_host_and_real_dispatch(mcp_agent):
-    """Boot registration claims the declaration and dispatches both actions."""
+    """Boot registration claims the declaration and preserves existing dispatch."""
     from lingtai.tools.mcp import DECLARATION
 
     assert DECLARATION.requires == ("workdir", "prompt_section")

--- a/tests/test_tool_settings_contract.py
+++ b/tests/test_tool_settings_contract.py
@@ -147,10 +147,10 @@ def test_public_export_and_exact_production_opt_ins():
         name: importlib.import_module(f"lingtai.tools.{modules.get(name, name)}").DECLARATION
         for name in OFFICIAL_TOOL_PLUGIN_NAMES
     }
-    expected_official = {"avatar", "email", "plugin", "system", "task_card"}
+    expected_official = {"avatar", "email", "mcp", "plugin", "system", "task_card"}
     assert {name for name, item in declarations.items() if item.settings} == expected_official
     assert expected_curated | expected_official == {
-        "avatar", "cloud_mail", "email", "feishu", "imap", "plugin", "system", "task_card", "whatsapp"
+        "avatar", "cloud_mail", "email", "feishu", "imap", "mcp", "plugin", "system", "task_card", "whatsapp"
     }
     for name, item in declarations.items():
         assert ("settings" in item.public_actions) is (name in expected_official)


### PR DESCRIPTION
## Final sequential merge candidate

This Draft is the independent **MCP** settings owner implementation rebased onto the exact cumulative main after Email.

- exact candidate commit: `396da2aeb576296ec0b3dd0eca8e5654857b5b42`
- exact parent: `de4b2a2713b4deb63045657089d775b68c6701f8`
- exact tree: `c310d7a1813bf1ee08855f139d9ed4dbe5f3ab43`
- stable patch id: `4e623b8ffba054410a0a4264cf831f312e2da2c8`
- resulting diff: **19 files changed, 486 insertions(+), 135 deletions(-)**
- one owner commit, canonical `Huang Zesen <hzsbazinga@outlook.com>` identity, clean worktree, and no tracked deletions
- 15 non-conflict MCP owner/test paths are byte-identical to the reviewed owner head; the two cumulative auto-merge paths preserve exact path-specific stable patch ids; the shared settings manual remains byte-identical to cumulative main

## Behavior

- opts only `mcp` into the generic read-only `settings` action in this PR
- reports fresh canonical effective `init.addons`, default `[]`, configurable through the authorized top-level `init.json` field plus refresh
- reports fresh canonical effective `init.mcp` with logical default `{}`, but always projects both current/default as `<redacted>` so nested server names, commands, arguments, paths, environment entries, and credential references never escape
- MCP has no generic `LINGTAI_MCP_*` settings environment variable; registry rows, identity documents, legacy `mcp/servers.json`, addon private config/session, Task Cards, and live client/process state remain outside these rows
- adds no generic writer, `set`, `reset`, mutation receipt, or central settings registry; actual changes remain in authorized owner file procedures, with full relaunch required when a healthy child's launch spec must change
- preserves cumulative curated owners `{cloud_mail, feishu, imap, whatsapp}` and official owners `{avatar, email, plugin, system, task_card}`, then adds only official `mcp`

## Validation

- complete changed-test surface plus environment/Anatomy validators: **122 passed / 2 exact-current-main baseline failures / 0 candidate-unique failures**
- both failures reproduce on clean `de4b2a27`: the Avatar fake negative-test literal and the pre-existing session-stats reciprocal-link gap
- 15 non-conflict owner paths match old reviewed head `495e2faa93c58f38b8ba183e35120060d0d84531` byte-for-byte
- cumulative auto-merges in `src/lingtai/tools/CONTRACT.md` and `tests/test_tool_plugin_declaration.py` retain the old MCP delta with exact path-specific stable patch ids
- shared settings manual blob is exactly cumulative-main blob `e5e7f367f4d8eb2af83a96a672aa6860623d25a2`
- live MCP acceptance: `mcp.settings` returned the exact two rows with `init.mcp` fully redacted, and original `mcp.info` returned 5 registered records with `problems=[]`
- `git diff --check`: pass

## Sequential merge boundary

Jason authorized the strict one-PR-at-a-time merge flow. This candidate is limited to MCP and is ready for the exact-head report followed by the guarded squash merge of **#1532 only**. It does not authorize another owner PR, release, deploy, live runtime refresh, registry/init/config/auth mutation, deletion, or cleanup.

Telegram: @lingtaidev3bot | Nickname: 澄一

Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
