### PR TITLE
feat(soul): add five-field settings show

### DIFF
--- a/src/lingtai/intrinsic_skills/system-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/SKILL.md
@@ -4,8 +4,8 @@ description: >
   Second-layer router for LingTai's progressive-disclosure operating manuals.
   Read this when resident substrate/procedures are too compact and you need the
   right lower reference; route from the table, then open that node.
-version: 1.19.0
-last_changed_at: "2026-08-28T00:00:00Z"
+version: 1.19.1
+last_changed_at: "2026-08-29T00:00:00Z"
 tags: [lingtai, agent, runtime, procedures, substrate, system, lifecycle, alarm, memory, communication, skills, settings, molt, summarize, nudge, updates, runtime-checks, refresh, preset, llm, adapters, codex, websocket]
 related_files:
 - src/lingtai/prompts/substrate/substrate.md
@@ -156,7 +156,7 @@ The router table is the routing authority; this list is the inventory.
 | LLM adapters; named adapter inventory; provider configuration; Codex REST vs WebSocket transport; `LINGTAI_CODEX_TRANSPORT` / `LINGTAI_CODEX_WS` opt-in; provider special behaviors | `reference/llm-adapters/SKILL.md` |
 | Authorized external attach; macOS `/usr/bin/sample`; exact PID/agent-dir incarnation verification; bounded content-free stacks; guarded controlled external `mcp.*` burst; diagnostic privacy | `reference/external-attach-diagnostic/SKILL.md` |
 | Molt mechanics, pad tending, session journals, post-wipe recovery | `context-manual` |
-| Soul tool; soul flow opt-in (`LINGTAI_SOUL_FLOW_ENABLED`); disabled-flow behavior; `delay_seconds` as cadence-not-off-switch; inquiry/config/voice/dismiss; privacy/cost rationale | `soul-manual` |
+| Soul tool; read-only Soul settings inventory; soul flow opt-in (`LINGTAI_SOUL_FLOW_ENABLED`); disabled-flow behavior; `delay_seconds` as cadence-not-off-switch; inquiry/config/voice/dismiss; privacy/cost rationale | `soul-manual` |
 | Authoring/publishing skills or changing skill catalog behavior | `skills-manual` |
 | Knowledge-entry layout and private durable memory | `knowledge-manual` |
 | MCP registration/activation/addon ownership | `mcp-manual` |

--- a/src/lingtai/tools/ANATOMY.md
+++ b/src/lingtai/tools/ANATOMY.md
@@ -168,8 +168,9 @@ capability names and lazy adapters.
 - `knowledge/` — private durable knowledge catalog, migrated to the LTP v2
   family envelope with the unchanged public actions `info`/`manual`
   (`src/lingtai/tools/knowledge/ANATOMY.md`).
-- `soul/` — the official declared `soul` family (its injected module remains only for kernel hooks): six action-separated children
-  (`inquiry`, `flow`, `config`, `voice`, `dismiss`, `manual`) behind one
+- `soul/` — the official declared `soul` family (its injected module remains
+  only for kernel hooks): seven action-separated children (`inquiry`, `flow`,
+  `config`, `voice`, `dismiss`, read-only `settings`, and `manual`) behind one
   model-facing root (`src/lingtai/tools/soul/ANATOMY.md`).
 - `bash/` — public `shell` composition owner for run/poll/cancel/manual
   (`src/lingtai/tools/bash/ANATOMY.md`); the public model-facing schema is
@@ -307,7 +308,8 @@ through a callback-only adapter without exposing the Agent, Store,
 configuration object, or writer, including its two-row settings projection.
 `src/lingtai/tools/soul/__init__.py` is the tenth slice: its `DECLARATION`
 preserves the public `inquiry | flow | config | voice | dismiss | manual`
-family and binds the five operational children only to `workdir` plus the
+family, adds the generic read-only `settings` child immediately before
+`manual`, and binds the five operational children only to `workdir` plus the
 explicit `SoulRuntimePort`; Soul stays an injected intrinsic for kernel
 lifecycle hooks while its model-facing root mounts only through the registrar,
 and its package manual is the sole operational body installed at the historical

--- a/src/lingtai/tools/CONTRACT.md
+++ b/src/lingtai/tools/CONTRACT.md
@@ -622,8 +622,9 @@ non-goal for third-party-versus-third-party mounts.
   Vision, and Web are accepted vertical evidence. Soul's declaration binds only
   `workdir`/`soul_runtime`;
   its focused suites (`tests/test_tool_family_soul_migration.py`,
-  `tests/test_soul_runtime_port_ab.py`) prove the explicit runtime port, exact
-  grant, preserved six-action surface, one mount, and sole package manual body at
+  `tests/test_soul_runtime_port_ab.py`, `tests/test_soul_settings.py`) prove the
+  explicit runtime port, exact grant, preserved six-action operational surface,
+  additive reserved SHOW child, one mount, and sole package manual body at
   `soul-manual`. Email's declaration
   binds only `workdir`/`email_runtime`; its focused suite proves the typed port,
   one mount/no capability row, canonical manual, and call-time replacement
@@ -979,13 +980,14 @@ addon decompression and unreachable from any action. That is why it is safe in
 `CORE_DEFAULTS`, and registration is registry-level only: registered, never
 running. See `src/lingtai/tools/plugin/CONTRACT.md`.
 
-`soul` (`inquiry | flow | config | voice | dismiss | manual`) is the seventh
-family migrated to this contract, and the first migrated *intrinsic*. Its final
-model-facing root is exactly `action`, `input`, `reasoning`, and `summarize`;
-each action owns one strict closed `input` object, and its `summarize` guidance
-profile is **short-result** for every action (see
-`src/lingtai/tools/soul/CONTRACT.md`). `soul` supports no settings file at
-either level and its manual says so explicitly. Being an intrinsic, it also
+`soul` (`inquiry | flow | config | voice | dismiss | settings | manual`) is the
+seventh family migrated to this contract, and the first migrated *intrinsic*.
+Its final model-facing root is exactly `action`, `input`, `reasoning`, and
+`summarize`; each action owns one strict closed `input` object, and its
+`summarize` guidance profile is **short-result** for every action (see
+`src/lingtai/tools/soul/CONTRACT.md`). The reserved `settings` child is a
+five-row SHOW over Soul's existing sources; `soul` still supports no settings
+file at either level and its manual says so explicitly. Being an intrinsic, it also
 proves one boundary `web` could not: `base_agent._dispatch_tool` injects the
 transport-only `_tc_id` into every intrinsic's args, so a migrated intrinsic
 drops that key at its own Host boundary before the closed-root check rather
@@ -1111,9 +1113,10 @@ envelope, and the reserved `manual` child's no-double-wrap result.
 
 `soul`'s migration evidence (`tests/test_tool_family_soul_migration.py`, plus
 the updated `tests/test_soul.py`, `tests/test_soul_consultation.py`,
-`tests/test_system_dismiss.py`, and `tests/test_intrinsic_manual_actions.py`)
-is likewise one family's local evidence: it covers all six child schemas and
-handlers, the closed root on both provider wires, wrong-branch rejection
+`tests/test_system_dismiss.py`, `tests/test_intrinsic_manual_actions.py`, and
+`tests/test_soul_settings.py`) is likewise one family's local evidence: it
+covers the six existing children plus additive reserved `settings`, the closed
+root on both provider wires, wrong-branch rejection
 before any handler I/O, `reasoning`/`_reasoning`/`summarize`/`_tc_id`
 isolation from child input, the reserved `manual` child's
 full-body/`manual_path` result with no double wrap and no soul operation, and

--- a/src/lingtai/tools/soul/ANATOMY.md
+++ b/src/lingtai/tools/soul/ANATOMY.md
@@ -4,6 +4,7 @@ related_files:
   - src/lingtai/tools/soul/BEHAVIORS.md
   - src/lingtai/tools/soul/__init__.py
   - src/lingtai/tools/soul/config.py
+  - src/lingtai/tools/soul/settings.py
   - src/lingtai/tools/soul/consultation.py
   - src/lingtai/tools/soul/flow.py
   - src/lingtai/tools/soul/inquiry.py
@@ -19,21 +20,23 @@ related_files:
   - tests/test_tool_plugin_declaration.py
   - tests/test_tool_family_soul_migration.py
   - tests/test_soul_runtime_port_ab.py
+  - tests/test_soul_settings.py
   - src/lingtai/tools/CONTRACT.md
   - src/lingtai/tools/tool_family/ANATOMY.md
   - ENVIRONMENT_VARIABLES.md
 maintenance: |
   Keep related_files as repo-relative paths to real files. Keep this map
   synchronized with Soul's structural composition and the paired contract.
-  The root package is the only whole-Agent compatibility bridge; the four
+  The root package is the only whole-Agent compatibility bridge; the five
   implementation consumers below receive SoulRuntimePort directly. Capability
   mentions require explicit related_files links to implementing code.
 ---
 # intrinsics/soul
 
 Soul is the official declared-host-plugin family for the agent's inner voice.
-Its public root owns the LTP-v2 envelope and six action children (`inquiry`,
-`flow`, `config`, `voice`, `dismiss`, and reserved `manual`). Soul's domain
+Its public root owns the LTP-v2 envelope and seven action children (`inquiry`,
+`flow`, `config`, `voice`, `dismiss`, read-only `settings`, and reserved
+`manual`). Soul's domain
 implementation receives the least-privilege `SoulRuntimePort`; it does not
 receive a whole Agent.
 
@@ -49,6 +52,9 @@ receive a whole Agent.
   `manifest.soul` persistence. `_handle_config()` and `_handle_voice()` read
   and mutate only the granted runtime's `config`, cadence, timer, logging, and
   `working_dir` properties.
+- `settings.py` — binds the generic five-field `SettingRow` projection to live
+  `SoulRuntimePort` cadence/config truth and the process flow gate. It exposes
+  a private-redacted prompt row and performs no mutation.
 - `flow.py` — opt-in gate, IDLE timer, fire lock, consultation-fire
   orchestration, notification publication, append-only records, and appendix
   rehydration. It accesses `shutdown`, `soul_timer`, `state`, `fire_lock`, and
@@ -60,7 +66,8 @@ receive a whole Agent.
   bounded consultation batches, timeout/token accounting, refusal handling, and
   synthesized flow-pair construction. Runtime access is through `chat`,
   `session`, `service`, `config`, `working_dir`, and `log` on the port.
-- `manual/SKILL.md` — the local operational guide for the six-action envelope,
+- `manual/SKILL.md` — the local operational guide for the seven-action
+  envelope, exact settings comment targets, real change procedures,
   disabled-flow/config behavior, and valid nullable input shapes.
 - `tests/test_soul_runtime_port_ab.py` — focused proof that the four consumers
   accept a structural port directly and that the root bridge preserves a real
@@ -69,10 +76,11 @@ receive a whole Agent.
 ## Connections
 
 - The declaration binder creates a `SoulRuntimePort` adapter in the host
-  composition layer; it never passes an Agent into `config.py`, `flow.py`,
-  `inquiry.py`, or `consultation.py`.
+  composition layer; it never passes an Agent into `config.py`, `settings.py`,
+  `flow.py`, `inquiry.py`, or `consultation.py`.
 - `__init__.py` dispatches `config`/`voice` to `config.py`, `inquiry` to
-  `inquiry.py`, and flow lifecycle work to `flow.py`. `flow.py` imports the
+  `inquiry.py`, flow lifecycle work to `flow.py`, and injects `settings.py`'s
+  provider through the generic ToolFamily seam. `flow.py` imports the
   consultation batch and diary helpers; `inquiry.py` imports prompt, send,
   token, and persistence helpers from sibling modules.
 - The root compatibility wrappers remain available for kernel lifecycle hooks
@@ -94,6 +102,8 @@ receive a whole Agent.
 
 - `config.py` writes `init.json` under `manifest.soul` for cadence, voice, and
   custom voice prompt.
+- `settings.py` writes no state; it reads the process flow gate and the live
+  cadence/voice values already owned by the runtime and config action.
 - `flow.py` appends `logs/soul_flow.jsonl` and may publish/clear the `soul`
   notification through the port. `inquiry.py` persists inquiry entries through
   the same Soul persistence operation and may publish `btw` for human source.

--- a/src/lingtai/tools/soul/BEHAVIORS.md
+++ b/src/lingtai/tools/soul/BEHAVIORS.md
@@ -9,6 +9,8 @@ related_files:
   - src/lingtai/tools/soul/ANATOMY.md
   - src/lingtai/tools/soul/__init__.py
   - src/lingtai/tools/soul/flow.py
+  - src/lingtai/tools/soul/settings.py
+  - tests/test_soul_settings.py
 maintenance: |
   Created during the every-contract-needs-behaviors sweep. Keep this file
   reciprocal with CONTRACT.md and ANATOMY.md (tridirectional loop): when a soul
@@ -19,8 +21,9 @@ maintenance: |
 
 Self-contained agent behavior tasks guarding the observable behavior clauses of
 `src/lingtai/tools/soul/CONTRACT.md` (flow opt-in gate, disabled/ongoing paths
-return before spawning, manual no-op, envelope enforcement). Pinned pytest
-commands must run from the repo root with the project's Python.
+return before spawning, manual no-op, five-field settings SHOW, envelope
+enforcement). Pinned pytest commands must run from the repo root with the
+project's Python.
 
 ## Behavior SU001 — flow's disabled and ongoing paths return before any fire thread, and manual touches no soul state
 
@@ -37,9 +40,31 @@ commands must run from the repo root with the project's Python.
 3. Call `soul(action="manual", input={}, reasoning="probe")` and confirm no timer, lock, consultation, config, voice, or notification state changed.
 
 ### Expected evidence
-- [ ] Step 1: the soul suites pass, pinning inquiry/flow/config/voice/dismiss/manual behavior and consultation pair building.
+- [ ] Step 1: the soul suites pass, pinning inquiry/flow/config/voice/dismiss/settings/manual behavior and consultation pair building.
 - [ ] Step 2: with the env opt-out, `flow` returns `{status: "disabled", enabled: False, env_var, message}` and spawns no fire thread; a second `flow` while a fire is in flight returns `{error: "soul flow ongoing, request rejected"}` before spawning.
 - [ ] Step 3: `manual` reads the installed manual and touches no soul state; a cross-action input key fails with `INVALID_ARGUMENT` before any handler I/O.
 
 ### Pass / Fail
 Pass when the suites pass and the gate/no-op observations hold. Fail on a fire thread spawning when disabled or ongoing, on a `manual` that touches soul state, or on an accepted cross-action input; record the evidence trail in the task report.
+
+## Behavior SU002 — settings shows five owner rows without mutation or partial truth
+
+- **id**: SU002
+- **title**: settings shows five owner rows without mutation or partial truth
+- **guards**: `soul-contract` § Tool surface
+- **runner**: any LingTai agent with `shell` access to this repository
+- **prerequisites**: a clean checkout of `<repo>` and its repository virtual environment
+- **estimate**: ≈ 5 minutes
+
+### Steps
+1. From `<repo>`, run `python -m pytest -q tests/test_soul_settings.py tests/test_tool_settings_contract.py` and capture the outcome.
+2. Inspect the successful Soul inventory fixture and the unavailable-current fixture in `tests/test_soul_settings.py`.
+3. Inspect `soul-manual` and resolve each returned `comment` fragment to its exact settings section.
+
+### Expected evidence
+- [ ] Step 1: the suites pass and the shared exact opt-in assertion identifies only System and Soul on this independent owner branch.
+- [ ] Step 2: success has exactly the five ordered Soul keys and exactly `key`/`current`/`default`/`configurable`/`comment`; the prompt is redacted, strict non-empty input fails, ordinary dismiss is unchanged, and unavailable current truth produces one fixed no-row failure.
+- [ ] Step 3: all five comments target manual sections containing meaning, accepted values, source/precedence, canonical env/config keys, timing, sensitivity/authorization notes, and the existing real change procedures.
+
+### Pass / Fail
+Pass when both suites pass, System and Soul are the exact opted-in official set, and every projected comment resolves. Fail on mutation through SHOW, an extra or missing row field, secret disclosure, partial-row unavailable output, a missing manual target, or any unrelated family opt-in.

--- a/src/lingtai/tools/soul/CONTRACT.md
+++ b/src/lingtai/tools/soul/CONTRACT.md
@@ -1,11 +1,13 @@
 ---
 name: soul-contract
 tool: soul
-contract_version: 2
+contract_version: 3
 root_contract: CONTRACT.md
 related_files:
+  - src/lingtai/tools/soul/BEHAVIORS.md
   - src/lingtai/tools/soul/__init__.py
   - src/lingtai/tools/soul/config.py
+  - src/lingtai/tools/soul/settings.py
   - src/lingtai/tools/soul/manual/SKILL.md
   - src/lingtai/kernel/tool_plugin/CONTRACT.md
   - src/lingtai/adapters/tool_plugin_host.py
@@ -16,6 +18,7 @@ related_files:
   - src/lingtai/tools/tool_family/CONTRACT.md
   - src/lingtai/kernel/tool_result_summary.py
   - tests/test_tool_family_soul_migration.py
+  - tests/test_soul_settings.py
 maintenance: |
   Keep related_files as repo-relative paths to real files. If behavior and this
   contract disagree, the code is the source of truth — fix the contract in the
@@ -27,20 +30,20 @@ maintenance: |
 # Soul capability contract
 
 `soul` is the agent's inner voice: on-demand past-self `inquiry`, mechanical
-periodic `flow` consultation, cadence/voice `config`, and a `dismiss` for the
-soul-flow notification. The implementation lives in `src/lingtai/tools/soul/`; the code
-is the source of truth.
+periodic `flow` consultation, cadence/voice `config`, a `dismiss` for the
+soul-flow notification, and read-only `settings` discovery. The implementation
+lives in `src/lingtai/tools/soul/`; the code is the source of truth.
 
 `soul` is migrated to the LingTai Tool Protocol v2 shape defined in
 `src/lingtai/tools/CONTRACT.md` and builds its schema composition and envelope
 dispatch on the generic `src/lingtai/tools/tool_family/` infrastructure. The
-public tool name, the six action values, every success/error payload, every
-log event, and every persistence path are exactly what they were before that
-migration; only the argument *shape* changed, from a flat root to
-`action` + one strict per-action `input`.
+generic settings contract adds one reserved SHOW action without changing the
+existing six action values, their success/error payloads, log events, or
+persistence paths. The settings action owns no writer.
 
 ## Routing Card
-Guarded by: [SU001](BEHAVIORS.md#behavior-su001)
+Guarded by: [SU001](BEHAVIORS.md#behavior-su001),
+[SU002](BEHAVIORS.md#behavior-su002)
 
 
 **Use this when:**
@@ -68,8 +71,8 @@ claims; log/notification paths -> §State & storage.
   `summarize`, with `additionalProperties: false`. `action`, `input`, and
   `reasoning` are required; `summarize` is optional Host presentation and is
   never action input. The action enum is `inquiry`, `flow`, `config`, `voice`,
-  `dismiss`, `manual` — one canonical child each, where the child's name is
-  simultaneously the public action value and the dispatch key.
+  `dismiss`, `settings`, `manual` — one canonical child each, where the child's
+  name is simultaneously the public action value and the dispatch key.
 - Each action owns one strict, closed `input` object. Declared optional fields
   use the provider-compatible nullable representation (`["number", "null"]`
   etc.); null means "absent" at dispatch.
@@ -83,8 +86,9 @@ claims; log/notification paths -> §State & storage.
 ## Declared host plugin
 
 `DECLARATION` is static at import and owns Soul's operational actions
-`inquiry | flow | config | voice | dismiss`; the reserved `manual` is appended
-from package-owned `manual/SKILL.md` as `soul-manual`. `_bind(host)` derives
+`inquiry | flow | config | voice | dismiss`; the reserved read-only `settings`
+and `manual` children are appended by the generic contract, with the latter
+using package-owned `manual/SKILL.md` as `soul-manual`. `_bind(host)` derives
 its name, input schemas, and manual destination from that declaration and gets
 only `workdir` plus `soul_runtime`. `AgentSoulRuntimeAdapter` implements the
 latter as the explicit self-state/flow vocabulary Soul consumes — current
@@ -94,10 +98,11 @@ operations — never a whole Agent or generic mount capability.
 The injected Soul module remains available only for kernel lifecycle hooks.
 `Agent` removes its temporary intrinsic dispatcher entry and mounts the public
 root through `register_agent_tool_plugins`; refresh repeats the controlled mount.
-The public name, six ordered actions, strict inputs, flow gate, persistence,
-results/errors, and historical `.library/intrinsic/capabilities/soul-manual/`
-manual path are unchanged. Any second operational owner for that destination
-must fail loudly rather than be resolved by scan order.
+The public name, existing six ordered actions, strict inputs, flow gate,
+persistence, results/errors, and historical
+`.library/intrinsic/capabilities/soul-manual/` manual path are unchanged. The
+reserved `settings` child is additive. Any second operational owner for that
+destination must fail loudly rather than be resolved by scan order.
 
 ## Tool surface
 
@@ -113,6 +118,7 @@ Inputs below are fields of that action's own `input` object, never of the root.
 | `config` | at least one non-null of `delay_seconds`, `consultation_past_count` | the other knob (nullable) | `{status: "ok", old, new}` (+ `soul_flow_enabled`/`note` when flow disabled) | `{error: "config requires at least one of ..."}`; range/type `{error}` for each field |
 | `voice` | — (read: both nullable fields null) | `set` (`inner`/`observer`/`custom`), `prompt` (required for `custom`) | `{status: "ok", current, available, prompt, ...}` | `{error: "set must be a string ..."}`; `{error: "Unknown voice profile: ..."}`; `{error: "set='custom' requires a non-empty 'prompt' ..."}`; `{error: "prompt is too long ..."}` |
 | `dismiss` | — (empty `input`) | — | `{status: "ok", message}` (delegates to `dismiss_channel(soul)`) | dismissal `{status: "error", ...}` from the shared helper |
+| `settings` | — (strict empty `input`) | — | `{settings: [{key, current, default, configurable, comment}, ...]}` with exactly five Soul rows | one fixed no-row failure for unavailable/malformed/unserializable provider truth; fixed oversize failure |
 | `manual` | — (strict empty `input`) | — | flat `{status, manual, manual_path}` (+ `error` when the manual is missing) | `{status: "degraded", ..., error: "soul-manual manual missing ..."}` |
 
 An unknown/absent `action` returns `{error: "Unknown soul action: ..."}`.
@@ -120,11 +126,23 @@ An unknown/absent `action` returns `{error: "Unknown soul action: ..."}`.
 `manual` performs **no** soul operation: it reads the installed manual and
 touches no timer, lock, consultation, config, voice, or notification state.
 
+The `settings` action is also read-only and takes exactly `input={}`. Its five
+rows are `flow_enabled`, `delay_seconds`, `consultation_past_count`, `voice`,
+and `voice_prompt`, in that order. Every successful row projects exactly
+`key`, `current`, `default`, `configurable`, and an exact `soul-manual#...`
+section pointer in `comment`; the custom prompt's current/default values are
+fully redacted. Current truth comes fresh from the live runtime and the same
+process flow gate the owner consumes. If any current value is unavailable or
+not JSON-safe, the provider raises and the generic action returns one bounded
+failure with no partial rows. `configurable` means the launcher, existing
+`config`, or existing atomic `voice` procedure can change the value; SHOW
+itself has no set/reset operation.
+
 ### Envelope enforcement
 
 - The root `allOf` correlates each `action` const with that action's exact
   `input` schema, so a provider that enforces `allOf`/`if`/`then` can reject a
-  mismatched pairing before invocation; `input.oneOf` discloses every action's
+  mismatched pairing before invocation; `input.anyOf` discloses every action's
   exact shape in one place.
 - Dispatch remains the always-authoritative, fail-closed boundary. An `input`
   key belonging to another action's branch (e.g. `action='inquiry'` with
@@ -189,6 +207,8 @@ init.json                   — manifest.soul persistence for config (delay_seco
 - `config`/`voice` update live agent state and persist to `init.json`
   (`manifest.soul`); `config` also restarts the wall-clock timer when
   `delay_seconds` changes.
+- `settings` only reads those live values plus the process flow gate; it never
+  writes `init.json`, process environment, timers, or notifications.
 - `dismiss` clears `.notification/soul.json` through
   `lingtai.kernel.notifications.dismiss_channel(agent, "soul", invoked_by="soul")`.
 
@@ -206,19 +226,20 @@ init.json                   — manifest.soul persistence for config (delay_seco
 
 | Claim | Source | Test |
 |---|---|---|
-| Schema exposes `inquiry`/`flow`/`config`/`voice`/`dismiss`/`manual` as action-separated children behind one closed LTP v2 root | `src/lingtai/tools/soul/__init__.py:get_schema` | `tests/test_soul.py`, `tests/test_tool_family_soul_migration.py` |
+| Schema exposes the existing operational children plus reserved `settings` and `manual` behind one closed LTP v2 root | `src/lingtai/tools/soul/__init__.py:get_schema` | `tests/test_soul.py`, `tests/test_tool_family_soul_migration.py` |
 | Each action's parameters live only in that action's own strict `input` branch | `src/lingtai/tools/soul/__init__.py` (child `input_schema` objects) | `tests/test_tool_family_soul_migration.py::test_action_parameters_are_no_longer_advertised_to_every_action` |
 | Cross-action `input` is rejected before any handler I/O | `src/lingtai/tools/soul/__init__.py:handle` via `tool_family.ToolFamily.handle` | `tests/test_tool_family_soul_migration.py::test_cross_action_input_is_rejected_before_any_handler_io` |
 | `manual` returns the full body plus host-local `manual_path`, no double wrap, and performs no soul operation | `src/lingtai/tools/soul/__init__.py:_adapt_manual_result`, `tool_family/manual.py:build_manual_child` | `tests/test_tool_family_soul_migration.py` (manual section), `tests/test_intrinsic_manual_actions.py` |
 | One public `soul` root on both the Chat and Responses wires, `reasoning` required | `src/lingtai/tools/soul/__init__.py:get_schema`, `kernel/base_agent/tools.py:_build_tool_schemas` | `tests/test_tool_family_soul_migration.py::test_agent_composition_keeps_reasoning_required_on_both_wires` |
 | The synthesized involuntary flow pair carries the current envelope, not the flat pre-migration shape | `src/lingtai/tools/soul/consultation.py:build_consultation_pair` | `tests/test_tool_family_soul_migration.py::test_synthesized_involuntary_flow_pair_uses_the_current_envelope`, `tests/test_soul_consultation.py::TestBuildConsultationPair::test_pair_uses_soul_flow_action` |
-| Schema and dispatch are generated from one child registry and cannot drift | `src/lingtai/tools/soul/__init__.py:_CHILD_SPECS`/`_build_children` | `tests/test_tool_family_soul_migration.py::test_schema_and_dispatch_come_from_one_registry` |
+| Schema and dispatch are generated from one child registry and cannot drift | `src/lingtai/tools/soul/__init__.py:_build_declared_children`/`_build_family` | `tests/test_tool_family_soul_migration.py::test_schema_and_dispatch_come_from_one_registry` |
 | `flow` is opt-in and returns a stable `disabled` status when the env var is unset | `src/lingtai/tools/soul/__init__.py:handle` (`_soul_flow_enabled`) | `tests/test_soul.py` |
 | A late consultation result is discarded after a state change | `src/lingtai/tools/soul/flow.py` | `tests/test_soul.py::test_consultation_fire_discards_late_result_after_state_change` |
 | `inquiry` returns a voice (or "(silence)") and persists the entry | `src/lingtai/tools/soul/__init__.py:handle`, `src/lingtai/tools/soul/inquiry.py:soul_inquiry` | `tests/test_soul_consultation.py` |
 | `config` validates `delay_seconds`/`consultation_past_count` bounds and persists to init.json | `src/lingtai/tools/soul/config.py:_handle_config`/`_persist_soul_config` | `tests/test_soul.py` |
 | `voice` reads/switches built-in profiles and stores custom prompts within the cap | `src/lingtai/tools/soul/config.py:_handle_voice`/`_persist_soul_voice` | `tests/test_soul.py` |
 | `dismiss` delegates to the shared `dismiss_channel` helper for the `soul` channel | `src/lingtai/tools/soul/__init__.py:handle` | `tests/test_system_dismiss.py::test_soul_dismiss_alias_uses_shared_helper` |
+| `settings` returns the exact five-field owner projection, redacts the custom prompt, and fails as one unit when current truth is unavailable | `src/lingtai/tools/soul/settings.py:soul_settings_provider` | `tests/test_soul_settings.py` |
 | Soul entries append to `logs/soul_flow.jsonl` keyed by `mode` | `src/lingtai/tools/soul/flow.py:_persist_soul_entry` | `tests/test_soul_consultation.py` |
 
 ## Verification matrix
@@ -233,13 +254,15 @@ init.json                   — manifest.soul persistence for config (delay_seco
 | A cross-action `input` never reaches a handler | `tests/test_tool_family_soul_migration.py::test_cross_action_input_is_rejected_before_any_handler_io` | Send `action='inquiry'` with `input={'delay_seconds': 60}` | A mis-paired call silently mutating cadence or burning an LLM call |
 | `manual` performs no soul operation | `tests/test_tool_family_soul_migration.py::test_manual_performs_no_soul_operation` | Call `soul(action='manual', input={})` and inspect init.json + logs | Reading the manual perturbing live soul state |
 | Synthesized flow calls stay envelope-shaped | `tests/test_tool_family_soul_migration.py::test_synthesized_involuntary_flow_pair_uses_the_current_envelope` | Trigger a fire, read the appended pair's args in chat history | History teaching a shape the schema rejects; a model imitating it gets `INVALID_ARGUMENT` |
+| Settings stays five-field SHOW-only | `tests/test_soul_settings.py` | Call `settings` twice around an authorized owner change | Secret disclosure, mutation through SHOW, or stale/unavailable truth presented as success |
 
 Run before merging soul changes:
 
 ```bash
 python -m pytest tests/test_soul.py tests/test_soul_consultation.py \
   tests/test_system_dismiss.py tests/test_tool_family_soul_migration.py \
-  tests/test_intrinsic_manual_actions.py -q
+  tests/test_intrinsic_manual_actions.py tests/test_soul_settings.py \
+  tests/test_tool_settings_contract.py -q
 ```
 
 ## Schema and glossary ownership

--- a/src/lingtai/tools/soul/__init__.py
+++ b/src/lingtai/tools/soul/__init__.py
@@ -60,6 +60,7 @@ from .flow import (
 )
 from .inquiry import _run_inquiry as _run_inquiry_impl
 from .inquiry import soul_inquiry as _soul_inquiry_impl
+from .settings import soul_settings_provider
 
 if TYPE_CHECKING:
     from lingtai.kernel.tool_plugin import SoulRuntimePort, ToolPluginHost, WorkdirPort
@@ -297,7 +298,7 @@ _DECLARED_INPUT_SCHEMAS: dict[str, dict[str, Any]] = {
 }
 
 _DESCRIPTION = (
-    "Your inner voice. One tool, six actions, each with its own strict input "
+    "Your inner voice. One tool, seven actions, each with its own strict input "
     "object: soul(action=..., input={...}, reasoning='why'). flow is OPT-IN "
     "and DISABLED by default: it runs only when the operator sets env "
     "LINGTAI_SOUL_FLOW_ENABLED=1 (then refreshes). While disabled, "
@@ -310,7 +311,8 @@ _DESCRIPTION = (
     "yourself a question; answer returns in the tool result. config: tune flow "
     "knobs at runtime (delay_seconds, consultation_past_count) — does not enable "
     "flow. voice: read or choose how your own soul-flow voice sounds. dismiss: "
-    "clear the current flow notification. manual: return the installed "
+    "clear the current flow notification. settings: show Soul's five current "
+    "settings without changing them. manual: return the installed "
     "soul-manual skill without performing any soul operation. Results are "
     "small, so leave root summarize false (short-result profile); call manual "
     "with summarize=false so the exact procedure is not summarized away. See "
@@ -352,17 +354,21 @@ def _build_family(
     children = _build_declared_children(runtime)
     if runtime is None:
         children.append(ChildTool("manual", MANUAL_INPUT_SCHEMA, lambda _i: {}, title="manual input"))
+        settings_provider = tuple
     else:
         children.append(build_manual_child(manual_source, DECLARATION.manual))
-    return ToolFamily(DECLARATION.name, children)
+        settings_provider = soul_settings_provider(runtime)
+    return ToolFamily(
+        DECLARATION.name,
+        children,
+        settings_provider=settings_provider,
+    )
 
 
 def _build_children(agent: Any) -> list[ChildTool]:
     """Compatibility test/hook view of the same declaration-owned children."""
     if agent is None:
-        return _build_declared_children(None) + [
-            ChildTool("manual", MANUAL_INPUT_SCHEMA, lambda _i: {}, title="manual input")
-        ]
+        return list(_build_family(None)._children.values())
     runtime = _coerce_runtime(agent)
     return list(_build_family(runtime, runtime)._children.values())
 
@@ -386,7 +392,8 @@ def _handle_bound(runtime: "SoulRuntimePort", manual_source: Any, args: Mapping[
         return {
             "error": (
                 f"Unknown soul action: {action if action is not None else ''}. "
-                "Use inquiry, config, voice, dismiss, manual, or wait for flow (mechanical)."
+                "Use inquiry, config, voice, dismiss, settings, manual, or wait "
+                "for flow (mechanical)."
             )
         }
     return result
@@ -413,6 +420,7 @@ DECLARATION = ToolPluginDeclaration(
     binder=_bind,
     requires=("workdir", "soul_runtime"),
     glossary_package=__package__,
+    settings=True,
 )
 
 SOUL_ACTIONS: tuple[str, ...] = DECLARATION.public_actions

--- a/src/lingtai/tools/soul/manual/SKILL.md
+++ b/src/lingtai/tools/soul/manual/SKILL.md
@@ -1,28 +1,31 @@
 ---
 name: soul-manual
 description: |
-  Operational guide for the `soul` tool — your inner voice: the one-tool/six-actions call shape, the `LINGTAI_SOUL_FLOW_ENABLED` opt-in gate, disabled-flow behavior, and the delay-is-cadence-not-an-off-switch semantics. Read it before calling `flow`, tuning `config`, or troubleshooting a `status: disabled` result.
-version: 1.2.0
-last_changed_at: "2026-08-07T00:00:00Z"
+  Operational guide for the `soul` tool — your inner voice: the seven-action call shape, read-only settings inventory, flow opt-in gate, cadence, consultation count, and voice procedures. Read it before calling `flow`, changing Soul configuration, or troubleshooting a `status: disabled` result.
+version: 1.3.0
+last_changed_at: "2026-08-29T00:00:00Z"
 related_files:
 - src/lingtai/tools/soul/__init__.py
 - src/lingtai/tools/soul/CONTRACT.md
 - src/lingtai/tools/CONTRACT.md
 - src/lingtai/tools/soul/flow.py
 - src/lingtai/tools/soul/config.py
+- src/lingtai/tools/soul/settings.py
 - src/lingtai/tools/soul/consultation.py
+- tests/test_soul_settings.py
 maintenance: |
   Tracks the tool/capability behavior it teaches; update when that tool's behavior changes.
 ---
 
 # Soul Manual
 
-`soul` is your inner voice. `inquiry`, `config`, `voice`, `dismiss`, and
-`manual` are **always available**. `flow` is **opt-in and disabled by default**.
+`soul` is your inner voice. `inquiry`, `config`, `voice`, `dismiss`, `settings`,
+and `manual` are **always available**. `flow` is **opt-in and disabled by
+default**.
 
 ## 0. How to call it
 
-One tool, six actions. Every call is `action` + that action's own strict `input`
+One tool, seven actions. Every call is `action` + that action's own strict `input`
 object + `reasoning`; another action's field is rejected before anything runs:
 
 ```json
@@ -36,6 +39,7 @@ object + `reasoning`; another action's field is rejected before anything runs:
 | `config` | `{"delay_seconds": <num or null>, "consultation_past_count": <int or null>}` — both keys are sent; at least one value must be non-null |
 | `voice` | `{"set": <profile or null>, "prompt": <text or null>}` — both null = read |
 | `dismiss` | `{}` |
+| `settings` | `{}` — read-only; returns the five-field inventory below |
 | `manual` | `{}` |
 
 Optional fields are declared nullable rather than omittable, so pass `null` for
@@ -44,6 +48,83 @@ the ones you are not setting.
 **`summarize`** is a root-level boolean (never inside `input`). Soul's results
 are all small, and summarizing risks losing a voice's exact wording — leave it
 false, especially for `manual`.
+
+## Settings inventory
+
+Call `soul(action="settings", input={}, reasoning="inspect Soul settings")` to
+read the current values. The action has no set/reset API and never writes the
+process environment or `init.json`. Every row has exactly `key`, `current`,
+`default`, `configurable`, and `comment`; each comment links back to one exact
+section below.
+
+### Flow enabled
+
+`flow_enabled` says whether periodic and voluntary Soul flow is currently
+enabled. The process gate accepts `1`, `true`, `yes`, or `on`
+(case-insensitive, surrounding whitespace ignored); anything else is false.
+The only source is the live process environment variable
+`LINGTAI_SOUL_FLOW_ENABLED`, with missing or unrecognized input falling back to
+the meaningful default `false`. SHOW rereads the same process value as the
+actual flow gate on every call. An authorized launcher/operator changes it by
+setting or unsetting that variable in the agent launch environment and then
+refreshing or restarting the agent; call SHOW again to verify. SHOW itself
+cannot enable flow.
+
+### Delay seconds
+
+`delay_seconds` is the live cadence between enabled Soul-flow fires. The
+meaningful default is `999999999.0`. At boot the current value is hydrated from
+`init.json` key `manifest.soul.delay` when authored, otherwise the default;
+after an authorized `config` call, SHOW reads the updated live
+`SoulRuntimePort.soul_delay`. There is no environment peer. The supported
+change procedure accepts a finite JSON number of at least `30`:
+`soul(action="config", input={"delay_seconds":300,"consultation_past_count":null}, reasoning="change Soul cadence")`.
+That action validates and persists the value, updates live state, and restarts
+the pending timer when applicable; call SHOW again to verify. Invalid config
+input returns the existing Soul error and changes nothing. The cadence does not
+enable or disable flow.
+
+### Consultation past count
+
+`consultation_past_count` is `K`, the number of past-snapshot voices in each
+enabled fire; total fan-out is `1 + K`. The meaningful default is `0`. At boot
+the current value is hydrated from `init.json` key
+`manifest.soul.consultation_past_count` when authored, otherwise the default;
+SHOW then reads that live config value. There is no environment peer. The
+supported change procedure accepts integers from `0` through `5`:
+`soul(action="config", input={"delay_seconds":null,"consultation_past_count":2}, reasoning="change Soul fan-out")`.
+The action rejects out-of-range input without changing state, persists valid
+input, and applies it to the next fire; call SHOW again to verify. The init
+loader type-checks authored values but does not reapply the config action's
+range rule, so SHOW reports the effective live integer rather than silently
+normalizing it.
+
+### Voice
+
+`voice` selects the consultation profile. The supported `voice` action accepts
+`inner`, `observer`, or `custom`; the meaningful default is `inner`. At boot
+the current value is hydrated from `init.json` key `manifest.soul.voice` when
+authored, otherwise the default; SHOW reads that live config value. There is no
+environment peer. Change a built-in with
+`soul(action="voice", input={"set":"observer","prompt":null}, reasoning="change Soul voice")`,
+or use the atomic custom procedure in the next section. Unknown action input
+returns Soul's existing error and changes nothing. The selection is persisted,
+applies to the next consultation, and should be verified with another SHOW.
+
+### Voice prompt
+
+`voice_prompt` is the custom consultation system prompt. The supported `voice`
+action accepts a non-empty string of at most `4000` characters when `voice` is
+`custom`; there is no meaningful prompt default. At boot the live value is
+hydrated from `init.json` key `manifest.soul.voice_prompt`; there is no
+environment peer. Because prompt text is sensitive, SHOW renders both
+`current` and `default` as `<redacted>` and never exposes the private
+sensitivity flag. Change profile and prompt atomically through
+`soul(action="voice", input={"set":"custom","prompt":"<private prompt>"}, reasoning="set my Soul framing")`.
+Switching to a built-in clears the stored custom prompt. Invalid input changes
+nothing; a valid change applies to the next consultation. Call SHOW again to
+verify the redacted row, and use the `voice` read mode only when authorized to
+inspect the actual resolved prompt.
 
 ## 1. The soul-flow gate
 
@@ -120,12 +201,12 @@ switch.
 
 ## 5. Checking the current state
 
-- **Prove flow is disabled:** Call
-  `soul(action='config', input={'delay_seconds': 300, 'consultation_past_count': null}, reasoning='check soul flow state')`;
-  a successful result with `soul_flow_enabled: false` proves that flow is
-  disabled while still saving the supplied knob. The `config` input must contain
-  both nullable keys, with at least one non-null value. When flow is enabled,
-  use the `flow` action's status/result or inspect the operator environment.
+- **Read without changing anything:** Call
+  `soul(action="settings", input={}, reasoning="check Soul state")`. Its five
+  rows report the current flow gate, cadence, consultation count, voice, and
+  redacted prompt. If any current truth is unavailable or not JSON-safe, the
+  whole action fails with `SETTINGS_UNAVAILABLE`; it never returns partial or
+  placeholder rows.
 - **Check the env from a shell:** use the model-facing shell envelope:
   `shell(action="run", input={"command": "printenv LINGTAI_SOUL_FLOW_ENABLED"}, reasoning="check Soul flow opt-in")`.
   Empty output means unset (disabled).
@@ -145,6 +226,8 @@ None of these depend on the env gate.
 - **`voice`** — read or set how your own soul-flow voice sounds
   (`inner`/`observer`/`custom`). Yours to choose; persists to `init.json`.
 - **`dismiss`** — clear the current soul-flow notification from the panel.
+- **`settings`** — show exactly five projected fields for each owned setting;
+  strict empty input, no mutation, and no partial-row success.
 - **`manual`** — return this manual. Reads one file and performs **no** soul
   operation: no timer change, no consultation, no config/voice/notification
   write.
@@ -154,7 +237,8 @@ None of these depend on the env gate.
 `soul` has **no** settings file at either LTP level — there is no
 `settings/soul.json` and no `settings/soul.<action>.json`. Cadence and voice
 live in `init.json` under `manifest.soul` (written by `config`/`voice`), and
-the flow gate lives in the process environment. Nothing here reads a
+the flow gate lives in the process environment. The read-only `settings`
+action inventories those existing owners; it neither implies nor reads a
 `settings/` file.
 
 ## 8. Privacy and cost rationale

--- a/src/lingtai/tools/soul/settings.py
+++ b/src/lingtai/tools/soul/settings.py
@@ -1,0 +1,85 @@
+"""Read-only projection of Soul's live settings."""
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+from lingtai.kernel.config import DEFAULT_SOUL_DELAY_SECONDS
+
+from ..tool_family import SettingRow, SettingsProvider
+from .flow import _soul_flow_enabled
+
+if TYPE_CHECKING:
+    from lingtai.kernel.tool_plugin import SoulRuntimePort
+
+
+def _finite_number(value: object, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise RuntimeError(f"Soul {name} is unavailable")
+    current = float(value)
+    if not math.isfinite(current):
+        raise RuntimeError(f"Soul {name} is unavailable")
+    return current
+
+
+def _integer(value: object, name: str) -> int:
+    if type(value) is not int:
+        raise RuntimeError(f"Soul {name} is unavailable")
+    return value
+
+
+def _text(value: object, name: str, *, allow_empty: bool = False) -> str:
+    if not isinstance(value, str) or (not allow_empty and not value):
+        raise RuntimeError(f"Soul {name} is unavailable")
+    value.encode("utf-8")
+    return value
+
+
+def soul_settings_provider(runtime: "SoulRuntimePort") -> SettingsProvider:
+    """Bind a fresh five-row SHOW provider to one live Soul runtime."""
+
+    def provide() -> tuple[SettingRow, ...]:
+        config = runtime.config
+        return (
+            SettingRow(
+                "flow_enabled",
+                _soul_flow_enabled(),
+                False,
+                True,
+                "soul-manual#flow-enabled",
+            ),
+            SettingRow(
+                "delay_seconds",
+                _finite_number(runtime.soul_delay, "delay_seconds"),
+                DEFAULT_SOUL_DELAY_SECONDS,
+                True,
+                "soul-manual#delay-seconds",
+            ),
+            SettingRow(
+                "consultation_past_count",
+                _integer(
+                    config.consultation_past_count,
+                    "consultation_past_count",
+                ),
+                0,
+                True,
+                "soul-manual#consultation-past-count",
+            ),
+            SettingRow(
+                "voice",
+                _text(config.soul_voice, "voice"),
+                "inner",
+                True,
+                "soul-manual#voice",
+            ),
+            SettingRow(
+                "voice_prompt",
+                _text(config.soul_voice_prompt, "voice_prompt", allow_empty=True),
+                None,
+                True,
+                "soul-manual#voice-prompt",
+                _sensitive=True,
+            ),
+        )
+
+    return provide

--- a/tests/ANATOMY.md
+++ b/tests/ANATOMY.md
@@ -338,6 +338,7 @@ related_files:
   - tests/test_snapshot.py
   - tests/test_soul.py
   - tests/test_soul_consultation.py
+  - tests/test_soul_settings.py
   - tests/test_source_drift.py
   - tests/test_status_snapshot.py
   - tests/test_streaming.py

--- a/tests/test_soul.py
+++ b/tests/test_soul.py
@@ -166,19 +166,21 @@ class TestSoulSchema:
 
     def _branch(self, schema, action):
         return next(
-            b for b in schema["properties"]["input"]["oneOf"]
-            if b["title"] == f"{action} input"
+            b for b in schema["properties"]["input"]["anyOf"]
+            if b["title"]
+            == ("settings inventory input" if action == "settings" else f"{action} input")
         )
 
-    def test_schema_exposes_six_actions(self):
+    def test_schema_exposes_seven_actions(self):
         schema = soul.get_schema("en")
-        # Six actions are agent-visible: inquiry (manual self-Q&A),
+        # Seven actions are agent-visible: inquiry (manual self-Q&A),
         # flow (opt-in; also fires mechanically on the wall clock),
         # config (agent adjusts cadence + K at runtime), voice (agent
         # picks/customizes own soul-flow prompt — read or set), dismiss
-        # (clear soul notification), and manual (installed soul-manual).
+        # (clear soul notification), settings (read-only inventory), and manual
+        # (installed soul-manual).
         assert schema["properties"]["action"]["enum"] == [
-            "inquiry", "flow", "config", "voice", "dismiss", "manual",
+            "inquiry", "flow", "config", "voice", "dismiss", "settings", "manual",
         ]
 
     def test_schema_inquiry_input_is_action_scoped(self):

--- a/tests/test_soul_consultation.py
+++ b/tests/test_soul_consultation.py
@@ -1894,7 +1894,7 @@ class TestSoulConfig:
         # (post-migration they no longer sit at the flat root, where every
         # other action advertised them too).
         branch = next(
-            b for b in schema["properties"]["input"]["oneOf"]
+            b for b in schema["properties"]["input"]["anyOf"]
             if b["title"] == "config input"
         )
         props = branch["properties"]

--- a/tests/test_soul_settings.py
+++ b/tests/test_soul_settings.py
@@ -1,0 +1,237 @@
+"""Focused proofs for Soul's five-field, read-only settings action."""
+from __future__ import annotations
+
+import importlib
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+from lingtai.kernel.config import DEFAULT_SOUL_DELAY_SECONDS
+from lingtai.kernel.tool_plugin import OFFICIAL_TOOL_PLUGIN_NAMES
+from lingtai.tools import soul
+
+_DEFAULT_INPUT = object()
+
+
+class _Runtime:
+    def __init__(
+        self,
+        *,
+        delay: float = DEFAULT_SOUL_DELAY_SECONDS,
+        count: int = 0,
+        voice: str = "inner",
+        prompt: str = "",
+    ) -> None:
+        self.soul_delay = delay
+        self.config = SimpleNamespace(
+            consultation_past_count=count,
+            soul_voice=voice,
+            soul_voice_prompt=prompt,
+        )
+        self.dismissed: list[tuple[str, str]] = []
+
+    def dismiss_notification(self, channel: str, *, invoked_by: str) -> dict:
+        self.dismissed.append((channel, invoked_by))
+        return {"status": "ok"}
+
+
+def _family(runtime: object, manual_source: Path):
+    return soul._build_family(runtime, manual_source)
+
+
+def _show(family, action_input: object = _DEFAULT_INPUT) -> dict:
+    if action_input is _DEFAULT_INPUT:
+        action_input = {}
+    return family.handle(
+        {"action": "settings", "input": action_input, "reasoning": "inspect"}
+    )
+
+
+def test_exact_five_field_rows_are_fresh_and_fully_redacted(tmp_path, monkeypatch):
+    monkeypatch.setenv("LINGTAI_SOUL_FLOW_ENABLED", "yes")
+    runtime = _Runtime(
+        delay=300.0,
+        count=2,
+        voice="custom",
+        prompt="fixture soul framing",
+    )
+    family = _family(runtime, tmp_path)
+
+    result = _show(family)
+
+    assert result == {
+        "settings": [
+            {
+                "key": "flow_enabled",
+                "current": True,
+                "default": False,
+                "configurable": True,
+                "comment": "soul-manual#flow-enabled",
+            },
+            {
+                "key": "delay_seconds",
+                "current": 300.0,
+                "default": DEFAULT_SOUL_DELAY_SECONDS,
+                "configurable": True,
+                "comment": "soul-manual#delay-seconds",
+            },
+            {
+                "key": "consultation_past_count",
+                "current": 2,
+                "default": 0,
+                "configurable": True,
+                "comment": "soul-manual#consultation-past-count",
+            },
+            {
+                "key": "voice",
+                "current": "custom",
+                "default": "inner",
+                "configurable": True,
+                "comment": "soul-manual#voice",
+            },
+            {
+                "key": "voice_prompt",
+                "current": "<redacted>",
+                "default": "<redacted>",
+                "configurable": True,
+                "comment": "soul-manual#voice-prompt",
+            },
+        ]
+    }
+    assert "fixture soul framing" not in repr(result)
+    assert [row["key"] for row in result["settings"]] == [
+        "flow_enabled",
+        "delay_seconds",
+        "consultation_past_count",
+        "voice",
+        "voice_prompt",
+    ]
+    assert all(
+        list(row) == ["key", "current", "default", "configurable", "comment"]
+        for row in result["settings"]
+    )
+
+    monkeypatch.setenv("LINGTAI_SOUL_FLOW_ENABLED", "0")
+    runtime.soul_delay = 600.0
+    runtime.config.consultation_past_count = 4
+    runtime.config.soul_voice = "observer"
+    runtime.config.soul_voice_prompt = "replacement fixture"
+    refreshed = _show(family)["settings"]
+    assert [row["current"] for row in refreshed] == [
+        False,
+        600.0,
+        4,
+        "observer",
+        "<redacted>",
+    ]
+    assert "replacement fixture" not in repr(refreshed)
+
+
+def test_settings_is_strict_read_only_and_comments_target_manual_sections(
+    tmp_path, monkeypatch
+):
+    monkeypatch.delenv("LINGTAI_SOUL_FLOW_ENABLED", raising=False)
+    runtime = _Runtime(delay=120.0, count=4, voice="observer")
+    before = (
+        runtime.soul_delay,
+        vars(runtime.config).copy(),
+        os.environ.get("LINGTAI_SOUL_FLOW_ENABLED"),
+        tuple(tmp_path.rglob("*")),
+    )
+    family = _family(runtime, tmp_path)
+
+    rows = _show(family)["settings"]
+
+    assert (
+        runtime.soul_delay,
+        vars(runtime.config),
+        os.environ.get("LINGTAI_SOUL_FLOW_ENABLED"),
+        tuple(tmp_path.rglob("*")),
+    ) == before
+    assert all(
+        _show(family, invalid)["error_code"] == "INVALID_ARGUMENT"
+        for invalid in ({"set": "voice"}, [], None)
+    )
+    assert (runtime.soul_delay, vars(runtime.config)) == before[:2]
+    manual = (
+        Path(soul.__file__).with_name("manual").joinpath("SKILL.md").read_text(
+            encoding="utf-8"
+        )
+    )
+    expected_headings = {
+        "soul-manual#flow-enabled": "### Flow enabled",
+        "soul-manual#delay-seconds": "### Delay seconds",
+        "soul-manual#consultation-past-count": "### Consultation past count",
+        "soul-manual#voice": "### Voice",
+        "soul-manual#voice-prompt": "### Voice prompt",
+    }
+    assert {row["comment"] for row in rows} == set(expected_headings)
+    assert all(heading in manual for heading in expected_headings.values())
+
+
+def test_unavailable_or_non_json_live_current_fails_the_whole_action(tmp_path):
+    class _UnavailableRuntime:
+        config = SimpleNamespace(
+            consultation_past_count=2,
+            soul_voice="inner",
+            soul_voice_prompt="",
+        )
+
+        @property
+        def soul_delay(self):
+            raise RuntimeError("private live-state failure")
+
+    failure = {
+        "status": "failed",
+        "error_code": "SETTINGS_UNAVAILABLE",
+        "message": "settings inventory is unavailable",
+    }
+    assert _show(_family(_UnavailableRuntime(), tmp_path)) == failure
+    assert _show(_family(_Runtime(delay=float("inf")), tmp_path)) == failure
+
+
+def test_family_opt_in_order_and_unchanged_dismiss_action(tmp_path):
+    assert soul.DECLARATION.settings is True
+    module_names = {"shell": "bash._tool_family", "web": "web_search"}
+    enabled = [
+        name
+        for name in OFFICIAL_TOOL_PLUGIN_NAMES
+        if importlib.import_module(
+            f"lingtai.tools.{module_names.get(name, name)}"
+        ).DECLARATION.settings
+    ]
+    assert enabled == ["mcp", "avatar", "email", "plugin", "notification", "soul", "system", "task_card"]
+    assert soul.DECLARATION.public_actions == (
+        "inquiry",
+        "flow",
+        "config",
+        "voice",
+        "dismiss",
+        "settings",
+        "manual",
+    )
+    schema = soul.get_schema()
+    assert schema["properties"]["action"]["enum"] == list(
+        soul.DECLARATION.public_actions
+    )
+    assert next(
+        branch
+        for branch in schema["properties"]["input"]["anyOf"]
+        if branch["title"] == "settings inventory input"
+    ) == {
+        "type": "object",
+        "properties": {},
+        "required": [],
+        "additionalProperties": False,
+        "title": "settings inventory input",
+    }
+
+    runtime = _Runtime()
+    result = _family(runtime, tmp_path).handle(
+        {"action": "dismiss", "input": {}, "reasoning": "clear notice"}
+    )
+    assert result == {
+        "status": "ok",
+        "message": "Soul flow notification dismissed.",
+    }
+    assert runtime.dismissed == [("soul", "soul")]

--- a/tests/test_tool_family_soul_migration.py
+++ b/tests/test_tool_family_soul_migration.py
@@ -1,9 +1,10 @@
 """``soul``'s migration onto the generic ToolFamily infra: action separation
 without any change to what soul actually does.
 
-The public tool name (``soul``) and its six action values (``inquiry``,
-``flow``, ``config``, ``voice``, ``dismiss``, ``manual``) are unchanged. What
-moved is only the *argument shape*: the pre-migration flat root advertised
+The public tool name (``soul``) and its existing six action values (``inquiry``,
+``flow``, ``config``, ``voice``, ``dismiss``, ``manual``) are unchanged; the
+generic read-only ``settings`` action is additive. What moved in the original
+migration is only the *argument shape*: the pre-migration flat root advertised
 every action's parameters to every action at once (``inquiry`` sat next to
 ``delay_seconds`` next to ``prompt``), so nothing at the schema level said
 which parameter belonged to which action. Post-migration each action owns one
@@ -27,7 +28,9 @@ from lingtai.tools import soul
 from lingtai.tools.soul import handle
 from lingtai.tools.tool_family import ToolFamilyError
 
-_ACTIONS = ("inquiry", "flow", "config", "voice", "dismiss", "manual")
+_ACTIONS = (
+    "inquiry", "flow", "config", "voice", "dismiss", "settings", "manual",
+)
 
 
 # ---------------------------------------------------------------------------
@@ -94,13 +97,14 @@ def _flow_disabled_by_default(monkeypatch):
 def _branch(action: str) -> dict:
     schema = soul.get_schema("en")
     return next(
-        b for b in schema["properties"]["input"]["oneOf"]
-        if b["title"] == f"{action} input"
+        b for b in schema["properties"]["input"]["anyOf"]
+        if b["title"]
+        == ("settings inventory input" if action == "settings" else f"{action} input")
     )
 
 
 # ---------------------------------------------------------------------------
-# Schemas — all six children, strict and action-scoped.
+# Schemas — all seven children, strict and action-scoped.
 # ---------------------------------------------------------------------------
 
 
@@ -118,14 +122,17 @@ def test_root_is_the_closed_ltp_v2_envelope():
     assert schema["properties"]["summarize"]["type"] == "boolean"
 
 
-def test_public_action_values_are_unchanged_by_the_migration():
+def test_public_actions_include_the_additive_settings_child():
     assert soul.get_schema("en")["properties"]["action"]["enum"] == list(_ACTIONS)
 
 
 def test_every_action_has_its_own_strict_closed_input_branch():
     schema = soul.get_schema("en")
-    branches = schema["properties"]["input"]["oneOf"]
-    assert [b["title"] for b in branches] == [f"{a} input" for a in _ACTIONS]
+    branches = schema["properties"]["input"]["anyOf"]
+    assert [b["title"] for b in branches] == [
+        "settings inventory input" if action == "settings" else f"{action} input"
+        for action in _ACTIONS
+    ]
     for branch in branches:
         assert branch["type"] == "object"
         assert branch["additionalProperties"] is False
@@ -148,7 +155,7 @@ def test_action_input_correlation_is_declared_at_the_schema_root():
         assert condition["if"]["properties"]["action"]["const"] == action
         assert condition["if"]["required"] == ["action"]
         then_input = condition["then"]["properties"]["input"]
-        # Same canonical child schema the ``oneOf`` branch discloses (the
+        # Same canonical child schema the ``anyOf`` branch discloses (the
         # branch only adds the presentational ``title``), so the correlation
         # layer and the disclosure layer cannot drift apart.
         assert then_input == {
@@ -172,7 +179,7 @@ def test_action_parameters_are_no_longer_advertised_to_every_action():
         assert leaked not in root_props
     assert set(_branch("inquiry")["properties"]) == {"inquiry"}
     assert set(_branch("voice")["properties"]) == {"set", "prompt"}
-    for no_input_action in ("flow", "dismiss", "manual"):
+    for no_input_action in ("flow", "dismiss", "settings", "manual"):
         assert _branch(no_input_action)["properties"] == {}
 
 
@@ -228,7 +235,7 @@ def test_no_action_or_input_field_can_enable_flow(agent):
     schema = soul.get_schema("en")
     every_input_field = {
         field
-        for branch in schema["properties"]["input"]["oneOf"]
+        for branch in schema["properties"]["input"]["anyOf"]
         for field in branch["properties"]
     }
     assert every_input_field == {
@@ -566,6 +573,7 @@ def test_manual_performs_no_soul_operation(agent, monkeypatch):
         ("voice", {"consultation_past_count": 1}),
         ("flow", {"delay_seconds": 300}),
         ("dismiss", {"inquiry": "hi"}),
+        ("settings", {"set": "voice"}),
         ("manual", {"inquiry": "hi"}),
     ],
 )
@@ -597,7 +605,7 @@ def test_unknown_action_preserves_souls_own_error(agent):
     assert result == {
         "error": (
             "Unknown soul action: meditate. Use inquiry, config, voice, "
-            "dismiss, manual, or wait for flow (mechanical)."
+            "dismiss, settings, manual, or wait for flow (mechanical)."
         )
     }
 
@@ -704,14 +712,17 @@ def test_flat_pre_migration_flow_args_are_now_rejected(agent):
 def test_schema_and_dispatch_come_from_one_registry(agent):
     """There is no second child list to drift: the module-level schema-only
     family and the per-call agent-bound family are built by the same
-    ``_build_children`` from the same ``_CHILD_SPECS`` + reserved manual."""
-    from lingtai.tools.tool_family import ToolFamily
+    declaration plus reserved settings/manual children."""
 
     schema_names = tuple(
-        b["title"].removesuffix(" input")
-        for b in soul.get_schema("en")["properties"]["input"]["oneOf"]
+        (
+            "settings"
+            if b["title"] == "settings inventory input"
+            else b["title"].removesuffix(" input")
+        )
+        for b in soul.get_schema("en")["properties"]["input"]["anyOf"]
     )
-    dispatch_names = ToolFamily("soul", soul._build_children(agent)).child_names
+    dispatch_names = tuple(child.name for child in soul._build_children(agent))
     assert schema_names == dispatch_names == _ACTIONS
 
 
@@ -774,7 +785,9 @@ def test_agent_composition_keeps_reasoning_required_on_both_wires(tmp_path):
         assert len(soul_schemas) == 1
         chat = _build_tools(soul_schemas)[0]["function"]["parameters"]
         responses = _build_responses_tools(soul_schemas)[0]["parameters"]
-        for wire, combinator in ((chat, "oneOf"), (responses, "anyOf")):
+        prompt = live._build_system_prompt()
+        assert isinstance(prompt, str) and prompt
+        for wire in (chat, responses):
             assert set(wire["properties"]) == {
                 "action", "input", "reasoning", "summarize",
             }
@@ -783,7 +796,10 @@ def test_agent_composition_keeps_reasoning_required_on_both_wires(tmp_path):
             # schema is what keeps it required.
             assert wire["required"] == ["action", "input", "reasoning"]
             assert wire["properties"]["action"]["enum"] == list(_ACTIONS)
-            branches = wire["properties"]["input"][combinator]
-            assert [b["title"] for b in branches] == [f"{a} input" for a in _ACTIONS]
+            branches = wire["properties"]["input"]["anyOf"]
+            assert [b["title"] for b in branches] == [
+                "settings inventory input" if action == "settings" else f"{action} input"
+                for action in _ACTIONS
+            ]
     finally:
         live.stop(timeout=1.0)

--- a/tests/test_tool_plugin_declaration.py
+++ b/tests/test_tool_plugin_declaration.py
@@ -320,8 +320,9 @@ def test_official_soul_mount_preserves_real_flow_and_packaged_manual(mcp_agent):
     from lingtai.tools.soul import DECLARATION
 
     assert DECLARATION.public_actions == (
-        "inquiry", "flow", "config", "voice", "dismiss", "manual",
+        "inquiry", "flow", "config", "voice", "dismiss", "settings", "manual",
     )
+    assert DECLARATION.settings is True
     assert DECLARATION.requires == ("workdir", "soul_runtime")
     assert mcp_agent.official_tool_plugins["soul"] is DECLARATION
     assert [schema.name for schema in mcp_agent._tool_schemas].count("soul") == 1

--- a/tests/test_tool_settings_contract.py
+++ b/tests/test_tool_settings_contract.py
@@ -147,10 +147,10 @@ def test_public_export_and_exact_production_opt_ins():
         name: importlib.import_module(f"lingtai.tools.{modules.get(name, name)}").DECLARATION
         for name in OFFICIAL_TOOL_PLUGIN_NAMES
     }
-    expected_official = {"avatar", "email", "mcp", "notification", "plugin", "system", "task_card"}
+    expected_official = {"avatar", "email", "mcp", "notification", "plugin", "soul", "system", "task_card"}
     assert {name for name, item in declarations.items() if item.settings} == expected_official
     assert expected_curated | expected_official == {
-        "avatar", "cloud_mail", "email", "feishu", "imap", "mcp", "notification", "plugin", "system", "task_card", "wechat", "whatsapp"
+        "avatar", "cloud_mail", "email", "feishu", "imap", "mcp", "notification", "plugin", "soul", "system", "task_card", "wechat", "whatsapp"
     }
     for name, item in declarations.items():
         assert ("settings" in item.public_actions) is (name in expected_official)


### PR DESCRIPTION
## Sequential final candidate

This is the independent **Soul** settings owner, now rebased as owner 12/19 onto the exact cumulative main that already contains owners #1524–#1534.

- final candidate commit: `51b85eed7cc1457eec3412abeb201fe8060a90dd`
- exact parent: `c50daeca778a2de6d9093f967ec6c669a0e9e027`
- resulting tree: `a9788eac1dfac0f22e6a3cd2f54cb742007ddbd0`
- final stable patch id: `e35f331e9788a2b5481db0a4a64ba04ffa58daf3`
- resulting diff: **16 files changed, 598 insertions(+), 101 deletions(-)**
- one owner commit; canonical `Huang Zesen <hzsbazinga@outlook.com>` author/committer; clean worktree; no tracked deletions

## Settings truth and live acceptance

Soul exposes exactly five ordered read-only rows, all `configurable=true`:

1. `flow_enabled`: process `LINGTAI_SOUL_FLOW_ENABLED`, default `false`; SHOW rereads the live gate, while launcher-env changes require refresh/restart.
2. `delay_seconds`: `manifest.soul.delay`, default `999999999.0`; no env peer; existing `config` persists and applies it live.
3. `consultation_past_count`: `manifest.soul.consultation_past_count`, default `0`; no env peer; existing `config` persists values 0–5 for the next fire.
4. `voice`: `manifest.soul.voice`, default `inner`; no env peer; existing `voice` action persists the profile for the next consultation.
5. `voice_prompt`: `manifest.soul.voice_prompt`, no meaningful default; no env peer; current/default are always `<redacted>`.

There is no `settings/soul.json` and no generic writer. Live dev-3 acceptance returned all five exact rows (`false`, `999999999.0`, `0`, `inner`, redacted prompt), and the original non-side-effecting `voice` read action returned `status=ok`, current `inner`, available `inner/observer`. No cadence, flow, voice, prompt, timer, LLM call, init, or notification state was changed.

## Rebase and preservation

The old reviewed head was `c0d5cb2f8f5bbab8d9cc9b087c63109f322ad478` on parent `1b25fd09069314b531cdb55aa08c533e037eea89`.

- the two predicted conflicts were the shared generic settings manual and shared settings contract test
- the generic manual is byte-identical to cumulative current main
- the shared test preserves curated `{cloud_mail, feishu, imap, wechat, whatsapp}` and official `{avatar, email, mcp, notification, plugin, system, task_card}`, then adds only official `soul`
- one additional stale isolated assertion inside `test_soul_settings.py` was found by the real cumulative test run and repaired to the exact official order: `mcp, avatar, email, plugin, notification, soul, system, task_card`
- 13/17 original owner paths retain identical path-specific stable patch IDs; 10 final path blobs are byte-identical to the old head
- the four patch-ID differences are the dropped superseded shared manual, cumulative Tools Anatomy, cumulative shared owner-set test, and the necessary cumulative Soul owner-order assertion
- candidate-changed files have no conflict markers; `git diff --check` passes

## Validation

- exact six-module Soul owner matrix: **231 passed**
- identical candidate/current-main governance, Anatomy, manual, env catalogue matrix: candidate **119 passed / 6 failed**; clean exact main **119 passed / the same 6 failed**
- those six baseline nodes are the existing kernel-LLM duplicate Anatomy link, Bash local-CONTRACT ownership, root `IMPLEMENTATION_REPORT.md` frontmatter plus the same duplicate link, notification manager template hash, Avatar env catalogue omission, and Session Stats ENV reciprocal link
- candidate-unique failures: **0**

## Current gate and boundaries

Jason authorized strict one-PR-at-a-time owner merges. This PR is eligible only for exact-head guarded squash merge after final remote/body verification and the human-facing final-head report. The source branch is retained. This work includes no release/deploy, live runtime or MCP refresh, Soul config/env/init mutation, Context opt-in, unrelated config/auth, deletion, or cleanup.

Telegram: @lingtaidev3bot | Nickname: 澄一

Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
