### PR TITLE
feat(shell): add read-only settings inventory

### DIFF
--- a/src/lingtai/tools/ANATOMY.md
+++ b/src/lingtai/tools/ANATOMY.md
@@ -173,7 +173,7 @@ capability names and lazy adapters.
   only for kernel hooks): seven action-separated children (`inquiry`, `flow`,
   `config`, `voice`, `dismiss`, read-only `settings`, and `manual`) behind one
   model-facing root (`src/lingtai/tools/soul/ANATOMY.md`).
-- `bash/` — public `shell` composition owner for run/poll/cancel/manual
+- `bash/` — public `shell` composition owner for run/poll/cancel/settings/manual
   (`src/lingtai/tools/bash/ANATOMY.md`); the public model-facing schema is
   the ToolFamily-composed LTP v2 envelope (`bash/_tool_family.py`) and is the
   package's only schema/description pair, while `ShellManager` remains the

--- a/src/lingtai/tools/CONTRACT.md
+++ b/src/lingtai/tools/CONTRACT.md
@@ -810,13 +810,15 @@ consequences, not local details: its `spawn` mission brief is root `reasoning`
 karma-gated while `spawn` and `manual` are not — a family must not hide a
 stronger child action behind a weaker family posture.
 
-`shell` (`run | poll | cancel | manual`) is the eighth: its final model-facing
+`shell` (`run | poll | cancel | settings | manual`) is the eighth: its final model-facing
 root is likewise exactly `action`, `input`, `reasoning`, and `summarize`, its
 run-only fields live only in `run`'s `input` and `job_id` only in
 `poll`/`cancel`'s, and its unchanged `ShellManager` engine — sync execution,
 the working-directory sandbox, the durable async lifecycle, cancellation, and
 terminal receipts — keeps its historical flat shape as a purely internal
-interface (see `src/lingtai/tools/bash/CONTRACT.md`).
+interface. Its declaration opts into the generic reserved, read-only SHOW child
+immediately before `manual`; Shell owns no settings file at either LTP level
+(see `src/lingtai/tools/bash/CONTRACT.md`).
 
 `skills` (`info | manual`) is the ninth: it keeps its public tool name and both
 public action values, adopts the same closed root, declares the canonical
@@ -1026,7 +1028,7 @@ from a module-level schema-only family and building an agent-bound one per
 `handle(agent, args)` call because an intrinsic module has no per-Agent
 manager instance to hold one, `shell` is its eighth, using it the same
 way while retaining a thin outer `handle()` that narrows the generic
-unknown-action message to its own four actions, `skills` is its ninth,
+unknown-action message to its own five actions, `skills` is its ninth,
 using it the same way but returning its canonical envelope failures
 verbatim, having no such diagnostics, `notification` is its tenth, binding an
 agent-hosted family through its static declared Host ports; generic composition

--- a/src/lingtai/tools/bash/ANATOMY.md
+++ b/src/lingtai/tools/bash/ANATOMY.md
@@ -12,6 +12,7 @@ related_files:
   - src/lingtai/tools/bash/__init__.py
   - src/lingtai/kernel/execution_workspace.py
   - src/lingtai/tools/bash/_tool_family.py
+  - src/lingtai/tools/tool_family/settings.py
   - src/lingtai/tools/tool_family/ANATOMY.md
   - src/lingtai/tools/tool_family/CONTRACT.md
   - src/lingtai/tools/bash/_async_supervisor.py
@@ -36,6 +37,7 @@ related_files:
   - tests/test_bash_async.py
   - tests/test_execution_workspace.py
   - tests/test_shell_tool_plugin_declaration.py
+  - tests/test_shell_settings.py
   - tests/test_layers_bash.py
   - src/lingtai/tools/bash/glossary-en.md
   - src/lingtai/tools/bash/glossary-zh.md
@@ -68,8 +70,8 @@ be explicitly opted into.
 
 ## Components
 
-- `bash/__init__.py` — the execution engine plus policy, sync execution, and durable async manager orchestration. It declares no schema or description of its own: the package's single public pair is re-exported from `_tool_family.py` at `__init__.py:43` under the canonical `get_schema`/`get_description` names, so there is exactly one model-facing surface and no second flat one to drift against. `setup` is only composition wiring: it passes policy/dialect overrides as immutable configuration to the static `DECLARATION` in `_tool_family.py`, then asks `register_agent_tool_plugins` to reserve, bind, activate, and mount the public `shell` tool through the official host path. `ShellManager` (`__init__.py:330`, aliased `BashManager` at `__init__.py:1467`) owns validation, manager semantics, durable-state rehydration, notification publication, and poll/cancel consumption; its `handle` dispatches `poll`/`cancel`/`run` only — `manual` is a family child and never reaches it. Its async start receipt and durable reminder body both teach the registered envelope call `shell(action="poll", input={"job_id": ...})`. `_augment_command_result` adds `ok`/`command_status`/`warning` fidelity fields (`__init__.py:191`). Sync `_run_sync` feeds a dialect's `stdin_script` through `subprocess.run(input=...)` so the PowerShell bootstrap receives the real command over UTF-8 stdin.
-- `bash/_tool_family.py` — the public/model-facing `shell` tool's LTP v2 envelope. `RUN_INPUT_SCHEMA`/`POLL_INPUT_SCHEMA`/`CANCEL_INPUT_SCHEMA`/`MANUAL_INPUT_SCHEMA` are four strict per-action schemas (run-only fields — `command`, `timeout`, `working_dir`, `async`, `reminder` — live only in `run`'s branch; `job_id` lives only in `poll`/`cancel`'s); `get_schema()` composes them via the generic `tool_family.ToolFamily` (root `allOf` correlation plus `input.oneOf` disclosure, same infra `web` uses), and `get_description()` here is the registered model-facing text documenting that action-separated call shape. Optional run fields are declared required-but-nullable per the strict-schema convention; `_strip_nulls` drops `null` (meaning *absent*) so `ShellManager`'s own runtime defaults apply, while falsy-but-present values (`timeout: 0`, `async: false`) pass through verbatim. `ShellFamilyDispatcher` is the per-agent, per-`ShellManager` handler registered by `setup()`: its `run`/`poll`/`cancel` child handlers flatten their own validated `input` (re-adding the matching `action` key) and delegate to the unchanged `ShellManager.handle` — the async lifecycle, durable state, and every existing `ShellManager` test keep exercising that exact code path. Its thin outer `handle()` adds exactly one Host normalization: narrowing the generic dispatcher's unknown-action message to Shell's own four actions. `manual` is registered directly from `tool_family.manual.build_manual_child`, the shared reserved-name contract, so it returns the canonical `content`/`structuredContent` shape; `MANUAL_INPUT_SCHEMA` is sourced from that same builder rather than re-declared, so the schema the wire advertises and the schema dispatch validates against are one definition. The engine has no manual branch at all — `manual` performs no shell operation and never reaches `ShellManager`.
+- `bash/__init__.py` — the execution engine plus policy, sync execution, and durable async manager orchestration. It declares no schema or description of its own: the package's single public pair is re-exported from `_tool_family.py` at `__init__.py:43` under the canonical `get_schema`/`get_description` names, so there is exactly one model-facing surface and no second flat one to drift against. `setup` is only composition wiring: it passes policy/dialect overrides as immutable configuration to the static `DECLARATION` in `_tool_family.py`, then asks `register_agent_tool_plugins` to reserve, bind, activate, and mount the public `shell` tool through the official host path. `ShellManager` (`__init__.py:330`, aliased `BashManager` at `__init__.py:1467`) owns validation, manager semantics, durable-state rehydration, notification publication, and poll/cancel consumption; its `handle` dispatches `poll`/`cancel`/`run` only — `settings` and `manual` are family children and never reach it. Its async start receipt and durable reminder body both teach the registered envelope call `shell(action="poll", input={"job_id": ...})`. `_augment_command_result` adds `ok`/`command_status`/`warning` fidelity fields (`__init__.py:191`). Sync `_run_sync` feeds a dialect's `stdin_script` through `subprocess.run(input=...)` so the PowerShell bootstrap receives the real command over UTF-8 stdin.
+- `bash/_tool_family.py` — the public/model-facing `shell` LTP v2 envelope. The static declaration opts Shell into the generic read-only `settings` child immediately before `manual`, so its five branches use `input.anyOf`; `_shell_setting_rows` reads seven existing manager/runtime facts into exact five-field rows and marks command policy for full private redaction without rendering its rules. `ShellFamilyDispatcher` otherwise keeps the existing run/poll/cancel flattening and raw-result delegation unchanged. Neither `settings` nor `manual` reaches `ShellManager`, and the exact owner procedures and setting semantics route to `bash/manual/SKILL.md`.
 - `bash/_shell_dialect.py` — the Bash-local `ShellDialect` port and serializable `ShellInvocation`; the POSIX extraction helper preserves the existing policy grammar. `ShellInvocation` gains an optional `stdin_script`: when set, the script is not placed on the child command line; spawners instead write it to the child's stdin as UTF-8 (PowerShell's ASCII-bootstrap transport).
 - `adapters/posix/bash.py` — `PosixBashDialect`, the first production adapter; it provides POSIX policy extraction and script-form shell invocation.
 - `adapters/shell.py` — `select_shell_dialect`, the outer selector for POSIX and PowerShell dialects; `adapters/bash.py` remains a private compatibility selector.
@@ -90,7 +92,7 @@ The canonical `shell` tool is a migrated LTP v2 family (`src/lingtai/tools/CONTR
 
 | Root field   | Type    | Description |
 |--------------|---------|-------------|
-| `action`     | string  | Required. One of `run`, `poll`, `cancel`, `manual`. No default. |
+| `action`     | string  | Required. One of `run`, `poll`, `cancel`, `settings`, `manual`. No default. |
 | `input`      | object  | Required. Strict, action-specific input; cross-action keys are rejected at dispatch. |
 | `reasoning`  | string  | Required. Host InvocationContext/audit metadata; never forwarded into `input`. |
 | `summarize`  | boolean | Optional root result post-processing control (default false); never forwarded into `input`. |
@@ -106,7 +108,13 @@ Per-action `input` (run-only fields exist only in `run`; `job_id` only in `poll`
 | `run`    | `reminder`     | number\|null | Last-resort async wake delay; `null` → default 1800. Consumed/validated only for async `run` |
 | `poll`   | `job_id`       | string  | Job ID returned by an async run |
 | `cancel` | `job_id`       | string  | Job ID returned by an async run |
+| `settings` | —             | —       | Strict empty `{}`; returns only read-only five-field setting rows |
 | `manual` | —              | —       | Strict empty `{}`; performs no shell operation |
+
+**Settings** (`action="settings"`): Reads fresh Shell-owned facts and returns
+only `key`, `current`, `default`, `configurable`, and an exact `shell-manual`
+section pointer. Provider failure is whole-action and command-policy values are
+fully redacted; there is no mutation API.
 
 **Manual** (`action="manual"`): Returns the shared ManualTool contract result — full `shell-manual` body at `content[0].text`, host-local path at `structuredContent.manual_path` — verbatim, with no double wrapping. It reaches no execution engine, spawns no process, and touches no job state, and it serves the installed manual body/path unchanged (`.library/intrinsic/capabilities/shell/SKILL.md`).
 

--- a/src/lingtai/tools/bash/BEHAVIORS.md
+++ b/src/lingtai/tools/bash/BEHAVIORS.md
@@ -19,6 +19,7 @@ related_files:
   - src/lingtai/kernel/llm/base.py
   - tests/test_shell_sandbox_containment.py
   - tests/test_shell_tool_plugin_declaration.py
+  - tests/test_shell_settings.py
   - tests/contracts/llm_conversation_input/test_send_str.py
   - tests/test_context_ownership_redesign.py
   - tests/test_repeated_tool_error_continue.py
@@ -135,11 +136,12 @@ outside or sibling-prefix path executes, or if the error message shape changes.
    and `additionalProperties`.
 2. Call `shell(action="run", input={"command": "pwd"}, reasoning="ok")`.
 3. Call `shell(action="frobnicate", input={}, reasoning="x")` — an action
-   that is not one of the four children.
+   that is not one of the five children.
 4. Call `shell(action="poll", input={"command": "pwd"}, reasoning="x")` — a
    `run`-only field smuggled into `poll`'s input.
-5. Call `shell(action="manual", input={}, reasoning="x")`.
-6. Call `shell(action="manual", input={"page": 2}, reasoning="x")`.
+5. Call `shell(action="settings", input={}, reasoning="x")`.
+6. Call `shell(action="manual", input={}, reasoning="x")`.
+7. Call `shell(action="manual", input={"page": 2}, reasoning="x")`.
 
 ### Expected evidence
 - [ ] Step 1: `properties == {action, input, reasoning, summarize}`,
@@ -147,19 +149,26 @@ outside or sibling-prefix path executes, or if the error message shape changes.
       `additionalProperties == false` (the strict LTP v2 root).
 - [ ] Step 2: `{status: "ok", ...}` — the valid envelope dispatches.
 - [ ] Step 3: `{status: "failed", error_code: "ACTION_REQUIRED", message:
-      "action must be one of run, poll, cancel, or manual"}`.
+      "action must be one of run, poll, cancel, settings, or manual"}`.
 - [ ] Step 4: `{status: "failed", error_code: "INVALID_ARGUMENT", message:
       "unsupported shell input field"}` — rejected before any job lookup.
-- [ ] Step 5: `{status: "ok", content: [{type: "text", text: <shell-manual
+- [ ] Step 5: exactly seven rows keyed `shell_kind`,
+      `sync_timeout_default_seconds`, `sync_timeout_max_seconds`,
+      `result_max_chars`, `async_default`,
+      `async_reminder_default_seconds`, and `command_policy`; every row has
+      exactly `key/current/default/configurable/comment`, and both command
+      policy values are `<redacted>`.
+- [ ] Step 6: `{status: "ok", content: [{type: "text", text: <shell-manual
       body>}], structuredContent: {manual_path}}`.
-- [ ] Step 6: `{status: "failed", error_code: "INVALID_ARGUMENT", message:
+- [ ] Step 7: `{status: "failed", error_code: "INVALID_ARGUMENT", message:
       "unsupported shell input field"}` — `manual` input is strict empty.
-- [ ] Steps 3, 4, 6 spawned no process and touched no job state.
+- [ ] Steps 3–7 spawned no process and touched no job state.
 
 ### Pass / Fail
-Pass when the root schema matches exactly and every invalid call is refused
-with the exact `error_code`/`message` above. Fail if an unknown action or a
-cross-action input key dispatches, or if the closed root gains a field.
+Pass when the root schema and settings inventory match exactly and every
+invalid call is refused with the exact `error_code`/`message` above. Fail if an
+unknown action or a cross-action input key dispatches, if settings leaks policy
+values, or if the closed root gains a field.
 
 ## Behavior S003 — send(str) reaches the provider transport as provider text
 

--- a/src/lingtai/tools/bash/CONTRACT.md
+++ b/src/lingtai/tools/bash/CONTRACT.md
@@ -1,13 +1,14 @@
 ---
 name: bash-contract
 tool: shell
-contract_version: 6
+contract_version: 7
 related_files:
   - src/lingtai/tools/bash/__init__.py
   - src/lingtai/kernel/execution_workspace.py
   - src/lingtai/tools/bash/_tool_family.py
   - src/lingtai/tools/tool_family/__init__.py
   - src/lingtai/tools/tool_family/manual.py
+  - src/lingtai/tools/tool_family/settings.py
   - src/lingtai/tools/CONTRACT.md
   - src/lingtai/kernel/tool_plugin/CONTRACT.md
   - src/lingtai/kernel/tool_plugin/ANATOMY.md
@@ -31,6 +32,7 @@ related_files:
   - src/lingtai/tools/bash/ANATOMY.md
   - src/lingtai/tools/bash/manual/SKILL.md
   - tests/test_shell_tool_plugin_declaration.py
+  - tests/test_shell_settings.py
   - tests/test_execution_workspace.py
   - src/lingtai/tools/daemon/execution_host.py
   - src/lingtai/tools/daemon/shell_prompt_events.py
@@ -73,7 +75,9 @@ invariants.
 ## Scope
 
 - Canonical tool name: `shell` (the retained implementation package is `lingtai.tools.bash`).
-- One public tool exposes three actions: `run` (default), `poll`, `cancel`.
+- One public family exposes `run`, `poll`, `cancel`, read-only `settings`, and
+  `manual`; the execution engine still handles only the three operational
+  actions.
 - Policy is file-based (`bash_policy.json` is the POSIX default; Windows selects the reviewed `powershell_policy.json`). `yolo=True` at setup
   installs an allow-everything policy (unsandboxed command set) and is the
   documented default for trusted agents. Two policy modes exist: **allowlist**
@@ -88,12 +92,14 @@ does not stream output incrementally (async jobs are polled, not streamed).
 
 `_tool_family.py` owns one static `ToolPluginDeclaration` for the canonical
 `"shell"` name: operational actions `("run", "poll", "cancel")`, reserved
-`manual="shell"`, the three existing strict action input schemas, and only
+`manual="shell"`, `settings=True`, the three existing strict operational input
+schemas, and only
 `("workdir", "notifications", "configuration")` as its host requirements.
 `setup()` supplies copied policy/dialect overrides through the configuration
 port and calls the kernel registrar; it does not call generic `add_tool`.
 `_bind(host)` constructs the retained `ShellManager` with the workdir and
-notification ports only, derives the public family/manual from the declaration,
+notification ports only, derives the public settings provider, family, and
+manual from the declaration,
 and defers async rehydration to its registrar-controlled activation step.
 The notification adapter preserves the existing idempotent system watchdog and
 Bash completion channel semantics. This is an internal least-privilege recut:
@@ -108,23 +114,40 @@ Guarded by: [S002](BEHAVIORS.md#behavior-s002)
 `src/lingtai/tools/CONTRACT.md`). Its public/model-facing root is exactly
 `action`, `input`, `reasoning`, and `summarize`; `action`, `input`, and
 `reasoning` are required and the root is closed
-(`additionalProperties: false`). The four canonical children are
-`run | poll | cancel | manual`; each child name is simultaneously the public
+(`additionalProperties: false`). The five canonical children are
+`run | poll | cancel | settings | manual`; each child name is simultaneously the public
 `action` value and the dispatch key, with no mapping layer. `action` has no
 default — it must be stated. The composed schema is built by the generic
 `tool_family` infrastructure in `src/lingtai/tools/bash/_tool_family.py`
 (`get_schema`), which correlates each `action` const to that child's own
 `input` schema at the root via `allOf`/`if`/`then` and additionally discloses
-every branch under `input.oneOf`.
+every branch under `input.anyOf` (the two strict-empty settings/manual branches
+intentionally overlap).
 
 Run-only fields (`command`, `timeout`, `working_dir`, `async`, `reminder`) exist
 only in `run`'s `input`; `job_id` exists only in `poll`'s and `cancel`'s.
-`manual` takes a strict empty `input`. Every child `input` is closed, and a key
+`settings` and `manual` each take strict empty `input={}`. Every child `input`
+is closed, and a key
 belonging to another action's branch is rejected at dispatch — before any
 handler I/O — with `{status: "failed", error_code: "INVALID_ARGUMENT",
 message: "unsupported shell input field"}`. An unknown `action` is rejected the
 same way with `error_code: "ACTION_REQUIRED"` and the message
-`action must be one of run, poll, cancel, or manual`.
+`action must be one of run, poll, cancel, settings, or manual`.
+
+`settings` is SHOW-only progressive disclosure. Normal success is exactly
+`{"settings": [...]}`; each row has exactly and in order `key`, `current`,
+`default`, `configurable`, and `comment`, where `comment` points to the exact
+`shell-manual` section owning meaning and the real external owner procedure.
+The Shell provider returns only the seven existing facts `shell_kind |
+sync_timeout_default_seconds | sync_timeout_max_seconds | result_max_chars |
+async_default | async_reminder_default_seconds | command_policy` in that order.
+Command-policy `current` and `default` project as `<redacted>`; the provider
+constructs only opaque safe markers and never renders policy paths or rules. An unavailable
+current, provider defect, malformed row, or unserializable value fails the whole
+action with the generic fixed `SETTINGS_UNAVAILABLE` response and no rows; the
+generic 65,536-byte complete-response bound applies. There is no
+set/reset/mutation action. The [Shell manual](manual/SKILL.md#settings-inventory)
+owns all per-setting detail.
 
 Following the strict-schema convention, optional run fields are declared
 REQUIRED but nullable: `null` means *absent* and is dropped before delegation,
@@ -160,9 +183,9 @@ exactly one `get_schema`/`get_description` pair — the migrated family surface 
 `_tool_family.py`, re-exported from `__init__.py` under those canonical names —
 so no second, pre-migration public schema exists to drift against.
 
-The engine serves no documentation: `ShellManager.handle` dispatches only
-`poll`, `cancel`, and `run`. `manual` is owned solely by the family's reserved
-child and never reaches the engine.
+The engine serves no settings or documentation: `ShellManager.handle` dispatches
+only `poll`, `cancel`, and `run`. `settings` and `manual` are owned solely by
+reserved family children and never reach the engine.
 
 Each child returns `ShellManager`'s own raw, canonical result verbatim. There
 is no Host envelope wrapped around a child result, and no child result nested
@@ -174,11 +197,12 @@ inside another action's result.
 | `run` (async) | `command`, `async: true` | `working_dir`, `timeout`, `reminder` | `{status: "ok", job_id, pid, message, handoff}`; `handoff` tells the model it may go idle or call `system(action='sleep')` while waiting for the terminal notification, and conditionally says that if Telegram is connected and a Task Card is available for the current turn, the model should use it to report progress via `telegram(action='manual')` and that manual's `Programmable Task Card` section; read `shell-manual` and `notification-manual` for details | `{status: "error", message}` — same validation errors, invalid boolean/non-numeric/non-finite/negative/too-large `reminder`, plus `Failed to start async job: ...` |
 | `poll` | `job_id` | — | running: `{status: "running", job_id, pid?}` while the recorded supervisor may still commit; known finished: `{status: "done", exit_status_known: true, exit_code, stdout, stderr, ok, command_status, warning?}`; unrecoverable/legacy terminal: `{status: "done", exit_status_known: false, exit_code: null, stdout, stderr}` | `{status: "error", message}` — missing/invalid `job_id`, `Job not found`, or an already terminal-consumed job |
 | `cancel` | `job_id` | — | `{status: "cancelled", job_id}` only after the supervisor has committed the held child's exact terminal status and cancellation atomically consumes/suppresses the job | `{status: "error", message}` — missing/invalid `job_id`, `Job not found`, terminal job, legacy job, or a durable cancellation request still awaiting a terminal commit (which remains pollable/remindable) |
+| `settings` | — (strict empty `{}`) | — | `{settings: [{key, current, default, configurable, comment}, ...]}` with command-policy values redacted | Fixed generic whole-action failure; never partial rows |
 | `manual` | — (strict empty `{}`) | — | `{status, content: [{type: "text", text: <full shell-manual body>}], structuredContent: {manual_path}}` — the shared ManualTool contract, returned without double wrapping | `status: "degraded"` plus `error` when the installed manual is missing |
 
-`manual` performs no shell operation: it never reaches the execution engine,
-spawns no process, and touches no job state. It serves the installed manual body
-and its host-local `manual_path` unchanged
+`settings` and `manual` perform no shell operation: neither reaches the
+execution engine, spawns a process, or touches job state. The manual child serves
+the installed manual body and its host-local `manual_path` unchanged
 (`.library/intrinsic/capabilities/shell/SKILL.md`, the destination
 `Agent._install_intrinsic_manuals` maps the retained `bash/manual/` bundle to).
 Its input schema is sourced from the shared `build_manual_child` builder, not

--- a/src/lingtai/tools/bash/_tool_family.py
+++ b/src/lingtai/tools/bash/_tool_family.py
@@ -4,7 +4,8 @@ The public/model-facing ``shell`` tool is migrated to the LingTai Tool
 Protocol v2 action-separated shape (``action``/``input``/``reasoning``/
 ``summarize``, see ``../CONTRACT.md``) using the generic, optional
 ``tool_family`` infrastructure (``../tool_family/__init__.py``). ``run``,
-``poll``, ``cancel``, and the reserved ``manual`` become four ``ChildTool``s
+``poll``, ``cancel``, and the reserved ``settings``/``manual`` actions become
+five ``ChildTool``s
 with their own strict per-action ``input`` schemas — run-only fields
 (``command``, ``timeout``, ``working_dir``, ``async``, ``reminder``) live only
 in ``run``'s branch; ``job_id`` lives only in ``poll``/``cancel``'s branches.
@@ -31,7 +32,7 @@ from typing import TYPE_CHECKING, Any, Mapping
 
 from lingtai.kernel.tool_plugin import BoundToolPlugin, ToolPluginDeclaration
 
-from ..tool_family import ChildTool, ToolFamily
+from ..tool_family import ChildTool, SettingRow, SettingsProvider, ToolFamily
 from ..tool_family.manual import MANUAL_INPUT_SCHEMA as _MANUAL_INPUT_SCHEMA, build_manual_child
 from ._shell_dialect import ShellKind
 
@@ -71,6 +72,71 @@ def resolve_timeout_max_seconds(environ: Mapping[str, str] | None = None) -> flo
     if not math.isfinite(value) or value <= 0:
         return _DEFAULT_TIMEOUT_MAX_SECONDS
     return max(value, float(_DEFAULT_TIMEOUT_SECONDS))
+
+
+def _shell_setting_rows(manager: Any) -> tuple[SettingRow, ...]:
+    """Read applied Shell facts without changing owner or process state."""
+    shell_kind = manager.shell_kind
+    if not isinstance(shell_kind, ShellKind):
+        raise RuntimeError("current shell kind is unavailable")
+    max_output = manager._max_output
+    if type(max_output) is not int or max_output <= 0:
+        raise RuntimeError("current result limit is unavailable")
+    policy = manager._policy
+    if not callable(getattr(policy, "is_allowed", None)):
+        raise RuntimeError("current command policy is unavailable")
+    return (
+        SettingRow(
+            "shell_kind",
+            shell_kind.value,
+            None,
+            True,
+            "shell-manual#shell-kind",
+        ),
+        SettingRow(
+            "sync_timeout_default_seconds",
+            _DEFAULT_TIMEOUT_SECONDS,
+            _DEFAULT_TIMEOUT_SECONDS,
+            False,
+            "shell-manual#sync-timeout-default",
+        ),
+        SettingRow(
+            "sync_timeout_max_seconds",
+            resolve_timeout_max_seconds(),
+            _DEFAULT_TIMEOUT_MAX_SECONDS,
+            True,
+            "shell-manual#sync-timeout-ceiling",
+        ),
+        SettingRow(
+            "result_max_chars",
+            max_output,
+            50_000,
+            True,
+            "shell-manual#result-size-limit",
+        ),
+        SettingRow(
+            "async_default",
+            False,
+            False,
+            False,
+            "shell-manual#async-default",
+        ),
+        SettingRow(
+            "async_reminder_default_seconds",
+            _DEFAULT_ASYNC_REMINDER_SECONDS,
+            _DEFAULT_ASYNC_REMINDER_SECONDS,
+            False,
+            "shell-manual#async-reminder-default",
+        ),
+        SettingRow(
+            "command_policy",
+            "configured",
+            "platform-packaged",
+            True,
+            "shell-manual#command-policy",
+            _sensitive=True,
+        ),
+    )
 
 RUN_INPUT_SCHEMA: dict[str, Any] = {
     "type": "object",
@@ -192,6 +258,7 @@ def get_description(
         "shell(action='run', input={'command': '...'}, reasoning='...') executes a command; "
         "shell(action='poll', input={'job_id': '...'}, reasoning='...') checks an async job; "
         "shell(action='cancel', input={'job_id': '...'}, reasoning='...') kills an async job; "
+        "shell(action='settings', input={}, reasoning='...') shows applied Shell settings; "
         "shell(action='manual', input={}, reasoning='...') returns the installed shell-manual skill. "
         "Returns exit_code, stdout, stderr, plus ok (bool) and command_status ('success'/'failed'). IMPORTANT: top-level status stays 'ok' even when the command FAILS — it only means the shell ran. "
         "Always check exit_code/ok and read the warning field (it names nonzero exits, Python tracebacks, and missing modules); never assume success from status alone. "
@@ -257,11 +324,19 @@ def _build_family() -> ToolFamily:
     children.append(
         ChildTool("manual", DECLARATION.manual_input_schema, _unused, title="manual input")
     )
-    return ToolFamily(DECLARATION.name, children)
+    def _schema_only_settings() -> tuple[SettingRow, ...]:
+        return ()
+
+    return ToolFamily(
+        DECLARATION.name,
+        children,
+        settings_provider=_schema_only_settings,
+    )
 
 
 def _build_dispatching_family(dispatcher: ShellFamilyDispatcher, manual_source: Any) -> ToolFamily:
     """Build the granted family with dispatcher-owned handlers and one manual."""
+    settings_provider: SettingsProvider = lambda: _shell_setting_rows(dispatcher.manager)
     return ToolFamily(
         DECLARATION.name,
         [
@@ -270,6 +345,7 @@ def _build_dispatching_family(dispatcher: ShellFamilyDispatcher, manual_source: 
             ChildTool("cancel", DECLARATION.input_schemas["cancel"], dispatcher._dispatch_cancel, title="cancel input"),
             build_manual_child(manual_source, DECLARATION.manual),
         ],
+        settings_provider=settings_provider,
     )
 
 
@@ -346,6 +422,7 @@ DECLARATION = ToolPluginDeclaration(
     binder=_bind,
     requires=("workdir", "notifications", "configuration"),
     glossary_package=__package__,
+    settings=True,
 )
 
 

--- a/src/lingtai/tools/bash/manual/SKILL.md
+++ b/src/lingtai/tools/bash/manual/SKILL.md
@@ -17,12 +17,14 @@ description: >
   Goose, OpenHands, and Crush are shell-only harnesses with no LingTai backend
   id. This manual owns only the shell-side supervision discipline (async +
   poll, reminders, scheduling, debugging, cleanup).
-version: 1.11.0
-last_changed_at: 2026-08-25T00:00:00Z
+version: 1.12.0
+last_changed_at: 2026-08-29T00:00:00Z
 related_files:
 - src/lingtai/tools/bash/__init__.py
+- src/lingtai/tools/bash/_tool_family.py
 - src/lingtai/tools/bash/CONTRACT.md
 - src/lingtai/tools/bash/ANATOMY.md
+- tests/test_shell_settings.py
 - src/lingtai/tools/bash/manual/reference/scheduled-work/SKILL.md
 - src/lingtai/tools/daemon/manual/SKILL.md
 - src/lingtai/tools/daemon/shell_prompt_events.py
@@ -110,6 +112,90 @@ applies no matter which CLI you run: the async + poll supervision rules in
    `reference/notification-reminders/SKILL.md`.
 5. **A scheduled job already exists and is misbehaving?** Read
    `reference/debugging-cleanup/SKILL.md` before editing blindly.
+
+## Settings inventory
+
+`shell(action="settings", input={}, reasoning="inspect applied Shell settings")`
+is read-only progressive disclosure. It returns only `key`, `current`,
+`default`, `configurable`, and the exact section pointer in `comment`.
+The input is strict empty: there is no set, reset, or other mutation form, and
+Shell owns no settings file. Read the matching section below before changing a
+value through its existing owner procedure, then call `settings` again to
+inspect the newly applied truth. If any current value cannot be read, the whole
+action returns `SETTINGS_UNAVAILABLE` without partial rows.
+
+### Shell kind
+
+`shell_kind` is the active command-language adapter: `posix`, `powershell`,
+`cmd`, `gitbash`, or `wsl`. It is public and configurable by an authorized
+Shell owner. Precedence is a valid capability `shell_kind` value, then a valid
+case-insensitive `LINGTAI_SHELL`, then platform discovery; invalid values fall
+through. Because platform discovery has no single universal fallback, the
+projected `default` is `null`. Change the capability/launcher configuration or
+call `setup(..., shell_kind="<kind>")`, then rebuild Shell (or relaunch the
+owning Agent) and verify with another SHOW. Dialect selection never bypasses
+command policy or the working-directory boundary.
+
+### Sync timeout default
+
+`sync_timeout_default_seconds` is the built-in `30`-second default used when a
+synchronous `run` supplies `input.timeout=null` or omits it through the internal
+compatibility path. It is public, built-in-only, has no config or environment
+key, and is therefore not family-configurable. To vary one call, pass a finite
+non-negative `input.timeout` no greater than the live ceiling; that per-run
+value applies immediately but does not change this default, so a later SHOW
+still reports `30`.
+
+### Sync timeout ceiling
+
+`sync_timeout_max_seconds` is the public hard ceiling for synchronous
+`input.timeout`. Its canonical owner environment key is
+`LINGTAI_TOOL_TIMEOUT_MAX_SECONDS`: a positive finite value wins over the
+built-in `120`; missing, blank, non-numeric, non-positive, or non-finite values
+use `120`, and values below `30` are floored to `30`. The value is read for
+each settings SHOW and each sync run. Change it only through the authorized
+process/launcher environment (relaunch if that environment is snapshotted at
+process start); the next operation in a process that sees the new value applies
+it. Work needing longer must use `input.async=true`.
+
+### Result size limit
+
+`result_max_chars` is the public per-stream character limit applied to captured
+stdout and stderr. The built-in default is `50000`; an authorized embedding
+owner may supply a positive integer through the existing
+`ShellManager(..., max_output=N)` construction procedure, which applies when
+that manager is built. The normal `setup` capability configuration exposes no
+`max_output` key and there is no environment key. Rebuild the embedding's
+manager/dispatcher and call SHOW again to verify the applied limit. This limit
+changes result disclosure only; it grants no command or filesystem authority.
+
+### Async default
+
+`async_default` is the public built-in `false` used when `run` does not select
+a mode. It has no config or environment key and is not family-configurable. Use
+`input.async=true` or `false` to select the mode for one run; that choice applies
+immediately and does not change the default reported by a second SHOW.
+
+### Async reminder default
+
+`async_reminder_default_seconds` is the public built-in `1800`-second
+last-resort wake delay for an async run with no explicit reminder. It has no
+config or environment key and is not family-configurable. For one async run,
+pass a finite non-negative `input.reminder` no greater than the platform timer
+bound; the value applies to that job only and does not change the default
+reported by SHOW.
+
+### Command policy
+
+`command_policy` is the security-sensitive allowlist, denylist, or allow-all
+policy bound to this Shell owner. Both `current` and `default` are always
+`<redacted>`; policy paths and rules never enter the settings response.
+Precedence is capability `yolo=true`, then `policy_file`, then the
+platform-packaged policy. These are the canonical capability/setup keys; there
+is no environment key. An authorized owner changes `yolo` or the reviewed
+policy file through existing capability configuration or
+`setup(..., policy_file=..., yolo=...)`, then rebuilds Shell. SHOW never grants
+mutation authority and a second SHOW remains redacted by design.
 
 ## Reading command results — never trust top-level `status` alone
 

--- a/tests/test_bash_async.py
+++ b/tests/test_bash_async.py
@@ -266,7 +266,7 @@ class TestBashAsync:
         # ``reminder`` is run-only: it exists solely in the ``run`` child's
         # input on the migrated envelope, and never on poll/cancel.
         branches = {
-            b["title"]: b for b in get_schema()["properties"]["input"]["oneOf"]
+            b["title"]: b for b in get_schema()["properties"]["input"]["anyOf"]
         }
         run_branch = branches["run input"]
         assert run_branch["properties"]["reminder"]["default"] == 1800.0

--- a/tests/test_intrinsic_manual_actions.py
+++ b/tests/test_intrinsic_manual_actions.py
@@ -308,10 +308,10 @@ def test_manual_schemas_preserve_runtime_checks_for_ordinary_file_calls(
     task_card_schema = task_card_tool.get_schema()
     assert task_card_schema["required"] == ["action", "input", "reasoning"]
     assert len(task_card_schema["properties"]["input"]["anyOf"]) == 7
-    # ``shell`` is migrated to the same LTP v2 envelope, with four children.
+    # ``shell`` opts into settings immediately before its manual.
     shell_schema = shell_tool.get_schema()
     assert shell_schema["required"] == ["action", "input", "reasoning"]
-    assert len(shell_schema["properties"]["input"]["oneOf"]) == 4
+    assert len(shell_schema["properties"]["input"]["anyOf"]) == 5
 
     agent = _StubAgent(tmp_path)
     agent._file_io = _ActionFileIO(tmp_path)

--- a/tests/test_layers_bash.py
+++ b/tests/test_layers_bash.py
@@ -264,7 +264,7 @@ class TestBashManager:
         # ``working_dir`` is a run-only field, so it lives in the ``run``
         # child's own input schema on the migrated envelope.
         run_branch = next(
-            b for b in get_schema("en")["properties"]["input"]["oneOf"]
+            b for b in get_schema("en")["properties"]["input"]["anyOf"]
             if b["title"] == "run input"
         )
         desc = run_branch["properties"]["working_dir"]["description"]

--- a/tests/test_shell_settings.py
+++ b/tests/test_shell_settings.py
@@ -1,0 +1,211 @@
+"""Focused proofs for Shell's read-only five-field settings inventory."""
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from lingtai.tools.bash import ShellManager, ShellPolicy
+from lingtai.tools.bash._shell_dialect import ShellKind
+from lingtai.tools.bash._tool_family import (
+    DECLARATION,
+    ShellFamilyDispatcher,
+    get_schema,
+)
+
+
+def _dispatcher(tmp_path: Path) -> tuple[ShellFamilyDispatcher, ShellManager]:
+    manager = ShellManager(
+        policy=ShellPolicy(allow=["fixture-command-not-for-output"]),
+        working_dir=str(tmp_path),
+        max_output=1_234,
+        shell_kind=ShellKind.POSIX,
+        rehydrate=False,
+    )
+    source = SimpleNamespace(_working_dir=tmp_path)
+    return ShellFamilyDispatcher(manager, source), manager
+
+
+def _settings(dispatcher: ShellFamilyDispatcher, action_input: object) -> dict:
+    return dispatcher.handle(
+        {
+            "action": "settings",
+            "input": action_input,
+            "reasoning": "inspect applied Shell settings",
+        }
+    )
+
+
+def test_shell_opts_in_immediately_before_manual():
+    assert DECLARATION.settings is True
+    assert DECLARATION.public_actions == (
+        "run",
+        "poll",
+        "cancel",
+        "settings",
+        "manual",
+    )
+    schema = get_schema()
+    assert schema["properties"]["action"]["enum"] == list(DECLARATION.public_actions)
+    assert [
+        branch["title"] for branch in schema["properties"]["input"]["anyOf"]
+    ] == [
+        "run input",
+        "poll input",
+        "cancel input",
+        "settings inventory input",
+        "manual input",
+    ]
+
+
+def test_exact_rows_values_flags_redaction_and_manual_targets(tmp_path, monkeypatch):
+    monkeypatch.delenv("LINGTAI_TOOL_TIMEOUT_MAX_SECONDS", raising=False)
+    dispatcher, manager = _dispatcher(tmp_path)
+    before = dict(manager.__dict__)
+
+    def _forbid_policy_render(_policy):
+        raise AssertionError("SHOW must not render command policy rules")
+
+    monkeypatch.setattr(ShellPolicy, "describe", _forbid_policy_render)
+    result = _settings(dispatcher, {})
+
+    expected = {
+        "shell_kind": (
+            "posix",
+            None,
+            True,
+            "shell-manual#shell-kind",
+            "Shell kind",
+        ),
+        "sync_timeout_default_seconds": (
+            30,
+            30,
+            False,
+            "shell-manual#sync-timeout-default",
+            "Sync timeout default",
+        ),
+        "sync_timeout_max_seconds": (
+            120.0,
+            120.0,
+            True,
+            "shell-manual#sync-timeout-ceiling",
+            "Sync timeout ceiling",
+        ),
+        "result_max_chars": (
+            1_234,
+            50_000,
+            True,
+            "shell-manual#result-size-limit",
+            "Result size limit",
+        ),
+        "async_default": (
+            False,
+            False,
+            False,
+            "shell-manual#async-default",
+            "Async default",
+        ),
+        "async_reminder_default_seconds": (
+            1_800.0,
+            1_800.0,
+            False,
+            "shell-manual#async-reminder-default",
+            "Async reminder default",
+        ),
+        "command_policy": (
+            "<redacted>",
+            "<redacted>",
+            True,
+            "shell-manual#command-policy",
+            "Command policy",
+        ),
+    }
+    rows = result["settings"]
+    assert [row["key"] for row in rows] == list(expected)
+    assert manager.__dict__ == before
+    for row in rows:
+        assert list(row) == [
+            "key",
+            "current",
+            "default",
+            "configurable",
+            "comment",
+        ]
+        current, default, configurable, comment, _heading = expected[row["key"]]
+        assert (row["current"], row["default"]) == (current, default)
+        assert row["configurable"] is configurable
+        assert row["comment"] == comment
+    assert "fixture-command-not-for-output" not in repr(result)
+
+    manual = (
+        Path(__file__).parents[1]
+        / "src"
+        / "lingtai"
+        / "tools"
+        / "bash"
+        / "manual"
+        / "SKILL.md"
+    ).read_text(encoding="utf-8")
+    for _current, _default, _configurable, comment, heading in expected.values():
+        assert comment == f"shell-manual#{heading.lower().replace(' ', '-')}"
+        assert f"### {heading}" in manual
+
+
+def test_fresh_effective_values_are_re_read(tmp_path, monkeypatch):
+    dispatcher, manager = _dispatcher(tmp_path)
+    monkeypatch.setenv("LINGTAI_TOOL_TIMEOUT_MAX_SECONDS", "47.5")
+    first = _settings(dispatcher, {})
+    manager._max_output = 2_345
+    monkeypatch.setenv("LINGTAI_TOOL_TIMEOUT_MAX_SECONDS", "63")
+    second = _settings(dispatcher, {})
+
+    assert first["settings"][2]["current"] == 47.5
+    assert second["settings"][2]["current"] == 63.0
+    assert first["settings"][2]["default"] == second["settings"][2]["default"] == 120.0
+    assert first["settings"][3]["current"] == 1_234
+    assert second["settings"][3]["current"] == 2_345
+
+
+def test_unavailable_current_returns_one_fixed_failure_without_rows(tmp_path):
+    dispatcher, manager = _dispatcher(tmp_path)
+    manager._max_output = None
+
+    assert _settings(dispatcher, {}) == {
+        "status": "failed",
+        "error_code": "SETTINGS_UNAVAILABLE",
+        "message": "settings inventory is unavailable",
+    }
+
+
+def test_settings_is_strict_empty_and_basic_run_dispatch_is_unchanged(
+    tmp_path, monkeypatch
+):
+    dispatcher, manager = _dispatcher(tmp_path)
+    assert _settings(dispatcher, {"set": "result_max_chars"}) == {
+        "status": "failed",
+        "error_code": "INVALID_ARGUMENT",
+        "message": "unsupported shell input field",
+    }
+    assert _settings(dispatcher, None) == {
+        "status": "failed",
+        "error_code": "INVALID_ARGUMENT",
+        "message": "input must be an object",
+    }
+    assert not {"set", "reset"} & set(DECLARATION.public_actions)
+
+    observed: list[dict] = []
+    monkeypatch.setattr(
+        manager,
+        "handle",
+        lambda args: observed.append(dict(args)) or {"status": "ok", "marker": "raw"},
+    )
+    result = dispatcher.handle(
+        {
+            "action": "run",
+            "input": {"command": "printf unchanged", "async": False},
+            "reasoning": "prove ordinary dispatch",
+        }
+    )
+    assert result == {"status": "ok", "marker": "raw"}
+    assert observed == [
+        {"command": "printf unchanged", "async": False, "action": "run"}
+    ]

--- a/tests/test_shell_tool_family_migration.py
+++ b/tests/test_shell_tool_family_migration.py
@@ -2,7 +2,7 @@
 
 Proves the public/model-facing ``shell`` tool is the ToolFamily-composed
 ``action``/``input``/``reasoning``/``summarize`` envelope over the canonical
-children ``run | poll | cancel | manual``, while ``ShellManager`` — the sync
+children ``run | poll | cancel | settings | manual``, while ``ShellManager`` — the sync
 execution path, the working-directory sandbox, the durable async lifecycle,
 cancellation, and terminal receipts — stays the exact, untouched engine the
 pre-migration suites (``test_bash_async.py``, ``test_layers_bash.py``,
@@ -30,6 +30,7 @@ from tests._notification_store_helpers import notification_store_for
 from lingtai.tools.bash import ShellManager, ShellPolicy, setup
 from lingtai.tools.bash._tool_family import (
     CANCEL_INPUT_SCHEMA,
+    DECLARATION,
     MANUAL_INPUT_SCHEMA,
     POLL_INPUT_SCHEMA,
     RUN_INPUT_SCHEMA,
@@ -37,7 +38,15 @@ from lingtai.tools.bash._tool_family import (
     get_schema,
 )
 
-_ACTIONS = ["run", "poll", "cancel", "manual"]
+_ACTIONS = ["run", "poll", "cancel", "settings", "manual"]
+_BRANCH_TITLES = [
+    "run input",
+    "poll input",
+    "cancel input",
+    "settings inventory input",
+    "manual input",
+]
+_SETTINGS_INPUT_SCHEMA = DECLARATION.public_input_schemas()["settings"]
 
 
 def _make_manager(tmp_path: Path) -> ShellManager:
@@ -131,9 +140,9 @@ def test_root_is_strict_action_input_reasoning_summarize():
     assert schema["properties"]["action"]["enum"] == _ACTIONS
 
 
-def test_canonical_children_are_the_four_shell_actions():
-    branches = get_schema()["properties"]["input"]["oneOf"]
-    assert [b["title"] for b in branches] == [f"{a} input" for a in _ACTIONS]
+def test_canonical_children_are_the_five_shell_actions():
+    branches = get_schema()["properties"]["input"]["anyOf"]
+    assert [b["title"] for b in branches] == _BRANCH_TITLES
 
 
 # ---------------------------------------------------------------------------
@@ -162,7 +171,13 @@ def test_run_only_fields_live_only_in_run_and_job_id_only_in_poll_cancel():
 
 
 def test_every_child_input_schema_is_closed_and_free_of_host_fields():
-    for schema in (RUN_INPUT_SCHEMA, POLL_INPUT_SCHEMA, CANCEL_INPUT_SCHEMA, MANUAL_INPUT_SCHEMA):
+    for schema in (
+        RUN_INPUT_SCHEMA,
+        POLL_INPUT_SCHEMA,
+        CANCEL_INPUT_SCHEMA,
+        _SETTINGS_INPUT_SCHEMA,
+        MANUAL_INPUT_SCHEMA,
+    ):
         assert schema["additionalProperties"] is False
         for host_field in ("action", "reasoning", "_reasoning", "summarize", "summary"):
             assert host_field not in schema["properties"]
@@ -177,6 +192,7 @@ def test_root_allof_correlates_each_action_const_to_its_own_input_schema():
         "run": RUN_INPUT_SCHEMA,
         "poll": POLL_INPUT_SCHEMA,
         "cancel": CANCEL_INPUT_SCHEMA,
+        "settings": _SETTINGS_INPUT_SCHEMA,
         "manual": MANUAL_INPUT_SCHEMA,
     }
     for condition in conditions:
@@ -189,14 +205,16 @@ def test_root_allof_correlates_each_action_const_to_its_own_input_schema():
 # Dispatch-time rejection (before any handler I/O)
 # ---------------------------------------------------------------------------
 
-def test_unknown_action_fails_with_shells_own_four_action_message(tmp_path):
+def test_unknown_action_fails_with_shells_own_five_action_message(tmp_path):
     dispatcher, _ = _make_dispatcher(tmp_path)
 
     result = dispatcher.handle({"action": "exec", "input": {}, "reasoning": "r"})
 
     assert result["status"] == "failed"
     assert result["error_code"] == "ACTION_REQUIRED"
-    assert result["message"] == "action must be one of run, poll, cancel, or manual"
+    assert result["message"] == (
+        "action must be one of run, poll, cancel, settings, or manual"
+    )
 
 
 @pytest.mark.parametrize(
@@ -562,7 +580,7 @@ def test_family_manual_worked_examples_use_the_registered_envelope():
     for flat in ('shell(async=', 'async=true,', 'job_id="job-', 'reminder=1800'):
         assert flat not in manual, f"manual still teaches the flat shape: {flat}"
 
-    # Every worked call opens with an explicit action= and is one of the four.
+    # Every worked call opens with an explicit action= and is one of the five.
     calls = re.findall(r'shell\(action="(\w+)"', manual)
     assert calls, "expected worked shell() examples in the manual"
     assert set(calls) <= set(_ACTIONS)
@@ -658,14 +676,14 @@ def test_shell_family_schema_survives_chat_and_responses_wires():
     chat = _build_tools([schema])[0]["function"]["parameters"]
     responses = _build_responses_tools([schema])[0]["parameters"]
 
-    for wire, combinator in ((chat, "oneOf"), (responses, "anyOf")):
+    for wire, combinator in ((chat, "anyOf"), (responses, "anyOf")):
         assert wire["type"] == "object"
         assert wire["required"] == ["action", "input", "reasoning"]
         assert wire["additionalProperties"] is False
         assert set(wire["properties"]) == {"action", "input", "reasoning", "summarize"}
         assert wire["properties"]["action"]["enum"] == _ACTIONS
         branches = wire["properties"]["input"][combinator]
-        assert [b["title"] for b in branches] == [f"{a} input" for a in _ACTIONS]
+        assert [b["title"] for b in branches] == _BRANCH_TITLES
         for branch in branches:
             assert branch["additionalProperties"] is False
             for host_field in ("reasoning", "_reasoning", "summarize"):

--- a/tests/test_shell_tool_plugin_declaration.py
+++ b/tests/test_shell_tool_plugin_declaration.py
@@ -53,7 +53,9 @@ def test_shell_declaration_is_static_and_derives_its_shipped_surface():
 
     assert DECLARATION.name == "shell"
     assert DECLARATION.actions == ("run", "poll", "cancel")
-    assert DECLARATION.public_actions == ("run", "poll", "cancel", "manual")
+    assert DECLARATION.public_actions == (
+        "run", "poll", "cancel", "settings", "manual"
+    )
     assert DECLARATION.requires == ("workdir", "notifications", "configuration")
     assert DECLARATION.manual == "shell"
     assert "shell" in OFFICIAL_TOOL_PLUGIN_NAMES
@@ -147,6 +149,22 @@ def test_official_shell_mount_uses_only_narrow_ports_and_keeps_real_dispatch(she
     assert sync["exit_code"] == 0
     assert sync["stdout"] == "official-shell"
     assert sync["command_status"] == "success"
+
+    settings = handler({
+        "action": "settings",
+        "input": {},
+        "reasoning": "inspect applied Shell settings",
+    })
+    assert [row["key"] for row in settings["settings"]] == [
+        "shell_kind",
+        "sync_timeout_default_seconds",
+        "sync_timeout_max_seconds",
+        "result_max_chars",
+        "async_default",
+        "async_reminder_default_seconds",
+        "command_policy",
+    ]
+    assert shell_agent._build_system_prompt()
 
     manual = handler({"action": "manual", "input": {}, "reasoning": "read Shell manual"})
     assert manual["status"] == "ok"

--- a/tests/test_tool_settings_contract.py
+++ b/tests/test_tool_settings_contract.py
@@ -147,10 +147,10 @@ def test_public_export_and_exact_production_opt_ins():
         name: importlib.import_module(f"lingtai.tools.{modules.get(name, name)}").DECLARATION
         for name in OFFICIAL_TOOL_PLUGIN_NAMES
     }
-    expected_official = {"avatar", "daemon", "email", "file", "mcp", "notification", "plugin", "soul", "system", "task_card"}
+    expected_official = {"avatar", "daemon", "email", "file", "mcp", "notification", "plugin", "shell", "soul", "system", "task_card"}
     assert {name for name, item in declarations.items() if item.settings} == expected_official
     assert expected_curated | expected_official == {
-        "avatar", "cloud_mail", "daemon", "email", "feishu", "file", "imap", "mcp", "notification", "plugin", "soul", "system", "task_card", "wechat", "whatsapp"
+        "avatar", "cloud_mail", "daemon", "email", "feishu", "file", "imap", "mcp", "notification", "plugin", "shell", "soul", "system", "task_card", "wechat", "whatsapp"
     }
     for name, item in declarations.items():
         assert ("settings" in item.public_actions) is (name in expected_official)


### PR DESCRIPTION
## Sequential owner candidate

This is the cumulative **Shell** owner candidate after the first 15 authorized settings-owner PRs. It is one owner commit on exact current main `6b232dd33752135c0b49dbad1194873d35735225`; it does not stack an unmerged owner branch.

- final candidate: `d920bd1a5f8352685a675cfe4a174a1982e99100`
- final tree: `51ac65d2f0af7f36ae471b9da902990a74b65b4a`
- resulting diff: **14 files, +508/-55**
- one owner commit, canonical `Huang Zesen <hzsbazinga@outlook.com>` author/committer, clean worktree, no tracked deletion
- stable whole-patch ID against the cumulative parent: `fa4bf7779ceb4b59070d4dc485e050f7bfa1ff57`

## Settings truth

Shell opts only its own public family into the generic read-only `settings` action. It exposes exactly seven applied settings in this order:

1. `shell_kind`
   - current/default: active dialect such as `posix` / `null`; `configurable=true`
   - precedence: valid capability `shell_kind` > valid case-insensitive `LINGTAI_SHELL` > platform discovery; invalid values fall through
   - no universal platform default exists, so default is null
   - applied when Shell is built; change the authorized capability/launcher or `setup(..., shell_kind=...)`, then rebuild/relaunch Shell

2. `sync_timeout_default_seconds`
   - current/default: `30 / 30`; `configurable=false`
   - built-in default; a finite non-negative per-call `run.timeout` within the live ceiling affects only that call and does not mutate this row

3. `sync_timeout_max_seconds`
   - current/default: live resolved ceiling / `120.0`; `configurable=true`
   - canonical owner is `LINGTAI_TOOL_TIMEOUT_MAX_SECONDS`
   - positive finite values win; missing, blank, non-numeric, non-positive, NaN, or infinite values fall back to 120.0; values below 30 are floored to 30.0
   - read fresh by every settings SHOW and synchronous run, rather than cached on the manager

4. `result_max_chars`
   - current/default: applied positive `ShellManager._max_output` / `50000`; `configurable=true`
   - limits captured stdout/stderr disclosure only and grants no command or filesystem authority
   - no normal setup capability key or env exists; an authorized embedding owner constructs a new `ShellManager(..., max_output=N)` with a positive non-bool integer, then rebuilds the manager/dispatcher

5. `async_default`
   - current/default: `false / false`; `configurable=false`
   - built-in default; `run.async=true|false` affects only the selected run

6. `async_reminder_default_seconds`
   - current/default: `1800.0 / 1800.0`; `configurable=false`
   - built-in default; a finite non-negative per-job `run.reminder` affects only that async job and does not mutate the default

7. `command_policy`
   - current/default: always `<redacted> / <redacted>`; `configurable=true`
   - precedence: authorized capability `yolo=true` > reviewed `policy_file` > platform-packaged policy
   - policy paths and rules never enter the inventory; an authorized owner changes the capability/setup input and rebuilds Shell

Settings has strict empty input, is SHOW-only, and never runs/polls/cancels a command, writes env/files, rebuilds a manager, or mutates policy. Shell owns no settings file and provides no generic set/reset/patch path. A missing/invalid current value, malformed row, serialization failure, or provider defect fails the whole bounded action as `SETTINGS_UNAVAILABLE`; it never returns partial rows.

The existing execution engine remains limited to `run`, `poll`, and `cancel`. Public action order is `run`, `poll`, `cancel`, `settings`, `manual`; the two strict-empty reserved inputs intentionally use `anyOf`. The historical flat manager interface remains internal and unchanged.

## Cumulative reconstruction

The old Draft had 15 changed paths. Against current main, **10/15 old path-specific stable patch IDs remain identical**. The five intentional cumulative differences are:

- the generic settings manual is already present on current main and remains byte-identical to it, so Shell no longer carries a duplicate patch there;
- shared tools `ANATOMY.md` and `CONTRACT.md` retain the same Shell semantic delta while preserving the already-merged owner prose around it;
- the intrinsic-manual schema test preserves every current family expectation and changes only Shell from four `oneOf` children to five `anyOf` children;
- the shared settings contract preserves every cumulative official/curated owner and Psyche, adding only declared official Shell.

## Acceptance

- live `shell.settings`: exactly seven five-field rows; only `command_policy` is redacted, in both current and default
- live harmless original `shell.run`: printed `shell-original-action-ok`, exit 0 / `ok=true`, with no file, process, or configuration mutation
- candidate-only settings module: **5 passed**
- six common affected modules: candidate and exact current main both **183 passed with the same one frozen-main async-supervisor failure**; candidate-unique failures: **0**
- bounded six-module architecture/environment/manual/settings/glossary differential: candidate and exact current main both **211 passed with the same five frozen-main failures**; candidate-unique failures: **0**
- candidate-source schema probe with explicit source path: exact public order `run,poll,cancel,settings,manual`, strict required root, five `anyOf` input branches
- candidate provider compile: pass
- `git diff --check`: pass
- the only conflict-marker-shaped literal is pre-existing historical documentation in Shell `CONTRACT.md` and exists identically on current main; there is no unresolved merge state

## Boundary

This PR carries only Shell's read-only five-field discovery, owner manual/contracts/tests, and the minimum cumulative shared contract updates. It does not add a generic settings writer, change command policy/dialect/timeout/output defaults, execute or cancel jobs, release/deploy, refresh a live runtime or MCP, mutate unrelated configuration/auth, opt Context into settings, touch Guardian #1550, delete data, or perform cleanup.

The sequential merge gate remains mechanical: publish with the exact old-head lease, verify the remote body/head, report the final head, then mark Ready and squash-merge only if exact main/head/body/tree/actor/identity guards still match.

Telegram: @lingtaidev3bot | Nickname: 澄一

Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai