### PR TITLE
feat(vision): expose owned settings and env parity

### DIFF
--- a/src/lingtai/tools/ANATOMY.md
+++ b/src/lingtai/tools/ANATOMY.md
@@ -125,8 +125,9 @@ capability names and lazy adapters.
   manual body installed as `file-manual`
   (`src/lingtai/tools/file/ANATOMY.md`).
 - `vision/` — public `vision` composition owner: one action-separated family
-  with canonical `analyze`/`check`/`list`/`manual` children over the existing
-  direct provider routing, declared as the thirteenth official host-plugin
+  with canonical `analyze`/`check`/`list`/`settings`/`manual` children over the
+  existing direct provider routing and one bind-time settings snapshot,
+  declared as the thirteenth official host-plugin
   slice against `workdir`/`active_provider`/`configuration`
   (`src/lingtai/tools/vision/ANATOMY.md`).
 - `browser/` — internal static browse Core/Port used by `web`
@@ -330,14 +331,14 @@ bind, the family-local `TaskCardNotificationsAdapter` consumes only the five
 native notification operations, and the producer stays channel-neutral (it
 writes the `taskcard/` artifact and never calls Telegram/Feishu).
 `src/lingtai/tools/vision/__init__.py` is the thirteenth slice: its
-`DECLARATION` owns the public `analyze | check | list | manual` family and
-binds `VisionManager` against `workdir`, the live read-through
+`DECLARATION` owns the public `analyze | check | list | settings | manual`
+family and binds `VisionManager` against `workdir`, the live read-through
 `active_provider`, and one `configuration` snapshot (`VisionConfiguration`,
 carried as the same `StaticConfigurationAdapter` mapping Shell uses and granted
 to `vision` alone through `extra_ports_for`); default routing uses only the
 active provider, an explicitly allowed `preset` resolves only that preset's own
-credential for the one requested call, `check`/`list`/`manual` make no
-image/provider request, and no provider/credential/MCP fallback is automatic.
+credential for the one requested call, `check`/`list`/`settings`/`manual` make
+no image/provider request, and no provider/credential/MCP fallback is automatic.
 `src/lingtai/tools/web_search/__init__.py` is the fourteenth slice: its
 `DECLARATION` owns the public `search | browse | manual` family and binds
 `WebManager` against `workdir`, the Web-owned typed `web_runtime` composition

--- a/src/lingtai/tools/CONTRACT.md
+++ b/src/lingtai/tools/CONTRACT.md
@@ -319,8 +319,9 @@ operation-native `task_card_notifications` port (five scalar operations, no
 generic publisher), keeping one manager across refresh and its channel-neutral
 `taskcard/` artifact ownership, and Vision retains `workdir` plus its live
 read-through `active_provider` and one setup-selected `configuration`
-snapshot, keeping its `analyze | check | list | manual` surface, active-provider
-default routing, allowed-preset own-credential borrowing, and no automatic
+snapshot plus a bind-time settings projection, keeping its
+`analyze | check | list | settings | manual` surface, active-provider default
+routing, allowed-preset own-credential borrowing, and no automatic
 provider/credential/MCP fallback, and Web retains `workdir` plus its Web-owned
 typed `web_runtime` composition (browser transport, immutable engine specs,
 and default provenance, granted by its own `setup` through `extra_ports_for`)
@@ -648,10 +649,11 @@ non-goal for third-party-versus-third-party mounts.
   `tests/test_vision_capability.py`, `tests/test_inherit_fallback.py`, the
   Vision case in `tests/test_tool_plugin_declaration.py`, and the strict
   controlled-host manual proof in `tests/test_intrinsic_manual_actions.py`)
-  prove the four-action schema/dispatch surface, active-provider default
+  plus `tests/test_vision_settings.py` prove the five-action schema/dispatch
+  and read-only settings surface, active-provider default
   routing, allowed-preset own-credential borrowing with no automatic
-  provider/MCP fallback, `check`/`list`/`manual` no-request boundaries, and the
-  package-owned manual. Web's declaration binds only
+  provider/MCP fallback, `check`/`list`/`settings`/`manual` no-request
+  boundaries, and the package-owned manual. Web's declaration binds only
   `workdir`/`web_runtime`/`provider_identity`; its focused suites
   (`tests/test_web_official_plugin.py`, `tests/test_web_composition_port.py`,
   the Web case in `tests/test_tool_plugin_declaration.py`, the strict
@@ -789,16 +791,17 @@ SHOW-only, provider-bound, and immediately before `manual`; it exposes exactly
 the File owner's 13 policy/selector rows without adding set/reset (see
 `src/lingtai/tools/file/CONTRACT.md`).
 
-`vision` (`analyze | check | list | manual`) is the fifth: it keeps its public
+`vision` (`analyze | check | list | settings | manual`) is the fifth: it keeps its public
 tool name and action values while moving to the same root envelope, with
 `analyze` owning the direct image request (default route: the active provider
 only; an explicitly allowed `preset` borrows only that preset's own route for
 the one call), `check` resolving the selected route without any image/provider
-request, `list` enumerating only authorized preset declarations, and `manual`
-the family-owned reserved child (see `src/lingtai/tools/vision/CONTRACT.md`).
-Its only settings surface is the fixed workdir-relative `settings/vision.json`
-endpoint file for the generic `local` provider; the two-level settings
-addressing rules do not apply to it.
+request, `list` enumerating only authorized preset declarations, `settings`
+showing one read-only applied bind snapshot, and `manual` the family-owned
+reserved child (see `src/lingtai/tools/vision/CONTRACT.md`). The fixed
+workdir-relative `settings/vision.json` remains the only Vision-owned document
+and configures only the generic `local` provider. SHOW adds no settings file,
+parser, writer, or generic control plane.
 
 `avatar` (`spawn | rules | manual`) is the sixth family migrated, keeping its
 public name and action values unchanged (see

--- a/src/lingtai/tools/vision/ANATOMY.md
+++ b/src/lingtai/tools/vision/ANATOMY.md
@@ -14,6 +14,7 @@ related_files:
   - src/lingtai/kernel/tool_plugin/ANATOMY.md
   - src/lingtai/adapters/tool_plugin_host.py
   - tests/test_tool_plugin_declaration.py
+  - tests/test_vision_settings.py
 maintenance: |
   Keep related_files as repo-relative paths to real files and keep anatomy links
   reciprocal. Update citations with structural code changes and run the document
@@ -25,49 +26,57 @@ maintenance: |
 ---
 # src/lingtai/tools/vision/
 
-The `vision` package is one declaration-derived public family with four model-facing
-children: `analyze`, `check`, `list`, and the reserved `manual`. The generic
+The `vision` package is one declaration-derived public family with five model-facing
+children: `analyze`, `check`, `list`, the opted-in reserved `settings`, and the
+reserved `manual`. The generic
 `tool_family` package owns schema composition and envelope dispatch; this package
 owns provider identity, allowed-preset borrowing, route classification, and every
 Vision result shape.
 
 ## Components
 
-- `__init__.py:129-144` — `_canonical_preset_path` resolves one allowed preset
+- `__init__.py:200-215` — `_canonical_preset_path` resolves one allowed preset
   reference (`~`, absolute, or workdir-relative spelling) to its canonical
   physical path; `list` keys its rows on it so one file appears once.
-- `__init__.py:218-278` — strict declaration-owned input schemas: `analyze`
+- `__init__.py:540-600` — strict declaration-owned input schemas: `analyze`
   requires `image_path` and nullable `question` and accepts nullable `preset`,
   `check` requires nullable `preset`, and `list` is strict empty input.
-- `__init__.py:281-379` — immutable `VisionConfiguration` (with
+- `__init__.py:604-716` — immutable `VisionConfiguration` (with
   `port_values`/`from_port_values`, the only translation to and from the kernel
   `ConfigurationPort` mapping), static description, and declaration-derived
   `_build_family`; import-time and host-bound families therefore expose the
-  same three operational children plus `manual`.
-- `__init__.py:392-413` — `VisionManager` retains only the granted workdir and
+  same three operational children plus generic `settings` and `manual`.
+- `__init__.py:718-744` — `VisionManager` retains only the granted workdir and
   live active-provider ports, the resolved service/reason, and the installed
   manual child; it does not retain an Agent.
-- `__init__.py:419-500` — `_build_service_from_preset` checks
+- `__init__.py:747-828` — `_build_service_from_preset` checks
   `manifest.preset.allowed`, loads the authorized preset read-only, and passes
   that preset's provider/model/credential identity to the direct resolver.
-- `__init__.py:502-589` — `_dispatch_analyze` resolves relative image paths,
+- `__init__.py:830-917` — `_dispatch_analyze` resolves relative image paths,
   performs one request on either the default or explicitly borrowed service, and
   returns the exact success/error shapes.
-- `__init__.py:591-638` — `_dispatch_check` constructs/resolves the selected route
+- `__init__.py:919-966` — `_dispatch_check` constructs/resolves the selected route
   and reports provider/model without sending an image request.
-- `__init__.py:640-693` — `_dispatch_list` mechanically classifies the active route
+- `__init__.py:968-1035` — `_dispatch_list` mechanically classifies the active route
   and only the authorized preset definitions, one row per physical preset in its
   declared spelling; it constructs no provider service.
-- `__init__.py:695-740` — `manual` reads the installed package manual through the
+- `__init__.py:1037-1072` — `manual` reads the installed package manual through the
   reserved child, then the host flattens its canonical body/path result once.
-- `__init__.py:744-808` — `_bind` and `DECLARATION` (with `setup` at the module
-  tail) compose Vision through the official registrar with `workdir`,
+- `__init__.py:144-526` and `1182-1563` — owner-local settings
+  snapshot/projection turns the successfully bound route and resolver-produced
+  protocol provenance into 13 exact `SettingRow` values. Sensitive inputs,
+  including path-like models, become presence markers before the generic
+  redaction boundary; an unavailable route raises into the generic
+  all-or-nothing failure.
+- `__init__.py:1076-1179` and `1566-1608` — `_bind`, `DECLARATION`, and `setup`
+  compose Vision through the official registrar with `workdir`,
   `active_provider`, and opaque `configuration` ports: `setup` hands the
   registrar `StaticConfigurationAdapter(VisionConfiguration(...).port_values())`
   through `extra_ports_for` for the `vision` declaration alone, and `_bind`
-  rebuilds the snapshot with `VisionConfiguration.from_port_values`.
-- `settings.py:1-188` — bounded, race-checked local-provider settings reader for
-  the workdir-relative `settings/vision.json` file.
+  rebuilds the snapshot with `VisionConfiguration.from_port_values`, resolves the
+  service once, and binds one read-only settings provider.
+- `settings.py:1-188` — bounded, stable, duplicate/unknown-field-rejecting
+  `settings/vision.json` reader retained for the local route; it has no writer.
 
 ## Connections
 
@@ -77,6 +86,9 @@ Vision result shape.
   `VisionConfiguration` snapshot; it never reaches through to an Agent.
 - Direct routes call the service implementations under `lingtai.services.vision`.
   Provider aliases and Codex route selection stay inside this family boundary.
+- Generic settings input enforcement, exact five-field projection, redaction,
+  failure, and response bounding stay in `tool_family`; Vision supplies only
+  the applied bind snapshot and stable owner-manual pointers.
 - Preset borrowing reads only an explicitly authorized preset and uses that
   preset's own provider/model/credential route for the one requested call. It
   does not switch the active preset and does not invoke MCP automatically.
@@ -87,16 +99,19 @@ Vision result shape.
 
 `setup` creates `VisionConfiguration` and delegates one official declaration to the
 kernel registrar. The registrar claims and mounts exactly one public `vision` root;
-`_bind` creates `VisionManager` and its declaration-derived family. The package
+`_bind` creates `VisionManager`, its bound settings provider, and its
+declaration-derived family. The package
 manual is the operational source, while the retained service package supplies
 provider adapters and this package supplies routing policy.
 
 ## State
 
 The manager retains ephemeral service, route reason, workdir, active-provider port,
-and family references. Preset files and local settings are read-only inputs for a
-call. Vision analyses are not persisted; manual content is bundled and installed
-into the agent's intrinsic capability library.
+family references, and one closure over the applied settings snapshot. SHOW writes
+nothing and never rereads the owner file. Preset files and local settings remain
+owner-managed inputs to the existing bind/refresh path. Vision analyses are not
+persisted; manual content is bundled and installed into the agent's intrinsic
+capability library.
 
 ## Notes
 

--- a/src/lingtai/tools/vision/BEHAVIORS.md
+++ b/src/lingtai/tools/vision/BEHAVIORS.md
@@ -1,6 +1,6 @@
 ---
 name: vision-behavior-tests
-behavior_version: 2
+behavior_version: 3
 labt_version: 2
 contract: CONTRACT.md
 anatomy: ANATOMY.md
@@ -14,6 +14,7 @@ related_files:
   - tests/test_tool_plugin_declaration.py
   - tests/test_tool_family_vision_migration.py
   - tests/test_vision_capability.py
+  - tests/test_vision_settings.py
   - tests/test_inherit_fallback.py
 maintenance: |
   Keep this file reciprocal with CONTRACT.md and ANATOMY.md (tridirectional
@@ -24,14 +25,14 @@ maintenance: |
 # Vision Capability Behavior Tests
 
 These self-contained LingTai Agent Behavior Tasks (LABTs) guard the observable
-four-action Vision contract. Pinned pytest commands run from the repository root
+five-action Vision contract. Pinned pytest commands run from the repository root
 with the project's Python, `PYTHONDONTWRITEBYTECODE=1`, and pytest's cache
 provider disabled.
 
-## Behavior VN001 — declaration exposes four strict correlated actions
+## Behavior VN001 — declaration exposes five strict correlated actions
 
 - **id**: VN001
-- **title**: declaration exposes analyze/check/list/manual with strict correlated input branches
+- **title**: declaration exposes analyze/check/list/settings/manual with strict correlated input branches
 - **guards**: `vision-contract` § Scope and declaration
 - **runner**: any LingTai agent with shell and file access to this repository
 - **prerequisites**: a clean checkout of `<repo>`
@@ -40,20 +41,21 @@ provider disabled.
 ### Steps
 1. From `<repo>`, run:
    `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src python -m pytest -q -p no:cacheprovider tests/test_tool_family_vision_migration.py -k 'public_actions or root_schema or child_input_schemas or correlated'`.
-2. Inspect `vision.get_schema()` and record the action enum and the four input
+2. Inspect `vision.get_schema()` and record the action enum and the five input
    branch titles.
 3. Send an unknown action, a non-object input, and a cross-action field through
    the manager; record that each fails before handler/provider work.
 
 ### Expected evidence
 - [ ] The action enum and branch titles are exactly `analyze`, `check`, `list`,
-  `manual`; `analyze` contains `image_path`, `question`, `preset`; `check`
-  contains only `preset`; `list` and `manual` are strict empty objects.
+  `settings`, `manual`; `analyze` contains `image_path`, `question`, `preset`;
+  `check` contains only `preset`; `list`, `settings`, and `manual` are strict
+  empty objects.
 - [ ] Root `action`/`input` correlations survive schema composition and invalid
   envelopes return an error before any provider I/O.
 
 ### Pass / Fail
-Pass when all four actions, strict branches, and correlation guards are present
+Pass when all five actions, strict branches, and correlation guards are present
 and invalid/cross-action calls are rejected before a child runs.
 
 ## Behavior VN002 — analyze uses one explicit route and fails closed
@@ -194,3 +196,39 @@ has no provider/configuration side effects.
 Pass when the local tests prove the narrow Vision-side contract. The shared
 registrar fixture and cumulative port/name union remain serialized integration
 gates, not parallel-lane evidence.
+
+## Behavior VN007 — settings is exact, applied, redacted, and read-only
+
+- **id**: VN007
+- **title**: settings shows one exact five-field applied snapshot without exposing private routing
+- **guards**: `vision-contract` § Settings discovery; § Results, errors, and state
+- **runner**: any LingTai agent with shell and file access to this repository
+- **prerequisites**: a disposable workdir and clearly fake private sentinels
+- **estimate**: ≈ 15 minutes
+
+### Steps
+1. Run:
+   `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src python -m pytest -q -p no:cacheprovider tests/test_vision_settings.py tests/test_tool_settings_contract.py`.
+2. Bind a valid local route, change its owner file afterward, and record the
+   exact 13-key order, five-field order, applied current/default values, and
+   unchanged second SHOW.
+3. Bind fake OpenAI and Codex routes carrying endpoint, key pointer/value,
+   header, token-path, and instructions sentinels; verify none renders.
+4. Call settings with a set/reset-shaped input and compare the owner file bytes;
+   then bind an invalid/manual-only route and record the fixed no-row failure.
+5. Run one ordinary analyze call through a recording service.
+
+### Expected evidence
+- [ ] `DECLARATION.settings is True`; `settings` appears exactly once immediately
+  before `manual` on the internal, Chat, and Responses schemas.
+- [ ] Each row is exactly key/current/default/configurable/comment in that order,
+  each comment resolves to its owner heading, and current stays the applied bind
+  snapshot until refresh.
+- [ ] Sensitive inputs never render or remain in the provider snapshot; non-empty
+  input writes nothing; unavailable truth yields no partial rows.
+- [ ] The generic 65,536-byte gate and an ordinary analyze result remain intact.
+
+### Pass / Fail
+Pass when focused tests prove exact order and values, manual anchors, complete
+redaction, all-or-nothing failure, no writer/client construction on SHOW, and
+ordinary-action non-regression.

--- a/src/lingtai/tools/vision/CONTRACT.md
+++ b/src/lingtai/tools/vision/CONTRACT.md
@@ -6,6 +6,7 @@ related_files:
   - src/lingtai/tools/vision/__init__.py
   - src/lingtai/tools/vision/ANATOMY.md
   - src/lingtai/tools/vision/BEHAVIORS.md
+  - src/lingtai/tools/vision/settings.py
   - src/lingtai/tools/vision/manual/SKILL.md
   - src/lingtai/tools/CONTRACT.md
   - src/lingtai/tools/tool_family/CONTRACT.md
@@ -14,6 +15,7 @@ related_files:
   - tests/test_tool_plugin_declaration.py
   - tests/test_tool_family_vision_migration.py
   - tests/test_vision_capability.py
+  - tests/test_vision_settings.py
   - tests/test_inherit_fallback.py
 maintenance: |
   Keep this contract aligned with the Vision declaration, owner Anatomy,
@@ -25,18 +27,20 @@ maintenance: |
 # Vision capability contract
 
 `vision` is an always-registered, action-separated capability. It has one public
-root and four canonical children: `analyze`, `check`, `list`, and the reserved
-family-owned `manual`. Direct provider setup, unsupported routes, and request
-failures fail closed with sanitized guidance; the capability never changes the
-active preset or automatically invokes another provider or MCP.
+root and five canonical children: `analyze`, `check`, `list`, the opted-in
+reserved `settings`, and the reserved family-owned `manual`. Direct provider
+setup, unsupported routes, and request failures fail closed with sanitized
+guidance; the capability never changes the active preset or automatically
+invokes another provider or MCP.
 
 ## Scope and declaration
 
 Guarded by: [VN001](BEHAVIORS.md#behavior-vn001)
 
-The static `DECLARATION` owns the three operational actions and their input
-schemas; the generic manual builder contributes the final reserved `manual`
-child. The public root is the strict Tool Protocol v2 envelope:
+The static `DECLARATION` owns the three operational actions, their input schemas,
+and the Vision settings opt-in; generic composition contributes `settings`
+immediately before the manual builder's final reserved `manual` child. The
+public root is the strict Tool Protocol v2 envelope:
 
 ```text
 action + input + reasoning + optional summarize
@@ -61,6 +65,8 @@ The exact child schemas are:
   borrowed route without sending an image.
 - `list`: strict empty object (`properties: {}`, `required: []`,
   `additionalProperties: false`).
+- `settings`: strict empty input; it shows the applied bind snapshot and has no
+  set/reset/write form.
 - `manual`: the generic strict empty manual input schema and the installed
   Vision manual body/path result.
 
@@ -91,6 +97,35 @@ registrar. The registrar owns claim/authorization/mount lifecycle; `_bind`
 creates the `VisionManager` and returns the one public plugin. The serialized
 host/registry/port implementation and its shared fixture are integration-owned;
 this family contract only specifies the Vision-side requirements above.
+
+## Settings discovery
+
+Guarded by: [VN007](BEHAVIORS.md#behavior-vn007)
+
+Vision inventories exactly these owner-route facts, in order: `provider`,
+`base_url`, `model`, `api_key`, `api_key_env`, `max_tokens`, `api_compat`,
+`wire_api`, `default_headers`, `token_path`, `instructions`,
+`max_output_tokens`, and `timeout`. A success row is exactly `key`, `current`,
+`default`, `configurable`, and `comment`; every comment is a stable
+`vision-manual#setting-...` pointer.
+
+The provider is bound to the same immutable `VisionConfiguration`, local-file
+snapshot, active-provider facts, and successfully constructed service used by
+the running manager. SHOW creates fresh row objects from that applied snapshot;
+it does not reread files or environment, inspect provider clients, or construct
+a service. A later owner-file or launcher change is prospective until the
+existing refresh/relaunch bind. A failed/manual-only route, an invalid local
+document, or an opaque injected `vision_service` outside the owner resolver
+makes the whole inventory unavailable rather than fabricating values.
+
+`base_url`, `api_key`, `api_key_env`, `default_headers`, `token_path`,
+`instructions`, and any path-like `model` are reduced to private presence
+markers before becoming `SettingRow(..., _sensitive=True)`. Generic projection
+therefore replaces both current and default with `<redacted>` and never projects
+the marker. Every row is `configurable: true` because an existing Vision owner
+procedure can change it through capability/preset composition, the local owner
+file where supported, or the launcher/secret route named by `api_key_env`; that
+never grants SHOW mutation authority.
 
 ## Routing and preset authorization
 
@@ -159,10 +194,14 @@ Guarded by: [VN002](BEHAVIORS.md#behavior-vn002),
   `degraded` with an empty body, truthful host-local path, and loader error.
   The canonical manual child result is flattened once by the host; it is never
   nested or double-wrapped.
+- `settings` success is `{"settings": [...]}` with only the five projected row
+  fields. Non-empty input fails before provider invocation. Unavailable,
+  malformed, or non-JSON truth yields the generic fixed no-row failure, and the
+  complete response is incrementally bounded to 65,536 UTF-8 bytes.
 
 ## Invariants and evidence
 
-- [VN001](BEHAVIORS.md#behavior-vn001) guards the four-action declaration,
+- [VN001](BEHAVIORS.md#behavior-vn001) guards the five-action declaration,
   strict branches, action/input correlation, and pre-handler rejection:
   `tests/test_tool_family_vision_migration.py`.
 - [VN002](BEHAVIORS.md#behavior-vn002) guards analyze success/failure shapes,
@@ -179,6 +218,11 @@ Guarded by: [VN002](BEHAVIORS.md#behavior-vn002),
 - [VN006](BEHAVIORS.md#behavior-vn006) guards the active-provider/configuration
   port seam and allowed-preset credential identity: declaration and migration
   tests, plus serialized shared-host tests at integration time.
+- [VN007](BEHAVIORS.md#behavior-vn007) guards exact settings order and field
+  order, effective current/default values, configurable semantics, stable manual
+  anchors, complete redaction, no-write behavior, whole-inventory failure, and
+  ordinary analyze non-regression: `tests/test_vision_settings.py` plus the
+  shared generic settings contract test.
 
 Run the focused Vision capability, service, migration, preset-routing, and
 manual-contract tests with bytecode and pytest cache disabled; run the shared

--- a/src/lingtai/tools/vision/__init__.py
+++ b/src/lingtai/tools/vision/__init__.py
@@ -26,23 +26,25 @@ value, so a placeholder is synthesized. Configure it with
 ``vision`` is migrated to the LingTai Tool Protocol v2 action-separated shape
 (``src/lingtai/tools/CONTRACT.md``): one public ``vision`` tool whose canonical
 children are ``analyze``/``check``/``list`` plus the family-owned reserved
-``manual``, composed and dispatched by the generic
-``lingtai.tools.tool_family`` infrastructure. The public tool name and action
-values are unchanged; only the call envelope moved from flat arguments to
-``action``/``input``/``reasoning``/``summarize``.
+``settings``/``manual`` actions, composed and dispatched by the generic
+``lingtai.tools.tool_family`` infrastructure. The public tool name and
+operational action values are unchanged; generic composition adds the new
+reserved ``settings`` action immediately before ``manual``. The call envelope
+moved from flat arguments to ``action``/``input``/``reasoning``/``summarize``.
 Provider routing, credential/identity resolution, and every action result
 shape are untouched by that migration.
 """
 from __future__ import annotations
 
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import TYPE_CHECKING, Any, Mapping
 
 from lingtai.kernel.tool_plugin import BoundToolPlugin, ToolPluginDeclaration, ToolPluginDeclarationError
 
-from ..tool_family import ChildTool, ToolFamily
+from ..tool_family import ChildTool, SettingRow, SettingsProvider, ToolFamily
 from ..tool_family.manual import MANUAL_INPUT_SCHEMA, build_manual_child
+from .settings import DEFAULT_LOCAL_BASE_URL, LocalVisionSettings, SettingsError
 
 
 if TYPE_CHECKING:
@@ -87,6 +89,72 @@ _CODEX_FAMILY = {"codex"} | _CODEX_POOL_ALIASES
 # vision-route alias alongside the LLM registry's two canonical adapter
 # spellings (``claude-code``/``claude_code``).
 _CLAUDE_CLI_FAMILY = {"claude-p", "claude-code", "claude_code"}
+
+_VISION_SETTING_KEYS = (
+    "provider",
+    "base_url",
+    "model",
+    "api_key",
+    "api_key_env",
+    "max_tokens",
+    "api_compat",
+    "wire_api",
+    "default_headers",
+    "token_path",
+    "instructions",
+    "max_output_tokens",
+    "timeout",
+)
+_VISION_SENSITIVE_SETTINGS = {
+    "base_url",
+    "api_key",
+    "api_key_env",
+    "default_headers",
+    "token_path",
+    "instructions",
+}
+_MODEL_DEFAULTS = {
+    "mlx": "mlx-community/paligemma2-3b-ft-docci-448-8bit",
+}
+_BASE_URL_DEFAULTS = {
+    "local": DEFAULT_LOCAL_BASE_URL,
+    "mimo": "https://api.xiaomimimo.com/v1",
+    "codex": "https://chatgpt.com/backend-api/codex",
+    "codex-pool": "https://chatgpt.com/backend-api/codex",
+    "codex_pool": "https://chatgpt.com/backend-api/codex",
+}
+_MAX_TOKENS_DEFAULTS = {
+    "local": 1024,
+    "openai": 1024,
+    "openrouter": 1024,
+    "custom": 1024,
+    "deepseek": 1024,
+    "zhipu": 1024,
+    "glm": 1024,
+    "grok": 1024,
+    "qwen": 1024,
+    "kimi": 1024,
+    "anthropic": 1024,
+    "minimax": 1024,
+    "mimo": 1024,
+    "mlx": 512,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class _VisionSettingsSnapshot:
+    """One applied bind snapshot containing no raw sensitive values."""
+
+    current: tuple[Any, ...]
+    default: tuple[Any, ...]
+    sensitive: tuple[bool, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _VisionRouteProvenance:
+    """Resolver-produced protocol provenance for the successfully bound route."""
+
+    api_compat: str | None = None
 
 
 def _same_codex_family(requested: str, active: str) -> bool:
@@ -202,6 +270,260 @@ def _effective_openai_wire(
     elif normalized is None:
         return "responses" if use_responses_api and not base_url else "chat_completions"
     return None
+
+
+def _plain_service_value(service: Any, *names: str) -> Any:
+    """Read one already-applied scalar without reaching into a client."""
+    for name in names:
+        try:
+            value = getattr(service, name)
+        except (AttributeError, TypeError):
+            continue
+        if isinstance(value, (str, int, float, bool)):
+            return value
+    return None
+
+
+def _model_is_path_like(value: str) -> bool:
+    """Return whether a model value has an explicit filesystem-path shape."""
+    candidate = value.strip()
+    return (
+        candidate.startswith(("~/", "~\\", "./", ".\\", "../", "..\\", "file://"))
+        or PurePosixPath(candidate).is_absolute()
+        or PureWindowsPath(candidate).is_absolute()
+    )
+
+
+def _vision_service_kind(provider: str, api_compat: str | None) -> str:
+    """Name the concrete Vision service boundary selected by the resolver."""
+    if provider in _CODEX_FAMILY:
+        return "codex"
+    if provider in {"mlx", "local", "anthropic", "gemini", "mimo", "openai"}:
+        return provider
+    if provider == "minimax" or api_compat == "anthropic":
+        return "anthropic"
+    return "openai"
+
+
+def _vision_settings_snapshot(
+    configuration: VisionConfiguration,
+    provider: str | None,
+    active_service: Any,
+    vision_service: Any,
+    local_settings: LocalVisionSettings | None,
+    route_provenance: _VisionRouteProvenance,
+) -> _VisionSettingsSnapshot:
+    """Project the exact successful bind inputs without retaining secrets."""
+    if vision_service is None or not isinstance(provider, str) or not provider.strip():
+        raise SettingsError("vision route is unavailable")
+
+    provider = provider.strip()
+    provider_key = provider.lower()
+    kwargs = dict(configuration.kwargs)
+    active_name = getattr(active_service, "provider", "")
+    active_key = active_name.lower() if isinstance(active_name, str) else ""
+    same_provider = _same_provider_identity(provider_key, active_key)
+    defaults = getattr(active_service, "_provider_defaults", None) if same_provider else None
+    bucket = defaults.get(active_key) if isinstance(defaults, dict) else None
+    bucket = bucket if isinstance(bucket, dict) else {}
+
+    api_compat = route_provenance.api_compat
+    service_kind = _vision_service_kind(provider_key, api_compat)
+    active_model = _plain_service_value(active_service, "_model") if same_provider else None
+    active_base_url = (
+        _plain_service_value(active_service, "_base_url") if same_provider else None
+    )
+
+    if provider_key == "local":
+        base_url = (
+            kwargs.get("base_url")
+            or (local_settings.base_url if local_settings is not None else None)
+            or DEFAULT_LOCAL_BASE_URL
+        )
+        model = (
+            kwargs.get("model")
+            or (local_settings.model if local_settings is not None else None)
+        )
+        max_tokens = kwargs.get("max_tokens")
+        if max_tokens is None and local_settings is not None:
+            max_tokens = local_settings.max_tokens
+    else:
+        base_url = (
+            kwargs.get("base_url")
+            or active_base_url
+            or bucket.get("base_url")
+            or _BASE_URL_DEFAULTS.get(provider_key)
+        )
+        model = kwargs.get("model") or active_model or bucket.get("model")
+        max_tokens = kwargs.get("max_tokens")
+
+    applied_model = _plain_service_value(
+        vision_service, "_model_name", "_model", "model"
+    )
+    model = applied_model or model or _MODEL_DEFAULTS.get(provider_key)
+    if not isinstance(model, str) or not model.strip():
+        raise SettingsError("vision model is unavailable")
+    model = model.strip()
+    model_is_sensitive = _model_is_path_like(model)
+    if model_is_sensitive:
+        model = True
+
+    applied_base_url = _plain_service_value(vision_service, "_base_url")
+    if applied_base_url is not None:
+        base_url = applied_base_url
+
+    applied_max_tokens = _plain_service_value(vision_service, "_max_tokens")
+    if applied_max_tokens is not None:
+        max_tokens = applied_max_tokens
+    if max_tokens is None:
+        max_tokens = _MAX_TOKENS_DEFAULTS.get(provider_key)
+        if max_tokens is None:
+            max_tokens = _MAX_TOKENS_DEFAULTS.get(service_kind)
+
+    applied_wire = _plain_service_value(vision_service, "_wire_api")
+    if isinstance(applied_wire, str):
+        wire_api = applied_wire
+    elif service_kind == "codex":
+        wire_api = "responses"
+    elif service_kind == "mimo":
+        wire_api = "chat_completions"
+    elif service_kind == "openai" or provider_key == "local":
+        wire_api = _effective_openai_wire(
+            kwargs.get("wire_api") or bucket.get("wire_api"),
+            use_responses_api=bucket.get("use_responses_api") is True,
+            base_url=base_url,
+        )
+    else:
+        wire_api = None
+
+    token_manager = getattr(vision_service, "_token_manager", None)
+    token_path = (
+        kwargs.get("token_path")
+        or bucket.get("codex_auth_path")
+        or _plain_service_value(token_manager, "_path")
+    )
+    instructions = (
+        _plain_service_value(vision_service, "_instructions")
+        or kwargs.get("instructions")
+    )
+    max_output_tokens = _plain_service_value(
+        vision_service, "_max_output_tokens"
+    )
+    if max_output_tokens is None:
+        max_output_tokens = kwargs.get("max_output_tokens")
+    timeout = _plain_service_value(vision_service, "_timeout")
+    if timeout is None:
+        timeout = kwargs.get("timeout")
+
+    uses_api_key = service_kind in {"openai", "anthropic", "gemini", "mimo"}
+    if provider_key == "local":
+        uses_api_key = True
+    uses_headers = service_kind in {"openai", "anthropic"}
+    current = {
+        "provider": provider,
+        "base_url": bool(base_url) if service_kind not in {"gemini", "mlx"} else None,
+        "model": model,
+        "api_key": True if uses_api_key else None,
+        "api_key_env": True if uses_api_key and configuration.api_key_env else None,
+        "max_tokens": max_tokens if service_kind != "codex" else None,
+        "api_compat": api_compat,
+        "wire_api": wire_api,
+        "default_headers": (
+            True
+            if uses_headers
+            and bool(kwargs.get("default_headers") or bucket.get("default_headers"))
+            else None
+        ),
+        "token_path": True if service_kind == "codex" and token_path else None,
+        "instructions": True if service_kind == "codex" and instructions else None,
+        "max_output_tokens": max_output_tokens if service_kind == "codex" else None,
+        "timeout": timeout if service_kind == "codex" else None,
+    }
+    default_wire = None
+    if service_kind == "codex":
+        default_wire = "responses"
+    elif service_kind in {"openai", "mimo"} or provider_key == "local":
+        default_wire = "chat_completions"
+    default = {
+        "provider": None,
+        "base_url": bool(_BASE_URL_DEFAULTS.get(provider_key)) or None,
+        "model": _MODEL_DEFAULTS.get(provider_key),
+        "api_key": True if provider_key == "local" else None,
+        "api_key_env": None,
+        "max_tokens": (
+            None
+            if service_kind == "codex"
+            else _MAX_TOKENS_DEFAULTS.get(
+                provider_key, _MAX_TOKENS_DEFAULTS.get(service_kind)
+            )
+        ),
+        "api_compat": None,
+        "wire_api": default_wire,
+        "default_headers": None,
+        "token_path": None,
+        "instructions": True if service_kind == "codex" else None,
+        "max_output_tokens": None,
+        "timeout": 120.0 if service_kind == "codex" else None,
+    }
+    return _VisionSettingsSnapshot(
+        current=tuple(current[key] for key in _VISION_SETTING_KEYS),
+        default=tuple(default[key] for key in _VISION_SETTING_KEYS),
+        sensitive=tuple(
+            key in _VISION_SENSITIVE_SETTINGS
+            or (key == "model" and model_is_sensitive)
+            for key in _VISION_SETTING_KEYS
+        ),
+    )
+
+
+def _vision_settings_provider(
+    configuration: VisionConfiguration,
+    provider: str | None,
+    active_service: Any,
+    vision_service: Any,
+    local_settings: LocalVisionSettings | None,
+    route_provenance: _VisionRouteProvenance,
+    failure: Exception | None,
+) -> SettingsProvider:
+    """Bind one SHOW-only provider to the already-applied Vision route."""
+    try:
+        if failure is not None:
+            raise failure
+        snapshot = _vision_settings_snapshot(
+            configuration,
+            provider,
+            active_service,
+            vision_service,
+            local_settings,
+            route_provenance,
+        )
+    except Exception:
+        return _unavailable_vision_settings
+
+    def provide() -> tuple[SettingRow, ...]:
+        return tuple(
+            SettingRow(
+                key=key,
+                current=current,
+                default=default,
+                configurable=True,
+                comment=f"vision-manual#setting-{key.replace('_', '-')}",
+                _sensitive=sensitive,
+            )
+            for key, current, default, sensitive in zip(
+                _VISION_SETTING_KEYS,
+                snapshot.current,
+                snapshot.default,
+                snapshot.sensitive,
+            )
+        )
+
+    return provide
+
+
+def _unavailable_vision_settings() -> tuple[SettingRow, ...]:
+    """Fail closed when no complete applied owner snapshot was bound."""
+    raise RuntimeError("vision settings unavailable")
 
 
 PROVIDERS = {
@@ -337,7 +659,9 @@ _DESCRIPTION = (
     "borrows another allowed preset's vision service (e.g. 'codex-pool'). "
     "Use vision(action='check', input={'preset': null}, reasoning='verify "
     "the vision route') to resolve which preset's vision service actually "
-    "works without sending an image. A real request failure returns a "
+    "works without sending an image. Use vision(action='settings', input={}, "
+    "reasoning='inspect the bound Vision route') for its read-only five-field "
+    "inventory. A real request failure returns a "
     "sanitized error and points to vision(action='manual', input={}, "
     "reasoning='load vision guidance') for read-only alternatives. No "
     "provider, model, credential, or MCP fallback is automatic."
@@ -349,6 +673,7 @@ def _build_family(
     check_handler: Any = _unused,
     list_handler: Any = _unused,
     manual_child: ChildTool | None = None,
+    settings_provider: SettingsProvider = _unavailable_vision_settings,
 ) -> ToolFamily:
     """Build Vision's declared family from its one static declaration.
 
@@ -376,6 +701,7 @@ def _build_family(
             manual_child
             or ChildTool("manual", DECLARATION.manual_input_schema, _unused, title="manual input")
         ],
+        settings_provider=settings_provider,
     )
 
 
@@ -398,6 +724,7 @@ class VisionManager:
         active_provider: "ActiveProviderPort",
         vision_service: "VisionService | None",
         manual_reason: str = "",
+        settings_provider: SettingsProvider = _unavailable_vision_settings,
     ) -> None:
         self._workdir = workdir
         self._active_provider = active_provider
@@ -410,6 +737,7 @@ class VisionManager:
             self._dispatch_check,
             self._dispatch_list,
             build_manual_child(workdir, DECLARATION.manual),
+            settings_provider,
         )
 
     def __call__(self, args: dict | None) -> dict:
@@ -488,7 +816,7 @@ class VisionManager:
         # ``provider`` is passed positionally below; drop the capability copy so
         # ``_resolve_direct_service`` never receives it twice (TypeError).
         kwargs.pop("provider", None)
-        service, service_reason = _resolve_direct_service(
+        service, service_reason, _route_provenance = _resolve_direct_service(
             self._workdir,
             self._active_provider,
             provider,
@@ -735,7 +1063,11 @@ class VisionManager:
         result = self._family.handle(args)
         if action == "manual" and "content" in result:
             return self._adapt_manual_result(result)
-        if result.get("status") == "failed" and "error_code" in result:
+        if (
+            action != "settings"
+            and result.get("status") == "failed"
+            and "error_code" in result
+        ):
             return {"status": "error", "message": result["message"]}
         return result
 
@@ -754,18 +1086,41 @@ def _bind(host: "ToolPluginHost") -> BoundToolPlugin:
     vision_service = configuration.vision_service
     provider = configuration.provider
     manual_reason = ""
+    active_service = host.active_provider.service if vision_service is None else None
     if vision_service is None and provider is None:
-        active_service = host.active_provider.service
         active_name = getattr(active_service, "provider", "")
         if isinstance(active_name, str) and active_name.strip():
             provider = active_name
+
+    local_settings: LocalVisionSettings | None = None
+    settings_failure: Exception | None = None
+    resolved_api_key = configuration.api_key
+    resolved_route = vision_service is None
+    route_provenance = _VisionRouteProvenance()
+    if resolved_route and configuration.api_key_env:
+        from lingtai.kernel.config_resolve import resolve_env
+
+        resolved_api_key = resolve_env(
+            configuration.api_key, configuration.api_key_env
+        )
+    if resolved_route and isinstance(provider, str) and provider.lower() == "local":
+        from .settings import read_local_settings
+
+        try:
+            local_settings = read_local_settings(host.workdir)
+        except SettingsError as exc:
+            settings_failure = exc
     if vision_service is None and provider is not None:
-        vision_service, manual_reason = _resolve_direct_service(
+        vision_service, manual_reason, route_provenance = _resolve_direct_service(
             host.workdir,
             host.active_provider,
             provider,
-            api_key=configuration.api_key,
-            api_key_env=configuration.api_key_env,
+            api_key=resolved_api_key,
+            identity_service=active_service,
+            local_settings=local_settings,
+            local_settings_error=(
+                settings_failure if isinstance(settings_failure, SettingsError) else None
+            ),
             **dict(configuration.kwargs),
         )
     elif vision_service is None:
@@ -778,6 +1133,15 @@ def _bind(host: "ToolPluginHost") -> BoundToolPlugin:
         host.active_provider,
         vision_service=vision_service,
         manual_reason=manual_reason,
+        settings_provider=_vision_settings_provider(
+            configuration,
+            provider if resolved_route else None,
+            active_service,
+            vision_service,
+            local_settings,
+            route_provenance,
+            settings_failure,
+        ),
     )
     return BoundToolPlugin(
         name=DECLARATION.name,
@@ -805,6 +1169,7 @@ DECLARATION = ToolPluginDeclaration(
     binder=_bind,
     requires=("workdir", "active_provider", "configuration"),
     glossary_package=__package__,
+    settings=True,
 )
 
 
@@ -822,8 +1187,10 @@ def _resolve_direct_service(
     api_key_env: str | None = None,
     *,
     identity_service: Any = None,
+    local_settings: LocalVisionSettings | None = None,
+    local_settings_error: SettingsError | None = None,
     **kwargs: Any,
-) -> tuple["VisionService | None", str]:
+) -> tuple["VisionService | None", str, _VisionRouteProvenance]:
     """Resolve a direct VisionService from provider + kwargs.
 
     ``identity_service`` overrides the active-provider port's service used for
@@ -834,6 +1201,7 @@ def _resolve_direct_service(
     """
     vision_service: "VisionService | None" = None
     manual_reason = ""
+    applied_api_compat: str | None = None
     if api_key_env:
         from lingtai.kernel.config_resolve import resolve_env
         api_key = resolve_env(api_key, api_key_env)
@@ -875,13 +1243,12 @@ def _resolve_direct_service(
         # guided setup steps instead. api_key is optional: local servers
         # ignore it, so a placeholder satisfies the OpenAI SDK.
         from lingtai.services.vision.openai import OpenAIVisionService
-        from .settings import (
-            DEFAULT_LOCAL_BASE_URL,
-            SettingsError,
-            read_local_settings,
-        )
+        from .settings import read_local_settings
         try:
-            local_settings = read_local_settings(workdir)
+            if local_settings_error is not None:
+                raise local_settings_error
+            if local_settings is None:
+                local_settings = read_local_settings(workdir)
         except SettingsError as exc:
             manual_reason = (
                 f"Local vision settings are invalid: {exc}; fix "
@@ -967,6 +1334,7 @@ def _resolve_direct_service(
         )
 
         if api_compat == "openai":
+            applied_api_compat = "openai"
             from lingtai.services.vision.openai import OpenAIVisionService
             svc_kwargs: dict = {
                 "api_key": api_key,
@@ -991,6 +1359,7 @@ def _resolve_direct_service(
                 except Exception as exc:
                     manual_reason = _setup_failure(provider, exc)
         elif api_compat == "anthropic":
+            applied_api_compat = "anthropic"
             from lingtai.services.vision.anthropic import AnthropicVisionService
             svc_kwargs = {
                 "api_key": api_key,
@@ -1123,10 +1492,13 @@ def _resolve_direct_service(
                 use_responses_api=isinstance(bucket, dict) and bucket.get("use_responses_api") is True,
                 base_url=kwargs.get("base_url") or active_base_url,
             )
-            if service_provider in {"openrouter", "deepseek", "zhipu", "glm", "grok", "qwen", "kimi"}:
+            if service_provider in {
+                "openrouter", "custom", "deepseek", "zhipu", "glm", "grok",
+                "qwen", "kimi",
+            }:
                 service_provider = "anthropic" if active_compat.lower() == "anthropic" else "openai"
-            elif service_provider == "custom":
-                service_provider = "anthropic" if active_compat.lower() == "anthropic" else "openai"
+                if active_compat.lower() in {"openai", "anthropic"}:
+                    applied_api_compat = active_compat.lower()
 
             # Provider-specific kwarg injection. Each branch is opt-in because
             # vision services have heterogeneous constructor signatures.
@@ -1184,7 +1556,11 @@ def _resolve_direct_service(
                     )
                 except Exception as exc:
                     manual_reason = _setup_failure(provider, exc)
-    return vision_service, manual_reason
+    return (
+        vision_service,
+        manual_reason,
+        _VisionRouteProvenance(api_compat=applied_api_compat),
+    )
 
 
 def setup(

--- a/src/lingtai/tools/vision/manual/SKILL.md
+++ b/src/lingtai/tools/vision/manual/SKILL.md
@@ -4,16 +4,19 @@ description: >
   Use this manual when the vision capability has no usable provider route or
   reports a direct setup/request failure and needs safe, provider-neutral
   troubleshooting guidance.
-last_changed_at: 2026-08-24T00:00:00Z
+last_changed_at: 2026-08-29T00:00:00Z
 related_files:
   - src/lingtai/tools/vision/__init__.py
   - src/lingtai/tools/vision/ANATOMY.md
   - src/lingtai/tools/vision/CONTRACT.md
   - src/lingtai/tools/vision/BEHAVIORS.md
+  - src/lingtai/tools/vision/settings.py
   - src/lingtai/kernel/tool_plugin/CONTRACT.md
 maintenance: |
-  Keep this manual provider-neutral and read-only. It must not import, name, or
-  link to a TUI package, credential, endpoint secret, or automatic MCP action.
+  Keep this manual provider-neutral and the settings action read-only. Keep each
+  projected comment pointer aligned with its exact Setting heading. It must not
+  import, expose, or link to a TUI package, credential value, endpoint secret,
+  or automatic MCP action.
 ---
 # Vision manual
 
@@ -25,7 +28,7 @@ host-global or another family's skill.
 
 ## Call shape
 
-`vision` is one action-separated tool with four strict actions:
+`vision` is one action-separated tool with five strict actions:
 
 - `vision(action="analyze", input={"image_path": "...", "question": null},
   reasoning="...")` — the direct image request. `image_path` and nullable
@@ -41,6 +44,11 @@ host-global or another family's skill.
   the active route and vision-capable presets in `manifest.preset.allowed`.
   It reads route declarations only: it constructs no provider service and
   reads no credential.
+- `vision(action="settings", input={}, reasoning="...")` — show the applied
+  bind-time configuration as rows containing exactly `key`, `current`,
+  `default`, `configurable`, and `comment`. Input is strictly `{}`. This action
+  never sets, resets, validates, re-reads, or writes configuration. Follow each
+  row's exact `comment` section below for meaning and the owner procedure.
 - `vision(action="manual", input={}, reasoning="...")` — this guidance. Its
   input is strictly empty; it reads the installed manual body/path and performs
   no config, credential, provider, image, or analyze operation.
@@ -49,6 +57,131 @@ host-global or another family's skill.
 becomes part of child input. Optional `summarize` is a root presentation
 control. An unknown action, root field, or cross-action input field is rejected
 before provider, credential, image, or manual-child work.
+
+## Settings inventory
+
+The inventory freezes the effective values used when Vision binds during boot
+or `system(action="refresh", input={}, reasoning="apply approved Vision config")`.
+SHOW does not re-read a file, environment variable, preset, or provider. If the
+provider or required model is not truthfully available, the local owner file is
+invalid, or an opaque injected service has no attributable owner route, the
+whole action returns `SETTINGS_UNAVAILABLE`; it never fabricates or emits
+partial rows. `configurable: true` means an existing owner procedure can change
+the value outside SHOW, not that this action can mutate anything.
+
+Each setting below names its own source and precedence because the routes do
+not share one universal chain. Every real change requires owner authorization,
+an edit through the named file/config/preset procedure, refresh or relaunch as
+stated, and a second SHOW to verify the newly applied snapshot.
+
+## Setting: provider
+
+The current direct-route provider. It comes from the explicit Vision capability
+or, when compatible, the active provider. There is no provider default and no
+automatic provider switch. Change `manifest.capabilities.vision.provider` in
+the active `init.json`/preset, then refresh. Routing changes do not grant
+credentials, installation, or network authority.
+
+## Setting: base-url
+
+The effective endpoint override. It comes from the explicit Vision capability,
+the same-provider active route, or — for `provider="local"` —
+`settings/vision.json` and then `http://localhost:11434/v1`. MiMo and Codex
+services also have their constructor endpoints. The value is sensitive and
+always redacted. Edit the existing capability/preset or local owner file,
+refresh, and SHOW again; never paste a private endpoint into logs or chat.
+
+## Setting: model
+
+The model identifier used by the bound route. It comes from the explicit Vision
+capability, the same-provider active route, the local owner file, or the
+successfully constructed service. Public identifiers are shown exactly; a
+path-like model value is private, so SHOW redacts both current and default.
+Local Vision has no model default. Only the explicit MLX route has a
+Vision-owned model default. Change the active capability/preset or local owner
+file, ensure any model pull/install has separate human approval, refresh, and
+verify with SHOW.
+
+## Setting: api-key
+
+Whether API credential material was applied. The resolved value comes from an
+explicit capability `api_key_env`/`api_key`, the same-provider credential, or
+the local owner file; local Vision otherwise uses a non-secret SDK placeholder.
+Codex and MLX do not consume this field. Current and default are always
+redacted—SHOW retains only presence, never raw material. Change the owner secret
+store or launcher configuration, then relaunch or refresh without printing it.
+
+## Setting: api-key-env
+
+Whether an explicit capability credential-variable pointer was applied. The
+pointer is resolved once during bind before raw-key fallback. Its name and value
+are both sensitive and redacted; there is no default. Change
+`manifest.capabilities.vision.api_key_env` and the launcher/secret-manager
+environment through their existing owner procedures, then relaunch or refresh.
+SHOW never reads or changes the process environment.
+
+## Setting: max-tokens
+
+The direct service's positive response-token cap. An explicit capability value
+wins; local Vision next reads `settings/vision.json`. OpenAI-compatible,
+Anthropic-compatible, MiMo, and local services default to `1024`; MLX defaults
+to `512`; routes that do not consume this field show `null`. Edit the existing
+capability/preset or local owner file, refresh, and verify with SHOW.
+
+## Setting: api-compat
+
+The compatibility family selected from explicit Vision configuration or the
+same active provider's defaults. Accepted values are `openai` or `anthropic`
+where the relay supports that protocol. There is no default and an irrelevant
+route shows `null`. Change the owning capability/provider configuration,
+refresh, run `check`, and verify with SHOW. It does not grant provider access.
+
+## Setting: wire-api
+
+The effective OpenAI-compatible wire. Accepted configuration values are
+`auto`, `chat_completions`, or `responses`; route support still decides whether
+construction succeeds. Local/OpenAI-compatible services normally resolve to
+`chat_completions`, while Codex is `responses`; non-applicable routes show
+`null`. Change the owning capability or same-provider configuration, refresh,
+run `check`, and verify with SHOW.
+
+## Setting: default-headers
+
+Whether provider-owned HTTP headers were applied to a compatible service.
+Explicit Vision headers precede same-provider defaults. The complete mapping,
+including header names, is sensitive and always redacted; no headers is the
+`null` default. Edit the owning capability/provider configuration, refresh, and
+SHOW again without logging the mapping.
+
+## Setting: token-path
+
+Whether a Codex OAuth identity path was applied. It comes from an explicit
+Vision value, the same provider's `codex_auth_path`, or authorized pool
+selection. Non-Codex routes show `null`. The path and token material are
+sensitive and always redacted. Use the existing Codex login/account-pool or
+preset procedure, then refresh and SHOW; never copy the file or token to output.
+
+## Setting: instructions
+
+Whether Codex Responses instructions were applied. Explicit Vision
+instructions win; the Codex service otherwise owns its concise-assistant
+default. Non-Codex routes show `null`. The text is sensitive and always
+redacted. Edit the active capability/preset, refresh, and SHOW again; never put
+credentials or authorization in instructions.
+
+## Setting: max-output-tokens
+
+The optional Codex Responses output cap. Accepted values are positive integers
+supported by the backend, or `null` to omit it; the default is `null`. Change
+the active capability/preset only after validating backend support, refresh,
+run `check`, and verify with SHOW. This is distinct from `max_tokens`.
+
+## Setting: timeout
+
+The Codex request timeout in positive finite seconds. An explicit capability
+value wins; Codex defaults to `120.0`, and non-Codex routes show `null`. Change
+the active capability/preset, refresh, and verify with SHOW. A larger timeout
+changes wait tolerance only; it grants no network, provider, or retry authority.
 
 ## Route behavior and failures
 
@@ -189,7 +322,8 @@ works. Examples:
 
 ### 2. Configure the endpoint
 
-Two equivalent ways; capability kwargs win over the file.
+Two equivalent owner procedures are available; capability input wins over the
+file. The public settings action only shows the bound result.
 
 **`settings/vision.json`** (agent working dir, applies on next refresh):
 

--- a/tests/test_intrinsic_manual_actions.py
+++ b/tests/test_intrinsic_manual_actions.py
@@ -303,8 +303,8 @@ def test_manual_schemas_preserve_runtime_checks_for_ordinary_file_calls(
     assert len(file_schema["properties"]["input"]["anyOf"]) == 7
     vision_schema = vision_tool.get_schema()
     assert vision_schema["required"] == ["action", "input", "reasoning"]
-    # analyze / check / list / manual — one branch per public action.
-    assert len(vision_schema["properties"]["input"]["oneOf"]) == 4
+    # analyze / check / list / settings / manual — one branch per public action.
+    assert len(vision_schema["properties"]["input"]["anyOf"]) == 5
     task_card_schema = task_card_tool.get_schema()
     assert task_card_schema["required"] == ["action", "input", "reasoning"]
     assert len(task_card_schema["properties"]["input"]["anyOf"]) == 7

--- a/tests/test_tool_family_vision_migration.py
+++ b/tests/test_tool_family_vision_migration.py
@@ -1,10 +1,10 @@
 """Focused acceptance for the action-separated public ``vision`` family.
 
-``vision`` keeps its public tool name and four public action values
-(``analyze``/``check``/``list``/``manual``) while moving to the LTP v2 envelope
+``vision`` keeps its public tool name and operational actions while generic
+composition inserts ``settings`` immediately before ``manual`` in the LTP v2 envelope
 (``action``/``input``/``reasoning``/``summarize``) composed and dispatched by
 the generic ``lingtai.tools.tool_family`` infrastructure. These tests pin the
-migration's own promises: exactly one public model root, both child schemas and
+migration's own promises: exactly one public model root, every child schema and
 handlers, envelope/cross-action rejection strictly *before* any provider I/O,
 a manual route that constructs and calls no provider, the exact preserved
 success/failure result shapes, and Chat/Responses wire parity with no double
@@ -126,9 +126,17 @@ def test_setup_registers_exactly_one_public_vision_root(tmp_path):
     assert agent.tools["vision"]["glossary_package"] == "lingtai.tools.vision"
 
 
-def test_public_actions_are_analyze_check_list_and_manual():
+def test_public_actions_insert_settings_immediately_before_manual():
     schema = get_schema()
-    assert schema["properties"]["action"]["enum"] == ["analyze", "check", "list", "manual"]
+    assert schema["properties"]["action"]["enum"] == [
+        "analyze", "check", "list", "settings", "manual"
+    ]
+
+
+def test_module_docs_distinguish_preserved_actions_from_new_settings_action():
+    assert "operational action values are unchanged" in vision_tool.__doc__
+    assert "new\nreserved ``settings`` action" in vision_tool.__doc__
+    assert "public tool name and action values are unchanged" not in vision_tool.__doc__
 
 
 # ---------------------------------------------------------------------------
@@ -152,7 +160,7 @@ def test_root_schema_correlates_each_action_const_with_its_own_input():
         cond["if"]["properties"]["action"]["const"]: cond["then"]["properties"]["input"]
         for cond in schema["allOf"]
     }
-    assert set(conditions) == {"analyze", "check", "list", "manual"}
+    assert set(conditions) == {"analyze", "check", "list", "settings", "manual"}
     assert set(conditions["analyze"]["properties"]) == {"image_path", "question", "preset"}
     assert conditions["list"]["properties"] == {}
     assert conditions["manual"]["properties"] == {}
@@ -163,15 +171,16 @@ def test_root_schema_correlates_each_action_const_with_its_own_input():
 
 
 def test_all_child_input_schemas_are_exposed_before_invocation():
-    branches = get_schema()["properties"]["input"]["oneOf"]
+    branches = get_schema()["properties"]["input"]["anyOf"]
     assert [b["title"] for b in branches] == [
         "analyze input",
         "check input",
         "list input",
+        "settings inventory input",
         "manual input",
     ]
 
-    analyze_branch, check_branch, list_branch, manual_branch = branches
+    analyze_branch, check_branch, list_branch, settings_branch, manual_branch = branches
     assert analyze_branch["required"] == ["image_path", "question"]
     assert analyze_branch["additionalProperties"] is False
     assert analyze_branch["properties"]["image_path"]["type"] == "string"
@@ -190,6 +199,10 @@ def test_all_child_input_schemas_are_exposed_before_invocation():
     assert list_branch["properties"] == {}
     assert list_branch["additionalProperties"] is False
 
+    assert settings_branch["properties"] == {}
+    assert settings_branch["required"] == []
+    assert settings_branch["additionalProperties"] is False
+
     assert manual_branch["properties"] == {}
     assert manual_branch["additionalProperties"] is False
 
@@ -197,7 +210,7 @@ def test_all_child_input_schemas_are_exposed_before_invocation():
 @pytest.mark.parametrize("reasoning", ["chat-wire", "responses-wire"])
 def test_reasoning_and_summarize_never_leak_into_child_input(tmp_path, reasoning):
     schema = get_schema()
-    for branch in schema["properties"]["input"]["oneOf"]:
+    for branch in schema["properties"]["input"]["anyOf"]:
         assert not {"reasoning", "_reasoning", "summarize", "action"} & set(
             branch["properties"]
         )
@@ -558,7 +571,9 @@ def test_no_bare_manual_pointer_survives_in_any_vision_owned_surface():
 
 def test_family_registers_the_reserved_manual_child_once(tmp_path):
     mgr = _manager(tmp_path)
-    assert mgr._family.child_names == ("analyze", "check", "list", "manual")
+    assert mgr._family.child_names == (
+        "analyze", "check", "list", "settings", "manual"
+    )
     assert mgr._family.has_manual()
 
 
@@ -590,7 +605,7 @@ def test_manual_child_input_schema_is_the_generic_owners_object(tmp_path):
 
     manual_branch = next(
         b
-        for b in get_schema()["properties"]["input"]["oneOf"]
+        for b in get_schema()["properties"]["input"]["anyOf"]
         if b["title"] == "manual input"
     )
     assert manual_branch["properties"] == MANUAL_INPUT_SCHEMA["properties"]
@@ -615,17 +630,20 @@ def test_vision_schema_survives_both_provider_wires():
     chat = _build_tools([schema])[0]["function"]["parameters"]
     responses = _build_responses_tools([schema])[0]["parameters"]
 
-    for wire, combinator in ((chat, "oneOf"), (responses, "anyOf")):
+    for wire, combinator in ((chat, "anyOf"), (responses, "anyOf")):
         assert wire["type"] == "object"
         assert wire["required"] == ["action", "input", "reasoning"]
         assert wire["additionalProperties"] is False
         assert set(wire["properties"]) == {"action", "input", "reasoning", "summarize"}
-        assert wire["properties"]["action"]["enum"] == ["analyze", "check", "list", "manual"]
+        assert wire["properties"]["action"]["enum"] == [
+            "analyze", "check", "list", "settings", "manual"
+        ]
         branches = wire["properties"]["input"][combinator]
         assert [b["title"] for b in branches] == [
             "analyze input",
             "check input",
             "list input",
+            "settings inventory input",
             "manual input",
         ]
         for branch in branches:
@@ -639,7 +657,9 @@ def test_vision_schema_survives_both_provider_wires():
             cond["if"]["properties"]["action"]["const"]: cond["then"]["properties"]["input"]
             for cond in wire["allOf"]
         }
-        assert set(correlated) == {"analyze", "check", "list", "manual"}
+        assert set(correlated) == {
+            "analyze", "check", "list", "settings", "manual"
+        }
         assert set(correlated["analyze"]["properties"]) == {"image_path", "question", "preset"}
         assert correlated["list"]["properties"] == {}
         assert correlated["manual"]["properties"] == {}
@@ -767,7 +787,7 @@ def test_preset_borrow_resolves_the_listed_presets_own_identity(tmp_path):
 
     with patch(
         "lingtai.tools.vision._resolve_direct_service",
-        return_value=(borrowed, ""),
+        return_value=(borrowed, "", vision_tool._VisionRouteProvenance()),
     ) as mock_resolve:
         mgr = _manager(tmp_path, _never_called_service())
         svc, reason, identity = mgr._build_service_from_preset("presets/codex-pool.json")
@@ -798,7 +818,7 @@ def test_analyze_with_preset_option_uses_the_borrowed_service(tmp_path):
 
     with patch(
         "lingtai.tools.vision._resolve_direct_service",
-        return_value=(borrowed, ""),
+        return_value=(borrowed, "", vision_tool._VisionRouteProvenance()),
     ):
         mgr = _manager(tmp_path, _never_called_service())
         result = mgr.handle(
@@ -904,7 +924,7 @@ def test_check_preset_reports_identity_without_image(tmp_path):
 
     with patch(
         "lingtai.tools.vision._resolve_direct_service",
-        return_value=(borrowed, ""),
+        return_value=(borrowed, "", vision_tool._VisionRouteProvenance()),
     ):
         mgr = _manager(tmp_path, _never_called_service())
         result = mgr.handle(
@@ -1350,7 +1370,7 @@ def test_vision_owner_docs_cover_all_actions_and_truthful_preset_boundary():
     behaviors = (root / "BEHAVIORS.md").read_text(encoding="utf-8")
     manual = (root / "manual" / "SKILL.md").read_text(encoding="utf-8")
 
-    for action in ("analyze", "check", "list", "manual"):
+    for action in ("analyze", "check", "list", "settings", "manual"):
         assert action in anatomy
         assert action in contract
         assert action in manual
@@ -1360,7 +1380,9 @@ def test_vision_owner_docs_cover_all_actions_and_truthful_preset_boundary():
     assert "allowed preset's own" in manual
     assert "reads another preset's secret" not in manual
     assert "auto-invokes MCP" in manual
-    for labt in ("VN001", "VN002", "VN003", "VN004", "VN005", "VN006"):
+    for labt in (
+        "VN001", "VN002", "VN003", "VN004", "VN005", "VN006", "VN007"
+    ):
         assert labt in behaviors
         assert f"{labt}](BEHAVIORS.md#behavior-{labt.lower()}" in contract or labt in contract
 

--- a/tests/test_tool_settings_contract.py
+++ b/tests/test_tool_settings_contract.py
@@ -147,10 +147,10 @@ def test_public_export_and_exact_production_opt_ins():
         name: importlib.import_module(f"lingtai.tools.{modules.get(name, name)}").DECLARATION
         for name in OFFICIAL_TOOL_PLUGIN_NAMES
     }
-    expected_official = {"avatar", "daemon", "email", "file", "mcp", "notification", "plugin", "shell", "soul", "system", "task_card"}
+    expected_official = {"avatar", "daemon", "email", "file", "mcp", "notification", "plugin", "shell", "soul", "system", "task_card", "vision"}
     assert {name for name, item in declarations.items() if item.settings} == expected_official
     assert expected_curated | expected_official == {
-        "avatar", "cloud_mail", "daemon", "email", "feishu", "file", "imap", "mcp", "notification", "plugin", "shell", "soul", "system", "task_card", "wechat", "whatsapp"
+        "avatar", "cloud_mail", "daemon", "email", "feishu", "file", "imap", "mcp", "notification", "plugin", "shell", "soul", "system", "task_card", "vision", "wechat", "whatsapp"
     }
     for name, item in declarations.items():
         assert ("settings" in item.public_actions) is (name in expected_official)

--- a/tests/test_vision_settings.py
+++ b/tests/test_vision_settings.py
@@ -1,0 +1,404 @@
+"""Focused proofs for Vision's read-only five-field settings inventory."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import MappingProxyType
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from lingtai.services.vision import VisionService
+from lingtai.tools.vision import DECLARATION, get_schema, setup
+
+
+_KEYS = (
+    "provider",
+    "base_url",
+    "model",
+    "api_key",
+    "api_key_env",
+    "max_tokens",
+    "api_compat",
+    "wire_api",
+    "default_headers",
+    "token_path",
+    "instructions",
+    "max_output_tokens",
+    "timeout",
+)
+_FIELDS = ("key", "current", "default", "configurable", "comment")
+_SENSITIVE = {
+    "base_url",
+    "api_key",
+    "api_key_env",
+    "default_headers",
+    "token_path",
+    "instructions",
+}
+_REDACTED = "<redacted>"
+
+
+class _StubAgent:
+    def __init__(self, working_dir: Path) -> None:
+        self._working_dir = working_dir
+        self.service = None
+        self.tools: dict[str, dict] = {}
+        self._official_tool_plugins: dict[str, object] = {}
+
+    @property
+    def working_dir(self) -> Path:
+        return self._working_dir
+
+    @property
+    def official_tool_plugins(self):
+        return MappingProxyType(self._official_tool_plugins)
+
+    def _authorize_official_tool_declaration(self, _declaration) -> None:
+        return None
+
+    def _record_official_tool_binding(self, _declaration, _plugin) -> None:
+        return None
+
+    def _mount_official_tool(self, transaction) -> None:
+        transaction.consume()
+        plugin = transaction.plugin
+        self.tools[plugin.name] = {
+            "schema": plugin.schema,
+            "handler": plugin.handler,
+        }
+        transaction.mark_mounted(self)
+
+    def _claim_official_tool(self, transaction) -> None:
+        self._official_tool_plugins[transaction.declaration.name] = (
+            transaction.declaration
+        )
+
+
+def _write_local_settings(path: Path, **values) -> Path:
+    target = path / "settings" / "vision.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        json.dumps({"schema_version": 1, **values}), encoding="utf-8"
+    )
+    return target
+
+
+def _show(manager, action_input: object = None) -> dict:
+    value = {} if action_input is None else action_input
+    return manager.handle(
+        {"action": "settings", "input": value, "reasoning": "test"}
+    )
+
+
+def _by_key(result: dict) -> dict[str, dict]:
+    return {row["key"]: row for row in result["settings"]}
+
+
+def test_local_inventory_is_exact_applied_snapshot_and_has_true_defaults(
+    tmp_path, monkeypatch
+):
+    pointer = "VISION_TEST_PRIVATE_POINTER"
+    pointer_secret = "pointer-secret-sentinel"
+    file_secret = "file-secret-sentinel"
+    private_url = "https://private-vision.invalid/v1"
+    monkeypatch.setenv(pointer, pointer_secret)
+    owner_file = _write_local_settings(
+        tmp_path,
+        base_url=private_url,
+        model="file-vision-model",
+        api_key=file_secret,
+        max_tokens=321,
+    )
+
+    with patch("lingtai.services.vision.openai.OpenAIVisionService") as factory:
+        manager = setup(
+            _StubAgent(tmp_path),
+            provider="local",
+            api_key_env=pointer,
+            api_compat="anthropic",
+        )
+        factory.assert_called_once_with(
+            api_key=pointer_secret,
+            model="file-vision-model",
+            base_url=private_url,
+            wire_api="chat_completions",
+            max_tokens=321,
+        )
+        factory.reset_mock()
+
+        # A later file edit is prospective: both the service and SHOW retain
+        # the successfully applied bind snapshot until the next refresh/bind.
+        owner_file.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "base_url": "https://later.invalid/v1",
+                    "model": "later-model",
+                    "max_tokens": 999,
+                }
+            ),
+            encoding="utf-8",
+        )
+        result = _show(manager)
+        assert _show(manager) == result
+        factory.assert_not_called()
+
+    assert DECLARATION.settings is True
+    assert DECLARATION.public_actions == (
+        "analyze", "check", "list", "settings", "manual"
+    )
+    assert get_schema()["properties"]["action"]["enum"] == list(
+        DECLARATION.public_actions
+    )
+    assert tuple(row["key"] for row in result["settings"]) == _KEYS
+    assert all(tuple(row) == _FIELDS for row in result["settings"])
+    assert all(row["configurable"] is True for row in result["settings"])
+
+    rows = _by_key(result)
+    assert rows["provider"]["current"] == "local"
+    assert rows["provider"]["default"] is None
+    assert rows["model"]["current"] == "file-vision-model"
+    assert rows["model"]["default"] is None
+    assert rows["max_tokens"]["current"] == 321
+    assert rows["max_tokens"]["default"] == 1024
+    assert rows["api_compat"]["current"] is None
+    assert rows["api_compat"]["default"] is None
+    assert rows["wire_api"]["current"] == "chat_completions"
+    assert rows["wire_api"]["default"] == "chat_completions"
+    assert rows["max_output_tokens"]["current"] is None
+    assert rows["max_output_tokens"]["default"] is None
+    assert rows["timeout"]["current"] is None
+    assert rows["timeout"]["default"] is None
+    for key in _SENSITIVE:
+        assert rows[key]["current"] == _REDACTED
+        assert rows[key]["default"] == _REDACTED
+    rendered = repr(result)
+    for private in (pointer, pointer_secret, file_secret, private_url):
+        assert private not in rendered
+
+
+def test_all_sensitive_route_inputs_are_redacted_by_construction(
+    tmp_path, monkeypatch
+):
+    pointer = "VISION_TEST_OPENAI_POINTER"
+    pointer_secret = "openai-pointer-secret"
+    private_url = "https://private-openai.invalid/v1"
+    private_header = "private-header-sentinel"
+    monkeypatch.setenv(pointer, pointer_secret)
+    with patch("lingtai.services.vision.create_vision_service") as factory:
+        openai_manager = setup(
+            _StubAgent(tmp_path),
+            provider="openai",
+            api_key_env=pointer,
+            model="private-openai-model",
+            base_url=private_url,
+            default_headers={"Authorization": private_header},
+        )
+        openai_result = _show(openai_manager)
+
+    private_token_path = "/private/codex-token-sentinel.json"
+    private_instructions = "private-instructions-sentinel"
+    private_codex_url = "https://private-codex.invalid/backend"
+    with patch("lingtai.services.vision.create_vision_service") as factory:
+        codex_manager = setup(
+            _StubAgent(tmp_path),
+            provider="codex",
+            model="gpt-test-vision",
+            base_url=private_codex_url,
+            token_path=private_token_path,
+            instructions=private_instructions,
+            max_output_tokens=77,
+            timeout=9.5,
+        )
+        codex_result = _show(codex_manager)
+        factory.assert_called_once()
+
+    private_model_path = str(tmp_path / "private-models" / "vision-model")
+    with patch("lingtai.services.vision.openai.OpenAIVisionService"):
+        path_model_result = _show(
+            setup(
+                _StubAgent(tmp_path),
+                provider="local",
+                model=private_model_path,
+            )
+        )
+
+    for result in (openai_result, codex_result):
+        rows = _by_key(result)
+        for key in _SENSITIVE:
+            assert rows[key]["current"] == _REDACTED
+            assert rows[key]["default"] == _REDACTED
+    codex_rows = _by_key(codex_result)
+    openai_rows = _by_key(openai_result)
+    assert openai_rows["model"]["current"] == "private-openai-model"
+    assert openai_rows["model"]["default"] is None
+    assert openai_rows["max_tokens"]["default"] == 1024
+    assert codex_rows["wire_api"]["current"] == "responses"
+    assert codex_rows["model"]["current"] == "gpt-test-vision"
+    assert codex_rows["model"]["default"] is None
+    assert codex_rows["max_output_tokens"]["current"] == 77
+    assert codex_rows["timeout"]["current"] == 9.5
+    assert codex_rows["timeout"]["default"] == 120.0
+    path_model_rows = _by_key(path_model_result)
+    assert path_model_rows["model"]["current"] == _REDACTED
+    assert path_model_rows["model"]["default"] == _REDACTED
+    rendered = repr((openai_result, codex_result, path_model_result))
+    for private in (
+        pointer,
+        pointer_secret,
+        private_url,
+        private_header,
+        private_token_path,
+        private_instructions,
+        private_codex_url,
+        private_model_path,
+    ):
+        assert private not in rendered
+
+
+def test_inherited_route_snapshots_only_the_same_active_provider(tmp_path):
+    active = MagicMock()
+    active.provider = "openai"
+    active._model = "active-vision-model"
+    active._base_url = "https://active-private.invalid/v1"
+    active.api_key = "active-private-key"
+    active._provider_defaults = {
+        "openai": {
+            "api_compat": "openai",
+            "default_headers": {"X-Private": "active-private-header"},
+            "wire_api": "auto",
+            "use_responses_api": True,
+        }
+    }
+    agent = _StubAgent(tmp_path)
+    agent.service = active
+
+    with patch("lingtai.services.vision.create_vision_service") as factory:
+        result = _show(setup(agent))
+        factory.assert_called_once_with(
+            "openai",
+            api_key="active-private-key",
+            model="active-vision-model",
+            base_url="https://active-private.invalid/v1",
+            default_headers={"X-Private": "active-private-header"},
+            wire_api="chat_completions",
+        )
+
+    rows = _by_key(result)
+    assert rows["provider"]["current"] == "openai"
+    assert rows["provider"]["default"] is None
+    assert rows["model"]["current"] == "active-vision-model"
+    assert rows["model"]["default"] is None
+    assert rows["wire_api"]["current"] == "chat_completions"
+    assert rows["wire_api"]["default"] == "chat_completions"
+    assert rows["api_compat"]["current"] is None
+    rendered = repr(result)
+    for private in (
+        "https://active-private.invalid/v1",
+        "active-private-key",
+        "X-Private",
+        "active-private-header",
+    ):
+        assert private not in rendered
+
+
+def test_api_compat_reports_only_a_protocol_selected_by_the_resolver(tmp_path):
+    with patch("lingtai.services.vision.create_vision_service") as factory:
+        result = _show(
+            setup(
+                _StubAgent(tmp_path),
+                provider="custom",
+                api_key="fake-relay-key",
+                model="relay-vision-model",
+                api_compat="anthropic",
+            )
+        )
+        factory.assert_called_once_with(
+            "anthropic",
+            api_key="fake-relay-key",
+            model="relay-vision-model",
+        )
+
+    assert _by_key(result)["api_compat"]["current"] == "anthropic"
+
+
+def test_every_comment_targets_its_exact_owner_manual_heading(tmp_path):
+    _write_local_settings(tmp_path, model="manual-target-model")
+    with patch("lingtai.services.vision.openai.OpenAIVisionService"):
+        rows = _show(setup(_StubAgent(tmp_path), provider="local"))["settings"]
+    manual = (
+        Path(__file__).parents[1]
+        / "src/lingtai/tools/vision/manual/SKILL.md"
+    ).read_text(encoding="utf-8")
+    for row in rows:
+        slug = row["key"].replace("_", "-")
+        assert row["comment"] == f"vision-manual#setting-{slug}"
+        assert f"## Setting: {slug}" in manual
+
+
+@pytest.mark.parametrize("invalid", ["missing-model", "invalid-document"])
+def test_unavailable_current_fails_the_whole_action_without_rows(
+    tmp_path, invalid
+):
+    if invalid == "invalid-document":
+        _write_local_settings(tmp_path, model="ignored", unknown=True)
+    with patch("lingtai.services.vision.openai.OpenAIVisionService") as factory:
+        manager = setup(_StubAgent(tmp_path), provider="local")
+        factory.assert_not_called()
+    assert _show(manager) == {
+        "status": "failed",
+        "error_code": "SETTINGS_UNAVAILABLE",
+        "message": "settings inventory is unavailable",
+    }
+
+
+def test_opaque_injected_service_does_not_fabricate_serialized_settings(tmp_path):
+    manager = setup(
+        _StubAgent(tmp_path), vision_service=MagicMock(spec=VisionService)
+    )
+    assert _show(manager) == {
+        "status": "failed",
+        "error_code": "SETTINGS_UNAVAILABLE",
+        "message": "settings inventory is unavailable",
+    }
+
+
+def test_settings_is_strict_read_only_and_never_changes_owner_file(tmp_path):
+    owner_file = _write_local_settings(tmp_path, model="unchanged-model")
+    before = owner_file.read_bytes()
+    with patch("lingtai.services.vision.openai.OpenAIVisionService") as factory:
+        manager = setup(_StubAgent(tmp_path), provider="local")
+        factory.reset_mock()
+        assert "settings" in _show(manager)
+        for invalid in (
+            {"set": "model", "value": "changed"},
+            {"reset": "model"},
+        ):
+            assert _show(manager, invalid) == {
+                "status": "failed",
+                "error_code": "INVALID_ARGUMENT",
+                "message": "unsupported vision input field",
+            }
+        factory.assert_not_called()
+    assert owner_file.read_bytes() == before
+
+
+def test_ordinary_analyze_action_is_unchanged(tmp_path):
+    service = MagicMock(spec=VisionService)
+    service.analyze_image.return_value = "ordinary-analysis"
+    manager = setup(_StubAgent(tmp_path), vision_service=service)
+    image = tmp_path / "image.png"
+    image.write_bytes(b"not-decoded-by-mock")
+
+    result = manager.handle(
+        {
+            "action": "analyze",
+            "input": {"image_path": str(image), "question": None},
+            "reasoning": "ordinary action",
+        }
+    )
+    assert result == {"status": "ok", "analysis": "ordinary-analysis"}
+    service.analyze_image.assert_called_once_with(
+        str(image), prompt="Describe what you see in this image."
+    )


### PR DESCRIPTION
## Sequential cumulative candidate

This Draft is the independent **Vision** owner implementation, cumulatively rebuilt onto exact current `main` `b70d9946fd4db291bbbe892d0bb76176246d85ef` after the first 16 owner merges. It does not stack on another unmerged owner PR.

- exact candidate commit: `7c0f52253d5bd462abd889ce785b1e42fed64f91`
- exact parent: `b70d9946fd4db291bbbe892d0bb76176246d85ef`
- exact tree: `5aece1b6cd222c165ebb5d69bf889603d126c15d`
- cumulative stable patch id: `b59d7621138a4f66d741a2b72c2b1a2fcdf5a08c`
- old reviewed source/lease: `b7eb50807673889356fc03303c6496c172fab151`; old reviewed patch id: `054e7259790cfdfdf2361c9ae5e144ed14c69c4b`
- resulting diff: **11 files changed, 1143 insertions(+), 106 deletions(-)**
- one owner commit, canonical `Huang Zesen <hzsbazinga@outlook.com>` author/committer, clean worktree, and no tracked deletions

## Preservation and cumulative resolution

- **7/12** old owner paths retain the exact path-specific stable patch id.
- The generic ToolPlugin settings manual is intentionally absent from the resulting diff because current cumulative `main` already owns the canonical bytes; the candidate remains byte-identical to `main` there.
- `src/lingtai/tools/{ANATOMY.md,CONTRACT.md}` preserve current cumulative owner truth and auto-merge only Vision's five-action/settings claims.
- `tests/test_intrinsic_manual_actions.py` preserves every current family expectation and changes only Vision from four `oneOf` children to five `anyOf` children: `analyze`, `check`, `list`, `settings`, `manual`.
- `tests/test_tool_settings_contract.py` preserves all existing official/curated owners and adds only declared official `vision` to both exact owner sets.

## Behavior

- opts only `vision` into the generic read-only `settings` action
- successful rows expose exactly `key`, `current`, `default`, `configurable`, and owner-manual `comment`
- reports the successfully bound default Vision route only; allowed borrowed presets remain per-call declarations and never replace the settings snapshot
- preserves owner-specific source, precedence, sensitivity/redaction, apply timing, and change authority in the owning manual
- fully redacts sensitive route/configuration values and fails the whole inventory closed rather than returning partial rows or fabricating provenance
- adds no generic writer, `set`, `reset`, mutation receipt, or central settings registry; actual changes remain in existing authorized owner procedures

## Validation

- live `vision.settings`: **13/13 ordered rows**, all configurable; six sensitive route/configuration values redacted in both `current` and `default`
- harmless original `vision.list`: active default route plus 14 allowed preset declarations, with no image/provider request
- complete owner/migration/shared acceptance: **223 passed**
- exact common selectors: candidate **213 passed**, clean current-main baseline **212 passed**; the one additional passing case is the existing migration surface extended by Vision settings
- candidate-only `tests/test_vision_settings.py`: **10 passed**
- exact broad governance selector: candidate and clean current-main baseline both **211 passed / the same 5 existing failures**; candidate-unique failures: **0**
- changed Python AST parse: **5/5**; `git diff --check`: pass; changed-path conflict markers: none
- old owner-patch static review remains with no open P0 or P1 finding; no new review layer was added

## Draft boundary and next gate

This remains **Draft** until the separately guarded exact-head squash merge. Under Jason's sequential owner authorization, the next gate is to verify the remote head/body/tree and report this exact final source before merging only #1540. The source branch remains retained. No release, deployment, unrelated live refresh, Vision configuration/auth mutation, Context opt-in, Guardian work, deletion, or cleanup is included.

Telegram: @lingtaidev3bot | Nickname: 澄一

Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
