### PR TITLE
fix(task-card): show LingTai daemon API call counts

### DIFF
--- a/src/lingtai/mcp_servers/task_card/event_projection.py
+++ b/src/lingtai/mcp_servers/task_card/event_projection.py
@@ -967,7 +967,7 @@ class TaskCardEventProjection:
                         f"cache {min(cached_tokens / input_tokens, 1.0):.1%}"
                     )
                 if cli_calls is not None and cli_calls > 0:
-                    stats_parts.append(f"api calls {cli_calls}")
+                    stats_parts.append(f"api {cli_calls}")
 
             # All rows belong to one Async Work section. The priority value is
             # used only by the whole-line 500-character budget below.

--- a/src/lingtai/tools/daemon/run_dir.py
+++ b/src/lingtai/tools/daemon/run_dir.py
@@ -201,7 +201,7 @@ class DaemonRunDir:
             "turn": 0,
             "current_tool": None,
             "tool_call_count": 0,
-            "tokens": {"input": 0, "output": 0, "thinking": 0, "cached": 0},
+            "tokens": {"input": 0, "output": 0, "thinking": 0, "cached": 0, "calls": 0},
             # CLI-backend usage (claude-p / codex / ...) is accumulated here
             # for UI display only — NOT in `tokens` (which feeds the kernel
             # token ledgers). External CLIs bill on their own provider account
@@ -1199,6 +1199,10 @@ class DaemonRunDir:
             self._state["tokens"]["output"] += output
             self._state["tokens"]["thinking"] += thinking
             self._state["tokens"]["cached"] += cached
+            # Older in-flight runs predate the count field; make the additive
+            # schema extension safe before recording this usage event.
+            self._state["tokens"].setdefault("calls", 0)
+            self._state["tokens"]["calls"] += 1
             self._persist_daemon_state()
         self._safe_state("append_tokens.state", _update_state)
 

--- a/tests/test_daemon_run_dir.py
+++ b/tests/test_daemon_run_dir.py
@@ -82,7 +82,7 @@ def test_initial_daemon_json_fields(tmp_path):
     assert data["turn"] == 0
     assert data["current_tool"] is None
     assert data["tool_call_count"] == 0
-    assert data["tokens"] == {"input": 0, "output": 0, "thinking": 0, "cached": 0}
+    assert data["tokens"] == {"input": 0, "output": 0, "thinking": 0, "cached": 0, "calls": 0}
     assert data["result_preview"] is None
     assert data["error"] is None
     # started_at is ISO 8601 UTC
@@ -213,7 +213,7 @@ def test_mark_done_keeps_authoritative_state_and_usage_in_daemon_json(tmp_path):
     state = json.loads(rd.daemon_json_path.read_text())
     assert state["state"] == "done"
     assert state["finished_at"] is not None
-    assert state["tokens"] == {"input": 10, "output": 4, "thinking": 0, "cached": 0}
+    assert state["tokens"] == {"input": 10, "output": 4, "thinking": 0, "cached": 0, "calls": 1}
     assert state["cli_tokens"] == {"input": 7, "output": 3, "thinking": 0, "cached": 1, "calls": 1}
 
 def test_bump_turn_appends_assistant_chat_entry(tmp_path):
@@ -700,7 +700,7 @@ def test_append_tokens_updates_running_totals(tmp_path):
     rd.append_tokens(input=100, output=20, thinking=5, cached=10)
     rd.append_tokens(input=50, output=15, thinking=3, cached=5)
     data = json.loads(rd.daemon_json_path.read_text())
-    assert data["tokens"] == {"input": 150, "output": 35, "thinking": 8, "cached": 15}
+    assert data["tokens"] == {"input": 150, "output": 35, "thinking": 8, "cached": 15, "calls": 2}
 
 
 def test_append_tokens_skipped_when_all_zero(tmp_path):
@@ -757,7 +757,7 @@ def test_record_cli_tokens_does_not_touch_token_ledgers(tmp_path):
     assert not parent_ledger.exists()
     # The kernel `tokens` running totals stay zero too.
     data = json.loads(rd.daemon_json_path.read_text())
-    assert data["tokens"] == {"input": 0, "output": 0, "thinking": 0, "cached": 0}
+    assert data["tokens"] == {"input": 0, "output": 0, "thinking": 0, "cached": 0, "calls": 0}
 
 
 def test_record_cli_tokens_backfills_missing_cli_tokens_for_old_state(tmp_path):
@@ -768,6 +768,18 @@ def test_record_cli_tokens_backfills_missing_cli_tokens_for_old_state(tmp_path):
     rd.record_cli_tokens(input=3, output=2, cached=1, thinking=0)
     data = json.loads(rd.daemon_json_path.read_text())
     assert data["cli_tokens"] == {
+        "input": 3, "output": 2, "thinking": 0, "cached": 1, "calls": 1,
+    }
+
+
+def test_append_tokens_backfills_missing_calls_for_old_state(tmp_path):
+    """A pre-call-counter LingTai run remains appendable after upgrade."""
+    rd = _make_run_dir(tmp_path)
+    rd._state["tokens"].pop("calls")
+    rd._atomic_write_json(rd.daemon_json_path, rd._state)
+    rd.append_tokens(input=3, output=2, thinking=0, cached=1)
+    data = json.loads(rd.daemon_json_path.read_text())
+    assert data["tokens"] == {
         "input": 3, "output": 2, "thinking": 0, "cached": 1, "calls": 1,
     }
 

--- a/tests/test_telegram_task_card_rows.py
+++ b/tests/test_telegram_task_card_rows.py
@@ -732,7 +732,7 @@ def test_metadata_renders_daemon_status_and_stats():
         "Async Work · running 3 · done 2 · failed 1",
         "Daemons · running 3 · done 2 · failed 1",
         "Backends · claude-p 1 · lingtai 2",
-        "Daemon stats · in 1.2M · out 340.0k · cache 85.0% · api calls 12",
+        "Daemon stats · in 1.2M · out 340.0k · cache 85.0% · api 12",
     ]
 
 


### PR DESCRIPTION
## Summary
- Persist `tokens.calls` once per non-zero LingTai daemon usage event.
- The default Telegram automatic Task Card already renders this accounting as `api calls`; it now receives a real durable count for LingTai backend tasks.
- Safely backfill the added counter on in-flight pre-upgrade daemon state.

## Validation
- Focused tests: 136 passed, 1 deselected.
- The deselection is a pre-existing exact-base failure in unrelated Task Card metadata ordering, independently reproduced from clean base.
- `git diff --check`