### PR TITLE
docs(daemon): guide manager runtime mismatch recovery

### DIFF
--- a/src/lingtai/adapters/posix/daemon_manager.py
+++ b/src/lingtai/adapters/posix/daemon_manager.py
@@ -153,14 +153,16 @@ def _ensure_manager(agent_working_dir: Path, *, pool_size: int) -> None:
         raise RuntimeError(
             "resident central daemon manager runtime identity does not match the "
             "current agent (loaded code head, source root, or daemon notification "
-            "protocol); refusing to submit new work"
+            "protocol); refusing to submit new work; see daemon-manual for safe "
+            "diagnosis and recovery"
         )
     if isinstance(started_at, (int, float)) and time.time() - started_at < _PID_STALE_AFTER_S:
         if info.get("manager_runtime_identity") == expected_runtime_identity:
             return
         raise RuntimeError(
             "starting central daemon manager runtime identity does not match the "
-            "current agent; refusing to submit new work"
+            "current agent; refusing to submit new work; see daemon-manual for safe "
+            "diagnosis and recovery"
         )
     token = uuid.uuid4().hex
     _write_private_json(

--- a/src/lingtai/tools/daemon/manual/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/SKILL.md
@@ -7,8 +7,8 @@ description: >
   hunch, understand `daemon(action="list", input={})`, use CLI backends and `backend_options`,
   and clean up daemon footprint. Read this after dispatching daemon work that is
   slow, failed, timed out, exited 143 / SIGTERM, or needs backend-specific reasoning.
-version: 0.13.0
-last_changed_at: 2026-08-29T00:00:00Z
+version: 0.13.1
+last_changed_at: 2026-08-30T00:00:00Z
 related_files:
 - src/lingtai/tools/daemon/CONTRACT.md
 - src/lingtai/tools/daemon/ANATOMY.md
@@ -308,6 +308,35 @@ Behavior notes:
   receipts, `daemon.json`, and aggregate truth remain readable; choose a bounded
   duration and let the delay-alarm mirror re-expose the channel. Read
   `notification-manual` before selecting the duration or handling expiry.
+
+### Runtime-identity mismatch after refresh
+
+If `emanate` refuses before a new worker starts with either **“resident central
+ daemon manager runtime identity does not match”** or **“starting central daemon
+ manager runtime identity does not match”**, stop retrying and use this manual.
+This is a fail-closed safety fence: it prevents a persistent POSIX manager loaded
+from different code, source root, or daemon-notification protocol from accepting
+new work. Existing queued or active work is deliberately not taken over.
+
+A common cause is an agent that has refreshed or changed runtime source while an
+older resident manager process remains alive (including a legacy record without
+the runtime-identity stamp). It is not by itself evidence that the requested
+model, preset, task, or repository is broken.
+
+1. **Inspect; do not reclaim or kill on a hunch.** Give the runtime owner the
+   error, manager PID/incarnation, runtime-identity record, queue count, and
+   journal states. A mismatch can coexist with real queued or active work.
+2. **Preserve fail-closed safety.** If the PID/incarnation cannot be confirmed,
+   any queue entry exists, or any journal is nonterminal, do not terminate or
+   take over the manager. Escalate to the runtime owner.
+3. **Only an authorized owner may recover an actually idle manager.** After
+   confirming the exact manager process, an empty queue, and terminal-only
+   journal records, perform a controlled manager restart, then run one small
+   no-write daemon check. Refresh/relaunch the agent only through its normal
+   lifecycle procedure; do not edit private manager records to bypass the fence.
+4. **Report the outcome.** State whether a fresh manager wrote a current runtime
+   identity and whether the bounded check dispatched and finished. If it still
+   refuses, preserve the exact error and escalate rather than repeatedly retrying.
 
 ## Core rules to keep resident
 

--- a/tests/test_daemon_central_manager.py
+++ b/tests/test_daemon_central_manager.py
@@ -264,7 +264,7 @@ def test_central_manager_refuses_mismatched_runtime_before_queue_write(tmp_path,
         lambda *_args, **_kwargs: pytest.fail("mismatched manager must not receive a capsule"),
     )
 
-    with pytest.raises(RuntimeError, match="runtime identity"):
+    with pytest.raises(RuntimeError, match="runtime identity.*daemon-manual"):
         daemon_manager.enqueue_manager_run(
             agent_working_dir=agent._working_dir,
             request=request,
@@ -297,7 +297,7 @@ def test_central_manager_refuses_mismatched_starting_identity(tmp_path, monkeypa
         lambda: _manager_runtime_identity("current-head"),
     )
 
-    with pytest.raises(RuntimeError, match="runtime identity"):
+    with pytest.raises(RuntimeError, match="runtime identity.*daemon-manual"):
         daemon_manager._ensure_manager(agent_working_dir, pool_size=1)
 
 


### PR DESCRIPTION
## Summary
- Adds a `daemon-manual` recovery pointer to the two central-manager runtime-identity refusal messages.
- Documents the fail-closed fence, common legacy-resident-manager cause, evidence to inspect, and the authorized idle-only recovery boundary.
- Adds regression coverage that both user-facing mismatch errors retain the manual pointer.

## Non-goals
- No manager handover/guard behavior change.
- No configuration mutation, FrontierPhysics change, or cleanup behavior change.

## Validation
- `PYTHONPATH="$WT/src" /Users/huangzesen/work/GitHub/lingtai-kernel/.venv/bin/python -m pytest -q tests/test_daemon_central_manager.py -k 'mismatched_runtime_before_queue_write or mismatched_starting_identity'` — 2 passed.
- `python -m compileall -q src/lingtai/adapters/posix/daemon_manager.py`.
- `git diff --check`.
- The broader focused file currently reports four notification-event assertion failures outside the changed mismatch-message paths; this PR does not modify notification behavior.

Telegram: @Marcovelliheliobot | Nickname: 曜弦
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai