### PR TITLE
Phase B/1: establish one-hop derived-admission policy

### DIFF
--- a/docs/references/provider-admission.md
+++ b/docs/references/provider-admission.md
@@ -1,0 +1,56 @@
+---
+related_files:
+  - src/lingtai/kernel/base_agent/ANATOMY.md
+  - src/lingtai/kernel/base_agent/CONTRACT.md
+  - src/lingtai/kernel/base_agent/BEHAVIORS.md
+  - src/lingtai/kernel/provider_admission.py
+  - tests/test_provider_admission.py
+maintenance: |
+  Manual for the Core provider-admission boundary. Keep it reachable from both
+  base_agent owner twins and align its one-hop and fail-closed guidance with the
+  Port, Contract, LABT, and focused tests.
+---
+
+# Provider admission
+
+Provider admission is the Core boundary that decides whether one concrete model
+request may reach a provider. It is not a sandbox and it is not a bearer-token
+transport: Core carries only private typed parent objects while the driving
+adapter owns authentication, current authority, and audit records.
+
+## How to compose it
+
+At the composition root, wrap the live `LLMService` with a
+`ProviderCallAdmissionPort`. Bind a `RootProviderAdmission` only after the
+driving adapter has admitted the root turn. The wrapper asks the Port again
+immediately before every `send`, `send_stream`, or direct `generate`; a
+refresh-created provider service must receive the same wrapper before use.
+
+A daemon or avatar launch may receive one `DerivedProviderAdmission` created
+from that root. The child class is typed (`DAEMON` or `AVATAR_CHILD`), the
+internal handle is not serializable, and a derived parent cannot create another
+derived parent. The Driver must independently enforce that same one-hop rule at
+its launch boundary.
+
+## Failure handling
+
+Only `GRANTED` permits provider I/O. Missing parent, malformed response, Port
+exception, `DENIED`, and `INDETERMINATE` all fail closed. Treat an unconnected
+derived adapter as `derived_admission_port_unconnected`; do not install a
+permissive fallback or reuse a root decision. A retry requests a new admission
+at the next real provider call.
+
+## Verifying a change
+
+Run:
+
+```bash
+python -m pytest -q tests/test_provider_admission.py
+```
+
+Read [BA005](../../src/lingtai/kernel/base_agent/BEHAVIORS.md#behavior-ba005)
+for the reproducible acceptance procedure. When adding a direct derived-launch
+constructor, update the source inventory and its sensitivity test. The inventory
+covers documented direct names, imports/re-exports, attributes, and simple
+assignment aliases; dynamic factories, registries, and override wrappers still
+require focused review and production-path E2E.

--- a/src/lingtai/kernel/base_agent/ANATOMY.md
+++ b/src/lingtai/kernel/base_agent/ANATOMY.md
@@ -28,6 +28,7 @@ related_files:
   - src/lingtai/kernel/turn_events.py
   - src/lingtai/kernel/turn_permissions.py
   - src/lingtai/kernel/provider_admission.py
+  - docs/references/provider-admission.md
   - src/lingtai/kernel/base_agent/worker_recovery.py
   - src/lingtai/adapters/tool_plugin_host.py
   - src/lingtai/tools/system/karma.py
@@ -81,7 +82,9 @@ Generic agent kernel. Single class `BaseAgent` with methods distributed across 6
   Port immediately before provider I/O. `turn.py` binds a root parent only
   after its final origin admission and resets it on turn/loop teardown.
   Adapters own authentication and transport; Core does not encode ACP, sockets,
-  paths, or a serializable bearer token here.
+  paths, or a serializable bearer token here. The operator procedure and
+  failure modes are in [`docs/references/provider-admission.md`](../../../../docs/references/provider-admission.md).
+  Guarded by [BA005](BEHAVIORS.md#behavior-ba005).
 - `BaseAgent._sleep_alarm_lock` / `_sleep_alarm_problem_signature` (`base_agent/__init__.py`) — narrow per-agent state shared only by `system.sleep(delay=...)` arming and lifecycle heartbeat expiry. It prevents expiry from consuming a later replacement alarm and bounds malformed-file diagnostics; it is not a scheduler or notification-store lock.
 - `BaseAgent._request_turn_cancel` / `_cancel_event` — the private, idempotent producer and process-global cooperative turn latch (`src/lingtai/kernel/base_agent/__init__.py:1231-1233`). Heartbeat signal-file producers route through it after consuming their files (`src/lingtai/kernel/base_agent/lifecycle.py:611-659`); successful refresh routes through it after watcher spawn and before shutdown (`src/lingtai/kernel/base_agent/lifecycle.py:1114-1129`); the official declared System host and retained direct compatibility adapter invoke it only after ASLEEP state/event publication (`src/lingtai/adapters/tool_plugin_host.py:1296-1299`, `src/lingtai/tools/system/karma.py:167-172`). Ownership and limits are normative in `CONTRACT.md` clause `agent-runtime.turn-cancel-latch.v1`.
 - `base_agent/identity.py` — Identity, manifest, and status (~315 lines). `_set_name` (`base_agent/identity.py:29`), `_set_nickname` (`base_agent/identity.py:42`), `_update_identity` (`base_agent/identity.py:48`), `_LLM_PUBLIC_KEYS` safelist constant (`base_agent/identity.py:73`), `_build_manifest` (`base_agent/identity.py:76`), `_safe_llm_from_service` (`base_agent/identity.py:117`) — surfaces a sanitized `llm` block (provider/model/base_url, safelisted) from the live `LLMService` instance for `.agent.json` and the identity prompt section (issue #78). Never reads from `init.json` (kernel stays preset-oblivious); preset metadata is added by the wrapper's `Agent._build_manifest` override. `_status` (`base_agent/identity.py:197`) reads `_lifecycle_clock.monotonic_seconds()` for uptime and `.wall_seconds()` for the no-progress/active-turn/heartbeat ages. `_safe_llm_from_service` is also reused (imported directly, not duplicated) by `kernel.session_stats.build_agent_record` for the Agent record's `model` block.

--- a/src/lingtai/kernel/base_agent/BEHAVIORS.md
+++ b/src/lingtai/kernel/base_agent/BEHAVIORS.md
@@ -14,6 +14,8 @@ related_files:
   - src/lingtai/kernel/execution_workspace.py
   - src/lingtai/kernel/turn_events.py
   - src/lingtai/kernel/turn_permissions.py
+  - src/lingtai/kernel/provider_admission.py
+  - docs/references/provider-admission.md
   - src/lingtai/kernel/base_agent/__init__.py
   - src/lingtai/adapters/tool_plugin_host.py
   - src/lingtai/tools/system/karma.py
@@ -29,6 +31,7 @@ related_files:
   - tests/test_execution_workspace.py
   - tests/test_turn_events.py
   - tests/test_turn_permissions.py
+  - tests/test_provider_admission.py
   - src/lingtai/adapters/acp/BEHAVIORS.md
 maintenance: |
   Created during the every-contract-needs-behaviors sweep. Keep this file
@@ -157,3 +160,31 @@ pending-cancel isolation assertion proves the turn ahead was untouched. Fail on
 a hanging/duplicate result, merged correlation, cancellation leaking to a later
 or earlier turn, failure represented as normal, or any hard provider-abort claim;
 record the evidence trail in the task report.
+
+## Behavior BA005 — every provider request is freshly admitted and a derived child cannot mint another child
+
+- **id**: BA005
+- **title**: every provider request is freshly admitted and a derived child cannot mint another child
+- **guards**: `agent-runtime.provider-admission.v1` in [CONTRACT.md](CONTRACT.md#contract-rules)
+- **supersedes**: `tests/test_provider_admission.py` (kept as bottom asserts)
+- **runner**: any LingTai coding agent with `shell` and `file` access to this repository
+- **prerequisites**: a clean checkout of `<repo>` and the project Python with pytest; no live provider credentials are required
+- **estimate**: ≈ 5 minutes
+
+### Steps
+
+1. From `<repo>`, run `python -m pytest -q tests/test_provider_admission.py`.
+2. Inspect the derived-admission tests: a `RootProviderAdmission` may create one typed daemon or avatar parent; attempting to create a child from that parent raises before provider I/O.
+3. Inspect the denied and indeterminate provider-call tests: they assert the recording provider has no calls; invoke two admitted calls and confirm the recording Port receives a fresh decision for each.
+4. Inspect the constructor-inventory sensitivity test. Confirm direct names, import aliases, package attributes, and module/function assignment aliases are recognized; review every inventory addition rather than treating the scan as a whole-program proof.
+
+### Expected evidence
+
+- [ ] The focused suite passes without a network provider call.
+- [ ] A nested daemon/avatar request cannot mint authority and no denied/indeterminate call reaches the recording provider.
+- [ ] Each actual provider request crosses the Port separately; a root grant is never reused as a derived-call grant.
+- [ ] The static inventory sees the documented direct forms, while dynamic factories, registry dispatch, and subclass/wrapper overrides remain explicit review blind spots.
+
+### Pass / Fail
+
+Pass when the focused suite proves fresh fail-closed admission and the one-hop limit, and the inventory sensitivity cases match the Contract. Fail if a child mints another child, an unavailable/denied call reaches provider I/O, a second call reuses an earlier decision, or an advertised static constructor form is invisible; record the evidence trail in the task report.

--- a/src/lingtai/kernel/base_agent/CONTRACT.md
+++ b/src/lingtai/kernel/base_agent/CONTRACT.md
@@ -373,17 +373,21 @@ Clause IDs are stable; each rule composes the linked normative source.
    surface reduction: a full-tool child must be able to make its real
    daemon/avatar request, which Core/Driver then reject before any provider
    I/O. In particular, the historical daemon `EMANATION_BLACKLIST` currently
-   filters those tools before authorization. It remains the temporary effective
-   safeguard until the driver-mediated adapter has first routed every production
-   derived-launch constructor through an observable domain decision, and a
-   production child has exercised real nested daemon/avatar requests that are
-   denied with zero provider I/O. Only then may puffo-v0 remove or bypass that
-   filter; removing it earlier opens a grandchild-launch window. The launch
+   filters both capabilities before authorization. The transition is ordered:
+   (1) every production derived-launch constructor first routes through an
+   observable domain decision; (2a) while the filter remains, a production
+   launch-path test reaches that decision and records the principal, requested
+   capability, and reason code; (3) only after 2a passes may puffo-v0 remove
+   or bypass the `daemon` and `avatar` filters together; (2b) the change that
+   removes those filters cannot merge until a production child uses each real
+   tool path, receives the denial, and a recording transport proves zero
+   provider I/O. Thus 2a proves that removing the old safeguard cannot make an
+   unguarded window, while 2b proves that the opened tool surface reaches the
+   intended refusal rather than empty-passing at the old filter. The launch
    inventory is a regression tripwire, not a one-time review: a new constructor
-   must fail until classified. The production decision records the principal,
-   requested capability, and reason code; the Core `TypeError` is merely a
-   structural backstop and must not be the only rejection signal. This adapter
-   integration is not delivered by this Core type boundary alone. A host that
+   must fail until classified. The Core `TypeError` is merely a structural
+   backstop and must not be the only rejection signal. This adapter integration
+   is not delivered by this Core type boundary alone. A host that
    binds a derived parent before its transport is connected receives explicit
    `derived_admission_port_unconnected` indeterminacy and rejects before
    provider I/O. Historical daemon/avatar routes do not yet bind that parent,

--- a/src/lingtai/kernel/base_agent/CONTRACT.md
+++ b/src/lingtai/kernel/base_agent/CONTRACT.md
@@ -424,14 +424,16 @@ Clause IDs are stable; each rule composes the linked normative source.
       interface that carries any of those derived facts MUST compare each one
       against that state and deny a mismatch with a distinct attack-signal
       reason code.
-   5. The real provider/capability requested by transport must exactly match
-      the grant. Consumption is Driver-side only: keyed by `admission_id`, an
-      atomic `unused -> consumed_before_io` CAS must succeed before provider
-      I/O. A local transport mark is not consumption; an unsuccessful CAS
-      prevents provider I/O.
+   5. The Driver-side CAS request carries the provider and exact capability
+      that transport is about to execute. In the same atomic operation, the
+      Driver compares both values with the grant issued for `admission_id` and
+      performs `unused -> consumed_before_io`; a mismatch fails as the distinct
+      attack-signal denial from requirement 4. A local transport mark is not
+      consumption; an unsuccessful CAS prevents provider I/O.
    6. A timeout or crash after that CAS and before a known provider result is
       `consumed_outcome_unknown`: the grant remains consumed and is never
-      restored or reused. A retry uses a new `call_id` and obtains a new grant.
+      restored or reused, and this outcome is recorded in the auditable
+      admission record. A retry uses a new `call_id` and obtains a new grant.
    7. Production E2E must assert the authorization seam's exact `reason_code`
       and an audit record linkable by `audit_id` or `admission_id`; merely
       observing a rejection is insufficient evidence that the seam ran.

--- a/src/lingtai/kernel/base_agent/CONTRACT.md
+++ b/src/lingtai/kernel/base_agent/CONTRACT.md
@@ -381,9 +381,12 @@ Clause IDs are stable; each rule composes the linked normative source.
    or bypass the `daemon` and `avatar` filters together; (2b) the change that
    removes those filters cannot merge until a production child uses each real
    tool path, receives the denial, and a recording transport proves zero
-   provider I/O. Thus 2a proves that removing the old safeguard cannot make an
-   unguarded window, while 2b proves that the opened tool surface reaches the
-   intended refusal rather than empty-passing at the old filter. The launch
+   provider I/O. Thus 2a proves that the decision already applies on every
+   production launch path covered by the inventory before the old safeguard is
+   removed; it does not prove the inventory's explicit static blind spots.
+   Those require focused review and production-path E2E. 2b proves that the
+   opened tool surface reaches the intended refusal rather than empty-passing
+   at the old filter. The launch
    inventory is a regression tripwire, not a one-time review: a new constructor
    must fail until classified. Its static matcher must cover direct-name and
    attribute calls, imported aliases, and package re-exports. It is not a

--- a/src/lingtai/kernel/base_agent/CONTRACT.md
+++ b/src/lingtai/kernel/base_agent/CONTRACT.md
@@ -364,7 +364,12 @@ Clause IDs are stable; each rule composes the linked normative source.
    correlation ids, paths, registry digests, prompt content, and tool output
    are not credentials. A derived daemon/avatar call uses a typed parent with
    an internal non-serializable handle and crosses the Port again for each
-   actual provider call; it cannot reuse a root grant. A host that binds a
+   actual provider call; it cannot reuse a root grant. v0 is explicitly
+   one-hop: only a `RootProviderAdmission` can mint a derived parent, and a
+   daemon/avatar child cannot mint another model-executing daemon/avatar.
+   Driver launch admission MUST reject the same nested request; adding recursive
+   derivation requires a new contract with per-hop authority and a recursive
+   production-boundary inventory. A host that binds a
    derived parent before its transport is connected receives explicit
    `derived_admission_port_unconnected` indeterminacy and rejects before
    provider I/O. Historical daemon/avatar routes do not yet bind that parent,

--- a/src/lingtai/kernel/base_agent/CONTRACT.md
+++ b/src/lingtai/kernel/base_agent/CONTRACT.md
@@ -437,10 +437,9 @@ Clause IDs are stable; each rule composes the linked normative source.
    dynamic concurrency factories. It presently inventories creation points,
    not dispatches to an already-created pool (`submit`, `map`, or
    `apply_async`); a future hardening must inventory those dispatch operations
-   as a separate axis. Its `(file, line, constructor)` keys are likewise an
-   intentionally narrow implementation: a later revision should use the
-   enclosing qualified function instead, so unrelated line movement cannot
-   turn the tripwire into mechanical maintenance. Neither limitation reduces
+   as a separate axis. Its `(file, enclosing qualified function, constructor)`
+   keys avoid mechanical churn from unrelated line movement while continuing
+   to distinguish independent construction sites. Neither limitation reduces
    the concrete propagation tests required above.
    A constrained composition MUST carry its origin policy at startup; a missing
    required policy rejects rather than falling back to the generic default. Its

--- a/src/lingtai/kernel/base_agent/CONTRACT.md
+++ b/src/lingtai/kernel/base_agent/CONTRACT.md
@@ -394,8 +394,11 @@ Clause IDs are stable; each rule composes the linked normative source.
    factory indirection) or subclasses/wrappers that override a launch entry;
    those are explicit blind spots that require focused review and production
    path E2E, not an inference from a green inventory. The Core `TypeError` is
-   merely a structural
-   backstop and must not be the only rejection signal. This adapter integration
+   merely a structural backstop and must not be the only rejection signal. The
+   derived-launch inventory uses `(file, enclosing qualified function,
+   constructor)` keys, so unrelated line movement does not turn that specific
+   tripwire into mechanical maintenance.
+   This adapter integration
    is not delivered by this Core type boundary alone. A host that
    binds a derived parent before its transport is connected receives explicit
    `derived_admission_port_unconnected` indeterminacy and rejects before
@@ -437,9 +440,10 @@ Clause IDs are stable; each rule composes the linked normative source.
    dynamic concurrency factories. It presently inventories creation points,
    not dispatches to an already-created pool (`submit`, `map`, or
    `apply_async`); a future hardening must inventory those dispatch operations
-   as a separate axis. Its `(file, enclosing qualified function, constructor)`
-   keys avoid mechanical churn from unrelated line movement while continuing
-   to distinguish independent construction sites. Neither limitation reduces
+   as a separate axis. Its `(file, line, constructor)` keys are likewise an
+   intentionally narrow implementation: a later revision should use the
+   enclosing qualified function instead, so unrelated line movement cannot
+   turn the tripwire into mechanical maintenance. Neither limitation reduces
    the concrete propagation tests required above.
    A constrained composition MUST carry its origin policy at startup; a missing
    required policy rejects rather than falling back to the generic default. Its

--- a/src/lingtai/kernel/base_agent/CONTRACT.md
+++ b/src/lingtai/kernel/base_agent/CONTRACT.md
@@ -398,8 +398,50 @@ Clause IDs are stable; each rule composes the linked normative source.
    derived-launch inventory uses `(file, enclosing qualified function,
    constructor)` keys, so unrelated line movement does not turn that specific
    tripwire into mechanical maintenance.
-   This adapter integration
-   is not delivered by this Core type boundary alone. A host that
+   This adapter integration is not delivered by this Core type boundary alone.
+   The following are **constrained host-adapter requirements**, not current
+   Core-seam delivery claims:
+
+   1. `provision_ref` is a Driver-registry opaque lookup handle bound to the
+      requested `launch_id` and `parent_launch_id`; it is non-transferable and
+      is never an artifact bearer. Only the Driver resolves it. A child,
+      parent, manifest, capsule, or other artifact cannot provide or override
+      identity, workdir, or agent-dir.
+   2. The Driver holds and actually uses the workdir and agent-dir directory
+      handles for execution (`fd` inheritance, `SCM_RIGHTS`, or a platform
+      equivalent). A `dev+ino` value is only an additional check on that
+      handle, never permission to resolve a path and reopen it later. A backend
+      that cannot establish this non-replaceable binding is unsupported and
+      fails closed.
+   3. On a same-OS-user host without sandbox isolation, this mechanism protects
+      against accidental confusion: wrong ref, ref reuse, cross-child use, and
+      lineage mismatch. It does not claim to resist a malicious child that can
+      directly modify the Driver registry.
+   4. `admit_provider_call` accepts only `launch_id`, a single-use `call_id`,
+      and an exact capability (`provider` plus `daemon` or `avatar`). The
+      Driver derives principal, root-session, depth, binding revision, and
+      lineage from current registry state keyed by `launch_id`. A compatibility
+      interface that carries any of those derived facts MUST compare each one
+      against that state and deny a mismatch with a distinct attack-signal
+      reason code.
+   5. The real provider/capability requested by transport must exactly match
+      the grant. Consumption is Driver-side only: keyed by `admission_id`, an
+      atomic `unused -> consumed_before_io` CAS must succeed before provider
+      I/O. A local transport mark is not consumption; an unsuccessful CAS
+      prevents provider I/O.
+   6. A timeout or crash after that CAS and before a known provider result is
+      `consumed_outcome_unknown`: the grant remains consumed and is never
+      restored or reused. A retry uses a new `call_id` and obtains a new grant.
+   7. Production E2E must assert the authorization seam's exact `reason_code`
+      and an audit record linkable by `audit_id` or `admission_id`; merely
+      observing a rejection is insufficient evidence that the seam ran.
+   8. In one run, one recording transport must observe a non-empty provider
+      call list for a legal root-to-one-hop path and `provider_calls == []` for
+      each refused nested daemon/avatar path. This proves the recorder is live
+      and rules out an empty assertion caused by a disconnected recorder.
+
+   Dynamic revoke freshness and propagation remain explicitly undelivered;
+   these requirements reserve no claim that they are already implemented. A host that
    binds a derived parent before its transport is connected receives explicit
    `derived_admission_port_unconnected` indeterminacy and rejects before
    provider I/O. Historical daemon/avatar routes do not yet bind that parent,

--- a/src/lingtai/kernel/base_agent/CONTRACT.md
+++ b/src/lingtai/kernel/base_agent/CONTRACT.md
@@ -369,8 +369,14 @@ Clause IDs are stable; each rule composes the linked normative source.
    daemon/avatar child cannot mint another model-executing daemon/avatar.
    Driver launch admission MUST reject the same nested request; adding recursive
    derivation requires a new contract with per-hop authority and a recursive
-   production-boundary inventory. A host that binds a
-   derived parent before its transport is connected receives explicit
+   production-boundary inventory. This is an authorization rule, not a tool
+   surface reduction: a full-tool child must be able to make its real
+   daemon/avatar request, which Core/Driver then reject before any provider
+   I/O. In particular, the historical daemon `EMANATION_BLACKLIST` currently
+   filters those tools before authorization and must be removed or bypassed for
+   the puffo-v0 derived composition as part of the driver-mediated adapter;
+   that integration is not delivered by this Core type boundary alone. A host
+   that binds a derived parent before its transport is connected receives explicit
    `derived_admission_port_unconnected` indeterminacy and rejects before
    provider I/O. Historical daemon/avatar routes do not yet bind that parent,
    so they remain outside this gate until the separate driver-mediated adapter

--- a/src/lingtai/kernel/base_agent/CONTRACT.md
+++ b/src/lingtai/kernel/base_agent/CONTRACT.md
@@ -19,6 +19,7 @@ related_files:
   - src/lingtai/kernel/turn_events.py
   - src/lingtai/kernel/turn_permissions.py
   - src/lingtai/kernel/provider_admission.py
+  - docs/references/provider-admission.md
   - src/lingtai/adapters/acp/CONTRACT.md
   - src/lingtai/adapters/tool_plugin_host.py
   - src/lingtai/tools/system/karma.py
@@ -79,7 +80,7 @@ maintenance: |
 Stable entry: `lingtai.kernel.agent-runtime.v1`.
 
 ## Purpose
-Guarded by: [BA001](BEHAVIORS.md#behavior-ba001), [BA002](BEHAVIORS.md#behavior-ba002)
+Guarded by: [BA001](BEHAVIORS.md#behavior-ba001), [BA002](BEHAVIORS.md#behavior-ba002), [BA005](BEHAVIORS.md#behavior-ba005)
 
 
 Agent runtime is the composed lifecycle promise of one LingTai agent process:
@@ -350,7 +351,8 @@ Clause IDs are stable; each rule composes the linked normative source.
    tool id/name; absent brokerage passes through, while broker exceptions or
    invalid decisions deny. It still promises no hard provider abort or
    running-tool preemption.
-13. `agent-runtime.provider-admission.v1` — A composition that injects a
+13. `agent-runtime.provider-admission.v1` — Guarded by
+   [BA005](BEHAVIORS.md#behavior-ba005). A composition that injects a
    `ProviderCallAdmissionPort` turns the service boundary into the single
    structural provider-call gate. Core binds a `RootProviderAdmission` only
    after the final correlated-turn origin check, and service/session proxies
@@ -389,7 +391,8 @@ Clause IDs are stable; each rule composes the linked normative source.
    at the old filter. The launch
    inventory is a regression tripwire, not a one-time review: a new constructor
    must fail until classified. Its static matcher must cover direct-name and
-   attribute calls, imported aliases, and package re-exports. It is not a
+   attribute calls, imported aliases, package re-exports, and direct simple
+   assignment aliases. It is not a
    whole-program proof over dynamic dispatch (`getattr`, registry lookup, or
    factory indirection) or subclasses/wrappers that override a launch entry;
    those are explicit blind spots that require focused review and production

--- a/src/lingtai/kernel/base_agent/CONTRACT.md
+++ b/src/lingtai/kernel/base_agent/CONTRACT.md
@@ -373,10 +373,18 @@ Clause IDs are stable; each rule composes the linked normative source.
    surface reduction: a full-tool child must be able to make its real
    daemon/avatar request, which Core/Driver then reject before any provider
    I/O. In particular, the historical daemon `EMANATION_BLACKLIST` currently
-   filters those tools before authorization and must be removed or bypassed for
-   the puffo-v0 derived composition as part of the driver-mediated adapter;
-   that integration is not delivered by this Core type boundary alone. A host
-   that binds a derived parent before its transport is connected receives explicit
+   filters those tools before authorization. It remains the temporary effective
+   safeguard until the driver-mediated adapter has first routed every production
+   derived-launch constructor through an observable domain decision, and a
+   production child has exercised real nested daemon/avatar requests that are
+   denied with zero provider I/O. Only then may puffo-v0 remove or bypass that
+   filter; removing it earlier opens a grandchild-launch window. The launch
+   inventory is a regression tripwire, not a one-time review: a new constructor
+   must fail until classified. The production decision records the principal,
+   requested capability, and reason code; the Core `TypeError` is merely a
+   structural backstop and must not be the only rejection signal. This adapter
+   integration is not delivered by this Core type boundary alone. A host that
+   binds a derived parent before its transport is connected receives explicit
    `derived_admission_port_unconnected` indeterminacy and rejects before
    provider I/O. Historical daemon/avatar routes do not yet bind that parent,
    so they remain outside this gate until the separate driver-mediated adapter

--- a/src/lingtai/kernel/base_agent/CONTRACT.md
+++ b/src/lingtai/kernel/base_agent/CONTRACT.md
@@ -385,7 +385,13 @@ Clause IDs are stable; each rule composes the linked normative source.
    unguarded window, while 2b proves that the opened tool surface reaches the
    intended refusal rather than empty-passing at the old filter. The launch
    inventory is a regression tripwire, not a one-time review: a new constructor
-   must fail until classified. The Core `TypeError` is merely a structural
+   must fail until classified. Its static matcher must cover direct-name and
+   attribute calls, imported aliases, and package re-exports. It is not a
+   whole-program proof over dynamic dispatch (`getattr`, registry lookup, or
+   factory indirection) or subclasses/wrappers that override a launch entry;
+   those are explicit blind spots that require focused review and production
+   path E2E, not an inference from a green inventory. The Core `TypeError` is
+   merely a structural
    backstop and must not be the only rejection signal. This adapter integration
    is not delivered by this Core type boundary alone. A host that
    binds a derived parent before its transport is connected receives explicit

--- a/src/lingtai/kernel/provider_admission.py
+++ b/src/lingtai/kernel/provider_admission.py
@@ -100,6 +100,12 @@ def begin_derived_provider_admission(
     string token.  The driver bridge may associate the returned object's hidden
     handle with its own in-memory transport state, but authority is re-decided
     when the actual provider call reaches :func:`require_provider_admission`.
+
+    v0 permits exactly one derived hop. This factory accepts a root admission,
+    never an existing derived admission, so Core cannot mint a nested
+    daemon/avatar parent by accident. The Driver must enforce the same rule at
+    its launch boundary; a future recursive profile needs an explicitly new
+    contract rather than relaxing this type boundary.
     """
 
     return DerivedProviderAdmission(root=root, call_class=call_class)

--- a/tests/test_provider_admission.py
+++ b/tests/test_provider_admission.py
@@ -124,6 +124,60 @@ def test_raw_provider_service_construction_inventory_is_explicit():
     }
 
 
+def _direct_constructor_calls(source: str, targets: set[str]) -> set[tuple[int, str]]:
+    """Return statically visible direct request-constructor call sites.
+
+    The helper is intentionally not a resolver: dynamic factories, registry
+    lookup, and subclass/wrapper overrides are reviewed outside this narrow
+    source inventory.  It does cover the direct forms promised by the
+    Contract, including aliases introduced through package re-exports.
+    """
+    tree = ast.parse(source)
+    aliases = set(targets)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom):
+            continue
+        for imported in node.names:
+            if imported.name in targets:
+                aliases.add(imported.asname or imported.name)
+
+    calls: set[tuple[int, str]] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if isinstance(node.func, ast.Name) and node.func.id in aliases:
+            constructor = node.func.id
+        elif (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr in targets
+        ):
+            constructor = node.func.attr
+        else:
+            continue
+        calls.add((node.lineno, constructor))
+    return calls
+
+
+def test_derived_launch_constructor_inventory_matches_promised_static_forms():
+    """Direct names, aliases/re-exports, and attribute calls remain covered."""
+    source = """\
+from package import DaemonSupervisorRequest as Request
+import package as pkg
+
+DaemonSupervisorRequest()\n
+Request()\n
+pkg.AvatarLaunchRequest()\n
+"""
+
+    assert _direct_constructor_calls(
+        source, {"DaemonSupervisorRequest", "AvatarLaunchRequest"}
+    ) == {
+        (4, "DaemonSupervisorRequest"),
+        (6, "Request"),
+        (8, "AvatarLaunchRequest"),
+    }
+
+
 def test_derived_launch_constructor_inventory_is_explicit():
     """Every direct derived-launch request constructor needs classification.
 
@@ -142,28 +196,10 @@ def test_derived_launch_constructor_inventory_is_explicit():
     inventory: set[tuple[str, int, str]] = set()
 
     for source in (root / "src" / "lingtai").rglob("*.py"):
-        tree = ast.parse(source.read_text(encoding="utf-8"))
-        aliases = set(targets)
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.ImportFrom):
-                continue
-            for imported in node.names:
-                if imported.name in targets:
-                    aliases.add(imported.asname or imported.name)
-
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.Call):
-                continue
-            if isinstance(node.func, ast.Name) and node.func.id in aliases:
-                constructor = node.func.id
-            elif (
-                isinstance(node.func, ast.Attribute)
-                and node.func.attr in targets
-            ):
-                constructor = node.func.attr
-            else:
-                continue
-            inventory.add((str(source.relative_to(root)), node.lineno, constructor))
+        for lineno, constructor in _direct_constructor_calls(
+            source.read_text(encoding="utf-8"), targets
+        ):
+            inventory.add((str(source.relative_to(root)), lineno, constructor))
 
     assert inventory == {
         # Decode is not a launch, but it is the one wire re-construction point

--- a/tests/test_provider_admission.py
+++ b/tests/test_provider_admission.py
@@ -124,7 +124,7 @@ def test_raw_provider_service_construction_inventory_is_explicit():
     }
 
 
-def _direct_constructor_calls(source: str, targets: set[str]) -> set[tuple[int, str]]:
+def _direct_constructor_calls(source: str, targets: set[str]) -> set[tuple[str, str]]:
     """Return statically visible direct request-constructor call sites.
 
     The helper is intentionally not a resolver: dynamic factories, registry
@@ -141,20 +141,41 @@ def _direct_constructor_calls(source: str, targets: set[str]) -> set[tuple[int, 
             if imported.name in targets:
                 aliases.add(imported.asname or imported.name)
 
-    calls: set[tuple[int, str]] = set()
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Call):
-            continue
-        if isinstance(node.func, ast.Name) and node.func.id in aliases:
-            constructor = node.func.id
-        elif (
-            isinstance(node.func, ast.Attribute)
-            and node.func.attr in targets
-        ):
-            constructor = node.func.attr
-        else:
-            continue
-        calls.add((node.lineno, constructor))
+    calls: set[tuple[str, str]] = set()
+
+    class _InventoryVisitor(ast.NodeVisitor):
+        def __init__(self) -> None:
+            self._scope: list[str] = []
+
+        def _visit_scoped(self, node: ast.AST, name: str) -> None:
+            self._scope.append(name)
+            self.generic_visit(node)
+            self._scope.pop()
+
+        def visit_ClassDef(self, node: ast.ClassDef) -> None:
+            self._visit_scoped(node, node.name)
+
+        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+            self._visit_scoped(node, node.name)
+
+        def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+            self._visit_scoped(node, node.name)
+
+        def visit_Call(self, node: ast.Call) -> None:
+            if isinstance(node.func, ast.Name) and node.func.id in aliases:
+                constructor = node.func.id
+            elif (
+                isinstance(node.func, ast.Attribute)
+                and node.func.attr in targets
+            ):
+                constructor = node.func.attr
+            else:
+                self.generic_visit(node)
+                return
+            calls.add((".".join(self._scope) or "<module>", constructor))
+            self.generic_visit(node)
+
+    _InventoryVisitor().visit(tree)
     return calls
 
 
@@ -164,17 +185,21 @@ def test_derived_launch_constructor_inventory_matches_promised_static_forms():
 from package import DaemonSupervisorRequest as Request
 import package as pkg
 
-DaemonSupervisorRequest()\n
-Request()\n
-pkg.AvatarLaunchRequest()\n
+def direct():
+    DaemonSupervisorRequest()
+    Request()
+
+class Launcher:
+    def by_attribute(self):
+        pkg.AvatarLaunchRequest()
 """
 
     assert _direct_constructor_calls(
         source, {"DaemonSupervisorRequest", "AvatarLaunchRequest"}
     ) == {
-        (4, "DaemonSupervisorRequest"),
-        (6, "Request"),
-        (8, "AvatarLaunchRequest"),
+        ("direct", "DaemonSupervisorRequest"),
+        ("direct", "Request"),
+        ("Launcher.by_attribute", "AvatarLaunchRequest"),
     }
 
 
@@ -193,26 +218,26 @@ def test_derived_launch_constructor_inventory_is_explicit():
     """
     root = Path(__file__).resolve().parents[1]
     targets = {"DaemonSupervisorRequest", "AvatarLaunchRequest"}
-    inventory: set[tuple[str, int, str]] = set()
+    inventory: set[tuple[str, str, str]] = set()
 
     for source in (root / "src" / "lingtai").rglob("*.py"):
-        for lineno, constructor in _direct_constructor_calls(
+        for scope, constructor in _direct_constructor_calls(
             source.read_text(encoding="utf-8"), targets
         ):
-            inventory.add((str(source.relative_to(root)), lineno, constructor))
+            inventory.add((str(source.relative_to(root)), scope, constructor))
 
     assert inventory == {
         # Decode is not a launch, but it is the one wire re-construction point
         # and therefore must stay visible beside the production constructors.
-        ("src/lingtai/kernel/daemon_supervisor/__init__.py", 97,
+        ("src/lingtai/kernel/daemon_supervisor/__init__.py", "decode_request",
          "DaemonSupervisorRequest"),
         # LingTai-backend daemon launch and external-CLI daemon launch.
-        ("src/lingtai/tools/daemon/__init__.py", 3520,
+        ("src/lingtai/tools/daemon/__init__.py", "DaemonManager._spawn_detached_lingtai_run",
          "DaemonSupervisorRequest"),
-        ("src/lingtai/tools/daemon/__init__.py", 5876,
+        ("src/lingtai/tools/daemon/__init__.py", "DaemonManager._handle_emanate_cli",
          "DaemonSupervisorRequest"),
         # Avatar detached-child launch.
-        ("src/lingtai/tools/avatar/__init__.py", 873,
+        ("src/lingtai/tools/avatar/__init__.py", "AvatarManager._launch",
          "AvatarLaunchRequest"),
     }
 

--- a/tests/test_provider_admission.py
+++ b/tests/test_provider_admission.py
@@ -130,7 +130,8 @@ def _direct_constructor_calls(source: str, targets: set[str]) -> set[tuple[str, 
     The helper is intentionally not a resolver: dynamic factories, registry
     lookup, and subclass/wrapper overrides are reviewed outside this narrow
     source inventory.  It does cover the direct forms promised by the
-    Contract, including aliases introduced through package re-exports.
+    Contract, including aliases introduced through imports, package re-exports,
+    and direct simple assignments.
     """
     tree = ast.parse(source)
     aliases = set(targets)
@@ -146,10 +147,16 @@ def _direct_constructor_calls(source: str, targets: set[str]) -> set[tuple[str, 
     class _InventoryVisitor(ast.NodeVisitor):
         def __init__(self) -> None:
             self._scope: list[str] = []
+            self._alias_scopes: list[set[str]] = [set(aliases)]
+
+        def _aliases(self) -> set[str]:
+            return set().union(*self._alias_scopes)
 
         def _visit_scoped(self, node: ast.AST, name: str) -> None:
             self._scope.append(name)
+            self._alias_scopes.append(set())
             self.generic_visit(node)
+            self._alias_scopes.pop()
             self._scope.pop()
 
         def visit_ClassDef(self, node: ast.ClassDef) -> None:
@@ -161,8 +168,24 @@ def _direct_constructor_calls(source: str, targets: set[str]) -> set[tuple[str, 
         def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
             self._visit_scoped(node, node.name)
 
+        def visit_Assign(self, node: ast.Assign) -> None:
+            if isinstance(node.value, ast.Name) and node.value.id in self._aliases():
+                self._alias_scopes[-1].update(
+                    target.id for target in node.targets if isinstance(target, ast.Name)
+                )
+            self.generic_visit(node)
+
+        def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+            if (
+                isinstance(node.value, ast.Name)
+                and node.value.id in self._aliases()
+                and isinstance(node.target, ast.Name)
+            ):
+                self._alias_scopes[-1].add(node.target.id)
+            self.generic_visit(node)
+
         def visit_Call(self, node: ast.Call) -> None:
-            if isinstance(node.func, ast.Name) and node.func.id in aliases:
+            if isinstance(node.func, ast.Name) and node.func.id in self._aliases():
                 constructor = node.func.id
             elif (
                 isinstance(node.func, ast.Attribute)
@@ -180,14 +203,19 @@ def _direct_constructor_calls(source: str, targets: set[str]) -> set[tuple[str, 
 
 
 def test_derived_launch_constructor_inventory_matches_promised_static_forms():
-    """Direct names, aliases/re-exports, and attribute calls remain covered."""
+    """Direct names, import/assignment aliases, and attributes remain covered."""
     source = """\
 from package import DaemonSupervisorRequest as Request
 import package as pkg
 
+ModuleRequest = DaemonSupervisorRequest
+
 def direct():
     DaemonSupervisorRequest()
     Request()
+    ModuleRequest()
+    local = DaemonSupervisorRequest
+    local()
 
 class Launcher:
     def by_attribute(self):
@@ -199,6 +227,8 @@ class Launcher:
     ) == {
         ("direct", "DaemonSupervisorRequest"),
         ("direct", "Request"),
+        ("direct", "ModuleRequest"),
+        ("direct", "local"),
         ("Launcher.by_attribute", "AvatarLaunchRequest"),
     }
 

--- a/tests/test_provider_admission.py
+++ b/tests/test_provider_admission.py
@@ -492,6 +492,16 @@ def test_derived_call_class_is_not_inferred_from_user_controlled_text():
     assert port.calls == [(derived, ProviderCallClass.DAEMON)]
 
 
+def test_v0_derived_admission_rejects_nested_derived_execution():
+    """v0 is deliberately one hop: a child cannot mint another parent."""
+
+    root = RootProviderAdmission("turn-a", RUNTIME_POLICY.policy_version)
+    child = begin_derived_provider_admission(root, ProviderCallClass.DAEMON)
+
+    with pytest.raises(TypeError, match="derived admission requires a root admission"):
+        begin_derived_provider_admission(child, ProviderCallClass.AVATAR_CHILD)  # type: ignore[arg-type]
+
+
 def test_denied_provider_admission_never_reaches_the_inner_service():
     """Attack oracle: a valid-looking root context cannot bypass a denial."""
 

--- a/tests/test_provider_admission.py
+++ b/tests/test_provider_admission.py
@@ -124,6 +124,63 @@ def test_raw_provider_service_construction_inventory_is_explicit():
     }
 
 
+def test_derived_launch_constructor_inventory_is_explicit():
+    """Every direct derived-launch request constructor needs classification.
+
+    This is step 1 of the v0 derived-admission transition.  It intentionally
+    inventories the request constructors, rather than claiming that a green
+    static scan proves every possible launch route: dynamic factories,
+    registry lookup, and subclass/wrapper overrides remain Contract-declared
+    blind spots for focused review and production-path E2E.
+
+    Direct names, ``from … import … as`` aliases (including package
+    re-exports), and attribute calls are all matched.  A new direct request
+    constructor must be explicitly classified before it can land.
+    """
+    root = Path(__file__).resolve().parents[1]
+    targets = {"DaemonSupervisorRequest", "AvatarLaunchRequest"}
+    inventory: set[tuple[str, int, str]] = set()
+
+    for source in (root / "src" / "lingtai").rglob("*.py"):
+        tree = ast.parse(source.read_text(encoding="utf-8"))
+        aliases = set(targets)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ImportFrom):
+                continue
+            for imported in node.names:
+                if imported.name in targets:
+                    aliases.add(imported.asname or imported.name)
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if isinstance(node.func, ast.Name) and node.func.id in aliases:
+                constructor = node.func.id
+            elif (
+                isinstance(node.func, ast.Attribute)
+                and node.func.attr in targets
+            ):
+                constructor = node.func.attr
+            else:
+                continue
+            inventory.add((str(source.relative_to(root)), node.lineno, constructor))
+
+    assert inventory == {
+        # Decode is not a launch, but it is the one wire re-construction point
+        # and therefore must stay visible beside the production constructors.
+        ("src/lingtai/kernel/daemon_supervisor/__init__.py", 97,
+         "DaemonSupervisorRequest"),
+        # LingTai-backend daemon launch and external-CLI daemon launch.
+        ("src/lingtai/tools/daemon/__init__.py", 3520,
+         "DaemonSupervisorRequest"),
+        ("src/lingtai/tools/daemon/__init__.py", 5876,
+         "DaemonSupervisorRequest"),
+        # Avatar detached-child launch.
+        ("src/lingtai/tools/avatar/__init__.py", 873,
+         "AvatarLaunchRequest"),
+    }
+
+
 def test_provider_dispatch_concurrency_inventory_is_explicit():
     """Concurrency creation points must be classified before they can land.
 


### PR DESCRIPTION
## Scope

Split from #1545. Establishes the core one-hop derived-admission policy and its source inventory.

- `provider_admission` ordering and inventory behavior
- BaseAgent normative contract for one-hop authorization
- Provider-admission regression coverage

## Boundary

Does not wire ACP Driver adapters, daemon/avatar process paths, or cross-repository E2E evidence. Those remain in later stacked PRs.

## Validation

- `git diff --check origin/main...HEAD` — pass
- `pytest -q tests/test_provider_admission.py` — 19 passed; 1 known baseline failure: `test_provider_dispatch_concurrency_inventory_is_explicit` also fails unchanged on exact `origin/main` (`cf0e3b6b`). This PR does not modify that baseline inventory.

## Stack

Base: `main` (`cf0e3b6bd498dcb0afdc8b1f94d5c59dd14fad99`)
Head: `2b927c89c0661b0befcc75d49b26107c444ee549`
Supersedes this slice of #1545; no approval is inherited from that PR.