### PR TITLE
Phase B/2: wire derived-admission call-site seam

### DIFF
--- a/src/lingtai/adapters/acp/puffo_v0.py
+++ b/src/lingtai/adapters/acp/puffo_v0.py
@@ -14,6 +14,8 @@ from typing import Any, Iterator
 
 from lingtai.kernel.turns import TurnAdmissionDecision, TurnOrigin
 from lingtai.kernel.provider_admission import (
+    DerivedLaunchCapability,
+    DerivedLaunchDecision,
     ProviderAdmissionParent,
     ProviderAdmissionState,
     ProviderCallClass,
@@ -79,6 +81,18 @@ class PuffoV0RuntimePolicy:
                 if allowed
                 else "derived_admission_port_unconnected"
             ),
+        )
+
+    def authorize_derived_launch(
+        self,
+        _parent: RootProviderAdmission,
+        _capability: DerivedLaunchCapability,
+    ) -> DerivedLaunchDecision:
+        """Refuse launch until the Driver-owned authority transport is wired."""
+
+        return DerivedLaunchDecision(
+            ProviderAdmissionState.INDETERMINATE,
+            "derived_launch_admission_port_unconnected",
         )
 
 

--- a/src/lingtai/adapters/tool_plugin_host.py
+++ b/src/lingtai/adapters/tool_plugin_host.py
@@ -477,17 +477,24 @@ class AgentAvatarParentAdapter:
     value is read through its one narrow closure when Avatar asks for it.
     """
 
-    __slots__ = ("_parent_name", "_venv_path", "_has_rule_privilege")
+    __slots__ = (
+        "_parent_name",
+        "_venv_path",
+        "_has_rule_privilege",
+        "_authorize_derived_launch",
+    )
 
     def __init__(
         self,
         parent_name: Callable[[], str],
         venv_path: Callable[[], str | None],
         has_rule_privilege: Callable[[], bool],
+        authorize_derived_launch: Callable[[Any], Any],
     ) -> None:
         self._parent_name = parent_name
         self._venv_path = venv_path
         self._has_rule_privilege = has_rule_privilege
+        self._authorize_derived_launch = authorize_derived_launch
 
     @property
     def parent_name(self) -> str:
@@ -499,6 +506,9 @@ class AgentAvatarParentAdapter:
 
     def has_rule_privilege(self) -> bool:
         return self._has_rule_privilege()
+
+    def authorize_derived_launch(self, capability: Any) -> Any:
+        return self._authorize_derived_launch(capability)
 
 
 
@@ -662,6 +672,7 @@ class AgentDaemonRuntimeAdapter:
         "_read_language",
         "_read_max_aed_attempts",
         "_read_tool_call_guard",
+        "_authorize_derived_launch",
         "_manager_options",
         "_setup_preset_capability",
         "_read_preset",
@@ -683,6 +694,7 @@ class AgentDaemonRuntimeAdapter:
         read_language: Callable[[], str],
         read_max_aed_attempts: Callable[[], int],
         read_tool_call_guard: Callable[[], Any],
+        authorize_derived_launch: Callable[[Any], Any],
         manager_options: Mapping[str, Any],
         setup_preset_capability: Callable[[str, Mapping[str, Any]], tuple[dict[str, Any], dict[str, Callable[[dict], dict]]]],
         read_preset: Callable[[], Mapping[str, Any]],
@@ -699,6 +711,7 @@ class AgentDaemonRuntimeAdapter:
         self._read_language = read_language
         self._read_max_aed_attempts = read_max_aed_attempts
         self._read_tool_call_guard = read_tool_call_guard
+        self._authorize_derived_launch = authorize_derived_launch
         self._manager_options = dict(manager_options)
         self._setup_preset_capability = setup_preset_capability
         self._read_preset = read_preset
@@ -736,6 +749,9 @@ class AgentDaemonRuntimeAdapter:
     @property
     def tool_call_guard(self) -> Any:
         return self._read_tool_call_guard()
+
+    def authorize_derived_launch(self, capability: Any) -> Any:
+        return self._authorize_derived_launch(capability)
 
     @property
     def manager_options(self) -> Mapping[str, Any]:
@@ -831,6 +847,13 @@ def daemon_runtime_for_agent(
         except Exception:
             return False
 
+    def _authorize_derived_launch(capability: Any) -> Any:
+        from lingtai.kernel.provider_admission import require_derived_launch_admission
+
+        return require_derived_launch_admission(
+            getattr(agent, "_derived_launch_admission_port", None), capability
+        )
+
     def _log(event_type: str, **fields: Any) -> None:
         log = getattr(agent, "_log", None)
         if callable(log):
@@ -884,6 +907,7 @@ def daemon_runtime_for_agent(
         read_language=_read_language,
         read_max_aed_attempts=_read_max_aed_attempts,
         read_tool_call_guard=lambda: getattr(agent, "_tool_call_guard", None),
+        authorize_derived_launch=_authorize_derived_launch,
         manager_options=manager_options,
         setup_preset_capability=_setup_preset_capability,
         read_preset=_read_preset,
@@ -1561,6 +1585,13 @@ def agent_host_ports(
     composition value arrives through ``extra_ports`` from ``web.setup`` alone.
     The registrar grants just ``requires``, never this whole map.
     """
+    def _authorize_derived_launch(capability: Any) -> Any:
+        from lingtai.kernel.provider_admission import require_derived_launch_admission
+
+        return require_derived_launch_admission(
+            getattr(agent, "_derived_launch_admission_port", None), capability
+        )
+
     ports = {"workdir": AgentWorkdirAdapter(lambda: agent.working_dir)}
     # Construct only the declaration's earned standard adapter. Lightweight Core
     # test agents need not implement MCP or Avatar APIs when Notification is being
@@ -1574,6 +1605,7 @@ def agent_host_ports(
             lambda: agent.agent_name or agent.working_dir.name,
             lambda: getattr(agent, "_venv_path", None),
             lambda: any((getattr(agent, "_admin", {}) or {}).values()),
+            _authorize_derived_launch,
         )
     elif plugin_name == "plugin":
         ports["plugin_catalog"] = AgentPluginCatalogAdapter(

--- a/src/lingtai/adapters/tool_plugin_host.py
+++ b/src/lingtai/adapters/tool_plugin_host.py
@@ -851,7 +851,11 @@ def daemon_runtime_for_agent(
         from lingtai.kernel.provider_admission import require_derived_launch_admission
 
         return require_derived_launch_admission(
-            getattr(agent, "_derived_launch_admission_port", None), capability
+            getattr(agent, "_derived_launch_admission_port", None),
+            capability,
+            required=bool(
+                getattr(agent, "_requires_derived_launch_admission_port", False)
+            ),
         )
 
     def _log(event_type: str, **fields: Any) -> None:
@@ -1589,7 +1593,11 @@ def agent_host_ports(
         from lingtai.kernel.provider_admission import require_derived_launch_admission
 
         return require_derived_launch_admission(
-            getattr(agent, "_derived_launch_admission_port", None), capability
+            getattr(agent, "_derived_launch_admission_port", None),
+            capability,
+            required=bool(
+                getattr(agent, "_requires_derived_launch_admission_port", False)
+            ),
         )
 
     ports = {"workdir": AgentWorkdirAdapter(lambda: agent.working_dir)}

--- a/src/lingtai/agent.py
+++ b/src/lingtai/agent.py
@@ -244,6 +244,7 @@ class Agent(BaseAgent):
         _forced_disable: frozenset[str] | None = None,
         _turn_origin_policy: Any | None = None,
         _requires_turn_origin_policy: bool = False,
+        _requires_derived_launch_admission_port: bool = False,
         _from_init_boot: bool = False,
         **kwargs: Any,
     ):
@@ -253,6 +254,9 @@ class Agent(BaseAgent):
         self._forced_disable = frozenset(_forced_disable or ())
         self._turn_origin_policy = _turn_origin_policy
         self._requires_turn_origin_policy = _requires_turn_origin_policy
+        self._requires_derived_launch_admission_port = (
+            _requires_derived_launch_admission_port
+        )
         # Psyche SHOW reports only the Pad configuration successfully consumed
         # by canonical reconstruction. Direct construction begins at the two
         # meaningful defaults; ambient init/source edits never mutate this pair.

--- a/src/lingtai/cli.py
+++ b/src/lingtai/cli.py
@@ -143,6 +143,7 @@ def build_agent(
     _turn_origin_policy=None,
     _requires_turn_origin_policy: bool = False,
     _provider_call_admission_port=None,
+    _derived_launch_admission_port=None,
 ) -> Agent:
     """Construct Agent from validated init data.
 
@@ -199,6 +200,7 @@ def build_agent(
         _turn_origin_policy=_turn_origin_policy,
         _requires_turn_origin_policy=_requires_turn_origin_policy,
         provider_call_admission_port=_provider_call_admission_port,
+        derived_launch_admission_port=_derived_launch_admission_port,
         _from_init_boot=True,
     )
 

--- a/src/lingtai/cli.py
+++ b/src/lingtai/cli.py
@@ -144,6 +144,7 @@ def build_agent(
     _requires_turn_origin_policy: bool = False,
     _provider_call_admission_port=None,
     _derived_launch_admission_port=None,
+    _requires_derived_launch_admission_port: bool = False,
 ) -> Agent:
     """Construct Agent from validated init data.
 
@@ -199,6 +200,9 @@ def build_agent(
         _forced_disable=_forced_disable,
         _turn_origin_policy=_turn_origin_policy,
         _requires_turn_origin_policy=_requires_turn_origin_policy,
+        _requires_derived_launch_admission_port=(
+            _requires_derived_launch_admission_port
+        ),
         provider_call_admission_port=_provider_call_admission_port,
         derived_launch_admission_port=_derived_launch_admission_port,
         _from_init_boot=True,

--- a/src/lingtai/cli_acp.py
+++ b/src/lingtai/cli_acp.py
@@ -68,6 +68,7 @@ def run_acp(
     turn_origin_policy=None,
     requires_turn_origin_policy: bool = False,
     provider_call_admission_port=None,
+    derived_launch_admission_port=None,
     puffo_runtime=None,
 ) -> None:
     """Compose one Agent and the local ACP stdio driving adapter.
@@ -145,6 +146,8 @@ def run_acp(
             build_options["_requires_turn_origin_policy"] = True
         if provider_call_admission_port is not None:
             build_options["_provider_call_admission_port"] = provider_call_admission_port
+        if derived_launch_admission_port is not None:
+            build_options["_derived_launch_admission_port"] = derived_launch_admission_port
         agent = build_agent(data, agent_dir, **build_options)
         agent._venv_path = str(venv_dir)
         agent.start()
@@ -232,6 +235,7 @@ def handle_acp_command(args) -> None:
         turn_origin_policy=RUNTIME_POLICY,
         requires_turn_origin_policy=True,
         provider_call_admission_port=RUNTIME_POLICY,
+        derived_launch_admission_port=RUNTIME_POLICY,
     )
 
 

--- a/src/lingtai/cli_acp.py
+++ b/src/lingtai/cli_acp.py
@@ -69,6 +69,7 @@ def run_acp(
     requires_turn_origin_policy: bool = False,
     provider_call_admission_port=None,
     derived_launch_admission_port=None,
+    requires_derived_launch_admission_port: bool = False,
     puffo_runtime=None,
 ) -> None:
     """Compose one Agent and the local ACP stdio driving adapter.
@@ -82,6 +83,10 @@ def run_acp(
     wire_out = output_stream if output_stream is not None else sys.stdout
     if requires_turn_origin_policy and turn_origin_policy is None:
         raise ValueError("constrained ACP composition requires a turn-origin policy")
+    if requires_derived_launch_admission_port and derived_launch_admission_port is None:
+        raise ValueError(
+            "constrained ACP composition requires a derived-launch admission port"
+        )
     if input_stream is None:
         reconfigure_in = getattr(wire_in, "reconfigure", None)
         if callable(reconfigure_in):
@@ -148,6 +153,8 @@ def run_acp(
             build_options["_provider_call_admission_port"] = provider_call_admission_port
         if derived_launch_admission_port is not None:
             build_options["_derived_launch_admission_port"] = derived_launch_admission_port
+        if requires_derived_launch_admission_port:
+            build_options["_requires_derived_launch_admission_port"] = True
         agent = build_agent(data, agent_dir, **build_options)
         agent._venv_path = str(venv_dir)
         agent.start()
@@ -236,6 +243,7 @@ def handle_acp_command(args) -> None:
         requires_turn_origin_policy=True,
         provider_call_admission_port=RUNTIME_POLICY,
         derived_launch_admission_port=RUNTIME_POLICY,
+        requires_derived_launch_admission_port=True,
     )
 
 

--- a/src/lingtai/kernel/base_agent/__init__.py
+++ b/src/lingtai/kernel/base_agent/__init__.py
@@ -485,6 +485,7 @@ class BaseAgent:
         source_revision_port: SourceRevisionPort,
         refresh_watcher: RefreshWatcherPort | None = None,
         provider_call_admission_port=None,
+        derived_launch_admission_port=None,
         intrinsics: "Mapping[str, Mapping[str, Any]] | None" = None,
         file_io: Any | None = None,
         mail_service: Any | None = None,
@@ -512,6 +513,11 @@ class BaseAgent:
         # ContextVar or be treated as covered here. Generic agents retain the
         # unwrapped historical path.
         self._provider_call_admission_port = provider_call_admission_port
+        # A separate host-mediated port decides daemon/avatar *process* launch.
+        # It is intentionally not inferred from the provider-call port: generic
+        # Agents preserve legacy behavior while a constrained composition must
+        # supply its own fail-closed Driver authority.
+        self._derived_launch_admission_port = derived_launch_admission_port
         if provider_call_admission_port is None:
             self.service = service
         else:

--- a/src/lingtai/kernel/provider_admission.py
+++ b/src/lingtai/kernel/provider_admission.py
@@ -22,6 +22,13 @@ class ProviderCallClass(str, Enum):
     AVATAR_CHILD = "avatar_child"
 
 
+class DerivedLaunchCapability(str, Enum):
+    """One production tool route that can create a derived execution."""
+
+    DAEMON = "daemon"
+    AVATAR = "avatar"
+
+
 class ProviderAdmissionState(str, Enum):
     """The driver-visible result of deciding one provider-call admission.
 
@@ -128,6 +135,23 @@ class ProviderCallDecision:
         return self.state is ProviderAdmissionState.GRANTED
 
 
+@dataclass(frozen=True, slots=True)
+class DerivedLaunchDecision:
+    """A Driver-owned decision before a daemon/avatar process can launch.
+
+    ``audit_id`` is correlation material only.  It is never a grant or a
+    substitute for the Core-private admission parent passed to the Port.
+    """
+
+    state: ProviderAdmissionState
+    reason_code: str
+    audit_id: str | None = None
+
+    @property
+    def allowed(self) -> bool:
+        return self.state is ProviderAdmissionState.GRANTED
+
+
 class ProviderCallAdmissionPort(Protocol):
     """Driver-facing Core port, invoked once per actual provider call.
 
@@ -145,6 +169,21 @@ class ProviderCallAdmissionPort(Protocol):
     ) -> ProviderCallDecision: ...
 
 
+class DerivedLaunchAdmissionPort(Protocol):
+    """Driver-facing decision port for one daemon/avatar launch request.
+
+    The root parent is a Core-private object rather than a path, registry ref,
+    correlation id, or user-provided depth.  A future Driver bridge resolves
+    all durable identity/lineage facts itself before returning a decision.
+    """
+
+    def authorize_derived_launch(
+        self,
+        parent: RootProviderAdmission,
+        capability: DerivedLaunchCapability,
+    ) -> DerivedLaunchDecision: ...
+
+
 class ProviderAdmissionError(PermissionError):
     """Raised before a provider request when admission is absent or denied."""
 
@@ -156,6 +195,14 @@ class ProviderAdmissionError(PermissionError):
         self.reason_code = reason_code
         self.state = state
         super().__init__(f"provider call was not admitted: {reason_code}")
+
+
+class DerivedLaunchAdmissionError(PermissionError):
+    """Raised before a derived process launch when authority is unavailable."""
+
+    def __init__(self, decision: DerivedLaunchDecision):
+        self.decision = decision
+        super().__init__(f"derived launch was not admitted: {decision.reason_code}")
 
 
 _current_parent: ContextVar[ProviderAdmissionParent | None] = ContextVar(
@@ -202,6 +249,59 @@ def current_provider_call_class() -> ProviderCallClass:
     if isinstance(parent, DerivedProviderAdmission):
         return parent.call_class
     return ProviderCallClass.ROOT
+
+
+def require_derived_launch_admission(
+    port: DerivedLaunchAdmissionPort | None,
+    capability: DerivedLaunchCapability,
+) -> DerivedLaunchDecision:
+    """Decide one daemon/avatar launch before it can create process state.
+
+    Generic LingTai compositions retain their historical behavior when no
+    derived-launch port is configured.  A constrained profile supplies a port;
+    missing root authority, malformed/raising ports, and all non-grants then
+    fail closed with a structured domain error before launch side effects.
+    """
+
+    if not isinstance(capability, DerivedLaunchCapability):
+        raise TypeError("derived launch capability must be typed")
+    if port is None:
+        return DerivedLaunchDecision(ProviderAdmissionState.GRANTED, "legacy_default")
+
+    parent = current_provider_admission()
+    if not isinstance(parent, RootProviderAdmission):
+        reason = (
+            "nested_derived_launch_denied"
+            if isinstance(parent, DerivedProviderAdmission)
+            else "missing_root_provider_admission"
+        )
+        raise DerivedLaunchAdmissionError(
+            DerivedLaunchDecision(ProviderAdmissionState.DENIED, reason)
+        )
+    try:
+        decision = port.authorize_derived_launch(parent, capability)
+    except Exception:
+        decision = DerivedLaunchDecision(
+            ProviderAdmissionState.INDETERMINATE,
+            "derived_launch_admission_port_error",
+        )
+    if (
+        not isinstance(decision, DerivedLaunchDecision)
+        or not isinstance(decision.state, ProviderAdmissionState)
+        or not isinstance(decision.reason_code, str)
+        or not decision.reason_code
+        or (
+            decision.audit_id is not None
+            and (not isinstance(decision.audit_id, str) or not decision.audit_id)
+        )
+    ):
+        decision = DerivedLaunchDecision(
+            ProviderAdmissionState.INDETERMINATE,
+            "malformed_derived_launch_admission_decision",
+        )
+    if not decision.allowed:
+        raise DerivedLaunchAdmissionError(decision)
+    return decision
 
 
 def require_provider_admission(port: ProviderCallAdmissionPort | None) -> None:
@@ -325,6 +425,10 @@ __all__ = [
     "DerivedProviderAdmission",
     "ProviderAdmittedChatSession",
     "ProviderAdmittedLLMService",
+    "DerivedLaunchAdmissionError",
+    "DerivedLaunchAdmissionPort",
+    "DerivedLaunchCapability",
+    "DerivedLaunchDecision",
     "ProviderAdmissionError",
     "ProviderAdmissionParent",
     "ProviderAdmissionState",
@@ -337,5 +441,6 @@ __all__ = [
     "clear_provider_admission",
     "clear_current_provider_admission",
     "current_provider_admission",
+    "require_derived_launch_admission",
     "require_provider_admission",
 ]

--- a/src/lingtai/kernel/provider_admission.py
+++ b/src/lingtai/kernel/provider_admission.py
@@ -254,6 +254,8 @@ def current_provider_call_class() -> ProviderCallClass:
 def require_derived_launch_admission(
     port: DerivedLaunchAdmissionPort | None,
     capability: DerivedLaunchCapability,
+    *,
+    required: bool = False,
 ) -> DerivedLaunchDecision:
     """Decide one daemon/avatar launch before it can create process state.
 
@@ -266,6 +268,13 @@ def require_derived_launch_admission(
     if not isinstance(capability, DerivedLaunchCapability):
         raise TypeError("derived launch capability must be typed")
     if port is None:
+        if required:
+            raise DerivedLaunchAdmissionError(
+                DerivedLaunchDecision(
+                    ProviderAdmissionState.INDETERMINATE,
+                    "required_derived_launch_admission_port_missing",
+                )
+            )
         return DerivedLaunchDecision(ProviderAdmissionState.GRANTED, "legacy_default")
 
     parent = current_provider_admission()

--- a/src/lingtai/kernel/tool_plugin/__init__.py
+++ b/src/lingtai/kernel/tool_plugin/__init__.py
@@ -346,7 +346,7 @@ class AvatarParentPort(Protocol):
         """Whether this parent may distribute rules through its avatar subtree."""
 
     def authorize_derived_launch(self, capability: Any) -> Any:
-        """Decide one avatar-derived process launch before process launch."""
+        """Decide one avatar-derived process launch before side effects."""
 
 
 class DaemonRuntimePort(Protocol):
@@ -393,7 +393,7 @@ class DaemonRuntimePort(Protocol):
         """Resolved construction options for this daemon manager binding."""
 
     def authorize_derived_launch(self, capability: Any) -> Any:
-        """Decide one daemon-derived process launch before process launch."""
+        """Decide one daemon-derived process launch before side effects."""
 
     def setup_preset_capability(
         self, name: str, kwargs: Mapping[str, Any]

--- a/src/lingtai/kernel/tool_plugin/__init__.py
+++ b/src/lingtai/kernel/tool_plugin/__init__.py
@@ -346,7 +346,7 @@ class AvatarParentPort(Protocol):
         """Whether this parent may distribute rules through its avatar subtree."""
 
     def authorize_derived_launch(self, capability: Any) -> Any:
-        """Decide one avatar-derived process launch before side effects."""
+        """Decide one avatar-derived process launch before process launch."""
 
 
 class DaemonRuntimePort(Protocol):
@@ -393,7 +393,7 @@ class DaemonRuntimePort(Protocol):
         """Resolved construction options for this daemon manager binding."""
 
     def authorize_derived_launch(self, capability: Any) -> Any:
-        """Decide one daemon-derived process launch before side effects."""
+        """Decide one daemon-derived process launch before process launch."""
 
     def setup_preset_capability(
         self, name: str, kwargs: Mapping[str, Any]

--- a/src/lingtai/kernel/tool_plugin/__init__.py
+++ b/src/lingtai/kernel/tool_plugin/__init__.py
@@ -345,6 +345,9 @@ class AvatarParentPort(Protocol):
     def has_rule_privilege(self) -> bool:
         """Whether this parent may distribute rules through its avatar subtree."""
 
+    def authorize_derived_launch(self, capability: Any) -> Any:
+        """Decide one avatar-derived process launch before side effects."""
+
 
 class DaemonRuntimePort(Protocol):
     """Daemon's capability-native view of the current agent runtime.
@@ -388,6 +391,9 @@ class DaemonRuntimePort(Protocol):
     @property
     def manager_options(self) -> Mapping[str, Any]:
         """Resolved construction options for this daemon manager binding."""
+
+    def authorize_derived_launch(self, capability: Any) -> Any:
+        """Decide one daemon-derived process launch before side effects."""
 
     def setup_preset_capability(
         self, name: str, kwargs: Mapping[str, Any]

--- a/src/lingtai/tools/avatar/__init__.py
+++ b/src/lingtai/tools/avatar/__init__.py
@@ -942,15 +942,14 @@ class AvatarManager:
             decision = DerivedLaunchDecision(
                 ProviderAdmissionState.GRANTED, "legacy_default"
             )
-        if decision.reason_code != "legacy_default":
-            self._append_ledger(
-                "avatar_admission_decision",
-                peer_name,
-                capability=DerivedLaunchCapability.AVATAR.value,
-                state=decision.state.value,
-                reason_code=decision.reason_code,
-                audit_id=decision.audit_id,
-            )
+        self._append_ledger(
+            "avatar_admission_decision",
+            peer_name,
+            capability=DerivedLaunchCapability.AVATAR.value,
+            state=decision.state.value,
+            reason_code=decision.reason_code,
+            audit_id=decision.audit_id,
+        )
 
     # ------------------------------------------------------------------
     # Ledger reading

--- a/src/lingtai/tools/avatar/__init__.py
+++ b/src/lingtai/tools/avatar/__init__.py
@@ -916,32 +916,23 @@ class AvatarManager:
         from lingtai.kernel.provider_admission import (
             DerivedLaunchAdmissionError,
             DerivedLaunchCapability,
-            DerivedLaunchDecision,
-            ProviderAdmissionState,
         )
 
-        authorize = getattr(self._host.avatar_parent, "authorize_derived_launch", None)
-        if callable(authorize):
-            try:
-                decision = authorize(DerivedLaunchCapability.AVATAR)
-            except DerivedLaunchAdmissionError as exc:
-                decision = exc.decision
-                self._append_ledger(
-                    "avatar_admission_decision",
-                    peer_name,
-                    capability=DerivedLaunchCapability.AVATAR.value,
-                    state=decision.state.value,
-                    reason_code=decision.reason_code,
-                    audit_id=decision.audit_id,
-                )
-                raise
-        else:
-            # Direct legacy test/composition hosts predate the narrow decision
-            # operation. Puffo-v0 never takes this branch: its Agent adapter
-            # always supplies a configured (currently fail-closed) port.
-            decision = DerivedLaunchDecision(
-                ProviderAdmissionState.GRANTED, "legacy_default"
+        try:
+            decision = self._host.avatar_parent.authorize_derived_launch(
+                DerivedLaunchCapability.AVATAR
             )
+        except DerivedLaunchAdmissionError as exc:
+            decision = exc.decision
+            self._append_ledger(
+                "avatar_admission_decision",
+                peer_name,
+                capability=DerivedLaunchCapability.AVATAR.value,
+                state=decision.state.value,
+                reason_code=decision.reason_code,
+                audit_id=decision.audit_id,
+            )
+            raise
         self._append_ledger(
             "avatar_admission_decision",
             peer_name,
@@ -950,6 +941,8 @@ class AvatarManager:
             reason_code=decision.reason_code,
             audit_id=decision.audit_id,
         )
+        if not decision.allowed:
+            raise DerivedLaunchAdmissionError(decision)
 
     # ------------------------------------------------------------------
     # Ledger reading

--- a/src/lingtai/tools/avatar/__init__.py
+++ b/src/lingtai/tools/avatar/__init__.py
@@ -365,7 +365,18 @@ class AvatarManager:
         reasoning = raw.get("_reasoning")
         self._pending_reasoning = reasoning if isinstance(reasoning, str) else None
         try:
-            result = self._family.handle(args)
+            try:
+                result = self._family.handle(args)
+            except Exception as exc:
+                from lingtai.kernel.provider_admission import DerivedLaunchAdmissionError
+
+                if not isinstance(exc, DerivedLaunchAdmissionError):
+                    raise
+                return {
+                    "error": str(exc),
+                    "reason_code": exc.decision.reason_code,
+                    "audit_id": exc.decision.audit_id,
+                }
         finally:
             self._pending_reasoning = None
         if result.get("error_code") == "ACTION_REQUIRED":
@@ -522,6 +533,8 @@ class AvatarManager:
                 },
                 "message": "Dry run — no process spawned, no files written.",
             }
+
+        self._authorize_derived_launch(peer_name)
 
         # Working dir: sibling of parent, named after the avatar. Defense-in-depth
         # scope check — resolve and assert the target's parent equals the network
@@ -897,6 +910,47 @@ class AvatarManager:
             AvatarLaunchRequest(argv=cmd, stderr_path=stderr_path)
         )
         return receipt, stderr_path
+
+    def _authorize_derived_launch(self, peer_name: str) -> None:
+        """Reach the host decision seam before avatar filesystem/process effects."""
+        from lingtai.kernel.provider_admission import (
+            DerivedLaunchAdmissionError,
+            DerivedLaunchCapability,
+            DerivedLaunchDecision,
+            ProviderAdmissionState,
+        )
+
+        authorize = getattr(self._host.avatar_parent, "authorize_derived_launch", None)
+        if callable(authorize):
+            try:
+                decision = authorize(DerivedLaunchCapability.AVATAR)
+            except DerivedLaunchAdmissionError as exc:
+                decision = exc.decision
+                self._append_ledger(
+                    "avatar_admission_decision",
+                    peer_name,
+                    capability=DerivedLaunchCapability.AVATAR.value,
+                    state=decision.state.value,
+                    reason_code=decision.reason_code,
+                    audit_id=decision.audit_id,
+                )
+                raise
+        else:
+            # Direct legacy test/composition hosts predate the narrow decision
+            # operation. Puffo-v0 never takes this branch: its Agent adapter
+            # always supplies a configured (currently fail-closed) port.
+            decision = DerivedLaunchDecision(
+                ProviderAdmissionState.GRANTED, "legacy_default"
+            )
+        if decision.reason_code != "legacy_default":
+            self._append_ledger(
+                "avatar_admission_decision",
+                peer_name,
+                capability=DerivedLaunchCapability.AVATAR.value,
+                state=decision.state.value,
+                reason_code=decision.reason_code,
+                audit_id=decision.audit_id,
+            )
 
     # ------------------------------------------------------------------
     # Ledger reading

--- a/src/lingtai/tools/daemon/__init__.py
+++ b/src/lingtai/tools/daemon/__init__.py
@@ -5555,7 +5555,13 @@ class DaemonManager:
                 )
             except Exception as e:
                 run_dir.mark_failed(e)
-                return {"status": "error", "message": str(e)}
+                result = {"status": "error", "message": str(e)}
+                from lingtai.kernel.provider_admission import DerivedLaunchAdmissionError
+
+                if isinstance(e, DerivedLaunchAdmissionError):
+                    result["reason_code"] = e.decision.reason_code
+                    result["audit_id"] = e.decision.audit_id
+                return result
             self._emanations[em_id] = {
                 "detached": True,
                 "task": spec["task"],
@@ -9539,6 +9545,8 @@ class DaemonManager:
             reason_code=decision.reason_code,
             audit_id=decision.audit_id,
         )
+        if not decision.allowed:
+            raise DerivedLaunchAdmissionError(decision)
 
 
 # Pair of the ``DEFAULT_MAX_TURNS`` assertion above: ``_tool_family``'s

--- a/src/lingtai/tools/daemon/__init__.py
+++ b/src/lingtai/tools/daemon/__init__.py
@@ -3479,14 +3479,14 @@ class DaemonManager:
         secret_capsule: dict | None = None,
         use_central_manager: bool = False,
     ) -> None:
-        """Write the run manifest and spawn the detached supervisor for it.
+        """Write the run manifest and spawn an already-authorized detached run.
 
-        Raises on any failure (unwritable manifest, spawn error, or a startup
-        handshake timeout) so the caller can mark the run failed and refuse
-        the batch entry cleanly — never claims a detached run started when it
-        did not.
+        The caller must authorize the derived launch before committing it to
+        the canonical dispatch ledger. Raises on any post-admission failure
+        (unwritable manifest, spawn error, or a startup handshake timeout) so
+        the caller can mark the run failed cleanly — never claims a detached
+        run started when it did not.
         """
-        self._authorize_derived_launch("daemon")
         from lingtai.kernel.daemon_supervisor import DaemonSupervisorRequest
         from lingtai.kernel.daemon_supervisor.manifest import build_manifest, write_manifest
 
@@ -5536,6 +5536,7 @@ class DaemonManager:
 
             self._close_task_mcp_clients(task_mcp_clients)  # none connected in this branch
             try:
+                self._authorize_derived_launch("daemon")
                 self._commit_dispatch(run_dir)
                 self._spawn_detached_lingtai_run(
                     run_dir,

--- a/src/lingtai/tools/daemon/__init__.py
+++ b/src/lingtai/tools/daemon/__init__.py
@@ -9532,14 +9532,13 @@ class DaemonManager:
                 audit_id=decision.audit_id,
             )
             raise
-        if decision.reason_code != "legacy_default":
-            self._log(
-                "derived_launch_admission_decision",
-                capability=capability.value,
-                state=decision.state.value,
-                reason_code=decision.reason_code,
-                audit_id=decision.audit_id,
-            )
+        self._log(
+            "derived_launch_admission_decision",
+            capability=capability.value,
+            state=decision.state.value,
+            reason_code=decision.reason_code,
+            audit_id=decision.audit_id,
+        )
 
 
 # Pair of the ``DEFAULT_MAX_TURNS`` assertion above: ``_tool_family``'s

--- a/src/lingtai/tools/daemon/__init__.py
+++ b/src/lingtai/tools/daemon/__init__.py
@@ -3486,6 +3486,7 @@ class DaemonManager:
         the batch entry cleanly — never claims a detached run started when it
         did not.
         """
+        self._authorize_derived_launch("daemon")
         from lingtai.kernel.daemon_supervisor import DaemonSupervisorRequest
         from lingtai.kernel.daemon_supervisor.manifest import build_manifest, write_manifest
 
@@ -5857,6 +5858,7 @@ class DaemonManager:
             # boundary.  The parent writes a complete, redacted manifest and
             # retains only the durable run-dir facade.
             try:
+                self._authorize_derived_launch("daemon")
                 self._commit_dispatch(run_dir)
                 from lingtai.kernel.daemon_supervisor import DaemonSupervisorRequest
                 from lingtai.kernel.daemon_supervisor.manifest import build_manifest, manifest_path_for, write_manifest
@@ -9509,6 +9511,35 @@ class DaemonManager:
     def _log(self, event_type: str, **fields) -> None:
         """Log through Daemon's narrow parent-runtime port."""
         self._runtime.log(event_type, **fields)
+
+    def _authorize_derived_launch(self, capability_name: str) -> None:
+        """Reach the host decision seam before a daemon launch side effect."""
+        from lingtai.kernel.provider_admission import (
+            DerivedLaunchAdmissionError,
+            DerivedLaunchCapability,
+        )
+
+        capability = DerivedLaunchCapability(capability_name)
+        try:
+            decision = self._runtime.authorize_derived_launch(capability)
+        except DerivedLaunchAdmissionError as exc:
+            decision = exc.decision
+            self._log(
+                "derived_launch_admission_decision",
+                capability=capability.value,
+                state=decision.state.value,
+                reason_code=decision.reason_code,
+                audit_id=decision.audit_id,
+            )
+            raise
+        if decision.reason_code != "legacy_default":
+            self._log(
+                "derived_launch_admission_decision",
+                capability=capability.value,
+                state=decision.state.value,
+                reason_code=decision.reason_code,
+                audit_id=decision.audit_id,
+            )
 
 
 # Pair of the ``DEFAULT_MAX_TURNS`` assertion above: ``_tool_family``'s

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -12,6 +12,14 @@ from unittest.mock import MagicMock
 import pytest
 
 from lingtai.kernel.config import AgentConfig
+from lingtai.kernel.provider_admission import (
+    DerivedLaunchCapability,
+    DerivedLaunchDecision,
+    ProviderAdmissionState,
+    RootProviderAdmission,
+    bind_provider_admission,
+    clear_provider_admission,
+)
 from lingtai.kernel.llm.base import ChatSession, FunctionSchema, LLMResponse, ToolCall, UsageMetadata
 from lingtai.kernel.llm.interface import ChatInterface, TextBlock, ToolCallBlock, ToolResultBlock
 from lingtai.kernel.tool_call_guard import GuardDecision, ToolCallGuard
@@ -1343,6 +1351,129 @@ def test_handle_emanate_maps_prompt_default_and_preserves_whitespace_before_deta
     assert "system task one" in prompts[0]
     assert "  first user  " not in prompts[0]
     assert "system task two" in prompts[1]
+
+
+def test_profile_daemon_launch_reaches_structured_admission_before_supervisor(
+    tmp_path, monkeypatch
+):
+    """The real emanate path reaches the 2a seam before process I/O."""
+    from lingtai.adapters.posix.daemon_supervisor import PosixDaemonSupervisorAdapter
+    from lingtai.adapters.acp.puffo_v0 import RUNTIME_POLICY
+
+    class _DenyingPort:
+        def __init__(self):
+            self.calls = []
+
+        def authorize_derived_launch(self, parent, capability):
+            self.calls.append((parent, capability))
+            return DerivedLaunchDecision(
+                ProviderAdmissionState.DENIED,
+                "derived_launch_denied_by_test",
+                audit_id="audit-daemon-2a",
+            )
+
+    agent = _make_agent(tmp_path, ["daemon"])
+    _enable_detached_fake_llm(agent, monkeypatch)
+    port = _DenyingPort()
+    agent._derived_launch_admission_port = port
+    supervisor_calls = []
+    audit = []
+    monkeypatch.setattr(
+        PosixDaemonSupervisorAdapter,
+        "spawn_detached",
+        lambda *_args, **_kwargs: supervisor_calls.append("spawn"),
+    )
+    monkeypatch.setattr(agent, "_log", lambda event, **fields: audit.append((event, fields)))
+
+    root = RootProviderAdmission("root-daemon-2a", RUNTIME_POLICY.policy_version)
+    token = bind_provider_admission(root)
+    try:
+        result = agent.get_capability("daemon").handle(
+            {"action": "emanate", "tasks": [{"task": "test", "tools": []}]}
+        )
+    finally:
+        clear_provider_admission(token)
+
+    assert result["status"] == "error"
+    assert "derived_launch_denied_by_test" in result["message"]
+    assert port.calls == [(root, DerivedLaunchCapability.DAEMON)]
+    assert supervisor_calls == []
+    decisions = [row for row in audit if row[0] == "derived_launch_admission_decision"]
+    assert decisions == [
+        (
+            "derived_launch_admission_decision",
+            {
+                "capability": "daemon",
+                "state": "denied",
+                "reason_code": "derived_launch_denied_by_test",
+                "audit_id": "audit-daemon-2a",
+            },
+        )
+    ]
+
+
+def test_profile_external_cli_daemon_launch_reaches_admission_before_supervisor(
+    tmp_path, monkeypatch
+):
+    """The shared external-CLI supervisor path cannot bypass the 2a seam."""
+    from lingtai.adapters.posix.daemon_supervisor import PosixDaemonSupervisorAdapter
+    from lingtai.adapters.acp.puffo_v0 import RUNTIME_POLICY
+
+    class _DenyingPort:
+        def __init__(self):
+            self.calls = []
+
+        def authorize_derived_launch(self, parent, capability):
+            self.calls.append((parent, capability))
+            return DerivedLaunchDecision(
+                ProviderAdmissionState.DENIED,
+                "derived_launch_denied_by_test",
+                audit_id="audit-external-cli-2a",
+            )
+
+    agent = _make_agent(tmp_path, ["daemon"])
+    port = _DenyingPort()
+    agent._derived_launch_admission_port = port
+    supervisor_calls = []
+    audit = []
+    monkeypatch.setattr(
+        PosixDaemonSupervisorAdapter,
+        "spawn_detached",
+        lambda *_args, **_kwargs: supervisor_calls.append("spawn"),
+    )
+    monkeypatch.setattr(agent, "_log", lambda event, **fields: audit.append((event, fields)))
+
+    root = RootProviderAdmission("root-external-cli-2a", RUNTIME_POLICY.policy_version)
+    token = bind_provider_admission(root)
+    try:
+        result = agent.get_capability("daemon").handle(
+            {
+                "action": "emanate",
+                "backend": "codex",
+                "tasks": [{"task": "test", "tools": []}],
+            }
+        )
+    finally:
+        clear_provider_admission(token)
+
+    assert result == {
+        "status": "error",
+        "message": "derived launch was not admitted: derived_launch_denied_by_test",
+    }
+    assert port.calls == [(root, DerivedLaunchCapability.DAEMON)]
+    assert supervisor_calls == []
+    decisions = [row for row in audit if row[0] == "derived_launch_admission_decision"]
+    assert decisions == [
+        (
+            "derived_launch_admission_decision",
+            {
+                "capability": "daemon",
+                "state": "denied",
+                "reason_code": "derived_launch_denied_by_test",
+                "audit_id": "audit-external-cli-2a",
+            },
+        )
+    ]
 
 
 def test_task_skills_render_compact_catalog_from_dir_and_file(tmp_path):

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -20,6 +20,7 @@ from lingtai.kernel.provider_admission import (
     bind_provider_admission,
     clear_provider_admission,
 )
+from lingtai.kernel import daemon_dispatch
 from lingtai.kernel.llm.base import ChatSession, FunctionSchema, LLMResponse, ToolCall, UsageMetadata
 from lingtai.kernel.llm.interface import ChatInterface, TextBlock, ToolCallBlock, ToolResultBlock
 from lingtai.kernel.tool_call_guard import GuardDecision, ToolCallGuard
@@ -1400,6 +1401,16 @@ def test_profile_daemon_launch_reaches_structured_admission_before_supervisor(
     assert result["audit_id"] == "audit-daemon-2a"
     assert port.calls == [(root, DerivedLaunchCapability.DAEMON)]
     assert supervisor_calls == []
+    assert daemon_dispatch.read_dispatches(
+        agent._working_dir, full_history=True
+    ).records == ()
+    assert daemon_dispatch.recovery_markers(agent._working_dir) == []
+    run_dirs = [
+        path for path in (agent._working_dir / "daemons").iterdir()
+        if path.is_dir() and path.name.startswith("em-")
+    ]
+    assert len(run_dirs) == 1
+    assert DaemonRunDir.read_state_from_disk(run_dirs[0]).get("dispatch_sequence") is None
     decisions = [row for row in audit if row[0] == "derived_launch_admission_decision"]
     assert decisions == [
         (

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1396,6 +1396,8 @@ def test_profile_daemon_launch_reaches_structured_admission_before_supervisor(
 
     assert result["status"] == "error"
     assert "derived_launch_denied_by_test" in result["message"]
+    assert result["reason_code"] == "derived_launch_denied_by_test"
+    assert result["audit_id"] == "audit-daemon-2a"
     assert port.calls == [(root, DerivedLaunchCapability.DAEMON)]
     assert supervisor_calls == []
     decisions = [row for row in audit if row[0] == "derived_launch_admission_decision"]

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1412,6 +1412,55 @@ def test_profile_daemon_launch_reaches_structured_admission_before_supervisor(
     ]
 
 
+def test_profile_daemon_grant_reaches_the_same_recording_supervisor(tmp_path, monkeypatch):
+    """The zero-supervisor assertion has a same-recorder positive control."""
+    from lingtai.adapters.acp.puffo_v0 import RUNTIME_POLICY
+    from tests._daemon_helpers import install_fake_detached_owner
+
+    class _GrantingPort:
+        def __init__(self):
+            self.calls = []
+
+        def authorize_derived_launch(self, parent, capability):
+            self.calls.append((parent, capability))
+            return DerivedLaunchDecision(
+                ProviderAdmissionState.GRANTED,
+                "derived_launch_allowed_by_test",
+                audit_id="audit-daemon-positive-2a",
+            )
+
+    agent = _make_agent(tmp_path, {"daemon": {"manager_pool_size": 0}})
+    _enable_detached_fake_llm(agent, monkeypatch)
+    port = _GrantingPort()
+    agent._derived_launch_admission_port = port
+    audit = []
+    records = install_fake_detached_owner(monkeypatch)
+    monkeypatch.setattr(agent, "_log", lambda event, **fields: audit.append((event, fields)))
+
+    root = RootProviderAdmission("root-daemon-positive-2a", RUNTIME_POLICY.policy_version)
+    token = bind_provider_admission(root)
+    try:
+        result = agent.get_capability("daemon").handle(
+            {"action": "emanate", "tasks": [{"task": "test", "tools": []}]}
+        )
+    finally:
+        clear_provider_admission(token)
+
+    assert result["status"] == "dispatched"
+    assert port.calls == [(root, DerivedLaunchCapability.DAEMON)]
+    assert len(records) == 1
+    assert records[0]["manifest"]["backend"] == "lingtai"
+    assert (
+        "derived_launch_admission_decision",
+        {
+            "capability": "daemon",
+            "state": "granted",
+            "reason_code": "derived_launch_allowed_by_test",
+            "audit_id": "audit-daemon-positive-2a",
+        },
+    ) in audit
+
+
 def test_profile_external_cli_daemon_launch_reaches_admission_before_supervisor(
     tmp_path, monkeypatch
 ):

--- a/tests/test_layers_avatar.py
+++ b/tests/test_layers_avatar.py
@@ -165,11 +165,14 @@ class TestAvatarManager:
         """Ledger should record the spawn event with name + boot_status."""
         from lingtai.agent import Agent
         parent = Agent(service=make_mock_service(), agent_name="parent", working_dir=tmp_path / "test",
-                            capabilities=["avatar"])
+                        capabilities=["avatar"])
         mgr = parent.get_capability("avatar")
         mgr.handle({"action": "spawn", "input": {"name": "clone", "confirm": True}})
         ledger = (parent._working_dir / "delegates" / "ledger.jsonl").read_text().strip()
-        record = json.loads(ledger)
+        records = [json.loads(line) for line in ledger.splitlines()]
+        assert records[0]["event"] == "avatar_admission_decision"
+        assert records[0]["reason_code"] == "legacy_default"
+        record = records[-1]
         assert record["name"] == "clone"
         assert record["boot_status"] == "ok"
 
@@ -179,6 +182,7 @@ class TestAvatarManager:
         """The real AvatarManager/Agent adapter path reaches the 2a seam."""
         from lingtai.adapters.acp.puffo_v0 import RUNTIME_POLICY
         from lingtai.kernel.provider_admission import (
+            DerivedLaunchCapability,
             DerivedLaunchDecision,
             ProviderAdmissionState,
             RootProviderAdmission,
@@ -218,7 +222,7 @@ class TestAvatarManager:
             clear_provider_admission(token)
 
         assert "derived_launch_denied_by_test" in result["error"]
-        assert port.calls == [(root, "avatar")]
+        assert port.calls == [(root, DerivedLaunchCapability.AVATAR)]
         assert not (parent._working_dir.parent / "child").exists()
         records = [
             json.loads(line)
@@ -237,6 +241,76 @@ class TestAvatarManager:
                 "audit_id": "audit-avatar-2a",
             }
         ]
+
+    def test_profile_avatar_grant_reaches_the_same_launch_recorder(
+        self, tmp_path, monkeypatch
+    ):
+        """The zero-avatar-spawn assertion has a same-recorder positive control."""
+        from lingtai.adapters.acp.puffo_v0 import RUNTIME_POLICY
+        from lingtai.kernel.provider_admission import (
+            DerivedLaunchCapability,
+            DerivedLaunchDecision,
+            ProviderAdmissionState,
+            RootProviderAdmission,
+            bind_provider_admission,
+            clear_provider_admission,
+        )
+        from lingtai.agent import Agent
+
+        class _GrantingPort:
+            def __init__(self):
+                self.calls = []
+
+            def authorize_derived_launch(self, parent, capability):
+                self.calls.append((parent, capability))
+                return DerivedLaunchDecision(
+                    ProviderAdmissionState.GRANTED,
+                    "derived_launch_allowed_by_test",
+                    audit_id="audit-avatar-positive-2a",
+                )
+
+        launch_calls = []
+        proc = MagicMock(pid=12345)
+        proc.poll.return_value = None
+        receipt = AvatarLaunchReceipt(pid=12345, handle=proc)
+        monkeypatch.setattr(
+            AvatarManager,
+            "_launch",
+            lambda _self, working_dir: (
+                launch_calls.append(working_dir)
+                or (receipt, Path("/tmp/avatar-positive-2a.stderr"))
+            ),
+        )
+        parent = Agent(
+            service=make_mock_service(),
+            agent_name="parent",
+            working_dir=tmp_path / "parent",
+            capabilities=["avatar"],
+            _turn_origin_policy=RUNTIME_POLICY,
+            derived_launch_admission_port=_GrantingPort(),
+        )
+        port = parent._derived_launch_admission_port
+        root = RootProviderAdmission("root-avatar-positive-2a", RUNTIME_POLICY.policy_version)
+        token = bind_provider_admission(root)
+        try:
+            result = parent.get_capability("avatar").handle(
+                {"action": "spawn", "input": {"name": "child", "confirm": True}}
+            )
+        finally:
+            clear_provider_admission(token)
+
+        assert result["status"] == "ok"
+        assert port.calls == [(root, DerivedLaunchCapability.AVATAR)]
+        assert launch_calls == [parent._working_dir.parent / "child"]
+        records = [
+            json.loads(line)
+            for line in (parent._working_dir / "delegates" / "ledger.jsonl")
+            .read_text(encoding="utf-8")
+            .splitlines()
+        ]
+        assert records[0]["event"] == "avatar_admission_decision"
+        assert records[0]["state"] == "granted"
+        assert records[0]["audit_id"] == "audit-avatar-positive-2a"
 
 
 class TestMissionQualityGate:

--- a/tests/test_layers_avatar.py
+++ b/tests/test_layers_avatar.py
@@ -173,6 +173,71 @@ class TestAvatarManager:
         assert record["name"] == "clone"
         assert record["boot_status"] == "ok"
 
+    def test_profile_avatar_launch_reaches_structured_admission_before_spawn(
+        self, tmp_path, monkeypatch
+    ):
+        """The real AvatarManager/Agent adapter path reaches the 2a seam."""
+        from lingtai.adapters.acp.puffo_v0 import RUNTIME_POLICY
+        from lingtai.kernel.provider_admission import (
+            DerivedLaunchDecision,
+            ProviderAdmissionState,
+            RootProviderAdmission,
+            bind_provider_admission,
+            clear_provider_admission,
+        )
+        from lingtai.agent import Agent
+
+        class _DenyingPort:
+            def __init__(self):
+                self.calls = []
+
+            def authorize_derived_launch(self, parent, capability):
+                self.calls.append((parent, capability))
+                return DerivedLaunchDecision(
+                    ProviderAdmissionState.DENIED,
+                    "derived_launch_denied_by_test",
+                    audit_id="audit-avatar-2a",
+                )
+
+        parent = Agent(
+            service=make_mock_service(),
+            agent_name="parent",
+            working_dir=tmp_path / "parent",
+            capabilities=["avatar"],
+            _turn_origin_policy=RUNTIME_POLICY,
+            derived_launch_admission_port=_DenyingPort(),
+        )
+        port = parent._derived_launch_admission_port
+        root = RootProviderAdmission("root-avatar-2a", RUNTIME_POLICY.policy_version)
+        token = bind_provider_admission(root)
+        try:
+            result = parent.get_capability("avatar").handle(
+                {"action": "spawn", "input": {"name": "child", "confirm": True}}
+            )
+        finally:
+            clear_provider_admission(token)
+
+        assert "derived_launch_denied_by_test" in result["error"]
+        assert port.calls == [(root, "avatar")]
+        assert not (parent._working_dir.parent / "child").exists()
+        records = [
+            json.loads(line)
+            for line in (parent._working_dir / "delegates" / "ledger.jsonl")
+            .read_text(encoding="utf-8")
+            .splitlines()
+        ]
+        assert records == [
+            {
+                "ts": records[0]["ts"],
+                "event": "avatar_admission_decision",
+                "name": "child",
+                "capability": "avatar",
+                "state": "denied",
+                "reason_code": "derived_launch_denied_by_test",
+                "audit_id": "audit-avatar-2a",
+            }
+        ]
+
 
 class TestMissionQualityGate:
     """Issue #33 — mission/dry_run/confirm guardrails on avatar_spawn."""

--- a/tests/test_provider_admission.py
+++ b/tests/test_provider_admission.py
@@ -10,6 +10,9 @@ import pytest
 
 from lingtai.adapters.acp.puffo_v0 import RUNTIME_POLICY
 from lingtai.kernel.provider_admission import (
+    DerivedLaunchAdmissionError,
+    DerivedLaunchCapability,
+    DerivedLaunchDecision,
     ProviderAdmittedLLMService,
     ProviderAdmissionError,
     ProviderAdmissionState,
@@ -19,6 +22,7 @@ from lingtai.kernel.provider_admission import (
     begin_derived_provider_admission,
     bind_provider_admission,
     clear_provider_admission,
+    require_derived_launch_admission,
 )
 from lingtai.kernel.llm_utils import send_with_timeout, send_with_timeout_stream
 from lingtai.llm.api_gate import APICallGate
@@ -82,6 +86,24 @@ class _MalformedAdmissionPort:
 class _RaisingAdmissionPort:
     def authorize_provider_call(self, _parent, _call_class):
         raise RuntimeError("authority unavailable")
+
+
+class _RecordingDerivedLaunchPort:
+    def __init__(self, *, state=ProviderAdmissionState.GRANTED):
+        self.state = state
+        self.calls = []
+
+    def authorize_derived_launch(self, parent, capability):
+        self.calls.append((parent, capability))
+        return DerivedLaunchDecision(
+            state=self.state,
+            reason_code=(
+                "derived_launch_allowed"
+                if self.state is ProviderAdmissionState.GRANTED
+                else "derived_launch_denied_by_test"
+            ),
+            audit_id="audit-derived-test",
+        )
 
 
 def test_raw_provider_service_construction_inventory_is_explicit():
@@ -361,8 +383,8 @@ def test_provider_dispatch_concurrency_inventory_is_explicit():
         ("src/lingtai/tools/bash/__init__.py", 1467, "Thread"),
         ("src/lingtai/tools/bash/__init__.py", 1714, "Thread"),
         ("src/lingtai/tools/daemon/__init__.py", 1764, "ThreadPoolExecutor"),
-        ("src/lingtai/tools/daemon/__init__.py", 6507, "Thread"),
-        ("src/lingtai/tools/daemon/__init__.py", 9111, "ThreadPoolExecutor"),
+        ("src/lingtai/tools/daemon/__init__.py", 6509, "Thread"),
+        ("src/lingtai/tools/daemon/__init__.py", 9113, "ThreadPoolExecutor"),
         ("src/lingtai/tools/daemon/claude_interactive.py", 611, "Thread"),
         ("src/lingtai/tools/daemon/execution_host.py", 610, "ThreadPoolExecutor"),
         ("src/lingtai/tools/daemon/posix_process.py", 112, "Thread"),
@@ -648,6 +670,60 @@ def test_v0_derived_admission_rejects_nested_derived_execution():
 
     with pytest.raises(TypeError, match="derived admission requires a root admission"):
         begin_derived_provider_admission(child, ProviderCallClass.AVATAR_CHILD)  # type: ignore[arg-type]
+
+
+def test_derived_launch_requires_root_admission_and_never_accepts_a_child_parent():
+    """A one-hop child cannot self-authorize another daemon/avatar launch."""
+
+    root = RootProviderAdmission("turn-a", RUNTIME_POLICY.policy_version)
+    child = begin_derived_provider_admission(root, ProviderCallClass.DAEMON)
+    port = _RecordingDerivedLaunchPort()
+    token = bind_provider_admission(child)
+    try:
+        with pytest.raises(
+            DerivedLaunchAdmissionError, match="nested_derived_launch_denied"
+        ) as raised:
+            require_derived_launch_admission(port, DerivedLaunchCapability.AVATAR)
+    finally:
+        clear_provider_admission(token)
+
+    assert raised.value.decision.state is ProviderAdmissionState.DENIED
+    assert port.calls == []
+
+
+def test_derived_launch_port_is_fail_closed_when_unconnected_or_indeterminate():
+    """A constrained profile cannot mistake an unavailable Driver for a grant."""
+
+    root = RootProviderAdmission("turn-a", RUNTIME_POLICY.policy_version)
+    token = bind_provider_admission(root)
+    try:
+        with pytest.raises(
+            DerivedLaunchAdmissionError,
+            match="derived_launch_admission_port_unconnected",
+        ) as raised:
+            require_derived_launch_admission(
+                RUNTIME_POLICY, DerivedLaunchCapability.DAEMON
+            )
+    finally:
+        clear_provider_admission(token)
+
+    assert raised.value.decision.state is ProviderAdmissionState.INDETERMINATE
+
+
+def test_derived_launch_port_returns_auditable_grant_for_an_admitted_root():
+    root = RootProviderAdmission("turn-a", RUNTIME_POLICY.policy_version)
+    port = _RecordingDerivedLaunchPort()
+    token = bind_provider_admission(root)
+    try:
+        decision = require_derived_launch_admission(
+            port, DerivedLaunchCapability.DAEMON
+        )
+    finally:
+        clear_provider_admission(token)
+
+    assert decision.allowed is True
+    assert decision.audit_id == "audit-derived-test"
+    assert port.calls == [(root, DerivedLaunchCapability.DAEMON)]
 
 
 def test_denied_provider_admission_never_reaches_the_inner_service():

--- a/tests/test_provider_admission.py
+++ b/tests/test_provider_admission.py
@@ -710,6 +710,25 @@ def test_derived_launch_port_is_fail_closed_when_unconnected_or_indeterminate():
     assert raised.value.decision.state is ProviderAdmissionState.INDETERMINATE
 
 
+def test_required_derived_launch_port_cannot_fall_back_to_legacy_default():
+    """A constrained composition must expose a missing Driver seam."""
+
+    root = RootProviderAdmission("turn-a", RUNTIME_POLICY.policy_version)
+    token = bind_provider_admission(root)
+    try:
+        with pytest.raises(
+            DerivedLaunchAdmissionError,
+            match="required_derived_launch_admission_port_missing",
+        ) as raised:
+            require_derived_launch_admission(
+                None, DerivedLaunchCapability.DAEMON, required=True
+            )
+    finally:
+        clear_provider_admission(token)
+
+    assert raised.value.decision.state is ProviderAdmissionState.INDETERMINATE
+
+
 def test_derived_launch_port_returns_auditable_grant_for_an_admitted_root():
     root = RootProviderAdmission("turn-a", RUNTIME_POLICY.policy_version)
     port = _RecordingDerivedLaunchPort()

--- a/tests/test_puffo_v0_profile.py
+++ b/tests/test_puffo_v0_profile.py
@@ -425,6 +425,7 @@ def test_profile_cli_resolves_an_opaque_id_before_composing_acp(monkeypatch, tmp
     assert observed["turn_origin_policy"] is RUNTIME_POLICY
     assert observed["requires_turn_origin_policy"] is True
     assert observed["provider_call_admission_port"] is RUNTIME_POLICY
+    assert observed["derived_launch_admission_port"] is RUNTIME_POLICY
     assert observed["puffo_runtime"] == runtime
 
 

--- a/tests/test_puffo_v0_profile.py
+++ b/tests/test_puffo_v0_profile.py
@@ -426,7 +426,22 @@ def test_profile_cli_resolves_an_opaque_id_before_composing_acp(monkeypatch, tmp
     assert observed["requires_turn_origin_policy"] is True
     assert observed["provider_call_admission_port"] is RUNTIME_POLICY
     assert observed["derived_launch_admission_port"] is RUNTIME_POLICY
+    assert observed["requires_derived_launch_admission_port"] is True
     assert observed["puffo_runtime"] == runtime
+
+
+def test_constrained_acp_refuses_to_start_without_its_derived_launch_port(tmp_path):
+    import lingtai.cli_acp as cli_acp
+
+    with pytest.raises(
+        ValueError, match="constrained ACP composition requires a derived-launch admission port"
+    ):
+        cli_acp.run_acp(
+            tmp_path,
+            input_stream=io.StringIO(),
+            output_stream=io.StringIO(),
+            requires_derived_launch_admission_port=True,
+        )
 
 
 def test_profile_cli_rejects_agent_dir_instead_of_ignoring_it(capsys):


### PR DESCRIPTION
Split from #1545. Adds the capability-facing derived-launch admission seam and enforces it at the ACP, CLI, plugin-host, daemon, and avatar call sites.

Boundary: depends on #1555; excludes process bootstrap, Driver adapter composition, and audit/E2E evidence.

Validation: `git diff --check codex/phase-b-01-core-admission-policy...HEAD` passes. Focused tests are run and reported separately; known source-inventory baseline drift is unchanged.

Base: #1555 (`2b927c89c0661b0befcc75d49b26107c444ee549`).