### PR TITLE
Phase B/4: isolated Driver authority protocol client foundation

### DIFF
--- a/src/lingtai/adapters/acp/ANATOMY.md
+++ b/src/lingtai/adapters/acp/ANATOMY.md
@@ -149,3 +149,8 @@ scope.
 `puffo-v0` is a second gate on its controlled entrypoint, not host isolation:
 the same OS identity can still alter the registry or bypass it by launching the
 generic `--agent-dir` ACP command. That is an explicit host trust boundary.
+
+`driver_authority.py` is process-local protocol state: one authenticated
+AF_UNIX stream, a bounded receive buffer, one request lock, endpoint identity,
+and any one-use lease not yet consumed by a future launch consumer. It contains
+no daemon queue, supervisor, profile, or persistent state.

--- a/src/lingtai/adapters/acp/CONTRACT.md
+++ b/src/lingtai/adapters/acp/CONTRACT.md
@@ -312,3 +312,13 @@ Follow the frontmatter maintenance block and the
 specification before changing any method or wire shape; record deliberate scope
 limits rather than advertising omitted capabilities. Do not introduce an ACP SDK
 or optional-dependencies section for this standard-library slice.
+
+## Driver authority client
+
+`driver_authority.py` is an isolated AF_UNIX client for the Puffo Driver
+admission protocol. Every hello and decision request carries a fresh `call_id`;
+a missing or mismatched response id closes the transport and fails closed.
+Granted derived-launch endpoints are opaque, one-use leases and remain within
+this adapter layer. This module does **not** compose ACP profiles or launch
+daemons, avatars, supervisors, or managers; those consumers belong to separate
+layers.

--- a/src/lingtai/adapters/acp/MANUAL.md
+++ b/src/lingtai/adapters/acp/MANUAL.md
@@ -318,3 +318,13 @@ objects. This keeps wire/session policy outside Core and makes cancellation and
 terminal settlement reusable by later driving adapters. Broader ACP capabilities
 should be added as separately accepted vertical slices, not guessed inside this
 one.
+
+## Driver authority protocol client
+
+This repository's client accepts an already-open AF_UNIX descriptor from a
+future composition layer. It has no environment/profile wiring in this slice.
+The peer must reply to hello and every request with the exact request `call_id`.
+Any timeout, malformed frame, unexpected descriptor, or correlation mismatch
+invalidates the stream; recreate the client rather than retrying it. A derived
+grant's endpoint is a one-use opaque lease, not an identifier that may be
+serialized or reopened.

--- a/src/lingtai/adapters/acp/driver_authority.py
+++ b/src/lingtai/adapters/acp/driver_authority.py
@@ -62,11 +62,12 @@ class DriverChildEndpointLease:
     def consume_for_posix_spawn(self) -> int:
         if self._consumed:
             raise DriverAuthorityTransportError("child endpoint lease already consumed")
-        self._consumed = True
         try:
-            return self._socket.detach()
+            endpoint_fd = self._socket.detach()
         except OSError as exc:
             raise DriverAuthorityTransportError("child endpoint lease unavailable") from exc
+        self._consumed = True
+        return endpoint_fd
 
     def close(self) -> None:
         if self._consumed:

--- a/src/lingtai/adapters/acp/driver_authority.py
+++ b/src/lingtai/adapters/acp/driver_authority.py
@@ -186,6 +186,10 @@ class DriverAuthorityClient(ProviderCallAdmissionPort):
                         except OSError:
                             pass
                         received_fd = None
+                        # A non-grant still retains its policy evidence, but
+                        # an endpoint on that frame violates framing. Retire
+                        # the authority stream before any later request.
+                        self._close_locked()
                     return DriverDerivedLaunchGrant(state, reason, audit_id)
                 if received_fd is None:
                     raise DriverAuthorityTransportError("granted launch omitted child endpoint")
@@ -275,7 +279,7 @@ class DriverAuthorityClient(ProviderCallAdmissionPort):
 
     @staticmethod
     def _parse_identity(response: dict[str, Any]) -> DriverAuthorityIdentity:
-        if response.get("version") != _PROTOCOL_VERSION:
+        if not DriverAuthorityClient._has_protocol_version(response):
             raise DriverAuthorityTransportError("authority protocol version mismatch")
         role, launch_id, capability = response.get("role"), response.get("launch_id"), response.get("capability")
         if role not in {"root", "derived"} or not isinstance(launch_id, str) or not launch_id:
@@ -288,7 +292,7 @@ class DriverAuthorityClient(ProviderCallAdmissionPort):
 
     @staticmethod
     def _decision(response: dict[str, Any]) -> tuple[ProviderAdmissionState, str, str | None]:
-        if response.get("version") != _PROTOCOL_VERSION:
+        if not DriverAuthorityClient._has_protocol_version(response):
             raise DriverAuthorityTransportError("authority protocol version mismatch")
         try: state = ProviderAdmissionState(response.get("state"))
         except (TypeError, ValueError) as exc: raise DriverAuthorityTransportError("authority decision state is invalid") from exc
@@ -296,6 +300,11 @@ class DriverAuthorityClient(ProviderCallAdmissionPort):
         if not isinstance(reason, str) or not reason or (audit_id is not None and (not isinstance(audit_id, str) or not audit_id)):
             raise DriverAuthorityTransportError("authority decision fields are invalid")
         return state, reason, audit_id
+
+    @staticmethod
+    def _has_protocol_version(response: dict[str, Any]) -> bool:
+        version = response.get("version")
+        return isinstance(version, int) and not isinstance(version, bool) and version == _PROTOCOL_VERSION
 
     @staticmethod
     def _checked_endpoint(fd: int) -> socket.socket:
@@ -316,4 +325,8 @@ class DriverAuthorityClient(ProviderCallAdmissionPort):
     def _valid_provider_parent(self, parent: ProviderAdmissionParent, call_class: ProviderCallClass) -> bool:
         if not isinstance(call_class, ProviderCallClass): return False
         if self._identity.role == "root": return isinstance(parent, RootProviderAdmission) and call_class is ProviderCallClass.ROOT
-        return isinstance(parent, DerivedProviderAdmission) and parent.call_class is call_class
+        if not isinstance(parent, DerivedProviderAdmission) or parent.call_class is not call_class:
+            return False
+        endpoint_capability = DerivedLaunchCapability(self._identity.capability)
+        endpoint_call_class = ProviderCallClass.DAEMON if endpoint_capability is DerivedLaunchCapability.DAEMON else ProviderCallClass.AVATAR_CHILD
+        return call_class is endpoint_call_class

--- a/src/lingtai/adapters/acp/driver_authority.py
+++ b/src/lingtai/adapters/acp/driver_authority.py
@@ -168,6 +168,7 @@ class DriverAuthorityClient(ProviderCallAdmissionPort):
         if not isinstance(capability, DerivedLaunchCapability):
             return DriverDerivedLaunchGrant(ProviderAdmissionState.INDETERMINATE, "driver_authority_unavailable")
         with self._lock:
+            received_fd: int | None = None
             try:
                 response, received_fd = self._exchange({
                     "op": "authorize_derived_launch", "call_id": self._call_id(),
@@ -184,11 +185,22 @@ class DriverAuthorityClient(ProviderCallAdmissionPort):
                             os.close(received_fd)
                         except OSError:
                             pass
+                        received_fd = None
                     return DriverDerivedLaunchGrant(state, reason, audit_id)
                 if received_fd is None:
                     raise DriverAuthorityTransportError("granted launch omitted child endpoint")
-                return DriverDerivedLaunchGrant(state, reason, audit_id, DriverChildEndpointLease(self._checked_endpoint(received_fd)))
+                # _checked_endpoint takes ownership of the descriptor, whether
+                # validation succeeds or fails. Clear this cleanup handle first
+                # so an error cannot close a recycled descriptor a second time.
+                endpoint_fd, received_fd = received_fd, None
+                endpoint = self._checked_endpoint(endpoint_fd)
+                return DriverDerivedLaunchGrant(state, reason, audit_id, DriverChildEndpointLease(endpoint))
             except DriverAuthorityTransportError:
+                if received_fd is not None:
+                    try:
+                        os.close(received_fd)
+                    except OSError:
+                        pass
                 self._close_locked()
                 return DriverDerivedLaunchGrant(ProviderAdmissionState.INDETERMINATE, "driver_authority_unavailable")
 

--- a/src/lingtai/adapters/acp/driver_authority.py
+++ b/src/lingtai/adapters/acp/driver_authority.py
@@ -1,0 +1,298 @@
+"""Narrow POSIX client for Puffo Driver admission authority.
+
+This module deliberately owns only the wire protocol and linear endpoint
+leases.  It does not start daemons, avatars, managers, supervisors, or an ACP
+profile; those are separate Kernel consumer layers.
+"""
+from __future__ import annotations
+
+import array
+import json
+import os
+import socket
+import struct
+import threading
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+from lingtai.kernel.provider_admission import (
+    DerivedLaunchCapability,
+    DerivedProviderAdmission,
+    ProviderAdmissionParent,
+    ProviderAdmissionState,
+    ProviderCallAdmissionPort,
+    ProviderCallClass,
+    ProviderCallDecision,
+    RootProviderAdmission,
+    begin_derived_provider_admission,
+)
+
+
+DRIVER_AUTHORITY_FD_ENV = "LINGTAI_DRIVER_AUTHORITY_FD"
+_PROTOCOL_VERSION = 1
+_MAX_FRAME_BYTES = 64 * 1024
+_DEFAULT_TIMEOUT_SECONDS = 2.0
+
+
+class DriverAuthorityTransportError(RuntimeError):
+    """A malformed, stale, or unavailable Driver exchange."""
+
+
+class DriverAuthorityEndpointBindingMismatch(DriverAuthorityTransportError):
+    """The Driver endpoint role cannot serve the local execution mode."""
+
+
+@dataclass(frozen=True, slots=True)
+class DriverAuthorityIdentity:
+    role: str
+    launch_id: str
+    capability: str | None
+
+
+class DriverChildEndpointLease:
+    """One-use ownership of a Driver-created AF_UNIX child endpoint."""
+
+    __slots__ = ("_socket", "_consumed")
+
+    def __init__(self, endpoint: socket.socket) -> None:
+        self._socket = endpoint
+        self._consumed = False
+
+    def consume_for_posix_spawn(self) -> int:
+        if self._consumed:
+            raise DriverAuthorityTransportError("child endpoint lease already consumed")
+        self._consumed = True
+        try:
+            return self._socket.detach()
+        except OSError as exc:
+            raise DriverAuthorityTransportError("child endpoint lease unavailable") from exc
+
+    def close(self) -> None:
+        if self._consumed:
+            return
+        self._consumed = True
+        try:
+            self._socket.close()
+        except OSError:
+            pass
+
+    def __del__(self) -> None:
+        self.close()
+
+
+@dataclass(frozen=True, slots=True)
+class DriverDerivedLaunchGrant:
+    """A Driver result kept private until a later Kernel consumer owns it."""
+
+    state: ProviderAdmissionState
+    reason_code: str
+    audit_id: str | None = None
+    child_endpoint_lease: DriverChildEndpointLease | None = None
+
+
+class DriverAuthorityClient(ProviderCallAdmissionPort):
+    """Authenticated request/response client; no lifecycle integration."""
+
+    __slots__ = ("_socket", "_identity", "_lock", "_timeout", "_buffer")
+
+    def __init__(self, endpoint: socket.socket, *, timeout: float = _DEFAULT_TIMEOUT_SECONDS):
+        if endpoint.family != socket.AF_UNIX or (endpoint.type & socket.SOCK_STREAM) != socket.SOCK_STREAM:
+            endpoint.close()
+            raise DriverAuthorityTransportError("authority endpoint must be an AF_UNIX stream socket")
+        if not isinstance(timeout, (int, float)) or isinstance(timeout, bool) or timeout <= 0:
+            endpoint.close()
+            raise DriverAuthorityTransportError("authority timeout must be positive")
+        self._socket = endpoint
+        self._timeout = float(timeout)
+        self._lock = threading.Lock()
+        self._buffer = bytearray()
+        try:
+            os.set_inheritable(endpoint.fileno(), False)
+            endpoint.settimeout(self._timeout)
+            response, received_fd = self._exchange({"op": "hello", "call_id": self._call_id()}, expect_fd=False)
+            if received_fd is not None:
+                os.close(received_fd)
+                raise DriverAuthorityTransportError("hello must not receive a child endpoint")
+            self._identity = self._parse_identity(response)
+        except Exception:
+            self._close_locked()
+            raise
+
+    @classmethod
+    def from_inherited_fd(cls, fd: int, *, timeout: float = _DEFAULT_TIMEOUT_SECONDS) -> "DriverAuthorityClient":
+        if not isinstance(fd, int) or isinstance(fd, bool) or fd < 0:
+            raise DriverAuthorityTransportError("authority fd is invalid")
+        try:
+            return cls(socket.socket(fileno=fd), timeout=timeout)
+        except OSError as exc:
+            raise DriverAuthorityTransportError("authority fd is unavailable") from exc
+
+    @property
+    def identity(self) -> DriverAuthorityIdentity:
+        return self._identity
+
+    def derived_provider_parent(self, expected_call_class: ProviderCallClass | None = None) -> DerivedProviderAdmission:
+        if self._identity.role != "derived" or self._identity.capability is None:
+            raise DriverAuthorityTransportError("root endpoint cannot become a derived parent")
+        capability = DerivedLaunchCapability(self._identity.capability)
+        call_class = ProviderCallClass.DAEMON if capability is DerivedLaunchCapability.DAEMON else ProviderCallClass.AVATAR_CHILD
+        if expected_call_class is not None and call_class is not expected_call_class:
+            raise DriverAuthorityEndpointBindingMismatch("authority endpoint capability does not match local child mode")
+        return begin_derived_provider_admission(
+            RootProviderAdmission(f"driver-launch:{self._identity.launch_id}", "driver-authority.v1"), call_class
+        )
+
+    def authorize_provider_call(self, parent: ProviderAdmissionParent, call_class: ProviderCallClass) -> ProviderCallDecision:
+        if not self._valid_provider_parent(parent, call_class):
+            return ProviderCallDecision(ProviderAdmissionState.DENIED, "provider_parent_endpoint_mismatch")
+        with self._lock:
+            try:
+                response, received_fd = self._exchange({
+                    "op": "authorize_provider_call", "call_id": self._call_id(),
+                    "launch_id": self._identity.launch_id, "provider": "llm", "capability": call_class.value,
+                }, expect_fd=False)
+                if received_fd is not None:
+                    os.close(received_fd)
+                    raise DriverAuthorityTransportError("provider decision must not return an endpoint")
+                state, reason, _audit = self._decision(response)
+                return ProviderCallDecision(state, reason)
+            except DriverAuthorityTransportError:
+                self._close_locked()
+                return ProviderCallDecision(ProviderAdmissionState.INDETERMINATE, "driver_authority_unavailable")
+
+    def request_derived_launch(self, parent: RootProviderAdmission, capability: DerivedLaunchCapability) -> DriverDerivedLaunchGrant:
+        if not isinstance(parent, RootProviderAdmission) or self._identity.role != "root":
+            return DriverDerivedLaunchGrant(ProviderAdmissionState.DENIED, "nested_derived_launch_denied")
+        if not isinstance(capability, DerivedLaunchCapability):
+            return DriverDerivedLaunchGrant(ProviderAdmissionState.INDETERMINATE, "driver_authority_unavailable")
+        with self._lock:
+            try:
+                response, received_fd = self._exchange({
+                    "op": "authorize_derived_launch", "call_id": self._call_id(),
+                    "launch_id": self._identity.launch_id, "capability": capability.value,
+                }, expect_fd=None)
+                state, reason, audit_id = self._decision(response)
+                if state is not ProviderAdmissionState.GRANTED:
+                    if received_fd is not None:
+                        os.close(received_fd)
+                        raise DriverAuthorityTransportError("non-grant must not return an endpoint")
+                    return DriverDerivedLaunchGrant(state, reason, audit_id)
+                if received_fd is None:
+                    raise DriverAuthorityTransportError("granted launch omitted child endpoint")
+                return DriverDerivedLaunchGrant(state, reason, audit_id, DriverChildEndpointLease(self._checked_endpoint(received_fd)))
+            except DriverAuthorityTransportError:
+                self._close_locked()
+                return DriverDerivedLaunchGrant(ProviderAdmissionState.INDETERMINATE, "driver_authority_unavailable")
+
+    def close(self) -> None:
+        with self._lock:
+            self._close_locked()
+
+    def _exchange(self, request: dict[str, Any], *, expect_fd: bool | None) -> tuple[dict[str, Any], int | None]:
+        call_id = request.get("call_id")
+        if not isinstance(call_id, str) or not call_id:
+            raise DriverAuthorityTransportError("authority request requires call_id")
+        self._send_frame({"version": _PROTOCOL_VERSION, **request})
+        response, received_fd = self._recv_frame()
+        if response.get("call_id") != call_id:
+            if received_fd is not None:
+                os.close(received_fd)
+            raise DriverAuthorityTransportError("authority response call_id does not match request")
+        if expect_fd is not None and expect_fd != (received_fd is not None):
+            if received_fd is not None:
+                os.close(received_fd)
+            raise DriverAuthorityTransportError("authority response carried an unexpected endpoint")
+        return response, received_fd
+
+    @staticmethod
+    def _call_id() -> str:
+        return uuid.uuid4().hex
+
+    def _send_frame(self, payload: dict[str, Any]) -> None:
+        try:
+            encoded = json.dumps(payload, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+            if len(encoded) > _MAX_FRAME_BYTES:
+                raise ValueError
+            self._socket.sendall(struct.pack("!I", len(encoded)) + encoded)
+        except (OSError, TimeoutError, TypeError, ValueError) as exc:
+            raise DriverAuthorityTransportError("authority request transport failed") from exc
+
+    def _recv_frame(self) -> tuple[dict[str, Any], int | None]:
+        fds = array.array("i")
+        try:
+            def read_exact(count: int) -> bytes:
+                while len(self._buffer) < count:
+                    data, ancdata, flags, _ = self._socket.recvmsg(_MAX_FRAME_BYTES + 4, socket.CMSG_SPACE(fds.itemsize))
+                    if not data or flags & socket.MSG_CTRUNC:
+                        raise DriverAuthorityTransportError("authority response transport failed")
+                    for level, kind, payload in ancdata:
+                        if level == socket.SOL_SOCKET and kind == socket.SCM_RIGHTS:
+                            fds.frombytes(payload[:len(payload) - len(payload) % fds.itemsize])
+                    self._buffer.extend(data)
+                value = bytes(self._buffer[:count]); del self._buffer[:count]
+                return value
+            size = struct.unpack("!I", read_exact(4))[0]
+            if size <= 0 or size > _MAX_FRAME_BYTES:
+                raise DriverAuthorityTransportError("authority response frame is out of bounds")
+            response = json.loads(read_exact(size).decode("utf-8"))
+            if not isinstance(response, dict) or len(fds) > 1:
+                raise DriverAuthorityTransportError("authority response is malformed")
+            return response, fds[0] if fds else None
+        except (OSError, TimeoutError, UnicodeDecodeError, json.JSONDecodeError, struct.error, DriverAuthorityTransportError) as exc:
+            for fd in fds:
+                try: os.close(fd)
+                except OSError: pass
+            if isinstance(exc, DriverAuthorityTransportError):
+                raise
+            raise DriverAuthorityTransportError("authority response transport failed") from exc
+
+    def _close_locked(self) -> None:
+        self._buffer.clear()
+        try: self._socket.close()
+        except OSError: pass
+
+    @staticmethod
+    def _parse_identity(response: dict[str, Any]) -> DriverAuthorityIdentity:
+        if response.get("version") != _PROTOCOL_VERSION:
+            raise DriverAuthorityTransportError("authority protocol version mismatch")
+        role, launch_id, capability = response.get("role"), response.get("launch_id"), response.get("capability")
+        if role not in {"root", "derived"} or not isinstance(launch_id, str) or not launch_id:
+            raise DriverAuthorityTransportError("authority hello identity is invalid")
+        if capability is not None and capability not in {item.value for item in DerivedLaunchCapability}:
+            raise DriverAuthorityTransportError("authority hello capability is invalid")
+        if (role == "root") != (capability is None):
+            raise DriverAuthorityTransportError("authority hello role/capability mismatch")
+        return DriverAuthorityIdentity(role, launch_id, capability)
+
+    @staticmethod
+    def _decision(response: dict[str, Any]) -> tuple[ProviderAdmissionState, str, str | None]:
+        if response.get("version") != _PROTOCOL_VERSION:
+            raise DriverAuthorityTransportError("authority protocol version mismatch")
+        try: state = ProviderAdmissionState(response.get("state"))
+        except (TypeError, ValueError) as exc: raise DriverAuthorityTransportError("authority decision state is invalid") from exc
+        reason, audit_id = response.get("reason_code"), response.get("audit_id")
+        if not isinstance(reason, str) or not reason or (audit_id is not None and (not isinstance(audit_id, str) or not audit_id)):
+            raise DriverAuthorityTransportError("authority decision fields are invalid")
+        return state, reason, audit_id
+
+    @staticmethod
+    def _checked_endpoint(fd: int) -> socket.socket:
+        endpoint: socket.socket | None = None
+        try:
+            endpoint = socket.socket(fileno=fd)
+            if endpoint.family != socket.AF_UNIX or (endpoint.type & socket.SOCK_STREAM) != socket.SOCK_STREAM:
+                raise OSError
+            endpoint.getpeername(); os.set_inheritable(endpoint.fileno(), False)
+            return endpoint
+        except OSError as exc:
+            try:
+                if endpoint is None: os.close(fd)
+                else: endpoint.close()
+            except OSError: pass
+            raise DriverAuthorityTransportError("granted child endpoint is invalid") from exc
+
+    def _valid_provider_parent(self, parent: ProviderAdmissionParent, call_class: ProviderCallClass) -> bool:
+        if not isinstance(call_class, ProviderCallClass): return False
+        if self._identity.role == "root": return isinstance(parent, RootProviderAdmission) and call_class is ProviderCallClass.ROOT
+        return isinstance(parent, DerivedProviderAdmission) and parent.call_class is call_class

--- a/src/lingtai/adapters/acp/driver_authority.py
+++ b/src/lingtai/adapters/acp/driver_authority.py
@@ -176,8 +176,14 @@ class DriverAuthorityClient(ProviderCallAdmissionPort):
                 state, reason, audit_id = self._decision(response)
                 if state is not ProviderAdmissionState.GRANTED:
                     if received_fd is not None:
-                        os.close(received_fd)
-                        raise DriverAuthorityTransportError("non-grant must not return an endpoint")
+                        # The policy outcome is authoritative even if the
+                        # response also violates endpoint framing. Release the
+                        # unexpected descriptor without erasing its reason or
+                        # audit evidence.
+                        try:
+                            os.close(received_fd)
+                        except OSError:
+                            pass
                     return DriverDerivedLaunchGrant(state, reason, audit_id)
                 if received_fd is None:
                     raise DriverAuthorityTransportError("granted launch omitted child endpoint")
@@ -225,11 +231,13 @@ class DriverAuthorityClient(ProviderCallAdmissionPort):
             def read_exact(count: int) -> bytes:
                 while len(self._buffer) < count:
                     data, ancdata, flags, _ = self._socket.recvmsg(_MAX_FRAME_BYTES + 4, socket.CMSG_SPACE(fds.itemsize))
-                    if not data or flags & socket.MSG_CTRUNC:
-                        raise DriverAuthorityTransportError("authority response transport failed")
                     for level, kind, payload in ancdata:
                         if level == socket.SOL_SOCKET and kind == socket.SCM_RIGHTS:
                             fds.frombytes(payload[:len(payload) - len(payload) % fds.itemsize])
+                    if not data:
+                        raise DriverAuthorityTransportError("authority peer closed")
+                    if flags & socket.MSG_CTRUNC:
+                        raise DriverAuthorityTransportError("authority ancillary data was truncated")
                     self._buffer.extend(data)
                 value = bytes(self._buffer[:count]); del self._buffer[:count]
                 return value

--- a/tests/test_driver_authority_adapter.py
+++ b/tests/test_driver_authority_adapter.py
@@ -8,6 +8,7 @@ import select
 import socket
 import struct
 import threading
+import time
 from unittest.mock import patch
 
 from lingtai.adapters.acp.driver_authority import (
@@ -17,6 +18,7 @@ from lingtai.adapters.acp.driver_authority import (
 from lingtai.kernel.provider_admission import (
     DerivedLaunchCapability,
     ProviderAdmissionState,
+    ProviderCallClass,
     RootProviderAdmission,
 )
 
@@ -69,7 +71,7 @@ def test_hello_and_provider_request_are_correlated():
         _send(sock, {"version": 1, "call_id": request["call_id"], "state": "granted", "reason_code": "allowed"})
     endpoint, thread, errors = _server(handler)
     client = DriverAuthorityClient(endpoint)
-    decision = client.authorize_provider_call(RootProviderAdmission("turn", "v1"), __import__("lingtai.kernel.provider_admission", fromlist=["ProviderCallClass"]).ProviderCallClass.ROOT)
+    decision = client.authorize_provider_call(RootProviderAdmission("turn", "v1"), ProviderCallClass.ROOT)
     thread.join(2)
     assert not errors
     assert decision.state is ProviderAdmissionState.GRANTED
@@ -135,3 +137,222 @@ def test_detach_failure_leaves_lease_closable():
     assert ready == [peer]
     assert peer.recv(1) == b""
     peer.close()
+
+
+def test_truncated_ancillary_data_closes_every_delivered_descriptor():
+    from lingtai.adapters.acp import driver_authority as authority_module
+
+    frame = struct.pack("!I", len(b'{"version":1}')) + b'{"version":1}'
+    delivered_fd = 731
+    client = object.__new__(DriverAuthorityClient)
+    client._socket = type("FakeSocket", (), {
+        "recvmsg": lambda _self, *_args: (frame, [(
+            socket.SOL_SOCKET, socket.SCM_RIGHTS, array.array("i", [delivered_fd]).tobytes(),
+        )], socket.MSG_CTRUNC, None),
+    })()
+    client._buffer = bytearray()
+    with patch.object(authority_module.os, "close") as close:
+        try:
+            client._recv_frame()
+        except DriverAuthorityTransportError as exc:
+            assert "ancillary data was truncated" in str(exc)
+        else:
+            raise AssertionError("truncated ancillary data was accepted")
+    close.assert_called_once_with(delivered_fd)
+
+
+def test_denied_child_endpoint_is_closed_without_erasing_driver_reason():
+    peer, driver_end = socket.socketpair()
+
+    def handler(sock):
+        _hello(sock)
+        request = _recv(sock)
+        _send(sock, {
+            "version": 1, "call_id": request["call_id"], "state": "denied",
+            "reason_code": "policy_denied", "audit_id": "audit-1",
+        }, fd=driver_end.fileno())
+        driver_end.close()
+
+    endpoint, thread, errors = _server(handler)
+    client = DriverAuthorityClient(endpoint)
+    decision = client.request_derived_launch(RootProviderAdmission("turn", "v1"), DerivedLaunchCapability.AVATAR)
+    thread.join(2)
+    assert not errors
+    assert decision.state is ProviderAdmissionState.DENIED
+    assert decision.reason_code == "policy_denied"
+    assert decision.audit_id == "audit-1"
+    assert peer.recv(1) == b""
+    peer.close()
+
+
+def test_unconnected_unix_endpoint_is_closed_by_the_grant_parser():
+    endpoint = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    fd = endpoint.detach()
+    try:
+        DriverAuthorityClient._checked_endpoint(fd)
+    except DriverAuthorityTransportError:
+        pass
+    else:
+        raise AssertionError("unconnected endpoint became a grant")
+    try:
+        os.fstat(fd)
+    except OSError:
+        pass
+    else:
+        os.close(fd)
+        raise AssertionError("rejected endpoint descriptor leaked")
+
+
+def test_grant_parser_closes_its_socket_wrapper_after_descriptor_adoption():
+    endpoint, peer = socket.socketpair()
+    fd = endpoint.detach()
+    with patch.object(os, "set_inheritable", side_effect=OSError("injected inheritable failure")):
+        try:
+            DriverAuthorityClient._checked_endpoint(fd)
+        except DriverAuthorityTransportError:
+            pass
+        else:
+            raise AssertionError("invalid adopted endpoint became a grant")
+    assert peer.recv(1) == b""
+    peer.close()
+
+
+def test_derived_endpoint_cannot_mint_a_second_child_even_with_a_socket():
+    def handler(sock):
+        _hello(sock, role="derived", capability="daemon")
+
+    endpoint, thread, errors = _server(handler)
+    client = DriverAuthorityClient(endpoint)
+    decision = client.request_derived_launch(RootProviderAdmission("turn", "v1"), DerivedLaunchCapability.DAEMON)
+    client.close()
+    thread.join(2)
+    assert not errors
+    assert decision.state is ProviderAdmissionState.DENIED
+    assert decision.reason_code == "nested_derived_launch_denied"
+
+
+def test_local_child_mode_must_match_driver_endpoint_capability():
+    def handler(sock):
+        _hello(sock, role="derived", capability="daemon")
+
+    endpoint, thread, errors = _server(handler)
+    client = DriverAuthorityClient(endpoint)
+    try:
+        client.derived_provider_parent(ProviderCallClass.AVATAR_CHILD)
+    except DriverAuthorityTransportError:
+        pass
+    else:
+        raise AssertionError("wrong derived endpoint capability was accepted")
+    client.close()
+    thread.join(2)
+    assert not errors
+
+
+def test_derived_provider_call_uses_its_own_endpoint_and_driver_known_fields():
+    def handler(sock):
+        _hello(sock, role="derived", capability="daemon")
+        request = _recv(sock)
+        assert request["op"] == "authorize_provider_call"
+        assert request["launch_id"] == "launch-1"
+        assert request["provider"] == "llm"
+        assert request["capability"] == "daemon"
+        _send(sock, {"version": 1, "call_id": request["call_id"], "state": "granted", "reason_code": "allowed"})
+
+    endpoint, thread, errors = _server(handler)
+    client = DriverAuthorityClient(endpoint)
+    decision = client.authorize_provider_call(client.derived_provider_parent(), ProviderCallClass.DAEMON)
+    thread.join(2)
+    assert not errors
+    assert decision.state is ProviderAdmissionState.GRANTED
+
+
+def test_malformed_driver_provider_reply_fails_closed_before_provider_io():
+    def handler(sock):
+        _hello(sock)
+        _recv(sock)
+        payload = b'{"version":1,"state":"granted","reason_code":""}'
+        sock.sendall(struct.pack("!I", len(payload)) + payload)
+
+    endpoint, thread, errors = _server(handler)
+    client = DriverAuthorityClient(endpoint)
+    decision = client.authorize_provider_call(RootProviderAdmission("turn", "v1"), ProviderCallClass.ROOT)
+    thread.join(2)
+    assert not errors
+    assert decision.state is ProviderAdmissionState.INDETERMINATE
+
+
+def test_provider_reply_with_an_endpoint_fails_closed_and_closes_it():
+    peer, driver_end = socket.socketpair()
+
+    def handler(sock):
+        _hello(sock)
+        request = _recv(sock)
+        _send(sock, {"version": 1, "call_id": request["call_id"], "state": "granted", "reason_code": "allowed"}, fd=driver_end.fileno())
+        driver_end.close()
+
+    endpoint, thread, errors = _server(handler)
+    client = DriverAuthorityClient(endpoint)
+    decision = client.authorize_provider_call(RootProviderAdmission("turn", "v1"), ProviderCallClass.ROOT)
+    thread.join(2)
+    assert not errors
+    assert decision.state is ProviderAdmissionState.INDETERMINATE
+    assert peer.recv(1) == b""
+    peer.close()
+
+
+def test_closed_truncated_or_timed_out_driver_reply_is_indeterminate():
+    for failure in ("closed", "truncated", "timeout"):
+        def handler(sock, failure=failure):
+            _hello(sock)
+            _recv(sock)
+            if failure == "truncated":
+                sock.sendall(struct.pack("!I", 12) + b"{}")
+            elif failure == "timeout":
+                time.sleep(0.05)
+
+        endpoint, thread, errors = _server(handler)
+        client = DriverAuthorityClient(endpoint, timeout=0.01)
+        decision = client.authorize_provider_call(RootProviderAdmission("turn", "v1"), ProviderCallClass.ROOT)
+        thread.join(2)
+        assert not errors
+        assert decision.state is ProviderAdmissionState.INDETERMINATE
+
+
+def test_timeout_invalidates_endpoint_so_late_grant_cannot_admit_next_call():
+    def handler(sock):
+        _hello(sock)
+        first = _recv(sock)
+        assert first["op"] == "authorize_provider_call"
+        time.sleep(0.03)
+        try:
+            _send(sock, {"version": 1, "call_id": first["call_id"], "state": "granted", "reason_code": "allowed"})
+            _recv(sock)
+        except OSError:
+            pass
+
+    endpoint, thread, errors = _server(handler)
+    client = DriverAuthorityClient(endpoint, timeout=0.02)
+    parent = RootProviderAdmission("turn", "v1")
+    first = client.authorize_provider_call(parent, ProviderCallClass.ROOT)
+    second = client.authorize_provider_call(parent, ProviderCallClass.ROOT)
+    client.close()
+    thread.join(2)
+    assert not errors
+    assert first.state is ProviderAdmissionState.INDETERMINATE
+    assert second.state is ProviderAdmissionState.INDETERMINATE
+
+
+def test_bad_driver_handshake_is_not_a_client():
+    def handler(sock):
+        request = _recv(sock)
+        _send(sock, {"version": 2, "call_id": request["call_id"], "role": "root", "launch_id": "launch-1", "capability": None})
+
+    endpoint, thread, errors = _server(handler)
+    try:
+        DriverAuthorityClient(endpoint)
+    except DriverAuthorityTransportError:
+        pass
+    else:
+        raise AssertionError("invalid handshake constructed a client")
+    thread.join(2)
+    assert not errors

--- a/tests/test_driver_authority_adapter.py
+++ b/tests/test_driver_authority_adapter.py
@@ -1,0 +1,115 @@
+"""Isolated protocol tests for the Driver authority client."""
+from __future__ import annotations
+
+import array
+import json
+import os
+import socket
+import struct
+import threading
+
+from lingtai.adapters.acp.driver_authority import (
+    DriverAuthorityClient,
+    DriverAuthorityTransportError,
+)
+from lingtai.kernel.provider_admission import (
+    DerivedLaunchCapability,
+    ProviderAdmissionState,
+    RootProviderAdmission,
+)
+
+
+def _recv(sock):
+    size = struct.unpack("!I", sock.recv(4))[0]
+    body = bytearray()
+    while len(body) < size:
+        body.extend(sock.recv(size - len(body)))
+    return json.loads(body.decode("utf-8"))
+
+
+def _send(sock, payload, *, fd=None):
+    encoded = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    frame = struct.pack("!I", len(encoded)) + encoded
+    if fd is None:
+        sock.sendall(frame)
+    else:
+        sock.sendmsg([frame], [(socket.SOL_SOCKET, socket.SCM_RIGHTS, array.array("i", [fd]))])
+
+
+def _server(handler):
+    client, server = socket.socketpair()
+    errors = []
+    def run():
+        try:
+            handler(server)
+        except BaseException as exc:  # retained for the caller assertion
+            errors.append(exc)
+        finally:
+            server.close()
+    thread = threading.Thread(target=run)
+    thread.start()
+    return client, thread, errors
+
+
+def _hello(sock, *, role="root", capability=None):
+    request = _recv(sock)
+    assert request["op"] == "hello"
+    assert isinstance(request["call_id"], str) and request["call_id"]
+    _send(sock, {"version": 1, "call_id": request["call_id"], "role": role, "launch_id": "launch-1", "capability": capability})
+
+
+def test_hello_and_provider_request_are_correlated():
+    def handler(sock):
+        _hello(sock)
+        request = _recv(sock)
+        assert request["op"] == "authorize_provider_call"
+        assert request["capability"] == "root"
+        _send(sock, {"version": 1, "call_id": request["call_id"], "state": "granted", "reason_code": "allowed"})
+    endpoint, thread, errors = _server(handler)
+    client = DriverAuthorityClient(endpoint)
+    decision = client.authorize_provider_call(RootProviderAdmission("turn", "v1"), __import__("lingtai.kernel.provider_admission", fromlist=["ProviderCallClass"]).ProviderCallClass.ROOT)
+    thread.join(2)
+    assert not errors
+    assert decision.state is ProviderAdmissionState.GRANTED
+
+
+def test_mismatched_call_id_closes_received_endpoint_and_fails_closed():
+    peer, driver_end = socket.socketpair()
+    def handler(sock):
+        _hello(sock)
+        request = _recv(sock)
+        _send(sock, {"version": 1, "call_id": "stale", "state": "granted", "reason_code": "allowed"}, fd=driver_end.fileno())
+        driver_end.close()
+    endpoint, thread, errors = _server(handler)
+    client = DriverAuthorityClient(endpoint)
+    decision = client.request_derived_launch(RootProviderAdmission("turn", "v1"), DerivedLaunchCapability.DAEMON)
+    thread.join(2)
+    assert not errors
+    assert decision.state is ProviderAdmissionState.INDETERMINATE
+    assert peer.recv(1) == b""
+    peer.close()
+
+
+def test_granted_launch_has_one_linear_inheritable_false_lease():
+    child, driver_end = socket.socketpair()
+    def handler(sock):
+        _hello(sock)
+        request = _recv(sock)
+        _send(sock, {"version": 1, "call_id": request["call_id"], "state": "granted", "reason_code": "allowed", "audit_id": "audit-1"}, fd=driver_end.fileno())
+        driver_end.close()
+    endpoint, thread, errors = _server(handler)
+    client = DriverAuthorityClient(endpoint)
+    grant = client.request_derived_launch(RootProviderAdmission("turn", "v1"), DerivedLaunchCapability.AVATAR)
+    thread.join(2)
+    assert not errors and grant.state is ProviderAdmissionState.GRANTED
+    fd = grant.child_endpoint_lease.consume_for_posix_spawn()
+    try:
+        assert os.get_inheritable(fd) is False
+    finally:
+        os.close(fd); child.close()
+    try:
+        grant.child_endpoint_lease.consume_for_posix_spawn()
+    except DriverAuthorityTransportError:
+        pass
+    else:
+        raise AssertionError("lease was reusable")

--- a/tests/test_driver_authority_adapter.py
+++ b/tests/test_driver_authority_adapter.py
@@ -56,6 +56,11 @@ def _server(handler):
     return client, thread, errors
 
 
+def _assert_peer_closed(peer):
+    peer.settimeout(2)
+    assert peer.recv(1) == b""
+
+
 def _hello(sock, *, role="root", capability=None):
     request = _recv(sock)
     assert request["op"] == "hello"
@@ -91,7 +96,7 @@ def test_mismatched_call_id_closes_received_endpoint_and_fails_closed():
     thread.join(2)
     assert not errors
     assert decision.state is ProviderAdmissionState.INDETERMINATE
-    assert peer.recv(1) == b""
+    _assert_peer_closed(peer)
     peer.close()
 
 
@@ -113,7 +118,7 @@ def test_malformed_derived_decision_closes_received_endpoint_and_fails_closed():
     thread.join(2)
     assert not errors
     assert decision.state is ProviderAdmissionState.INDETERMINATE
-    assert peer.recv(1) == b""
+    _assert_peer_closed(peer)
     peer.close()
 
 
@@ -158,7 +163,7 @@ def test_detach_failure_leaves_lease_closable():
     lease.close()
     ready, _, _ = select.select([peer], [], [], 0.2)
     assert ready == [peer]
-    assert peer.recv(1) == b""
+    _assert_peer_closed(peer)
     peer.close()
 
 
@@ -204,7 +209,7 @@ def test_denied_child_endpoint_is_closed_without_erasing_driver_reason():
     assert decision.state is ProviderAdmissionState.DENIED
     assert decision.reason_code == "policy_denied"
     assert decision.audit_id == "audit-1"
-    assert peer.recv(1) == b""
+    _assert_peer_closed(peer)
     peer.close()
 
 
@@ -236,7 +241,7 @@ def test_grant_parser_closes_its_socket_wrapper_after_descriptor_adoption():
             pass
         else:
             raise AssertionError("invalid adopted endpoint became a grant")
-    assert peer.recv(1) == b""
+    _assert_peer_closed(peer)
     peer.close()
 
 
@@ -343,7 +348,7 @@ def test_denied_endpoint_reply_invalidates_authority_before_a_second_request():
     assert not errors
     assert first.state is ProviderAdmissionState.DENIED
     assert second.state is ProviderAdmissionState.INDETERMINATE
-    assert peer.recv(1) == b""
+    _assert_peer_closed(peer)
     peer.close()
     granted_peer.close()
 
@@ -397,7 +402,7 @@ def test_provider_reply_with_an_endpoint_fails_closed_and_closes_it():
     thread.join(2)
     assert not errors
     assert decision.state is ProviderAdmissionState.INDETERMINATE
-    assert peer.recv(1) == b""
+    _assert_peer_closed(peer)
     peer.close()
 
 

--- a/tests/test_driver_authority_adapter.py
+++ b/tests/test_driver_authority_adapter.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 import array
 import json
 import os
+import select
 import socket
 import struct
 import threading
+from unittest.mock import patch
 
 from lingtai.adapters.acp.driver_authority import (
     DriverAuthorityClient,
@@ -113,3 +115,23 @@ def test_granted_launch_has_one_linear_inheritable_false_lease():
         pass
     else:
         raise AssertionError("lease was reusable")
+
+
+def test_detach_failure_leaves_lease_closable():
+    endpoint, peer = socket.socketpair()
+    from lingtai.adapters.acp.driver_authority import DriverChildEndpointLease
+
+    lease = DriverChildEndpointLease(endpoint)
+    with patch.object(socket.socket, "detach", side_effect=OSError("injected detach failure")):
+        try:
+            lease.consume_for_posix_spawn()
+        except DriverAuthorityTransportError:
+            pass
+        else:
+            raise AssertionError("detach failure did not surface")
+
+    lease.close()
+    ready, _, _ = select.select([peer], [], [], 0.2)
+    assert ready == [peer]
+    assert peer.recv(1) == b""
+    peer.close()

--- a/tests/test_driver_authority_adapter.py
+++ b/tests/test_driver_authority_adapter.py
@@ -94,6 +94,28 @@ def test_mismatched_call_id_closes_received_endpoint_and_fails_closed():
     peer.close()
 
 
+def test_malformed_derived_decision_closes_received_endpoint_and_fails_closed():
+    peer, driver_end = socket.socketpair()
+
+    def handler(sock):
+        _hello(sock)
+        request = _recv(sock)
+        _send(sock, {
+            "version": 1, "call_id": request["call_id"], "state": "granted",
+            "reason_code": "",  # invalid decision field
+        }, fd=driver_end.fileno())
+        driver_end.close()
+
+    endpoint, thread, errors = _server(handler)
+    client = DriverAuthorityClient(endpoint)
+    decision = client.request_derived_launch(RootProviderAdmission("turn", "v1"), DerivedLaunchCapability.DAEMON)
+    thread.join(2)
+    assert not errors
+    assert decision.state is ProviderAdmissionState.INDETERMINATE
+    assert peer.recv(1) == b""
+    peer.close()
+
+
 def test_granted_launch_has_one_linear_inheritable_false_lease():
     child, driver_end = socket.socketpair()
     def handler(sock):

--- a/tests/test_driver_authority_adapter.py
+++ b/tests/test_driver_authority_adapter.py
@@ -20,6 +20,7 @@ from lingtai.kernel.provider_admission import (
     ProviderAdmissionState,
     ProviderCallClass,
     RootProviderAdmission,
+    begin_derived_provider_admission,
 )
 
 
@@ -286,6 +287,84 @@ def test_derived_provider_call_uses_its_own_endpoint_and_driver_known_fields():
     thread.join(2)
     assert not errors
     assert decision.state is ProviderAdmissionState.GRANTED
+
+
+def test_daemon_endpoint_cannot_admit_avatar_child_call_class():
+    def handler(sock):
+        _hello(sock, role="derived", capability="daemon")
+        ready, _, _ = select.select([sock], [], [], 0.2)
+        if ready:
+            request = _recv(sock)
+            _send(sock, {
+                "version": 1, "call_id": request["call_id"], "state": "granted",
+                "reason_code": "unexpected_avatar_child_grant",
+            })
+
+    endpoint, thread, errors = _server(handler)
+    client = DriverAuthorityClient(endpoint)
+    avatar_parent = begin_derived_provider_admission(
+        RootProviderAdmission("turn", "v1"), ProviderCallClass.AVATAR_CHILD,
+    )
+    decision = client.authorize_provider_call(avatar_parent, ProviderCallClass.AVATAR_CHILD)
+    thread.join(2)
+    client.close()
+    assert not errors
+    assert decision.state is ProviderAdmissionState.DENIED
+    assert decision.reason_code == "provider_parent_endpoint_mismatch"
+
+
+def test_denied_endpoint_reply_invalidates_authority_before_a_second_request():
+    peer, denied_driver_end = socket.socketpair()
+    granted_peer, granted_driver_end = socket.socketpair()
+
+    def handler(sock):
+        _hello(sock)
+        first = _recv(sock)
+        _send(sock, {
+            "version": 1, "call_id": first["call_id"], "state": "denied",
+            "reason_code": "policy_denied",
+        }, fd=denied_driver_end.fileno())
+        denied_driver_end.close()
+        try:
+            second = _recv(sock)
+        except struct.error:
+            return
+        _send(sock, {
+            "version": 1, "call_id": second["call_id"], "state": "granted",
+            "reason_code": "unexpected_second_grant",
+        }, fd=granted_driver_end.fileno())
+        granted_driver_end.close()
+
+    endpoint, thread, errors = _server(handler)
+    client = DriverAuthorityClient(endpoint)
+    first = client.request_derived_launch(RootProviderAdmission("turn", "v1"), DerivedLaunchCapability.DAEMON)
+    second = client.request_derived_launch(RootProviderAdmission("turn", "v1"), DerivedLaunchCapability.AVATAR)
+    thread.join(2)
+    assert not errors
+    assert first.state is ProviderAdmissionState.DENIED
+    assert second.state is ProviderAdmissionState.INDETERMINATE
+    assert peer.recv(1) == b""
+    peer.close()
+    granted_peer.close()
+
+
+def test_boolean_protocol_version_cannot_construct_client():
+    def handler(sock):
+        request = _recv(sock)
+        _send(sock, {
+            "version": True, "call_id": request["call_id"], "role": "root",
+            "launch_id": "launch-1", "capability": None,
+        })
+
+    endpoint, thread, errors = _server(handler)
+    try:
+        DriverAuthorityClient(endpoint)
+    except DriverAuthorityTransportError:
+        pass
+    else:
+        raise AssertionError("boolean protocol version constructed a client")
+    thread.join(2)
+    assert not errors
 
 
 def test_malformed_driver_provider_reply_fails_closed_before_provider_io():


### PR DESCRIPTION
Introduces the isolated ACP Driver authority protocol client foundation: the protocol client, linear child-endpoint lease, ACP contract/manual updates, and protocol-only tests.

Deliberately deferred: composition into supervisor, execution child, avatar, and CLI boundaries; audit wiring; and end-to-end evidence. Those belong to the downstream consumer PRs, rebuilt on this foundation.

Base: `main`.

Validation: `git diff --check`, `py_compile`, and 17 direct protocol checks pass locally. This environment does not have pytest, so this is not reported as a full pytest run.