### PR TITLE
Phase B/6: harden Driver restart and supervisor handoff

### DIFF
--- a/src/lingtai/adapters/acp/MANUAL.md
+++ b/src/lingtai/adapters/acp/MANUAL.md
@@ -165,10 +165,10 @@ must still provide verified ancestry and decide every actual provider call.
 This repository does not claim its identity/workdir binding, CAS consumption,
 or dynamic revoke is complete.
 
-Derived avatar directories and derived daemon run directories persist only the
-restrictive fact that authority is required; the immediate environment marker
-is redundant. A restarted child that loses its fd therefore fails closed at the
-provider gate. The daemon and avatar compositions also reject a Driver hello
+Derived avatar directories and versioned derived-daemon supervisor manifests
+persist only the restrictive fact that authority is required; the immediate
+environment marker is redundant. A restarted child that loses its fd therefore
+fails closed at the provider gate. The daemon and avatar compositions also reject a Driver hello
 whose derived capability does not match their local execution mode with
 `endpoint_binding_mismatch`, before provider I/O.
 This is an initiation boundary, not content provenance: non-ACP systems can

--- a/src/lingtai/adapters/acp/driver_authority.py
+++ b/src/lingtai/adapters/acp/driver_authority.py
@@ -177,7 +177,7 @@ class DriverAuthorityAdapter(ProviderCallAdmissionPort):
         return self._identity.launch_id
 
     def derived_provider_parent(
-        self, expected_call_class: ProviderCallClass | None = None
+        self, expected_call_class: ProviderCallClass
     ) -> DerivedProviderAdmission:
         """Return the local Core context for this Driver-bound child endpoint.
 
@@ -195,7 +195,9 @@ class DriverAuthorityAdapter(ProviderCallAdmissionPort):
             if capability is DerivedLaunchCapability.DAEMON
             else ProviderCallClass.AVATAR_CHILD
         )
-        if expected_call_class is not None and call_class is not expected_call_class:
+        if not isinstance(expected_call_class, ProviderCallClass):
+            raise TypeError("expected_call_class must be a ProviderCallClass")
+        if call_class is not expected_call_class:
             raise DriverAuthorityEndpointBindingMismatch(
                 "authority endpoint capability does not match local child mode"
             )

--- a/src/lingtai/adapters/posix/daemon_supervisor.py
+++ b/src/lingtai/adapters/posix/daemon_supervisor.py
@@ -72,10 +72,12 @@ def adopt_supervisor_authority_endpoint() -> None:
     _SUPERVISOR_AUTHORITY_ENDPOINT = endpoint
 
 
-def _take_supervisor_authority_fd() -> int | None:
-    """Detach the exact adopted endpoint for the one execution child only."""
+def _take_supervisor_authority_fd(module: str) -> int | None:
+    """Detach the exact endpoint only for the execution-child entrypoint."""
 
     global _SUPERVISOR_AUTHORITY_ENDPOINT
+    if module != EXECUTION_CHILD_MODULE:
+        return None
     endpoint = _SUPERVISOR_AUTHORITY_ENDPOINT
     _SUPERVISOR_AUTHORITY_ENDPOINT = None
     if endpoint is None:
@@ -260,7 +262,7 @@ class PosixDaemonSupervisorAdapter(DaemonSupervisorPort):
         parts = [str(source_root)]
         parts.extend(p for p in env.get("PYTHONPATH", "").split(os.pathsep) if p)
         env["PYTHONPATH"] = os.pathsep.join(dict.fromkeys(parts))
-        authority_fd = _take_supervisor_authority_fd()
+        authority_fd = _take_supervisor_authority_fd(module)
         if authority_fd is not None:
             # The env value is just a locator for this exact object in the
             # execution child. The supervisor no longer retains either form.

--- a/src/lingtai/adapters/posix/daemon_supervisor.py
+++ b/src/lingtai/adapters/posix/daemon_supervisor.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import json
 import os
+import logging
 import re
 import socket
 import subprocess
@@ -48,6 +49,7 @@ _CLI_CREDENTIAL_ENV_NAMES = {
     "cursor": {"OPENAI_API_KEY", "ANTHROPIC_API_KEY", "CURSOR_API_KEY"},
 }
 _SUPERVISOR_AUTHORITY_ENDPOINT: socket.socket | None = None
+_LOGGER = logging.getLogger(__name__)
 
 
 def adopt_supervisor_authority_endpoint() -> None:
@@ -62,10 +64,17 @@ def adopt_supervisor_authority_endpoint() -> None:
     raw_fd = os.environ.pop("LINGTAI_DRIVER_AUTHORITY_FD", None)
     if raw_fd is None:
         return
+    endpoint: socket.socket | None = None
     try:
         endpoint = socket.socket(fileno=int(raw_fd))
         os.set_inheritable(endpoint.fileno(), False)
-    except (OSError, ValueError):
+    except (OSError, ValueError) as exc:
+        if endpoint is not None:
+            try:
+                endpoint.close()
+            except OSError:
+                pass
+        _LOGGER.warning("daemon_supervisor_authority_endpoint_invalid: %s", exc)
         return
     if _SUPERVISOR_AUTHORITY_ENDPOINT is not None:
         _SUPERVISOR_AUTHORITY_ENDPOINT.close()
@@ -73,7 +82,12 @@ def adopt_supervisor_authority_endpoint() -> None:
 
 
 def _take_supervisor_authority_fd(module: str) -> int | None:
-    """Detach the exact endpoint only for the execution-child entrypoint."""
+    """Detach the exact endpoint only for one execution-child spawn attempt.
+
+    An attempted spawn consumes this one-shot transport even if ``Popen`` then
+    fails. The supervisor does not retry with the old endpoint; a later attempt
+    has no authority and must fail closed.
+    """
 
     global _SUPERVISOR_AUTHORITY_ENDPOINT
     if module != EXECUTION_CHILD_MODULE:

--- a/src/lingtai/adapters/posix/daemon_supervisor.py
+++ b/src/lingtai/adapters/posix/daemon_supervisor.py
@@ -65,13 +65,20 @@ def adopt_supervisor_authority_endpoint() -> None:
     if raw_fd is None:
         return
     endpoint: socket.socket | None = None
+    adopted_fd: int | None = None
     try:
-        endpoint = socket.socket(fileno=int(raw_fd))
+        adopted_fd = int(raw_fd)
+        endpoint = socket.socket(fileno=adopted_fd)
         os.set_inheritable(endpoint.fileno(), False)
     except (OSError, ValueError) as exc:
         if endpoint is not None:
             try:
                 endpoint.close()
+            except OSError:
+                pass
+        elif adopted_fd is not None:
+            try:
+                os.close(adopted_fd)
             except OSError:
                 pass
         _LOGGER.warning("daemon_supervisor_authority_endpoint_invalid: %s", exc)

--- a/src/lingtai/adapters/posix/daemon_supervisor.py
+++ b/src/lingtai/adapters/posix/daemon_supervisor.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import socket
 import subprocess
 from pathlib import Path
 
@@ -46,6 +47,43 @@ _CLI_CREDENTIAL_ENV_NAMES = {
     "deepseek": {"DEEPSEEK_API_KEY"},
     "cursor": {"OPENAI_API_KEY", "ANTHROPIC_API_KEY", "CURSOR_API_KEY"},
 }
+_SUPERVISOR_AUTHORITY_ENDPOINT: socket.socket | None = None
+
+
+def adopt_supervisor_authority_endpoint() -> None:
+    """Adopt the inherited endpoint once, then erase its numeric locator.
+
+    The detached supervisor owns an endpoint object rather than repeatedly
+    re-parsing an env fd number.  This keeps an unrelated later fd reuse from
+    becoming a fake authority handoff on the second process hop.
+    """
+
+    global _SUPERVISOR_AUTHORITY_ENDPOINT
+    raw_fd = os.environ.pop("LINGTAI_DRIVER_AUTHORITY_FD", None)
+    if raw_fd is None:
+        return
+    try:
+        endpoint = socket.socket(fileno=int(raw_fd))
+        os.set_inheritable(endpoint.fileno(), False)
+    except (OSError, ValueError):
+        return
+    if _SUPERVISOR_AUTHORITY_ENDPOINT is not None:
+        _SUPERVISOR_AUTHORITY_ENDPOINT.close()
+    _SUPERVISOR_AUTHORITY_ENDPOINT = endpoint
+
+
+def _take_supervisor_authority_fd() -> int | None:
+    """Detach the exact adopted endpoint for the one execution child only."""
+
+    global _SUPERVISOR_AUTHORITY_ENDPOINT
+    endpoint = _SUPERVISOR_AUTHORITY_ENDPOINT
+    _SUPERVISOR_AUTHORITY_ENDPOINT = None
+    if endpoint is None:
+        return None
+    try:
+        return endpoint.detach()
+    except OSError:
+        return None
 
 
 def selected_credential_environment(backend: str) -> dict[str, str]:
@@ -153,13 +191,13 @@ class PosixDaemonSupervisorAdapter(DaemonSupervisorPort):
                     DRIVER_AUTHORITY_FD_ENV,
                     consume_posix_child_endpoint_lease,
                 )
-                from lingtai.tools.daemon.execution_host import (
-                    mark_derived_daemon_requires_authority,
+                from lingtai.kernel.daemon_supervisor.manifest import (
+                    mark_manifest_requires_derived_launch_admission,
                 )
 
                 # Persist before handing off the process. A later wrapper or
                 # manual restart must remain restricted even if it loses env.
-                mark_derived_daemon_requires_authority(run_dir)
+                mark_manifest_requires_derived_launch_admission(run_dir)
                 authority_fd = consume_posix_child_endpoint_lease(authority_lease)
                 env[DRIVER_AUTHORITY_FD_ENV] = str(authority_fd)
                 # Restrictive boot requirement only, never a grant/bearer.
@@ -222,18 +260,11 @@ class PosixDaemonSupervisorAdapter(DaemonSupervisorPort):
         parts = [str(source_root)]
         parts.extend(p for p in env.get("PYTHONPATH", "").split(os.pathsep) if p)
         env["PYTHONPATH"] = os.pathsep.join(dict.fromkeys(parts))
-        authority_fd = None
-        raw_authority_fd = env.get("LINGTAI_DRIVER_AUTHORITY_FD")
-        if raw_authority_fd is not None:
-            try:
-                authority_fd = int(raw_authority_fd)
-                os.set_inheritable(authority_fd, False)
-            except (OSError, ValueError):
-                # The execution child will receive the locator only if this
-                # supervisor owns a live endpoint. A broken descriptor must
-                # not be silently inherited as an apparent authority.
-                env.pop("LINGTAI_DRIVER_AUTHORITY_FD", None)
-                authority_fd = None
+        authority_fd = _take_supervisor_authority_fd()
+        if authority_fd is not None:
+            # The env value is just a locator for this exact object in the
+            # execution child. The supervisor no longer retains either form.
+            env["LINGTAI_DRIVER_AUTHORITY_FD"] = str(authority_fd)
         if read_fd is not None:
             env["LINGTAI_DAEMON_CAPSULE_FD"] = str(read_fd)
         stdout_path = run_dir / ("execution.stdout.log" if "execution_child" in module else "resume-owner.stdout.log")
@@ -308,5 +339,6 @@ class PosixDaemonSupervisorAdapter(DaemonSupervisorPort):
 
 __all__ = [
     "PosixDaemonSupervisorAdapter", "ENTRYPOINT_MODULE", "EXECUTION_CHILD_MODULE",
-    "RESUME_OWNER_MODULE", "selected_credential_environment",
+    "RESUME_OWNER_MODULE", "adopt_supervisor_authority_endpoint",
+    "selected_credential_environment",
 ]

--- a/src/lingtai/adapters/posix/daemon_supervisor_entrypoint.py
+++ b/src/lingtai/adapters/posix/daemon_supervisor_entrypoint.py
@@ -57,21 +57,6 @@ def _read_capsule() -> dict | None:
         return None
 
 
-def _mark_driver_authority_cloexec() -> None:
-    """Keep a child authority fd out of arbitrary supervisor descendants."""
-
-    raw_fd = os.environ.get("LINGTAI_DRIVER_AUTHORITY_FD")
-    if raw_fd is None:
-        return
-    try:
-        os.set_inheritable(int(raw_fd), False)
-    except (OSError, ValueError):
-        # Leave the locator in place. The eventual child composition translates
-        # an invalid descriptor to structured INDETERMINATE rather than a
-        # legacy grant.
-        pass
-
-
 def main(argv: list[str]) -> int:
     """Decode the single encoded-request argument and run the supervisor.
 
@@ -86,7 +71,8 @@ def main(argv: list[str]) -> int:
             "usage: python -m lingtai.adapters.posix.daemon_supervisor_entrypoint "
             "<encoded-request>"
         )
-    _mark_driver_authority_cloexec()
+    from .daemon_supervisor import adopt_supervisor_authority_endpoint
+    adopt_supervisor_authority_endpoint()
     request = decode_request(argv[0])
     run_supervisor(request, capsule=_read_capsule())
     return 0

--- a/src/lingtai/cli.py
+++ b/src/lingtai/cli.py
@@ -389,7 +389,6 @@ def run(working_dir: Path) -> None:
         or os.environ.get(DERIVED_AVATAR_EXECUTION_ENV) == "1"
     ):
         from lingtai.adapters.acp.driver_authority import (
-            DriverAuthorityAdapter,
             DriverAuthorityEndpointBindingMismatch,
             EndpointBindingMismatchAuthorityAdapter,
             UnavailableDriverAuthorityAdapter,
@@ -409,14 +408,9 @@ def run(working_dir: Path) -> None:
             None if authority_was_missing else authority
         )
         try:
-            if isinstance(authority, DriverAuthorityAdapter):
-                build_options["_derived_provider_admission_parent"] = (
-                    authority.derived_provider_parent(ProviderCallClass.AVATAR_CHILD)
-                )
-            else:
-                build_options["_derived_provider_admission_parent"] = (
-                    authority.derived_provider_parent(ProviderCallClass.AVATAR_CHILD)
-                )
+            build_options["_derived_provider_admission_parent"] = (
+                authority.derived_provider_parent(ProviderCallClass.AVATAR_CHILD)
+            )
         except DriverAuthorityEndpointBindingMismatch:
             # A daemon endpoint in an avatar child (or vice versa) is not
             # authority for this composition, even if its hello is self-consistent.

--- a/src/lingtai/kernel/base_agent/CONTRACT.md
+++ b/src/lingtai/kernel/base_agent/CONTRACT.md
@@ -418,7 +418,10 @@ Clause IDs are stable; each rule composes the linked normative source.
    supervisor manifest before child start. Env is redundant only. Losing the
    fd or env on a later restart
    therefore installs an unavailable provider gate and rejects before provider
-   I/O rather than restoring generic behavior. Core's local one-shot lease guard is resource management,
+   I/O rather than restoring generic behavior. Those persistent child-local
+   requirements prevent accidental launch and restart confusion; they do not
+   resist a same-OS-user child that can rewrite its own avatar directory or
+   daemon run manifest to remove/downgrade the requirement. Core's local one-shot lease guard is resource management,
    not the security claim: the Driver must atomically enforce
    `ISSUED -> CLAIMED` when the first v1 handshake succeeds, and must
    deny/audit every competing or later claimant. Any wire disagreement with

--- a/src/lingtai/kernel/base_agent/CONTRACT.md
+++ b/src/lingtai/kernel/base_agent/CONTRACT.md
@@ -413,9 +413,10 @@ Clause IDs are stable; each rule composes the linked normative source.
    exists; an absent, closed, malformed, version-mismatched, or unavailable
    endpoint is structured `INDETERMINATE` before spawn or provider I/O and can
    never fall back to `legacy_default`. A derived endpoint cannot mint a second
-   child endpoint. A derived avatar directory and a derived daemon run
-   directory each persist a restrictive requirement marker before their child
-   starts; env is redundant only. Losing the fd or env on a later restart
+   child endpoint. A derived avatar directory persists a restrictive marker;
+   a derived daemon persists the same restrictive requirement in its versioned
+   supervisor manifest before child start. Env is redundant only. Losing the
+   fd or env on a later restart
    therefore installs an unavailable provider gate and rejects before provider
    I/O rather than restoring generic behavior. Core's local one-shot lease guard is resource management,
    not the security claim: the Driver must atomically enforce

--- a/src/lingtai/kernel/daemon_supervisor/ANATOMY.md
+++ b/src/lingtai/kernel/daemon_supervisor/ANATOMY.md
@@ -45,8 +45,9 @@ The supervisor Port and durable run schemas define the narrow process boundary; 
 - `tools/daemon/supervisor_runtime.py:77-138` — detached startup identity, run attachment, and terminal dispatch.
 - `tools/daemon/supervisor_runtime.py:219-394` — execution-child ownership plus the exact control/deadline watcher.
 - `adapters/posix/daemon_supervisor.py:53-283` — concrete interpreter/session/log
-  launch adapter; it adopts one inherited authority endpoint once, logs and
-  discards malformed transport, and transfers it to one execution-child spawn.
+  launch adapter; it adopts one inherited authority endpoint once, closes a
+  raw descriptor when adoption fails, logs/discards malformed transport, and
+  transfers it to one execution-child spawn.
 - `tools/daemon/execution_host.py:24-224` — composition root that reuses manager setup and every `_BackendSpec` runner; selected Shell alone invokes its private composer for the run-local `shell_prompt_events.py` NotificationPort adapter and `<run>/shell-jobs` namespace, rather than the stub's absent Agent route or shared parent jobs.
 
 ## Connections

--- a/src/lingtai/kernel/daemon_supervisor/ANATOMY.md
+++ b/src/lingtai/kernel/daemon_supervisor/ANATOMY.md
@@ -35,13 +35,18 @@ The supervisor Port and durable run schemas define the narrow process boundary; 
 ## Components
 
 - `__init__.py:34-134` — immutable request wire schema and spawn Port.
-- `manifest.py:44-190` — secret-free manifest build/write/read and identity validation.
+- `manifest.py:48-205` — secret-free manifest build/write/read and identity
+  validation; its derived-admission predicate preserves an explicit restrictive
+  bit across a schema downgrade and emits a diagnostic rather than treating it
+  as evidence-free legacy state.
 - `control.py:12-96` — UUID request spool with schema/run identity and ack markers.
 - `agent_stub.py:1-58` — the minimal agent surface a detached run composes against, so Core owns no live Agent.
 - `adapters/windows/daemon_supervisor.py:117-247` — the Windows launch adapter for the same Port.
 - `tools/daemon/supervisor_runtime.py:77-138` — detached startup identity, run attachment, and terminal dispatch.
 - `tools/daemon/supervisor_runtime.py:219-394` — execution-child ownership plus the exact control/deadline watcher.
-- `adapters/posix/daemon_supervisor.py:94-267` (`PosixDaemonSupervisorAdapter`) — concrete interpreter/session/log launch adapter.
+- `adapters/posix/daemon_supervisor.py:53-283` — concrete interpreter/session/log
+  launch adapter; it adopts one inherited authority endpoint once, logs and
+  discards malformed transport, and transfers it to one execution-child spawn.
 - `tools/daemon/execution_host.py:24-224` — composition root that reuses manager setup and every `_BackendSpec` runner; selected Shell alone invokes its private composer for the run-local `shell_prompt_events.py` NotificationPort adapter and `<run>/shell-jobs` namespace, rather than the stub's absent Agent route or shared parent jobs.
 
 ## Connections

--- a/src/lingtai/kernel/daemon_supervisor/CONTRACT.md
+++ b/src/lingtai/kernel/daemon_supervisor/CONTRACT.md
@@ -58,6 +58,10 @@ or process handle is retained, and no broad process matching is performed.
 When it receives an opaque Driver authority lease, it passes only the resulting
 child endpoint to the detached supervisor and then its exact execution child;
 the root endpoint is close-on-exec and never becomes a child `pass_fds` entry.
+That execution-child spawn attempt consumes the supervisor-held endpoint even
+when process launch fails; the supervisor cannot retry it and any later attempt
+fails closed without authority. An invalid inherited endpoint is discarded and
+recorded as a supervisor diagnostic rather than silently treated as absent.
 Windows has no equivalent Driver endpoint transport and rejects such a lease
 before launch.
 

--- a/src/lingtai/kernel/daemon_supervisor/CONTRACT.md
+++ b/src/lingtai/kernel/daemon_supervisor/CONTRACT.md
@@ -61,7 +61,9 @@ the root endpoint is close-on-exec and never becomes a child `pass_fds` entry.
 That execution-child spawn attempt consumes the supervisor-held endpoint even
 when process launch fails; the supervisor cannot retry it and any later attempt
 fails closed without authority. An invalid inherited endpoint is discarded and
-recorded as a supervisor diagnostic rather than silently treated as absent.
+recorded as a supervisor diagnostic rather than silently treated as absent; if
+socket adoption itself fails, the adapter closes the raw descriptor it still
+owns before returning the fail-closed result.
 Windows has no equivalent Driver endpoint transport and rejects such a lease
 before launch.
 

--- a/src/lingtai/kernel/daemon_supervisor/manifest.py
+++ b/src/lingtai/kernel/daemon_supervisor/manifest.py
@@ -13,8 +13,10 @@ import shlex
 from pathlib import Path
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
-MANIFEST_SCHEMA = "lingtai.daemon_supervisor_manifest.v2"
+MANIFEST_SCHEMA = "lingtai.daemon_supervisor_manifest.v3"
+_LEGACY_MANIFEST_SCHEMA = "lingtai.daemon_supervisor_manifest.v2"
 MANIFEST_FILENAME = "supervisor_manifest.json"
+DERIVED_LAUNCH_ADMISSION_REQUIRED_FIELD = "derived_launch_admission_required"
 _REQUIRED_FIELDS = (
     "schema", "run_id", "backend", "parent_working_dir", "run_dir", "task",
     "tools", "max_turns", "timeout_s", "group_id",
@@ -39,6 +41,20 @@ _SENSITIVE_CONTAINER_RE = re.compile(
 
 def manifest_path_for(run_dir: Path) -> Path:
     return Path(run_dir) / MANIFEST_FILENAME
+
+
+def manifest_requires_derived_launch_admission(manifest: dict) -> bool:
+    """Read the durable restrictive bit without letting malformed v3 widen.
+
+    v2 manifests predate this security property and keep their historical
+    generic behavior. Every v3 manifest is explicit at construction; a missing
+    or malformed value in v3 is deliberately restrictive instead of silently
+    restoring legacy provider I/O.
+    """
+
+    if manifest.get("schema") != MANIFEST_SCHEMA:
+        return False
+    return manifest.get(DERIVED_LAUNCH_ADMISSION_REQUIRED_FIELD) is not False
 
 
 def _is_reference_key(key: object) -> bool:
@@ -269,6 +285,7 @@ def build_manifest(
     """Build the supervisor input record without resolved credentials."""
     return {
         "schema": MANIFEST_SCHEMA,
+        DERIVED_LAUNCH_ADMISSION_REQUIRED_FIELD: False,
         "run_id": run_id,
         "backend": backend,
         "parent_working_dir": parent_working_dir,
@@ -302,13 +319,24 @@ def write_manifest(run_dir: Path, manifest: dict) -> Path:
     return path
 
 
+def mark_manifest_requires_derived_launch_admission(run_dir: Path) -> dict:
+    """Atomically persist the derived restriction before process handoff."""
+
+    path = manifest_path_for(run_dir)
+    manifest = read_manifest(path)
+    manifest["schema"] = MANIFEST_SCHEMA
+    manifest[DERIVED_LAUNCH_ADMISSION_REQUIRED_FIELD] = True
+    write_manifest(Path(run_dir), manifest)
+    return manifest
+
+
 def read_manifest(path: Path) -> dict:
     """Read and validate identity-bearing manifest fields."""
     path = Path(path).resolve()
     data = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(data, dict):
         raise ValueError(f"daemon supervisor manifest at {path} is not a JSON object")
-    if data.get("schema") != MANIFEST_SCHEMA:
+    if data.get("schema") not in {MANIFEST_SCHEMA, _LEGACY_MANIFEST_SCHEMA}:
         raise ValueError(
             f"daemon supervisor manifest at {path} has unexpected schema "
             f"{data.get('schema')!r}, expected {MANIFEST_SCHEMA!r}"
@@ -345,7 +373,9 @@ def redact_durable_argv(argv: list[str] | None) -> list[str] | None:
 
 
 __all__ = [
-    "MANIFEST_SCHEMA", "MANIFEST_FILENAME", "manifest_path_for", "build_manifest",
-    "write_manifest", "read_manifest", "redact_durable_value", "redact_durable_argv",
+    "MANIFEST_SCHEMA", "MANIFEST_FILENAME", "DERIVED_LAUNCH_ADMISSION_REQUIRED_FIELD",
+    "manifest_path_for", "manifest_requires_derived_launch_admission", "build_manifest",
+    "write_manifest", "read_manifest", "mark_manifest_requires_derived_launch_admission",
+    "redact_durable_value", "redact_durable_argv",
     "redact_durable_event_fields", "secret_argv_values",
 ]

--- a/src/lingtai/kernel/daemon_supervisor/manifest.py
+++ b/src/lingtai/kernel/daemon_supervisor/manifest.py
@@ -8,6 +8,7 @@ kept dependency-free so it remains a Core schema/validation boundary.
 from __future__ import annotations
 
 import json
+import logging
 import re
 import shlex
 from pathlib import Path
@@ -17,6 +18,8 @@ MANIFEST_SCHEMA = "lingtai.daemon_supervisor_manifest.v3"
 _LEGACY_MANIFEST_SCHEMA = "lingtai.daemon_supervisor_manifest.v2"
 MANIFEST_FILENAME = "supervisor_manifest.json"
 DERIVED_LAUNCH_ADMISSION_REQUIRED_FIELD = "derived_launch_admission_required"
+_MISSING = object()
+_LOGGER = logging.getLogger(__name__)
 _REQUIRED_FIELDS = (
     "schema", "run_id", "backend", "parent_working_dir", "run_dir", "task",
     "tools", "max_turns", "timeout_s", "group_id",
@@ -44,17 +47,26 @@ def manifest_path_for(run_dir: Path) -> Path:
 
 
 def manifest_requires_derived_launch_admission(manifest: dict) -> bool:
-    """Read the durable restrictive bit without letting malformed v3 widen.
+    """Read the durable restrictive bit without letting downgrade widen.
 
     v2 manifests predate this security property and keep their historical
-    generic behavior. Every v3 manifest is explicit at construction; a missing
-    or malformed value in v3 is deliberately restrictive instead of silently
-    restoring legacy provider I/O.
+    generic behavior only when they carry no restrictive evidence. Every v3
+    manifest is explicit at construction; a missing or malformed value in v3
+    is deliberately restrictive. A non-v3 manifest that still carries the bit
+    is a downgrade signal, not legacy evidence, and remains restrictive with a
+    visible diagnostic.
     """
 
-    if manifest.get("schema") != MANIFEST_SCHEMA:
+    value = manifest.get(DERIVED_LAUNCH_ADMISSION_REQUIRED_FIELD, _MISSING)
+    if manifest.get("schema") == MANIFEST_SCHEMA:
+        return value is not False
+    if value is _MISSING or value is False:
         return False
-    return manifest.get(DERIVED_LAUNCH_ADMISSION_REQUIRED_FIELD) is not False
+    _LOGGER.warning(
+        "derived_launch_admission_manifest_schema_downgrade",
+        extra={"manifest_schema": manifest.get("schema")},
+    )
+    return True
 
 
 def _is_reference_key(key: object) -> bool:

--- a/src/lingtai/tools/daemon/execution_host.py
+++ b/src/lingtai/tools/daemon/execution_host.py
@@ -16,7 +16,9 @@ from pathlib import Path
 from types import SimpleNamespace
 
 from lingtai.kernel.daemon_supervisor.agent_stub import DaemonSupervisorAgentStub
-from lingtai.kernel._fsutil import atomic_write_json
+from lingtai.kernel.daemon_supervisor.manifest import (
+    manifest_requires_derived_launch_admission,
+)
 from lingtai.kernel.llm.base import FunctionSchema
 from lingtai.adapters.posix.process_identity import (
     process_identity,
@@ -30,34 +32,6 @@ from lingtai.tools.daemon.process_port import (
 
 _DAEMON_COMMON_NAME = "daemon_common"
 _REDACTED_MARKER = "<redacted>"
-_DERIVED_DAEMON_STATE_NAME = "derived_daemon_authority.json"
-_DERIVED_DAEMON_STATE = {
-    "schema_version": 1,
-    "requires_derived_launch_admission": True,
-}
-
-
-def derived_daemon_state_path(run_directory: Path) -> Path:
-    """Return the run-local durable requirement marker for a derived daemon."""
-
-    return Path(run_directory) / _DERIVED_DAEMON_STATE_NAME
-
-
-def mark_derived_daemon_requires_authority(run_directory: Path) -> None:
-    """Persist the restrictive bit before starting a Driver-derived daemon."""
-
-    atomic_write_json(
-        derived_daemon_state_path(run_directory), _DERIVED_DAEMON_STATE, fsync=True
-    )
-
-
-def derived_daemon_requires_authority(run_directory: Path) -> bool:
-    """Treat any surviving marker object, including a broken symlink, as restrictive."""
-
-    marker = derived_daemon_state_path(run_directory)
-    return marker.exists() or marker.is_symlink()
-
-
 def _default_detached_process_port():
     """Compose the platform's detached-scope daemon process Port.
 
@@ -122,7 +96,7 @@ class DetachedDaemonExecutionHost:
         self._agent._provider_call_admission_port = None
         self._agent._derived_provider_admission_parent = None
         if (
-            derived_daemon_requires_authority(run_dir.path)
+            manifest_requires_derived_launch_admission(manifest)
             or os.environ.get("LINGTAI_DERIVED_DAEMON_EXECUTION") == "1"
         ):
             # The Driver-launched child accepts only a Driver-created endpoint

--- a/src/lingtai/tools/daemon/execution_host.py
+++ b/src/lingtai/tools/daemon/execution_host.py
@@ -105,7 +105,6 @@ class DetachedDaemonExecutionHost:
             # launch; a bad endpoint installs an unavailable provider gate and
             # cannot fall back to generic provider I/O.
             from lingtai.adapters.acp.driver_authority import (
-                DriverAuthorityAdapter,
                 DriverAuthorityEndpointBindingMismatch,
                 EndpointBindingMismatchAuthorityAdapter,
                 UnavailableDriverAuthorityAdapter,
@@ -121,10 +120,7 @@ class DetachedDaemonExecutionHost:
                 self._agent._derived_launch_admission_port = authority
             self._agent._provider_call_admission_port = authority
             try:
-                if isinstance(authority, DriverAuthorityAdapter):
-                    parent = authority.derived_provider_parent(ProviderCallClass.DAEMON)
-                else:
-                    parent = authority.derived_provider_parent(ProviderCallClass.DAEMON)
+                parent = authority.derived_provider_parent(ProviderCallClass.DAEMON)
             except DriverAuthorityEndpointBindingMismatch:
                 authority.close()
                 mismatch = EndpointBindingMismatchAuthorityAdapter()

--- a/tests/ANATOMY.md
+++ b/tests/ANATOMY.md
@@ -12,6 +12,7 @@ related_files:
   - tests/_agent_dir_helpers.py
   - tests/_agent_presence_helpers.py
   - tests/_chat_completion_helpers.py
+  - tests/_daemon_authority_probe.py
   - tests/_daemon_helpers.py
   - tests/_detached_cli_parent.py
   - tests/_fake_codex_app_server.py
@@ -513,6 +514,9 @@ complete, not to pair with a governed contract.
   - **Detached-process parents:** `_detached_cli_parent.py` and
     `_manager_detached_parent.py`, executed as real child processes by the
     daemon and lifecycle suites.
+  - **Authority child probe:** `_daemon_authority_probe.py`, executed by the
+    detached-supervisor tests to prove a child can handshake only with its
+    passed Driver endpoint and cannot reopen the parent endpoint.
 - `codex` and `opencode` — executable `/bin/sh` shims on the test PATH. Each
   execs `_fake_resume_cli.py` under `${PYTHON:-python}`; `opencode` additionally
   exports `FAKE_DAEMON_CLI=opencode` so one fake CLI serves both daemon

--- a/tests/_daemon_authority_probe.py
+++ b/tests/_daemon_authority_probe.py
@@ -1,0 +1,37 @@
+"""Minimal real execution-child probe used by daemon authority boundary tests."""
+from __future__ import annotations
+
+import errno
+import json
+import os
+import socket
+import struct
+import sys
+
+
+def main(result_path: str) -> int:
+    result: dict[str, object] = {}
+    try:
+        root = socket.socket(fileno=int(os.environ["ROOT_AUTHORITY_FD"]))
+    except OSError as exc:
+        result["root_errno"] = exc.errno
+    else:
+        result["root_open"] = True
+        root.close()
+    child = socket.socket(fileno=int(os.environ["LINGTAI_DRIVER_AUTHORITY_FD"]))
+    request = json.dumps({"version": 1, "op": "hello"}, separators=(",", ":")).encode()
+    child.sendall(struct.pack("!I", len(request)) + request)
+    header = child.recv(4)
+    size = struct.unpack("!I", header)[0]
+    response = bytearray()
+    while len(response) < size:
+        response.extend(child.recv(size - len(response)))
+    result["child_role"] = json.loads(bytes(response).decode())["role"]
+    child.close()
+    with open(result_path, "w", encoding="utf-8") as output:
+        json.dump(result, output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1]))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -942,7 +942,7 @@ def test_run_marks_derived_avatar_child_as_requiring_authority(monkeypatch, tmp_
 
     cli.run(tmp_path)
 
-    assert captured["kwargs"] == {"_requires_derived_launch_admission_port": True}
+    assert captured["kwargs"]["_requires_derived_launch_admission_port"] is True
 
 
 def test_run_marks_persisted_avatar_child_as_requiring_authority(monkeypatch, tmp_path):
@@ -995,7 +995,7 @@ def test_run_marks_persisted_avatar_child_as_requiring_authority(monkeypatch, tm
 
     cli.run(tmp_path)
 
-    assert captured["kwargs"] == {"_requires_derived_launch_admission_port": True}
+    assert captured["kwargs"]["_requires_derived_launch_admission_port"] is True
 
 
 def test_run_keeps_malformed_persisted_avatar_state_restrictive(monkeypatch, tmp_path):
@@ -1045,7 +1045,7 @@ def test_run_keeps_malformed_persisted_avatar_state_restrictive(monkeypatch, tmp
 
     cli.run(tmp_path)
 
-    assert captured["kwargs"] == {"_requires_derived_launch_admission_port": True}
+    assert captured["kwargs"]["_requires_derived_launch_admission_port"] is True
 
 
 def test_derived_avatar_marker_io_error_stays_restrictive(monkeypatch, tmp_path):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1129,6 +1129,132 @@ def test_avatar_child_cli_boot_reaches_structured_missing_authority_denial(
     ]
 
 
+def test_avatar_composition_preserves_cross_mode_endpoint_binding_denial(
+    monkeypatch, tmp_path,
+):
+    """A daemon endpoint in the real avatar boot keeps the mismatch reason."""
+    import socket
+    import struct
+    import threading
+
+    from lingtai import cli
+    from lingtai.adapters.acp.driver_authority import (
+        DRIVER_AUTHORITY_FD_ENV,
+        EndpointBindingMismatchAuthorityAdapter,
+    )
+    from lingtai.kernel.provider_admission import (
+        ProviderAdmittedLLMService,
+        ProviderAdmissionError,
+        bind_provider_admission,
+        clear_provider_admission,
+    )
+    from lingtai.tools.avatar._launcher import (
+        DERIVED_AVATAR_STATE,
+        derived_avatar_state_path,
+    )
+
+    class _Flag:
+        def set(self):
+            pass
+
+    class _Shutdown:
+        def wait(self):
+            return None
+
+    class _FakeAgent:
+        def __init__(self):
+            self._asleep = _Flag()
+            self._shutdown = _Shutdown()
+            self._state = None
+            self._venv_path = None
+
+        def start(self):
+            pass
+
+        def stop(self, timeout=10.0):
+            pass
+
+    class _InnerSession:
+        interface = object()
+        pre_request_hook = None
+
+        def __init__(self):
+            self.calls = []
+
+        def send(self, message):
+            self.calls.append(message)
+            return message
+
+    class _InnerService:
+        def __init__(self):
+            self.session = _InnerSession()
+
+        def create_session(self, *_args, **_kwargs):
+            return self.session
+
+    _write_init(tmp_path)
+    state_path = derived_avatar_state_path(tmp_path)
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(json.dumps(DERIVED_AVATAR_STATE), encoding="utf-8")
+    client, server = socket.socketpair()
+    server_errors = []
+
+    def driver_server():
+        try:
+            header = server.recv(4)
+            assert len(header) == 4
+            size = struct.unpack("!I", header)[0]
+            assert json.loads(server.recv(size).decode()) == {"version": 1, "op": "hello"}
+            payload = json.dumps(
+                {
+                    "version": 1,
+                    "role": "derived",
+                    "launch_id": "daemon-child",
+                    "capability": "daemon",
+                },
+                separators=(",", ":"),
+            ).encode()
+            server.sendall(struct.pack("!I", len(payload)) + payload)
+        except BaseException as exc:
+            server_errors.append(exc)
+        finally:
+            server.close()
+
+    captured = {}
+    thread = threading.Thread(target=driver_server)
+    thread.start()
+    monkeypatch.setattr(cli, "_check_duplicate_process", lambda working_dir: None)
+    monkeypatch.setattr(cli, "_clean_signal_files", lambda working_dir: None)
+    monkeypatch.setattr(cli, "_install_signal_handlers", lambda working_dir, agent: None)
+    monkeypatch.setattr(cli, "build_agent", lambda data, working_dir, **kwargs: captured.update(kwargs=kwargs) or _FakeAgent())
+    import lingtai.venv_resolve as venv_resolve
+
+    monkeypatch.setattr(venv_resolve, "resolve_venv", lambda data: tmp_path / "runtime-venv")
+    monkeypatch.setenv(DRIVER_AUTHORITY_FD_ENV, str(client.fileno()))
+    try:
+        cli.run(tmp_path)
+    finally:
+        try:
+            client.close()
+        except OSError:
+            pass
+    thread.join(timeout=2)
+
+    assert server_errors == []
+    port = captured["kwargs"]["_provider_call_admission_port"]
+    parent = captured["kwargs"]["_derived_provider_admission_parent"]
+    assert isinstance(port, EndpointBindingMismatchAuthorityAdapter)
+    inner = _InnerService()
+    service = ProviderAdmittedLLMService(inner, port)
+    token = bind_provider_admission(parent)
+    try:
+        with pytest.raises(ProviderAdmissionError, match="endpoint_binding_mismatch"):
+            service.create_session("system").send("must-not-reach-provider")
+    finally:
+        clear_provider_admission(token)
+    assert inner.session.calls == []
+
+
 def test_avatar_spawned_directory_stays_restricted_without_launch_env(
     monkeypatch, tmp_path,
 ):

--- a/tests/test_daemon_detached_supervisor.py
+++ b/tests/test_daemon_detached_supervisor.py
@@ -1445,6 +1445,26 @@ def test_invalid_supervisor_authority_fd_is_logged_and_removed(monkeypatch, capl
     assert "daemon_supervisor_authority_endpoint_invalid" in caplog.text
 
 
+def test_supervisor_closes_fd_when_endpoint_adoption_fails(monkeypatch):
+    """A failed socket wrapper must not orphan the consumed environment fd."""
+    from lingtai.adapters.posix import daemon_supervisor as supervisor_module
+
+    closed: list[int] = []
+    monkeypatch.setattr(supervisor_module, "_SUPERVISOR_AUTHORITY_ENDPOINT", None)
+    monkeypatch.setenv("LINGTAI_DRIVER_AUTHORITY_FD", "731")
+    monkeypatch.setattr(
+        supervisor_module.socket,
+        "socket",
+        lambda *, fileno: (_ for _ in ()).throw(OSError("simulated adoption failure")),
+    )
+    monkeypatch.setattr(supervisor_module.os, "close", closed.append)
+
+    supervisor_module.adopt_supervisor_authority_endpoint()
+
+    assert "LINGTAI_DRIVER_AUTHORITY_FD" not in os.environ
+    assert closed == [731]
+
+
 def test_real_daemon_second_hop_loses_root_fd_but_keeps_the_adopted_endpoint(
     tmp_path, monkeypatch,
 ):

--- a/tests/test_daemon_detached_supervisor.py
+++ b/tests/test_daemon_detached_supervisor.py
@@ -1394,8 +1394,8 @@ def test_daemon_execution_composition_preserves_cross_mode_endpoint_binding_deni
     assert inner.session.calls == []
 
 
-def test_v3_daemon_manifest_missing_or_malformed_requirement_is_restrictive(tmp_path):
-    """Only an explicit v3 false, or legacy v2, may retain generic behavior."""
+def test_daemon_manifest_restricts_schema_downgrade_with_explicit_evidence(tmp_path):
+    """Only evidence-free legacy manifests may retain generic behavior."""
     from lingtai.kernel.daemon_supervisor.manifest import (
         DERIVED_LAUNCH_ADMISSION_REQUIRED_FIELD,
         manifest_requires_derived_launch_admission,
@@ -1412,7 +1412,37 @@ def test_v3_daemon_manifest_missing_or_malformed_requirement_is_restrictive(tmp_
     manifest[DERIVED_LAUNCH_ADMISSION_REQUIRED_FIELD] = "not-a-bool"
     assert manifest_requires_derived_launch_admission(manifest) is True
     manifest["schema"] = "lingtai.daemon_supervisor_manifest.v2"
+    assert manifest_requires_derived_launch_admission(manifest) is True
+    manifest[DERIVED_LAUNCH_ADMISSION_REQUIRED_FIELD] = False
     assert manifest_requires_derived_launch_admission(manifest) is False
+    manifest.pop(DERIVED_LAUNCH_ADMISSION_REQUIRED_FIELD)
+    assert manifest_requires_derived_launch_admission(manifest) is False
+
+
+def test_daemon_manifest_schema_downgrade_is_observable(tmp_path, caplog):
+    from lingtai.kernel.daemon_supervisor.manifest import (
+        DERIVED_LAUNCH_ADMISSION_REQUIRED_FIELD,
+        manifest_requires_derived_launch_admission,
+    )
+
+    manifest = {
+        "schema": "unexpected-schema",
+        DERIVED_LAUNCH_ADMISSION_REQUIRED_FIELD: True,
+    }
+    with caplog.at_level("WARNING"):
+        assert manifest_requires_derived_launch_admission(manifest) is True
+    assert "derived_launch_admission_manifest_schema_downgrade" in caplog.text
+
+
+def test_invalid_supervisor_authority_fd_is_logged_and_removed(monkeypatch, caplog):
+    from lingtai.adapters.posix import daemon_supervisor as supervisor_module
+
+    monkeypatch.setattr(supervisor_module, "_SUPERVISOR_AUTHORITY_ENDPOINT", None)
+    monkeypatch.setenv("LINGTAI_DRIVER_AUTHORITY_FD", "not-a-fd")
+    with caplog.at_level("WARNING"):
+        supervisor_module.adopt_supervisor_authority_endpoint()
+    assert "LINGTAI_DRIVER_AUTHORITY_FD" not in os.environ
+    assert "daemon_supervisor_authority_endpoint_invalid" in caplog.text
 
 
 def test_real_daemon_second_hop_loses_root_fd_but_keeps_the_adopted_endpoint(

--- a/tests/test_daemon_detached_supervisor.py
+++ b/tests/test_daemon_detached_supervisor.py
@@ -17,12 +17,14 @@ cannot cross a process boundary).
 from __future__ import annotations
 
 import json
+import errno
 import os
 import signal
 import socket
 import subprocess
 import textwrap
 import threading
+import struct
 
 import pytest
 import sys
@@ -263,8 +265,8 @@ def test_posix_supervisor_hands_only_one_driver_child_endpoint_to_its_child(
     assert kwargs["env"]["LINGTAI_DRIVER_AUTHORITY_FD"] == str(child_fds[0])
     assert kwargs["env"]["LINGTAI_DERIVED_DAEMON_EXECUTION"] == "1"
     assert kwargs["close_fds"] is True
-    from lingtai.tools.daemon.execution_host import derived_daemon_state_path
-    assert derived_daemon_state_path(run_dir.path).is_file()
+    from lingtai.kernel.daemon_supervisor.manifest import read_manifest
+    assert read_manifest(manifest_path_for(run_dir.path))["derived_launch_admission_required"] is True
 
 
 def test_detached_lingtai_run_survives_agent_stop_shutdown_and_reaches_done(tmp_path):
@@ -1201,9 +1203,10 @@ def test_persisted_daemon_child_without_fd_fails_before_provider_io(tmp_path, mo
         bind_provider_admission,
         clear_provider_admission,
     )
-    from lingtai.tools.daemon.execution_host import (
-        DetachedDaemonExecutionHost,
-        mark_derived_daemon_requires_authority,
+    from lingtai.tools.daemon.execution_host import DetachedDaemonExecutionHost
+    from lingtai.kernel.daemon_supervisor.manifest import (
+        mark_manifest_requires_derived_launch_admission,
+        read_manifest,
     )
     from threading import Event
 
@@ -1235,7 +1238,10 @@ def test_persisted_daemon_child_without_fd_fails_before_provider_io(tmp_path, mo
         llm={"provider": "fake", "model": "fake", "api_key": None,
              "base_url": None, "context_window": None, "provider_defaults": None},
     )
-    mark_derived_daemon_requires_authority(run_dir.path)
+    from lingtai.kernel.daemon_supervisor.manifest import write_manifest
+    write_manifest(run_dir.path, manifest)
+    mark_manifest_requires_derived_launch_admission(run_dir.path)
+    manifest = read_manifest(manifest_path_for(run_dir.path))
     host = DetachedDaemonExecutionHost(run_dir, manifest, Event(), Event())
     inner = _InnerService()
     service = ProviderAdmittedLLMService(inner, host._agent._provider_call_admission_port)
@@ -1248,7 +1254,79 @@ def test_persisted_daemon_child_without_fd_fails_before_provider_io(tmp_path, mo
     assert inner.session.calls == []
 
 
+def test_v3_daemon_manifest_missing_or_malformed_requirement_is_restrictive(tmp_path):
+    """Only an explicit v3 false, or legacy v2, may retain generic behavior."""
+    from lingtai.kernel.daemon_supervisor.manifest import (
+        DERIVED_LAUNCH_ADMISSION_REQUIRED_FIELD,
+        manifest_requires_derived_launch_admission,
+    )
 
+    manifest = build_manifest(
+        run_id="run", backend="lingtai", parent_working_dir=str(tmp_path),
+        run_dir=str(tmp_path / "run"), task="task", tools=[], max_turns=1,
+        timeout_s=1, group_id=None,
+    )
+    assert manifest_requires_derived_launch_admission(manifest) is False
+    manifest.pop(DERIVED_LAUNCH_ADMISSION_REQUIRED_FIELD)
+    assert manifest_requires_derived_launch_admission(manifest) is True
+    manifest[DERIVED_LAUNCH_ADMISSION_REQUIRED_FIELD] = "not-a-bool"
+    assert manifest_requires_derived_launch_admission(manifest) is True
+    manifest["schema"] = "lingtai.daemon_supervisor_manifest.v2"
+    assert manifest_requires_derived_launch_admission(manifest) is False
+
+
+def test_real_daemon_second_hop_loses_root_fd_but_keeps_the_adopted_endpoint(
+    tmp_path, monkeypatch,
+):
+    """The supervisor relays its held endpoint object, never an env fd number."""
+    from lingtai.adapters.posix import daemon_supervisor as supervisor_module
+
+    run_dir = _make_run_dir(tmp_path, task="authority two-hop probe")
+    root_client, root_driver = socket.socketpair()
+    child_client, child_driver = socket.socketpair()
+    result_path = tmp_path / "two-hop-result.json"
+    server_errors: list[BaseException] = []
+
+    def driver_server():
+        try:
+            header = child_driver.recv(4)
+            assert len(header) == 4
+            size = struct.unpack("!I", header)[0]
+            assert json.loads(child_driver.recv(size).decode()) == {"version": 1, "op": "hello"}
+            response = json.dumps(
+                {"version": 1, "role": "derived", "launch_id": "child-1", "capability": "daemon"},
+                separators=(",", ":"),
+            ).encode()
+            child_driver.sendall(struct.pack("!I", len(response)) + response)
+        except BaseException as exc:
+            server_errors.append(exc)
+        finally:
+            child_driver.close()
+
+    source_root = str(Path(__file__).resolve().parents[1])
+    monkeypatch.setenv("PYTHONPATH", source_root + os.pathsep + str(Path(source_root) / "src"))
+    monkeypatch.setenv("ROOT_AUTHORITY_FD", str(root_client.fileno()))
+    monkeypatch.setenv("LINGTAI_DRIVER_AUTHORITY_FD", str(child_client.fileno()))
+    supervisor_module.adopt_supervisor_authority_endpoint()
+    assert "LINGTAI_DRIVER_AUTHORITY_FD" not in os.environ
+    server = threading.Thread(target=driver_server)
+    server.start()
+    try:
+        child = PosixDaemonSupervisorAdapter._spawn_capsule_process(
+            "tests._daemon_authority_probe", sys.executable, [str(result_path)],
+            run_dir=run_dir.path,
+        )
+        assert child.wait(timeout=2) == 0
+        server.join(timeout=2)
+        assert server_errors == []
+        assert json.loads(result_path.read_text()) == {
+            "root_errno": errno.EBADF,
+            "child_role": "derived",
+        }
+    finally:
+        root_client.close()
+        root_driver.close()
+        child_driver.close()
 def test_detached_shell_async_uses_run_local_events_not_agent_notifications(tmp_path):
     """Actual detached Shell async completion is pollable without an Agent sink."""
     from lingtai.tools.daemon.execution_host import DetachedDaemonExecutionHost

--- a/tests/test_daemon_detached_supervisor.py
+++ b/tests/test_daemon_detached_supervisor.py
@@ -269,6 +269,50 @@ def test_posix_supervisor_hands_only_one_driver_child_endpoint_to_its_child(
     assert read_manifest(manifest_path_for(run_dir.path))["derived_launch_admission_required"] is True
 
 
+def test_supervisor_reserve_endpoint_skips_resume_owner_and_reaches_execution_child(
+    tmp_path, monkeypatch,
+):
+    """Only the exact execution-child module may consume the held endpoint."""
+    from lingtai.adapters.posix import daemon_supervisor as supervisor_module
+
+    run_dir = _make_run_dir(tmp_path, task="authority module routing")
+    client, driver = socket.socketpair()
+    calls = []
+
+    def fake_popen(*args, **kwargs):
+        calls.append((args, kwargs))
+        return object()
+
+    monkeypatch.setattr(supervisor_module.subprocess, "Popen", fake_popen)
+    monkeypatch.setenv("LINGTAI_DRIVER_AUTHORITY_FD", str(client.fileno()))
+    supervisor_module.adopt_supervisor_authority_endpoint()
+    adapter = PosixDaemonSupervisorAdapter()
+    try:
+        adapter.spawn_resume_owner(
+            python_executable=sys.executable,
+            manifest_path=str(run_dir.path / "manifest.json"),
+            run_id=run_dir.run_id,
+            run_dir=run_dir.path,
+            generation="g1",
+        )
+        adapter.spawn_execution_child(
+            python_executable=sys.executable,
+            manifest_path=str(run_dir.path / "manifest.json"),
+            run_id=run_dir.run_id,
+            run_dir=run_dir.path,
+        )
+    finally:
+        driver.close()
+
+    assert len(calls) == 2
+    _resume_args, resume_kwargs = calls[0]
+    _execution_args, execution_kwargs = calls[1]
+    assert "LINGTAI_DRIVER_AUTHORITY_FD" not in resume_kwargs["env"]
+    assert resume_kwargs["pass_fds"] == ()
+    assert "LINGTAI_DRIVER_AUTHORITY_FD" in execution_kwargs["env"]
+    assert len(execution_kwargs["pass_fds"]) == 1
+
+
 def test_detached_lingtai_run_survives_agent_stop_shutdown_and_reaches_done(tmp_path):
     """Acceptance test 1: real detached LingTai run outlives shutdown_for_agent_stop."""
     from lingtai.tools import daemon as daemon_module
@@ -1254,6 +1298,102 @@ def test_persisted_daemon_child_without_fd_fails_before_provider_io(tmp_path, mo
     assert inner.session.calls == []
 
 
+def test_daemon_execution_composition_preserves_cross_mode_endpoint_binding_denial(
+    tmp_path, monkeypatch,
+):
+    """An avatar endpoint in the real daemon host keeps the mismatch reason."""
+    from lingtai.adapters.acp.driver_authority import (
+        DRIVER_AUTHORITY_FD_ENV,
+        EndpointBindingMismatchAuthorityAdapter,
+    )
+    from lingtai.kernel.daemon_supervisor.manifest import (
+        mark_manifest_requires_derived_launch_admission,
+        read_manifest,
+    )
+    from lingtai.kernel.provider_admission import (
+        ProviderAdmittedLLMService,
+        ProviderAdmissionError,
+        bind_provider_admission,
+        clear_provider_admission,
+    )
+    from lingtai.tools.daemon.execution_host import DetachedDaemonExecutionHost
+    from threading import Event
+
+    class _InnerSession:
+        def __init__(self):
+            self.calls = []
+            self.interface = object()
+            self.pre_request_hook = None
+
+        def send(self, message):
+            self.calls.append(message)
+            return message
+
+    class _InnerService:
+        def __init__(self):
+            self.session = _InnerSession()
+
+        def create_session(self, *_args, **_kwargs):
+            return self.session
+
+    monkeypatch.delenv("LINGTAI_DERIVED_DAEMON_EXECUTION", raising=False)
+    run_dir = _make_run_dir(tmp_path, task="daemon endpoint cross-mode")
+    manifest = build_manifest(
+        run_id=run_dir.run_id, backend="lingtai",
+        parent_working_dir=str(run_dir.path.parent.parent), run_dir=str(run_dir.path),
+        task="daemon endpoint cross-mode", tools=[], max_turns=1, timeout_s=30,
+        group_id=None,
+        llm={"provider": "fake", "model": "fake", "api_key": None,
+             "base_url": None, "context_window": None, "provider_defaults": None},
+    )
+    write_manifest(run_dir.path, manifest)
+    mark_manifest_requires_derived_launch_admission(run_dir.path)
+    manifest = read_manifest(manifest_path_for(run_dir.path))
+    client, server = socket.socketpair()
+    server_errors = []
+
+    def driver_server():
+        try:
+            header = server.recv(4)
+            assert len(header) == 4
+            size = struct.unpack("!I", header)[0]
+            assert json.loads(server.recv(size).decode()) == {"version": 1, "op": "hello"}
+            payload = json.dumps(
+                {"version": 1, "role": "derived", "launch_id": "avatar-child", "capability": "avatar"},
+                separators=(",", ":"),
+            ).encode()
+            server.sendall(struct.pack("!I", len(payload)) + payload)
+        except BaseException as exc:
+            server_errors.append(exc)
+        finally:
+            server.close()
+
+    thread = threading.Thread(target=driver_server)
+    thread.start()
+    monkeypatch.setenv(DRIVER_AUTHORITY_FD_ENV, str(client.fileno()))
+    try:
+        host = DetachedDaemonExecutionHost(run_dir, manifest, Event(), Event())
+    finally:
+        try:
+            client.close()
+        except OSError:
+            pass
+    thread.join(timeout=2)
+
+    assert server_errors == []
+    port = host._agent._provider_call_admission_port
+    assert isinstance(port, EndpointBindingMismatchAuthorityAdapter)
+    inner = _InnerService()
+    service = ProviderAdmittedLLMService(inner, port)
+    token = bind_provider_admission(host._agent._derived_provider_admission_parent)
+    try:
+        with pytest.raises(ProviderAdmissionError, match="endpoint_binding_mismatch"):
+            service.create_session("system").send("must-not-reach-provider")
+    finally:
+        clear_provider_admission(token)
+    assert inner.session.calls == []
+
+
 def test_v3_daemon_manifest_missing_or_malformed_requirement_is_restrictive(tmp_path):
     """Only an explicit v3 false, or legacy v2, may retain generic behavior."""
     from lingtai.kernel.daemon_supervisor.manifest import (
@@ -1307,6 +1447,12 @@ def test_real_daemon_second_hop_loses_root_fd_but_keeps_the_adopted_endpoint(
     monkeypatch.setenv("PYTHONPATH", source_root + os.pathsep + str(Path(source_root) / "src"))
     monkeypatch.setenv("ROOT_AUTHORITY_FD", str(root_client.fileno()))
     monkeypatch.setenv("LINGTAI_DRIVER_AUTHORITY_FD", str(child_client.fileno()))
+    # The subprocess probe replaces the execution entrypoint solely to inspect
+    # its inherited descriptors.  The companion module-routing test exercises
+    # the production ``spawn_execution_child`` selection itself.
+    monkeypatch.setattr(
+        supervisor_module, "EXECUTION_CHILD_MODULE", "tests._daemon_authority_probe"
+    )
     supervisor_module.adopt_supervisor_authority_endpoint()
     assert "LINGTAI_DRIVER_AUTHORITY_FD" not in os.environ
     server = threading.Thread(target=driver_server)

--- a/tests/test_driver_authority_adapter.py
+++ b/tests/test_driver_authority_adapter.py
@@ -349,6 +349,31 @@ def test_local_child_mode_must_match_the_driver_endpoint_capability(
     assert errors == []
 
 
+def test_derived_provider_parent_requires_an_explicit_local_child_mode():
+    """A new composition cannot silently skip its endpoint-mode comparison."""
+    client, server = socket.socketpair()
+
+    def handler(sock):
+        assert _recv_frame(sock) == {"version": 1, "op": "hello"}
+        _send_frame(
+            sock,
+            {
+                "version": 1,
+                "role": "derived",
+                "launch_id": "child-1",
+                "capability": "daemon",
+            },
+        )
+
+    thread, errors = _server_thread(server, handler)
+    adapter = DriverAuthorityAdapter(client)
+    with pytest.raises(TypeError, match="expected_call_class"):
+        adapter.derived_provider_parent()  # type: ignore[call-arg]
+    adapter.close()
+    thread.join(timeout=2)
+    assert errors == []
+
+
 @pytest.mark.parametrize(
     "call_class", [ProviderCallClass.DAEMON, ProviderCallClass.AVATAR_CHILD]
 )
@@ -419,7 +444,7 @@ def test_derived_provider_call_uses_its_own_endpoint_and_driver_known_fields():
 
     thread, errors = _server_thread(server, handler)
     adapter = DriverAuthorityAdapter(client)
-    parent = adapter.derived_provider_parent()
+    parent = adapter.derived_provider_parent(ProviderCallClass.DAEMON)
     decision = adapter.authorize_provider_call(parent, ProviderCallClass.DAEMON)
     thread.join(timeout=2)
 
@@ -459,7 +484,8 @@ def test_driver_reports_endpoint_binding_mismatch_as_a_distinct_denial():
     thread, errors = _server_thread(server, handler)
     adapter = DriverAuthorityAdapter(client)
     decision = adapter.authorize_provider_call(
-        adapter.derived_provider_parent(), ProviderCallClass.AVATAR_CHILD
+        adapter.derived_provider_parent(ProviderCallClass.AVATAR_CHILD),
+        ProviderCallClass.AVATAR_CHILD,
     )
     thread.join(timeout=2)
 

--- a/tests/test_driver_authority_adapter.py
+++ b/tests/test_driver_authority_adapter.py
@@ -18,6 +18,7 @@ from lingtai.adapters.acp.driver_authority import (
     DriverAuthorityAdapter,
     DriverChildEndpointLease,
     DriverAuthorityEndpointBindingMismatch,
+    EndpointBindingMismatchAuthorityAdapter,
     DriverAuthorityTransportError,
     UnavailableDriverAuthorityAdapter,
     authority_adapter_from_environment,
@@ -26,6 +27,8 @@ from lingtai.adapters.acp.driver_authority import (
 from lingtai.kernel.provider_admission import (
     DerivedLaunchCapability,
     ProviderAdmissionState,
+    ProviderAdmittedLLMService,
+    ProviderAdmissionError,
     ProviderCallClass,
     RootProviderAdmission,
     begin_derived_provider_admission,
@@ -344,6 +347,42 @@ def test_local_child_mode_must_match_the_driver_endpoint_capability(
     adapter.close()
     thread.join(timeout=2)
     assert errors == []
+
+
+@pytest.mark.parametrize(
+    "call_class", [ProviderCallClass.DAEMON, ProviderCallClass.AVATAR_CHILD]
+)
+def test_cross_mode_binding_mismatch_rejects_before_inner_provider_io(call_class):
+    """Both child compositions use the typed mismatch denial, never generic I/O."""
+
+    class InnerSession:
+        interface = object()
+        pre_request_hook = None
+
+        def __init__(self):
+            self.calls = []
+
+        def send(self, message):
+            self.calls.append(message)
+            return message
+
+    class InnerService:
+        def __init__(self):
+            self.session = InnerSession()
+
+        def create_session(self, *_args, **_kwargs):
+            return self.session
+
+    adapter = EndpointBindingMismatchAuthorityAdapter()
+    inner = InnerService()
+    service = ProviderAdmittedLLMService(inner, adapter)
+    token = bind_provider_admission(adapter.derived_provider_parent(call_class))
+    try:
+        with pytest.raises(ProviderAdmissionError, match="endpoint_binding_mismatch"):
+            service.create_session("system").send("must-not-reach-provider")
+    finally:
+        clear_provider_admission(token)
+    assert inner.session.calls == []
 
 
 def test_derived_provider_call_uses_its_own_endpoint_and_driver_known_fields():

--- a/tests/test_provider_admission.py
+++ b/tests/test_provider_admission.py
@@ -387,7 +387,7 @@ def test_provider_dispatch_concurrency_inventory_is_explicit():
         ("src/lingtai/tools/daemon/__init__.py", 6540, "Thread"),
         ("src/lingtai/tools/daemon/__init__.py", 9144, "ThreadPoolExecutor"),
         ("src/lingtai/tools/daemon/claude_interactive.py", 611, "Thread"),
-        ("src/lingtai/tools/daemon/execution_host.py", 701, "ThreadPoolExecutor"),
+        ("src/lingtai/tools/daemon/execution_host.py", 675, "ThreadPoolExecutor"),
         ("src/lingtai/tools/daemon/posix_process.py", 112, "Thread"),
         ("src/lingtai/tools/daemon/runtime.py", 133, "Thread"),
         ("src/lingtai/tools/daemon/runtime.py", 220, "Thread"),

--- a/tests/test_provider_admission.py
+++ b/tests/test_provider_admission.py
@@ -387,7 +387,7 @@ def test_provider_dispatch_concurrency_inventory_is_explicit():
         ("src/lingtai/tools/daemon/__init__.py", 6540, "Thread"),
         ("src/lingtai/tools/daemon/__init__.py", 9144, "ThreadPoolExecutor"),
         ("src/lingtai/tools/daemon/claude_interactive.py", 611, "Thread"),
-        ("src/lingtai/tools/daemon/execution_host.py", 675, "ThreadPoolExecutor"),
+        ("src/lingtai/tools/daemon/execution_host.py", 671, "ThreadPoolExecutor"),
         ("src/lingtai/tools/daemon/posix_process.py", 112, "Thread"),
         ("src/lingtai/tools/daemon/runtime.py", 133, "Thread"),
         ("src/lingtai/tools/daemon/runtime.py", 220, "Thread"),


### PR DESCRIPTION
Split from #1545. Hardens restart failure boundaries, daemon authority handoff/manifest composition, and cross-mode endpoint denial.

Boundary: depends on #1559; excludes tool-surface/D6 audits, endpoint lifecycle follow-ups, and E2E harnesses.

Validation: `git diff --check codex/phase-b-05-driver-lease...HEAD` passes.

Base: #1559 (`16343c1866831c175783de0e26aff2f0d18892b1`).