### PR TITLE
Phase B/9: audit nested launches and dispose rejected leases

### DIFF
--- a/ANATOMY.md
+++ b/ANATOMY.md
@@ -51,6 +51,7 @@ related_files:
   - scripts/check_docs_governance.py
   - scripts/setup_driver_supervisor_e2e_env.sh
   - scripts/verify_driver_executor_audit.py
+  - scripts/verify_driver_nested_launch_audit.py
   - scripts/generate_release_manifest.py
   - scripts/publish_release_assets.py
   - scripts/sync_gitee_mirror.py
@@ -221,8 +222,9 @@ disclosure, and fail-loud mismatch reports; do not duplicate that rule here.
   `release.published` event (or an explicit `workflow_dispatch` with
   `publish: true`) — every other trigger shape stays dry-run. The Driver
   acceptance probes use `setup_driver_supervisor_e2e_env.sh` to create the
-  supported isolated interpreter; `verify_driver_executor_audit.py` then
-  checks Driver executor audit boundaries against source-only Puffo input.
+  supported isolated interpreter; `verify_driver_executor_audit.py` and
+  `verify_driver_nested_launch_audit.py` then check executor and rejected
+  nested-launch audit boundaries against source-only Puffo input.
 - [`.github/`](.github/) — GitHub Actions, issue templates, and pull request
   templates. `workflows/wheels.yml` is the release build/verify/manifest
   pipeline; `kernel-windows-pr.yml` and `shell-windows-pr.yml` are the native

--- a/scripts/verify_driver_nested_launch_audit.py
+++ b/scripts/verify_driver_nested_launch_audit.py
@@ -9,6 +9,11 @@ provider recorder unchanged.
 
 It verifies the admission seam itself.  LingTai's daemon/avatar production
 dispatch regressions live in the normal test suite and use the same typed seam.
+
+Before running, create the supported isolated interpreter with
+``scripts/setup_driver_supervisor_e2e_env.sh <venv-dir>``. Use
+``<venv-dir>/bin/python`` and pass both source roots with ``--lingtai-src``
+and ``--puffo-src``; do not install the Puffo runtime into that environment.
 """
 
 from __future__ import annotations

--- a/scripts/verify_driver_nested_launch_audit.py
+++ b/scripts/verify_driver_nested_launch_audit.py
@@ -1,0 +1,155 @@
+"""Cross-repository D1 probe for Driver-audited nested launch denial.
+
+This is deliberately a cross-repository acceptance script: the Driver audit
+IDs must be issued by Puffo's real authority server, rather than by a LingTai
+test double.  It exercises a legal root-to-one-hop daemon launch, one child
+provider call, then nested daemon and avatar launch requests.  The latter two
+must reach Driver, be denied with distinct non-empty audit IDs, and leave the
+provider recorder unchanged.
+
+It verifies the admission seam itself.  LingTai's daemon/avatar production
+dispatch regressions live in the normal test suite and use the same typed seam.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+import sys
+from typing import Any
+
+
+def _load(lingtai_src: Path, puffo_src: Path) -> tuple[Any, ...]:
+    sys.path[:0] = [str(puffo_src.resolve(strict=True)), str(lingtai_src.resolve(strict=True))]
+    from lingtai.adapters.acp.driver_authority import (
+        DriverAuthorityAdapter,
+        consume_posix_child_endpoint_lease,
+    )
+    from lingtai.kernel.provider_admission import (
+        DerivedLaunchAdmissionError,
+        DerivedLaunchCapability,
+        ProviderAdmittedLLMService,
+        ProviderCallClass,
+        RootProviderAdmission,
+        bind_provider_admission,
+        clear_provider_admission,
+        current_provider_call_audit_id,
+        require_derived_launch_admission,
+    )
+    from puffo_agent.agent.harness.driver_authority_server import DriverAuthorityServer
+
+    return (
+        DriverAuthorityAdapter,
+        consume_posix_child_endpoint_lease,
+        DerivedLaunchAdmissionError,
+        DerivedLaunchCapability,
+        ProviderAdmittedLLMService,
+        ProviderCallClass,
+        RootProviderAdmission,
+        bind_provider_admission,
+        clear_provider_admission,
+        current_provider_call_audit_id,
+        require_derived_launch_admission,
+        DriverAuthorityServer,
+    )
+
+
+def main(lingtai_src: Path, puffo_src: Path) -> None:
+    (
+        Adapter,
+        consume_lease,
+        LaunchError,
+        LaunchCapability,
+        AdmittedService,
+        CallClass,
+        RootAdmission,
+        bind,
+        clear,
+        current_audit_id,
+        require_launch,
+        Server,
+    ) = _load(lingtai_src, puffo_src)
+
+    class RecordingProvider:
+        def __init__(self) -> None:
+            self.provider_calls: list[str | None] = []
+
+        def generate(self, _prompt: str) -> str:
+            self.provider_calls.append(current_audit_id())
+            return "generated"
+
+    server = Server()
+    root_adapter = None
+    child_adapter = None
+    try:
+        root_endpoint = server.issue_root(launch_id="root-nested-audit")
+        root_fd = os.dup(root_endpoint.fileno())
+        root_endpoint.close()
+        root_adapter = Adapter.from_inherited_fd(root_fd)
+
+        root = RootAdmission("turn-nested-audit", "puffo-v0.e2e")
+        root_token = bind(root)
+        try:
+            launch = require_launch(root_adapter, LaunchCapability.DAEMON)
+        finally:
+            clear(root_token)
+
+        child_fd = consume_lease(launch.child_endpoint_lease)
+        child_adapter = Adapter.from_inherited_fd(child_fd)
+        child_parent = child_adapter.derived_provider_parent(CallClass.DAEMON)
+        provider = RecordingProvider()
+        service = AdmittedService(provider, child_adapter)
+
+        child_token = bind(child_parent)
+        try:
+            assert service.generate("legal child provider call") == "generated"
+            nested = []
+            for capability in (LaunchCapability.DAEMON, LaunchCapability.AVATAR):
+                try:
+                    require_launch(child_adapter, capability)
+                except LaunchError as exc:
+                    nested.append(exc.decision)
+                else:
+                    raise AssertionError(f"nested {capability.value} launch was granted")
+        finally:
+            clear(child_token)
+
+        records = server.audit_records()
+        provider_records = [
+            record for record in records if record.operation == "authorize_provider_call"
+        ]
+        nested_records = [
+            record
+            for record in records
+            if record.operation == "authorize_derived_launch"
+            and record.reason_code == "nested_derived_launch_denied"
+        ]
+        print(f"provider_calls={provider.provider_calls}")
+        print(f"provider_audits={[record.audit_id for record in provider_records]}")
+        print(f"nested_audits={[record.audit_id for record in nested_records]}")
+
+        assert len(provider_records) == 1
+        assert provider.provider_calls == [provider_records[0].audit_id]
+        assert len(nested) == 2
+        assert all(decision.reason_code == "nested_derived_launch_denied" for decision in nested)
+        assert all(isinstance(decision.audit_id, str) and decision.audit_id for decision in nested)
+        assert [decision.audit_id for decision in nested] == [
+            record.audit_id for record in nested_records
+        ]
+        assert len(nested_records) == 2
+        assert len(provider.provider_calls) == 1
+    finally:
+        if child_adapter is not None:
+            child_adapter.close()
+        if root_adapter is not None:
+            root_adapter.close()
+        server.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--lingtai-src", required=True, type=Path)
+    parser.add_argument("--puffo-src", required=True, type=Path)
+    args = parser.parse_args()
+    main(args.lingtai_src, args.puffo_src)

--- a/src/lingtai/adapters/acp/CONTRACT.md
+++ b/src/lingtai/adapters/acp/CONTRACT.md
@@ -262,7 +262,9 @@ argv, environment, or MCP command from the remote caller.
     another caller's decision. Every decision response MUST echo its request's
     `call_id`; mismatch closes any delivered endpoint and fails closed. Core does
     not parse fd/frame/registry data. A derived endpoint is server-bound to
-    `depth=1` and cannot mint another child. A persistent derived marker means
+    `depth=1` and cannot mint another child; its nested daemon/avatar request
+    still crosses the Driver endpoint so Driver returns and audits the typed
+    denial before Core applies its one-hop backstop. A persistent derived marker means
     authority is required, never granted: missing, closed, malformed, or
     unavailable transport is a structured indeterminate denial before any
     spawn/provider I/O and never a `legacy_default` fallback. This wiring does

--- a/src/lingtai/adapters/acp/driver_authority.py
+++ b/src/lingtai/adapters/acp/driver_authority.py
@@ -247,15 +247,27 @@ class DriverAuthorityAdapter(ProviderCallAdmissionPort):
 
     def authorize_derived_launch(
         self,
-        parent: RootProviderAdmission,
+        parent: ProviderAdmissionParent,
         capability: DerivedLaunchCapability,
     ) -> DerivedLaunchDecision:
-        if not isinstance(parent, RootProviderAdmission) or self._identity.role != "root":
-            return DerivedLaunchDecision(
-                ProviderAdmissionState.DENIED,
-                "nested_derived_launch_denied",
-            )
         if not isinstance(capability, DerivedLaunchCapability):
+            return DerivedLaunchDecision(
+                ProviderAdmissionState.INDETERMINATE,
+                "derived_launch_admission_port_unconnected",
+            )
+        if self._identity.role == "root":
+            if not isinstance(parent, RootProviderAdmission):
+                return DerivedLaunchDecision(
+                    ProviderAdmissionState.DENIED,
+                    "endpoint_binding_mismatch",
+                )
+        elif self._identity.role == "derived":
+            if not isinstance(parent, DerivedProviderAdmission):
+                return DerivedLaunchDecision(
+                    ProviderAdmissionState.DENIED,
+                    "endpoint_binding_mismatch",
+                )
+        else:
             return DerivedLaunchDecision(
                 ProviderAdmissionState.INDETERMINATE,
                 "derived_launch_admission_port_unconnected",
@@ -526,7 +538,7 @@ class UnavailableDriverAuthorityAdapter(ProviderCallAdmissionPort):
 
     def authorize_derived_launch(
         self,
-        _parent: RootProviderAdmission,
+        _parent: ProviderAdmissionParent,
         _capability: DerivedLaunchCapability,
     ) -> DerivedLaunchDecision:
         return DerivedLaunchDecision(
@@ -562,7 +574,7 @@ class EndpointBindingMismatchAuthorityAdapter(ProviderCallAdmissionPort):
 
     def authorize_derived_launch(
         self,
-        _parent: RootProviderAdmission,
+        _parent: ProviderAdmissionParent,
         _capability: DerivedLaunchCapability,
     ) -> DerivedLaunchDecision:
         return DerivedLaunchDecision(

--- a/src/lingtai/adapters/acp/puffo_v0.py
+++ b/src/lingtai/adapters/acp/puffo_v0.py
@@ -85,7 +85,7 @@ class PuffoV0RuntimePolicy:
 
     def authorize_derived_launch(
         self,
-        _parent: RootProviderAdmission,
+        _parent: ProviderAdmissionParent,
         _capability: DerivedLaunchCapability,
     ) -> DerivedLaunchDecision:
         """Refuse launch until the Driver-owned authority transport is wired."""

--- a/src/lingtai/kernel/base_agent/CONTRACT.md
+++ b/src/lingtai/kernel/base_agent/CONTRACT.md
@@ -369,7 +369,10 @@ Clause IDs are stable; each rule composes the linked normative source.
    actual provider call; it cannot reuse a root grant. v0 is explicitly
    one-hop: only a `RootProviderAdmission` can mint a derived parent, and a
    daemon/avatar child cannot mint another model-executing daemon/avatar.
-   Driver launch admission MUST reject the same nested request; adding recursive
+   Driver launch admission MUST reject and audit the same nested request with
+   its own reason code and audit correlation; when a live Port exists, Core
+   MUST present the request to that Port before applying its structural
+   backstop. Adding recursive
    derivation requires a new contract with per-hop authority and a recursive
    production-boundary inventory. This is an authorization rule, not a tool
    surface reduction: a full-tool child must be able to make its real
@@ -405,7 +408,8 @@ Clause IDs are stable; each rule composes the linked normative source.
    It is neither complete 2b nor merge authorization. Complete 2b additionally
    requires a real Driver server to issue and claim the endpoint on a legal
    root-to-one-hop launch, then the same recording transport must show a
-   non-empty legal provider call and empty denied nested calls. A protocol test
+   non-empty legal provider call, empty denied nested calls, and one Driver
+   denial audit with a non-empty audit id for each real nested tool request. A protocol test
    fixture can prove Core-only interoperability but cannot replace that
    production Driver-server gate. **Acceptance record:** this is a Step 3
    refusal-side scoped candidate only and carries **NO MERGE** authorization.
@@ -416,8 +420,10 @@ Clause IDs are stable; each rule composes the linked normative source.
    and any global removal of the generic daemon/avatar filter remain
    unimplemented. Persistent child markers prevent accidental launch/restart
    confusion only; a same-OS-user child able to rewrite its own directory or
-   run manifest is outside this guarantee. The Core `TypeError` is
-   merely a structural backstop and must not be the only rejection signal. The
+   run manifest is outside this guarantee. The Core local nested denial is
+   merely a structural backstop and must not be the only rejection signal: a
+   live Driver Port is attempted first so Driver owns the nested denial audit.
+   The
    derived-launch inventory uses `(file, enclosing qualified function,
    constructor)` keys, so unrelated line movement does not turn that specific
    tripwire into mechanical maintenance.

--- a/src/lingtai/kernel/provider_admission.py
+++ b/src/lingtai/kernel/provider_admission.py
@@ -186,7 +186,7 @@ class DerivedLaunchAdmissionPort(Protocol):
 
     def authorize_derived_launch(
         self,
-        parent: RootProviderAdmission,
+        parent: ProviderAdmissionParent,
         capability: DerivedLaunchCapability,
     ) -> DerivedLaunchDecision: ...
 
@@ -289,7 +289,18 @@ def require_derived_launch_admission(
 
     if not isinstance(capability, DerivedLaunchCapability):
         raise TypeError("derived launch capability must be typed")
+    parent = current_provider_admission()
     if port is None:
+        # Preserve the structural one-hop backstop even if a constrained child
+        # loses its transport.  With a live port the same nested request must
+        # still cross Driver so it receives the authoritative denial/audit.
+        if isinstance(parent, DerivedProviderAdmission):
+            raise DerivedLaunchAdmissionError(
+                DerivedLaunchDecision(
+                    ProviderAdmissionState.DENIED,
+                    "nested_derived_launch_denied",
+                )
+            )
         if required:
             raise DerivedLaunchAdmissionError(
                 DerivedLaunchDecision(
@@ -299,15 +310,12 @@ def require_derived_launch_admission(
             )
         return DerivedLaunchDecision(ProviderAdmissionState.GRANTED, "legacy_default")
 
-    parent = current_provider_admission()
-    if not isinstance(parent, RootProviderAdmission):
-        reason = (
-            "nested_derived_launch_denied"
-            if isinstance(parent, DerivedProviderAdmission)
-            else "missing_root_provider_admission"
-        )
+    if not isinstance(parent, (RootProviderAdmission, DerivedProviderAdmission)):
         raise DerivedLaunchAdmissionError(
-            DerivedLaunchDecision(ProviderAdmissionState.DENIED, reason)
+            DerivedLaunchDecision(
+                ProviderAdmissionState.DENIED,
+                "missing_root_provider_admission",
+            )
         )
     try:
         decision = port.authorize_derived_launch(parent, capability)
@@ -333,6 +341,16 @@ def require_derived_launch_admission(
         decision = DerivedLaunchDecision(
             ProviderAdmissionState.INDETERMINATE,
             "malformed_derived_launch_admission_decision",
+        )
+    # A nested request must be presented to Driver first, so the Driver can
+    # record its own denial.  Core remains a second, structural one-hop
+    # backstop: an erroneous Driver grant can never create a second child.
+    if isinstance(parent, DerivedProviderAdmission) and decision.allowed:
+        decision = DerivedLaunchDecision(
+            ProviderAdmissionState.DENIED,
+            "nested_derived_launch_denied",
+            audit_id=decision.audit_id,
+            admission_id=decision.admission_id,
         )
     if not decision.allowed:
         raise DerivedLaunchAdmissionError(decision)

--- a/src/lingtai/kernel/provider_admission.py
+++ b/src/lingtai/kernel/provider_admission.py
@@ -279,9 +279,10 @@ def _discard_child_endpoint_lease(lease: object | None) -> None:
     Core deliberately does not know the adapter's lease type or its file
     descriptor.  It may nevertheless reject a malformed decision, or keep its
     one-hop structural backstop after a faulty Driver grant.  In both cases
-    retaining the opaque handoff would strand the authority endpoint.  Adapter
+    retaining the opaque handoff would defer release to its finalizer.  Adapter
     leases expose a no-argument ``close`` method; unknown opaque values remain
-    harmlessly non-closable so Core stays transport-neutral.
+    harmlessly non-closable so Core stays transport-neutral.  This makes the
+    disposal deterministic; it does not claim a CPython finalizer leak.
     """
 
     close = getattr(lease, "close", None)

--- a/src/lingtai/kernel/provider_admission.py
+++ b/src/lingtai/kernel/provider_admission.py
@@ -273,6 +273,26 @@ def current_provider_call_class() -> ProviderCallClass:
     return ProviderCallClass.ROOT
 
 
+def _discard_child_endpoint_lease(lease: object | None) -> None:
+    """Best-effort dispose an opaque handoff Core will not pass to spawn.
+
+    Core deliberately does not know the adapter's lease type or its file
+    descriptor.  It may nevertheless reject a malformed decision, or keep its
+    one-hop structural backstop after a faulty Driver grant.  In both cases
+    retaining the opaque handoff would strand the authority endpoint.  Adapter
+    leases expose a no-argument ``close`` method; unknown opaque values remain
+    harmlessly non-closable so Core stays transport-neutral.
+    """
+
+    close = getattr(lease, "close", None)
+    if callable(close):
+        try:
+            close()
+        except Exception:
+            # A cleanup failure must never turn a Driver denial into a launch.
+            pass
+
+
 def require_derived_launch_admission(
     port: DerivedLaunchAdmissionPort | None,
     capability: DerivedLaunchCapability,
@@ -337,7 +357,16 @@ def require_derived_launch_admission(
             decision.state is ProviderAdmissionState.GRANTED
             and decision.child_endpoint_lease is None
         )
+        or (
+            decision.state is not ProviderAdmissionState.GRANTED
+            and decision.child_endpoint_lease is not None
+        )
     ):
+        _discard_child_endpoint_lease(
+            decision.child_endpoint_lease
+            if isinstance(decision, DerivedLaunchDecision)
+            else None
+        )
         decision = DerivedLaunchDecision(
             ProviderAdmissionState.INDETERMINATE,
             "malformed_derived_launch_admission_decision",
@@ -346,6 +375,7 @@ def require_derived_launch_admission(
     # record its own denial.  Core remains a second, structural one-hop
     # backstop: an erroneous Driver grant can never create a second child.
     if isinstance(parent, DerivedProviderAdmission) and decision.allowed:
+        _discard_child_endpoint_lease(decision.child_endpoint_lease)
         decision = DerivedLaunchDecision(
             ProviderAdmissionState.DENIED,
             "nested_derived_launch_denied",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1425,10 +1425,9 @@ def test_persisted_derived_child_exposes_both_tools_and_denies_nested_launches(
         "status": "error",
         "message": "derived launch was not admitted: nested_derived_launch_denied",
         "reason_code": "nested_derived_launch_denied",
-        # Driver routing is introduced by #1563.  At this layer Core's
-        # structural nested-launch backstop owns the refusal and has no
-        # Driver audit correlation yet.
-        "audit_id": None,
+        # #1563 routes nested requests through Driver before Core's one-hop
+        # backstop, so the public refusal keeps Driver's audit correlation.
+        "audit_id": "audit-nested-daemon",
     }
     assert daemon_audit == [
         (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1328,6 +1328,24 @@ def test_persisted_derived_child_exposes_both_tools_and_denies_nested_launches(
                     "admission_id": "admission-ordinary-provider",
                 }
             )
+            for capability, audit_id in (
+                ("avatar", "audit-nested-avatar"),
+                ("daemon", "audit-nested-daemon"),
+            ):
+                assert receive_frame() == {
+                    "version": 1,
+                    "op": "authorize_derived_launch",
+                    "launch_id": "avatar-child",
+                    "capability": capability,
+                }
+                send_frame(
+                    {
+                        "version": 1,
+                        "state": "denied",
+                        "reason_code": "nested_derived_launch_denied",
+                        "audit_id": audit_id,
+                    }
+                )
         except BaseException as exc:
             server_errors.append(exc)
         finally:
@@ -1402,6 +1420,7 @@ def test_persisted_derived_child_exposes_both_tools_and_denies_nested_launches(
     assert server_errors == []
 
     assert avatar_result["reason_code"] == "nested_derived_launch_denied"
+    assert avatar_result["audit_id"] == "audit-nested-avatar"
     assert daemon_result == {
         "status": "error",
         "message": "derived launch was not admitted: nested_derived_launch_denied",
@@ -1418,7 +1437,7 @@ def test_persisted_derived_child_exposes_both_tools_and_denies_nested_launches(
                 "capability": "daemon",
                 "state": "denied",
                 "reason_code": "nested_derived_launch_denied",
-                "audit_id": None,
+                "audit_id": "audit-nested-daemon",
             },
         )
     ]

--- a/tests/test_daemon_detached_supervisor.py
+++ b/tests/test_daemon_detached_supervisor.py
@@ -1867,6 +1867,25 @@ def test_persisted_detached_child_opens_both_tools_and_reaches_nested_denial(
                 separators=(",", ":"),
             ).encode()
             server.sendall(struct.pack("!I", len(payload)) + payload)
+            header = server.recv(4)
+            assert len(header) == 4
+            size = struct.unpack("!I", header)[0]
+            assert json.loads(server.recv(size).decode()) == {
+                "version": 1,
+                "op": "authorize_derived_launch",
+                "launch_id": "daemon-child",
+                "capability": "daemon",
+            }
+            payload = json.dumps(
+                {
+                    "version": 1,
+                    "state": "denied",
+                    "reason_code": "nested_derived_launch_denied",
+                    "audit_id": "audit-nested-daemon",
+                },
+                separators=(",", ":"),
+            ).encode()
+            server.sendall(struct.pack("!I", len(payload)) + payload)
         except BaseException as exc:
             server_errors.append(exc)
         finally:
@@ -1893,6 +1912,7 @@ def test_persisted_detached_child_opens_both_tools_and_reaches_nested_denial(
 
     assert server_errors == []
     assert raised.value.decision.reason_code == "nested_derived_launch_denied"
+    assert raised.value.decision.audit_id == "audit-nested-daemon"
 
 
 def test_detached_file_manifest_injects_file_io(tmp_path):

--- a/tests/test_driver_authority_adapter.py
+++ b/tests/test_driver_authority_adapter.py
@@ -381,10 +381,11 @@ def test_granted_launch_rejects_non_unix_stream_child_endpoint_before_spawn():
     assert leaked == set()
 
 
-def test_derived_endpoint_cannot_mint_a_second_child_even_if_it_has_a_socket():
+def test_derived_endpoint_asks_driver_to_audit_and_deny_a_second_child():
     client, server = socket.socketpair()
 
     def handler(sock):
+        sock.settimeout(0.5)
         assert _recv_frame(sock) == {"version": 1, "op": "hello"}
         _send_frame(
             sock,
@@ -395,20 +396,35 @@ def test_derived_endpoint_cannot_mint_a_second_child_even_if_it_has_a_socket():
                 "capability": "daemon",
             },
         )
+        assert _recv_frame(sock) == {
+            "version": 1,
+            "op": "authorize_derived_launch",
+            "launch_id": "child-1",
+            "capability": "daemon",
+        }
+        _send_frame(
+            sock,
+            {
+                "version": 1,
+                "state": "denied",
+                "reason_code": "nested_derived_launch_denied",
+                "audit_id": "audit-nested-1",
+            },
+        )
 
     thread, errors = _server_thread(server, handler)
     adapter = DriverAuthorityAdapter(client)
     root = RootProviderAdmission("turn-1", "puffo-v0.full-tool-acp-ingress.v1")
     child = begin_derived_provider_admission(root, ProviderCallClass.DAEMON)
-    # The Core boundary rejects nested derived work before it asks the Driver.
     token = bind_provider_admission(child)
     try:
-        with pytest.raises(Exception, match="nested_derived_launch_denied"):
+        with pytest.raises(Exception, match="nested_derived_launch_denied") as raised:
             require_derived_launch_admission(adapter, DerivedLaunchCapability.DAEMON)
     finally:
         clear_provider_admission(token)
     thread.join(timeout=2)
     assert errors == []
+    assert raised.value.decision.audit_id == "audit-nested-1"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_driver_authority_adapter.py
+++ b/tests/test_driver_authority_adapter.py
@@ -396,12 +396,14 @@ def test_derived_endpoint_asks_driver_to_audit_and_deny_a_second_child():
                 "capability": "daemon",
             },
         )
-        assert _recv_frame(sock) == {
+        request = _recv_frame(sock)
+        assert {key: request[key] for key in request if key != "call_id"} == {
             "version": 1,
             "op": "authorize_derived_launch",
             "launch_id": "child-1",
             "capability": "daemon",
         }
+        assert isinstance(request["call_id"], str) and request["call_id"]
         _send_frame(
             sock,
             {

--- a/tests/test_provider_admission.py
+++ b/tests/test_provider_admission.py
@@ -142,7 +142,7 @@ class _RecordingDerivedLaunchPort:
 
 
 class _CloseTrackingLease:
-    """Opaque lease stand-in used to prove Core disposes rejected grants."""
+    """Opaque stand-in proving Core explicitly disposes rejected grants."""
 
     def __init__(self):
         self.close_calls = 0
@@ -797,8 +797,8 @@ def test_derived_launch_reports_a_child_request_to_the_port_then_denies_it():
     assert port.calls == [(child, DerivedLaunchCapability.AVATAR)]
 
 
-def test_nested_driver_grant_is_denied_and_its_opaque_lease_is_closed():
-    """A buggy Driver grant cannot create a child or strand its endpoint."""
+def test_nested_driver_grant_is_denied_and_its_opaque_lease_is_explicitly_closed():
+    """A buggy Driver grant cannot create a child and is not left to finalization."""
 
     root = RootProviderAdmission("turn-a", RUNTIME_POLICY.policy_version)
     child = begin_derived_provider_admission(root, ProviderCallClass.DAEMON)

--- a/tests/test_provider_admission.py
+++ b/tests/test_provider_admission.py
@@ -141,6 +141,16 @@ class _RecordingDerivedLaunchPort:
         )
 
 
+class _CloseTrackingLease:
+    """Opaque lease stand-in used to prove Core disposes rejected grants."""
+
+    def __init__(self):
+        self.close_calls = 0
+
+    def close(self):
+        self.close_calls += 1
+
+
 def test_raw_provider_service_construction_inventory_is_explicit():
     """A new raw service constructor must be classified before it can land.
 
@@ -785,6 +795,39 @@ def test_derived_launch_reports_a_child_request_to_the_port_then_denies_it():
 
     assert raised.value.decision.state is ProviderAdmissionState.DENIED
     assert port.calls == [(child, DerivedLaunchCapability.AVATAR)]
+
+
+def test_nested_driver_grant_is_denied_and_its_opaque_lease_is_closed():
+    """A buggy Driver grant cannot create a child or strand its endpoint."""
+
+    root = RootProviderAdmission("turn-a", RUNTIME_POLICY.policy_version)
+    child = begin_derived_provider_admission(root, ProviderCallClass.DAEMON)
+    lease = _CloseTrackingLease()
+
+    class IncorrectlyGrantingPort:
+        def authorize_derived_launch(self, parent, capability):
+            assert parent is child
+            assert capability is DerivedLaunchCapability.AVATAR
+            return DerivedLaunchDecision(
+                ProviderAdmissionState.GRANTED,
+                "incorrect_driver_grant",
+                audit_id="audit-incorrect-grant",
+                child_endpoint_lease=lease,
+            )
+
+    token = bind_provider_admission(child)
+    try:
+        with pytest.raises(
+            DerivedLaunchAdmissionError, match="nested_derived_launch_denied"
+        ) as raised:
+            require_derived_launch_admission(
+                IncorrectlyGrantingPort(), DerivedLaunchCapability.AVATAR
+            )
+    finally:
+        clear_provider_admission(token)
+
+    assert raised.value.decision.audit_id == "audit-incorrect-grant"
+    assert lease.close_calls == 1
 
 
 def test_derived_launch_port_is_fail_closed_when_unconnected_or_indeterminate():

--- a/tests/test_provider_admission.py
+++ b/tests/test_provider_admission.py
@@ -768,8 +768,8 @@ def test_v0_derived_admission_rejects_nested_derived_execution():
         begin_derived_provider_admission(child, ProviderCallClass.AVATAR_CHILD)  # type: ignore[arg-type]
 
 
-def test_derived_launch_requires_root_admission_and_never_accepts_a_child_parent():
-    """A one-hop child cannot self-authorize another daemon/avatar launch."""
+def test_derived_launch_reports_a_child_request_to_the_port_then_denies_it():
+    """Core remains a backstop, but Driver sees and audits a nested request."""
 
     root = RootProviderAdmission("turn-a", RUNTIME_POLICY.policy_version)
     child = begin_derived_provider_admission(root, ProviderCallClass.DAEMON)
@@ -784,7 +784,7 @@ def test_derived_launch_requires_root_admission_and_never_accepts_a_child_parent
         clear_provider_admission(token)
 
     assert raised.value.decision.state is ProviderAdmissionState.DENIED
-    assert port.calls == []
+    assert port.calls == [(child, DerivedLaunchCapability.AVATAR)]
 
 
 def test_derived_launch_port_is_fail_closed_when_unconnected_or_indeterminate():


### PR DESCRIPTION
Split from #1545. Routes nested launches through the Driver audit and makes rejection-driven lease disposal deterministic, with focused contract/tests.

Boundary: depends on #1562; excludes daemon dispatch script evidence, later endpoint lifecycle hardening, and first-hop E2E.

Validation: `git diff --check codex/phase-b-08-executor-audit-probe...HEAD` passes.

Base: #1562 (`eca956d5ddab6f292274751ab5fc76093affb4c6`).