### PR TITLE
Phase B/12: document mutation-test provenance policy

### DIFF
--- a/tests/CONTRACT.md
+++ b/tests/CONTRACT.md
@@ -174,6 +174,18 @@ pass. A faster run that quietly changed semantics is a regression, not a win. Do
 not lower a permanent interval/timeout to "go faster" when the real fix is to
 wake the wait; prove the cadence/interval is preserved.
 
+### 13. Mutation evidence must run without timestamp bytecode reuse
+
+Mutation runs are source-level evidence, so they must not execute a `.pyc`
+compiled from a previous mutation or restoration. Run every must-red mutation
+and its restored control with `python -B` or `PYTHONDONTWRITEBYTECODE=1` (or
+clear the affected `__pycache__` between each phase). Python's normal
+timestamp validation accepts an unchanged `(mtime, size)` pair: a same-second,
+same-length edit can therefore make a restored source run the mutated bytecode
+or make a mutation run the old bytecode. Record the bytecode mode alongside
+the mutation command. A mutation result without that provenance is not
+evidence that the assertion did—or did not—carry the regression.
+
 ## Maintenance
 
 This charter is prose guidance, not a governed interface, so it has no

--- a/tests/CONTRACT.md
+++ b/tests/CONTRACT.md
@@ -87,14 +87,20 @@ only the mock.
 ### 4. Source pinning
 
 Run the kernel from this checkout, not from an installed wheel, so the test
-exercises the code under review. Pin the source and the interpreter explicitly:
+exercises the code under review. Choose the source by running `pytest` from the
+checkout itself, and pin the interpreter explicitly:
 
 ```bash
-PYTHONPATH="$PWD/src" /path/to/project/.venv/bin/python -m pytest -q <targets>
+cd /path/to/lingtai-checkout
+/path/to/project/.venv/bin/python -m pytest -q <targets>
 ```
 
-An unpinned run can silently import a different installed `lingtai`, turning a
-green bar into a lie about the working tree.
+This repository's pytest configuration supplies its checkout-local `src/`.
+Do not use `PYTHONPATH` to select another worktree: here it is not a source pin
+and can silently leave pytest running the current checkout. To test another
+tree, run pytest *from that tree*. An unpinned run can silently import a
+different installed `lingtai`, turning a green bar into a lie about the working
+tree.
 
 ### 5. Deterministic validation
 
@@ -202,9 +208,14 @@ import sys
 
 # Let pytest choose its own import path first. Inspect the module it actually
 # loaded afterwards; pre-importing it here would alter that observation.
+evidence_module = "<module>"
+if evidence_module in sys.modules:
+    print("INVALID: evidence module was loaded before pytest")
+    raise SystemExit(2)
+
 import pytest
 exit_code = pytest.main(["<target>"])
-module = sys.modules.get("<module>")
+module = sys.modules.get(evidence_module)
 if module is None or not getattr(module, "__file__", None):
     print("INVALID: pytest did not load the required evidence module")
     raise SystemExit(2)

--- a/tests/CONTRACT.md
+++ b/tests/CONTRACT.md
@@ -195,6 +195,13 @@ PYTHONPYCACHEPREFIX="$phase_pyc_cache" \
   python -B -m pytest <target>
 ```
 
+Do not use `PYTHONPATH=<other-worktree>` to select a mutation tree for
+`pytest`. This repository's pytest configuration injects its own `src/` path,
+which can take precedence and silently run the clean checkout instead. Mutate
+the source in the same worktree that invokes pytest, unless a deliberately
+different import configuration is used and the test records the runtime
+`module.__file__` (or equivalent loaded-path evidence).
+
 Python's normal timestamp validation accepts an unchanged `(mtime, size)`
 pair: a same-second, same-length edit can therefore make a restored source run
 the mutated bytecode or make a mutation run the old bytecode. Before trusting
@@ -208,7 +215,9 @@ its absence. Record the cache-isolation method and the three outcomes —
 `clean-pass → mutation-must-red → restored-clean-pass` — with the mutation
 command. A phase without this provenance is **invalid**, not pass or fail; a
 result without it is not evidence that the assertion did—or did not—carry the
-regression.
+regression. Prefer a loaded-code fingerprint that differs in the mutation
+phase and returns exactly to the clean baseline in the restored phase: unlike
+sentinel absence alone, that also excludes an older stale cache.
 
 ## Maintenance
 

--- a/tests/CONTRACT.md
+++ b/tests/CONTRACT.md
@@ -177,14 +177,32 @@ wake the wait; prove the cadence/interval is preserved.
 ### 13. Mutation evidence must run without timestamp bytecode reuse
 
 Mutation runs are source-level evidence, so they must not execute a `.pyc`
-compiled from a previous mutation or restoration. Run every must-red mutation
-and its restored control with `python -B` or `PYTHONDONTWRITEBYTECODE=1` (or
-clear the affected `__pycache__` between each phase). Python's normal
-timestamp validation accepts an unchanged `(mtime, size)` pair: a same-second,
-same-length edit can therefore make a restored source run the mutated bytecode
-or make a mutation run the old bytecode. Record the bytecode mode alongside
-the mutation command. A mutation result without that provenance is not
-evidence that the assertion did—or did not—carry the regression.
+compiled from a previous mutation or restoration. The clean baseline, the
+must-red mutation, and the restored control must each run in a separate fresh
+process. Before *each* phase, clear the affected package's `__pycache__`, or
+give that phase a distinct, empty `PYTHONPYCACHEPREFIX`. `python -B` and
+`PYTHONDONTWRITEBYTECODE=1` are useful supplements, but not substitutes: they
+prevent writing new bytecode, not reading an existing cache that still matches
+Python's timestamp check.
+
+Put the isolation in the copied command, not merely in accompanying prose. For
+example, run this once per phase, with a new temporary directory each time:
+
+```bash
+phase_pyc_cache="$(mktemp -d)"
+PYTHONPYCACHEPREFIX="$phase_pyc_cache" \
+  PYTHONDONTWRITEBYTECODE=1 \
+  python -B -m pytest <target>
+```
+
+Python's normal timestamp validation accepts an unchanged `(mtime, size)`
+pair: a same-second, same-length edit can therefore make a restored source run
+the mutated bytecode or make a mutation run the old bytecode. Before trusting
+each phase's result, verify the pin, import/load path, and either the relevant
+source hash or a mutation sentinel. Record the cache-isolation method and the
+three outcomes — `clean-pass → mutation-must-red → restored-clean-pass` — with
+the mutation command. A result without that provenance is not evidence that
+the assertion did—or did not—carry the regression.
 
 ## Maintenance
 

--- a/tests/CONTRACT.md
+++ b/tests/CONTRACT.md
@@ -185,21 +185,43 @@ give that phase a distinct, empty `PYTHONPYCACHEPREFIX`. `python -B` and
 prevent writing new bytecode, not reading an existing cache that still matches
 Python's timestamp check.
 
-Put the isolation in the copied command, not merely in accompanying prose. For
-example, run this once per phase, with a new temporary directory each time:
+Put the isolation and runtime provenance in the copied command, not merely in
+accompanying prose. Run this once per phase, with a new temporary directory
+each time. Replace `<module>`, `<code-object-on-tested-path>`, and `<target>`
+with the module, code object, and pytest target exercised by the regression:
 
 ```bash
 phase_pyc_cache="$(mktemp -d)"
 PYTHONPYCACHEPREFIX="$phase_pyc_cache" \
   PYTHONDONTWRITEBYTECODE=1 \
-  python -B -m pytest <target>
+  python -B - <<'PY'
+import hashlib
+import importlib
+import inspect
+from pathlib import Path
+import sys
+
+# Match this repository's pytest source root before importing the evidence
+# module; the resulting pytest.main call stays in this same process.
+sys.path.insert(0, str(Path("src").resolve()))
+module = importlib.import_module("<module>")
+selected = module
+for part in "<code-object-on-tested-path>".split("."):
+    selected = getattr(selected, part)
+code_object = inspect.unwrap(selected).__code__
+print(f"loaded_module={Path(module.__file__).resolve()}")
+print(f"co_code_sha256={hashlib.sha256(code_object.co_code).hexdigest()}")
+
+import pytest
+raise SystemExit(pytest.main(["<target>"]))
+PY
 ```
 
 Do not use `PYTHONPATH=<other-worktree>` to select a mutation tree for
 `pytest`. This repository's pytest configuration injects its own `src/` path,
 which can take precedence and silently run the clean checkout instead. Mutate
 the source in the same worktree that invokes pytest, unless a deliberately
-different import configuration is used and the test records the runtime
+different import configuration is used and the command records the runtime
 `module.__file__` (or equivalent loaded-path evidence).
 
 Python's normal timestamp validation accepts an unchanged `(mtime, size)`

--- a/tests/CONTRACT.md
+++ b/tests/CONTRACT.md
@@ -198,11 +198,17 @@ PYTHONPYCACHEPREFIX="$phase_pyc_cache" \
 Python's normal timestamp validation accepts an unchanged `(mtime, size)`
 pair: a same-second, same-length edit can therefore make a restored source run
 the mutated bytecode or make a mutation run the old bytecode. Before trusting
-each phase's result, verify the pin, import/load path, and either the relevant
-source hash or a mutation sentinel. Record the cache-isolation method and the
-three outcomes — `clean-pass → mutation-must-red → restored-clean-pass` — with
-the mutation command. A result without that provenance is not evidence that
-the assertion did—or did not—carry the regression.
+each phase's result, verify the pin, import/load path, and runtime evidence
+that that phase's own code executed: a sentinel emitted by the mutated code
+path at run time, or an equivalent fingerprint of the loaded code object. A
+source hash or source-level `grep` proves only the file's current state; it
+does not prove which bytes ran and cannot satisfy this requirement. The
+mutation phase must show the runtime sentinel and the restored phase must show
+its absence. Record the cache-isolation method and the three outcomes —
+`clean-pass → mutation-must-red → restored-clean-pass` — with the mutation
+command. A phase without this provenance is **invalid**, not pass or fail; a
+result without it is not evidence that the assertion did—or did not—carry the
+regression.
 
 ## Maintenance
 

--- a/tests/CONTRACT.md
+++ b/tests/CONTRACT.md
@@ -196,24 +196,27 @@ PYTHONPYCACHEPREFIX="$phase_pyc_cache" \
   PYTHONDONTWRITEBYTECODE=1 \
   python -B - <<'PY'
 import hashlib
-import importlib
 import inspect
 from pathlib import Path
 import sys
 
-# Match this repository's pytest source root before importing the evidence
-# module; the resulting pytest.main call stays in this same process.
-sys.path.insert(0, str(Path("src").resolve()))
-module = importlib.import_module("<module>")
+# Let pytest choose its own import path first. Inspect the module it actually
+# loaded afterwards; pre-importing it here would alter that observation.
+import pytest
+exit_code = pytest.main(["<target>"])
+module = sys.modules.get("<module>")
+if module is None or not getattr(module, "__file__", None):
+    print("INVALID: pytest did not load the required evidence module")
+    raise SystemExit(2)
+
 selected = module
 for part in "<code-object-on-tested-path>".split("."):
     selected = getattr(selected, part)
 code_object = inspect.unwrap(selected).__code__
 print(f"loaded_module={Path(module.__file__).resolve()}")
 print(f"co_code_sha256={hashlib.sha256(code_object.co_code).hexdigest()}")
-
-import pytest
-raise SystemExit(pytest.main(["<target>"]))
+print(f"python={sys.version}")
+raise SystemExit(exit_code)
 PY
 ```
 
@@ -240,6 +243,10 @@ result without it is not evidence that the assertion did—or did not—carry th
 regression. Prefer a loaded-code fingerprint that differs in the mutation
 phase and returns exactly to the clean baseline in the restored phase: unlike
 sentinel absence alone, that also excludes an older stale cache.
+`co_code` is a three-phase invariant within one interpreter/runtime, not a
+cross-reviewer identifier: Python versions may produce different bytecode for
+the same source. Record the runtime and compare only `clean == restored !=
+mutation` within that one environment.
 
 ## Maintenance
 

--- a/tests/CONTRACT.md
+++ b/tests/CONTRACT.md
@@ -209,8 +209,13 @@ import sys
 # Let pytest choose its own import path first. Inspect the module it actually
 # loaded afterwards; pre-importing it here would alter that observation.
 evidence_module = "<module>"
-if evidence_module in sys.modules:
-    print("INVALID: evidence module was loaded before pytest")
+root_package = evidence_module.split(".")[0]
+preloaded = sorted(
+    name for name in sys.modules
+    if name == root_package or name.startswith(root_package + ".")
+)
+if preloaded:
+    print(f"INVALID: {root_package} was imported before pytest: {preloaded[:3]}")
     raise SystemExit(2)
 
 import pytest


### PR DESCRIPTION
Split from #1545. Adds the test-suite policy for bytecode-safe mutation validation and source/runtime provenance.

Boundary: depends on #1565; documentation/test-governance only, with no production runtime behavior change.

Validation: `git diff --check codex/phase-b-11-endpoint-lifecycle...HEAD` passes.

Base: #1565 (`89324b7ae78f781ceb5c80fb13c2ed93e7f7664b`).