### PR TITLE
Phase B/16: provide reproducible Driver E2E environment

### DIFF
--- a/scripts/verify_driver_supervisor_execution_e2e.py
+++ b/scripts/verify_driver_supervisor_execution_e2e.py
@@ -12,9 +12,10 @@ The deterministic fake LLM exists only to avoid a live model dependency.  The
 Driver server, lease, two process boundaries, entrypoint adoption, and
 provider-call adjudication are all real.
 
-Run this probe from LingTai's exact `uv sync --locked` interpreter.  The
-`--puffo-src` input is source-only: Puffo's runtime environment has an
-incompatible MCP-major dependency and must not be injected into this process.
+Run `scripts/setup_driver_supervisor_e2e_env.sh <venv-dir>` first and invoke
+this probe with that interpreter. The `--puffo-src` input is source-only:
+Puffo's runtime environment has an incompatible MCP-major dependency and must
+not be injected into this process.
 """
 from __future__ import annotations
 
@@ -40,9 +41,10 @@ def _require_e2e_environment() -> None:
         raise RuntimeError(
             "E2E_ENVIRONMENT_INVALID: the selected mcp "
             f"({installed}) does not provide mcp.server.ServerRequestContext; "
-            "run from LingTai's `uv sync --locked` environment with only "
-            "Puffo source on --puffo-src (do not inject Puffo site-packages) "
-            "before interpreting the Driver lifecycle verdict"
+            "create the supported interpreter with "
+            "scripts/setup_driver_supervisor_e2e_env.sh and use only Puffo "
+            "source on --puffo-src (do not inject Puffo site-packages) before "
+            "interpreting the Driver lifecycle verdict"
         ) from exc
 
 


### PR DESCRIPTION
Split from #1545. Adds the reproducible setup helper for the Driver supervisor E2E environment.

Boundary: depends on #1569; no admission runtime behavior or E2E verdict semantics change.

Validation: `git diff --check codex/phase-b-15-e2e-runtime-boundary...HEAD` passes.

Base: #1569 (`1ad8581b0881858328be21f20bb689af6bba345d`).