### PR TITLE
Phase B/18: align split-stack test expectations

### DIFF
--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1497,7 +1497,7 @@ def test_profile_daemon_launch_reaches_structured_admission_before_supervisor(
 def test_profile_daemon_grant_reaches_the_same_recording_supervisor(tmp_path, monkeypatch):
     """The zero-supervisor assertion has a same-recorder positive control."""
     from lingtai.adapters.acp.puffo_v0 import RUNTIME_POLICY
-    from tests._daemon_helpers import install_fake_detached_owner
+    from lingtai.adapters.posix.daemon_supervisor import PosixDaemonSupervisorAdapter
 
     class _GrantingPort:
         def __init__(self):
@@ -1517,7 +1517,15 @@ def test_profile_daemon_grant_reaches_the_same_recording_supervisor(tmp_path, mo
     port = _GrantingPort()
     agent._derived_launch_admission_port = port
     audit = []
-    records = install_fake_detached_owner(monkeypatch)
+    supervisor_calls = []
+    monkeypatch.setattr(
+        PosixDaemonSupervisorAdapter,
+        "spawn_detached",
+        lambda *_args, **_kwargs: supervisor_calls.append("spawn"),
+    )
+    monkeypatch.setattr(
+        agent.get_capability("daemon"), "_await_supervisor_startup", lambda _run: None
+    )
     monkeypatch.setattr(agent, "_log", lambda event, **fields: audit.append((event, fields)))
 
     root = RootProviderAdmission("root-daemon-positive-2a", RUNTIME_POLICY.policy_version)
@@ -1531,8 +1539,7 @@ def test_profile_daemon_grant_reaches_the_same_recording_supervisor(tmp_path, mo
 
     assert result["status"] == "dispatched"
     assert port.calls == [(root, DerivedLaunchCapability.DAEMON)]
-    assert len(records) == 1
-    assert records[0]["manifest"]["backend"] == "lingtai"
+    assert supervisor_calls == ["spawn"]
     assert (
         "derived_launch_admission_decision",
         {

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1517,12 +1517,12 @@ def test_profile_daemon_grant_reaches_the_same_recording_supervisor(tmp_path, mo
     port = _GrantingPort()
     agent._derived_launch_admission_port = port
     audit = []
-    supervisor_calls = []
-    monkeypatch.setattr(
-        PosixDaemonSupervisorAdapter,
-        "spawn_detached",
-        lambda *_args, **_kwargs: supervisor_calls.append("spawn"),
-    )
+    supervisor_requests = []
+
+    def record_spawn(_adapter, request, **_kwargs):
+        supervisor_requests.append(request)
+
+    monkeypatch.setattr(PosixDaemonSupervisorAdapter, "spawn_detached", record_spawn)
     monkeypatch.setattr(
         agent.get_capability("daemon"), "_await_supervisor_startup", lambda _run: None
     )
@@ -1539,7 +1539,11 @@ def test_profile_daemon_grant_reaches_the_same_recording_supervisor(tmp_path, mo
 
     assert result["status"] == "dispatched"
     assert port.calls == [(root, DerivedLaunchCapability.DAEMON)]
-    assert supervisor_calls == ["spawn"]
+    assert len(supervisor_requests) == 1
+    manifest = json.loads(
+        Path(supervisor_requests[0].manifest_path).read_text(encoding="utf-8")
+    )
+    assert manifest["backend"] == "lingtai"
     assert (
         "derived_launch_admission_decision",
         {

--- a/tests/test_layers_avatar.py
+++ b/tests/test_layers_avatar.py
@@ -269,7 +269,7 @@ class TestAvatarManager:
     def test_profile_avatar_grant_reaches_the_same_launch_recorder(
         self, tmp_path, monkeypatch
     ):
-        """The zero-avatar-spawn assertion has a same-recorder positive control."""
+        """The zero-avatar-directory assertion has a positive control too."""
         from lingtai.adapters.acp.puffo_v0 import RUNTIME_POLICY
         from lingtai.kernel.provider_admission import (
             DerivedLaunchCapability,
@@ -330,6 +330,7 @@ class TestAvatarManager:
 
         assert result["status"] == "ok"
         assert port.calls == [(root, DerivedLaunchCapability.AVATAR)]
+        assert (parent._working_dir.parent / "child").is_dir()
         assert launch_calls == [parent._working_dir.parent / "child"]
         records = [
             json.loads(line)


### PR DESCRIPTION
Split from #1545. Reconciles two test expectations after linearizing the stacked branches: daemon supervisor positive-control recording and avatar working-directory positive-control assertion.

Boundary: depends on #1571; test-only. This PR makes the complete split stack tree exactly equal to the original #1545 head.

Validation:
- `git diff --exit-code origin/codex/derived-admission-adapter-clean HEAD` — pass (exact tree equivalence)
- `git diff --check origin/main...HEAD` — pass
- focused daemon/avatar alignment tests — 2 passed

Base: #1571 (`cff8ffe5bb03ef2e354ec343298bd363d05fa546`).