### PR TITLE
fix: reject derived launches before durable run setup

### DIFF
--- a/src/lingtai/tools/daemon/__init__.py
+++ b/src/lingtai/tools/daemon/__init__.py
@@ -5396,6 +5396,19 @@ class DaemonManager:
                 "preset_handlers": preset_handlers,
             })
 
+        # Every task is one derived launch request. Admit the entire batch
+        # before publishing its shared immutable task-file store: a denial in
+        # any later task must not leave earlier task input blobs or manifests
+        # behind. The decisions remain task-indexed for downstream Driver
+        # adapters, which attach one child endpoint lease to each launch.
+        from lingtai.kernel.provider_admission import DerivedLaunchAdmissionError
+        try:
+            launch_decisions = self._authorize_derived_launch_batch(
+                "daemon", len(tasks)
+            )
+        except DerivedLaunchAdmissionError as error:
+            return self._admission_error_result(error)
+
         ids = []
         group_id = DaemonRunDir.new_group_id()
         parent_addr = self._workdir.path.name
@@ -5454,15 +5467,6 @@ class DaemonManager:
             task_context = self._append_daemon_common_context(task_context)
 
             system_prompt = "[daemon prompt pending MCP startup]"
-
-            # Admission is deliberately before constructing ``DaemonRunDir``:
-            # that constructor creates a per-run directory and durable prompt /
-            # state files. A rejected derived launch must leave no run artifact.
-            from lingtai.kernel.provider_admission import DerivedLaunchAdmissionError
-            try:
-                self._authorize_derived_launch("daemon")
-            except DerivedLaunchAdmissionError as error:
-                return self._admission_error_result(error)
 
             # Construct run_dir — creates folder on disk, writes daemon.json,
             # .prompt, .heartbeat, daemon_start event. If FS construction fails,
@@ -5705,6 +5709,17 @@ class DaemonManager:
                 backend_env=backend_env,
             ))
 
+        # Every task is one derived launch request. Complete all admission
+        # decisions before publishing the batch's shared immutable task-file
+        # store, so a later denial cannot retain an earlier task's input.
+        from lingtai.kernel.provider_admission import DerivedLaunchAdmissionError
+        try:
+            launch_decisions = self._authorize_derived_launch_batch(
+                "daemon", len(tasks)
+            )
+        except DerivedLaunchAdmissionError as error:
+            return self._admission_error_result(error)
+
         ids = []
         group_id = DaemonRunDir.new_group_id()
         parent_addr = self._workdir.path.name
@@ -5750,14 +5765,6 @@ class DaemonManager:
                     "\n\nParent-provided daemon context (oneshot):\n"
                     + task_context
                 )
-            # The external path has the same durable run-dir boundary as the
-            # native LingTai path. Do not materialize its prompt, state, or
-            # backend MCP configuration until the derived launch is admitted.
-            from lingtai.kernel.provider_admission import DerivedLaunchAdmissionError
-            try:
-                self._authorize_derived_launch("daemon")
-            except DerivedLaunchAdmissionError as error:
-                return self._admission_error_result(error)
             try:
                 run_dir = DaemonRunDir(
                     parent_working_dir=self._workdir.path,
@@ -9544,7 +9551,30 @@ class DaemonManager:
             "audit_id": error.decision.audit_id,
         }
 
-    def _authorize_derived_launch(self, capability_name: str) -> None:
+    @staticmethod
+    def _close_unconsumed_derived_launch_decisions(decisions: list[object]) -> None:
+        """Release pre-authorized decisions that have not reached a child yet.
+
+        This base layer has no resource-bearing decisions. The Driver adapter
+        layer supplies a child endpoint lease per decision and replaces this
+        hook with deterministic release before it can use batch pre-admission.
+        """
+        return None
+
+    def _authorize_derived_launch_batch(
+        self, capability_name: str, task_count: int
+    ) -> list[object]:
+        """Authorize every child in a batch before any durable batch write."""
+        decisions: list[object] = []
+        try:
+            for _ in range(task_count):
+                decisions.append(self._authorize_derived_launch(capability_name))
+        except Exception:
+            self._close_unconsumed_derived_launch_decisions(decisions)
+            raise
+        return decisions
+
+    def _authorize_derived_launch(self, capability_name: str) -> object:
         """Reach the host decision seam before a daemon launch side effect."""
         from lingtai.kernel.provider_admission import (
             DerivedLaunchAdmissionError,
@@ -9573,6 +9603,7 @@ class DaemonManager:
         )
         if not decision.allowed:
             raise DerivedLaunchAdmissionError(decision)
+        return decision
 
 
 # Pair of the ``DEFAULT_MAX_TURNS`` assertion above: ``_tool_family``'s

--- a/src/lingtai/tools/daemon/__init__.py
+++ b/src/lingtai/tools/daemon/__init__.py
@@ -5455,6 +5455,15 @@ class DaemonManager:
 
             system_prompt = "[daemon prompt pending MCP startup]"
 
+            # Admission is deliberately before constructing ``DaemonRunDir``:
+            # that constructor creates a per-run directory and durable prompt /
+            # state files. A rejected derived launch must leave no run artifact.
+            from lingtai.kernel.provider_admission import DerivedLaunchAdmissionError
+            try:
+                self._authorize_derived_launch("daemon")
+            except DerivedLaunchAdmissionError as error:
+                return self._admission_error_result(error)
+
             # Construct run_dir — creates folder on disk, writes daemon.json,
             # .prompt, .heartbeat, daemon_start event. If FS construction fails,
             # propagate as a tool-level error and skip scheduling for this spec.
@@ -5536,7 +5545,6 @@ class DaemonManager:
 
             self._close_task_mcp_clients(task_mcp_clients)  # none connected in this branch
             try:
-                self._authorize_derived_launch("daemon")
                 self._commit_dispatch(run_dir)
                 self._spawn_detached_lingtai_run(
                     run_dir,
@@ -5742,6 +5750,14 @@ class DaemonManager:
                     "\n\nParent-provided daemon context (oneshot):\n"
                     + task_context
                 )
+            # The external path has the same durable run-dir boundary as the
+            # native LingTai path. Do not materialize its prompt, state, or
+            # backend MCP configuration until the derived launch is admitted.
+            from lingtai.kernel.provider_admission import DerivedLaunchAdmissionError
+            try:
+                self._authorize_derived_launch("daemon")
+            except DerivedLaunchAdmissionError as error:
+                return self._admission_error_result(error)
             try:
                 run_dir = DaemonRunDir(
                     parent_working_dir=self._workdir.path,
@@ -5865,7 +5881,6 @@ class DaemonManager:
             # boundary.  The parent writes a complete, redacted manifest and
             # retains only the durable run-dir facade.
             try:
-                self._authorize_derived_launch("daemon")
                 self._commit_dispatch(run_dir)
                 from lingtai.kernel.daemon_supervisor import DaemonSupervisorRequest
                 from lingtai.kernel.daemon_supervisor.manifest import build_manifest, manifest_path_for, write_manifest
@@ -9518,6 +9533,16 @@ class DaemonManager:
     def _log(self, event_type: str, **fields) -> None:
         """Log through Daemon's narrow parent-runtime port."""
         self._runtime.log(event_type, **fields)
+
+    @staticmethod
+    def _admission_error_result(error: "DerivedLaunchAdmissionError") -> dict[str, str]:
+        """Expose structured refusal evidence without creating a run artifact."""
+        return {
+            "status": "error",
+            "message": str(error),
+            "reason_code": error.decision.reason_code,
+            "audit_id": error.decision.audit_id,
+        }
 
     def _authorize_derived_launch(self, capability_name: str) -> None:
         """Reach the host decision seam before a daemon launch side effect."""

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1387,10 +1387,19 @@ def test_profile_daemon_launch_reaches_structured_admission_before_supervisor(
     monkeypatch.setattr(agent, "_log", lambda event, **fields: audit.append((event, fields)))
 
     root = RootProviderAdmission("root-daemon-2a", RUNTIME_POLICY.policy_version)
+    sensitive_input = agent._working_dir / "sensitive-input.txt"
+    sensitive_input.write_text("sensitive task input\n", encoding="utf-8")
     token = bind_provider_admission(root)
     try:
         result = agent.get_capability("daemon").handle(
-            {"action": "emanate", "tasks": [{"task": "test", "tools": []}]}
+            {
+                "action": "emanate",
+                "tasks": [{
+                    "task": "test",
+                    "tools": [],
+                    "task_files": [{"path": "sensitive-input.txt"}],
+                }],
+            }
         )
     finally:
         clear_provider_admission(token)
@@ -1410,6 +1419,7 @@ def test_profile_daemon_launch_reaches_structured_admission_before_supervisor(
         path.is_dir() and path.name.startswith("em-")
         for path in daemon_root.iterdir()
     )
+    assert not (daemon_root / "_task_files").exists()
     decisions = [row for row in audit if row[0] == "derived_launch_admission_decision"]
     assert decisions == [
         (
@@ -1473,6 +1483,130 @@ def test_profile_daemon_grant_reaches_the_same_recording_supervisor(tmp_path, mo
     ) in audit
 
 
+@pytest.mark.parametrize("backend", ["lingtai", "codex"])
+def test_profile_daemon_batch_admits_each_child_before_task_file_materialization(
+    tmp_path, monkeypatch, backend
+):
+    """Every child is admitted before the batch publishes immutable inputs."""
+    from lingtai.adapters.acp.puffo_v0 import RUNTIME_POLICY
+    from tests._daemon_helpers import install_fake_detached_owner
+
+    class _GrantingPort:
+        def __init__(self):
+            self.calls = []
+
+        def authorize_derived_launch(self, parent, capability):
+            self.calls.append((parent, capability))
+            return DerivedLaunchDecision(
+                ProviderAdmissionState.GRANTED,
+                "derived_launch_allowed_by_batch_test",
+                audit_id=f"audit-daemon-batch-{backend}",
+            )
+
+    agent = _make_agent(tmp_path, {"daemon": {"manager_pool_size": 0}})
+    if backend == "lingtai":
+        _enable_detached_fake_llm(agent, monkeypatch)
+    port = _GrantingPort()
+    agent._derived_launch_admission_port = port
+    records = install_fake_detached_owner(monkeypatch)
+    input_path = agent._working_dir / "batch-input.txt"
+    input_path.write_text("batch task input\n", encoding="utf-8")
+
+    root = RootProviderAdmission(
+        f"root-daemon-batch-{backend}", RUNTIME_POLICY.policy_version
+    )
+    token = bind_provider_admission(root)
+    try:
+        request = {
+            "action": "emanate",
+            "tasks": [
+                {
+                    "task": "first",
+                    "tools": [],
+                    "task_files": [{"path": "batch-input.txt"}],
+                },
+                {"task": "second", "tools": []},
+            ],
+        }
+        if backend != "lingtai":
+            request["backend"] = backend
+        result = agent.get_capability("daemon").handle(request)
+    finally:
+        clear_provider_admission(token)
+
+    assert result["status"] == "dispatched"
+    assert port.calls == [(root, DerivedLaunchCapability.DAEMON)] * 2
+    assert len(records) == 2
+    assert (agent._working_dir / "daemons" / "_task_files").is_dir()
+
+
+@pytest.mark.parametrize("backend", ["lingtai", "codex"])
+def test_profile_daemon_later_batch_denial_leaves_no_task_file_store_or_run(
+    tmp_path, monkeypatch, backend
+):
+    """Pre-authorizing all children keeps later denial free of durable residue."""
+    from lingtai.adapters.acp.puffo_v0 import RUNTIME_POLICY
+    from tests._daemon_helpers import install_fake_detached_owner
+
+    class _GrantThenDenyPort:
+        def __init__(self):
+            self.calls = []
+
+        def authorize_derived_launch(self, parent, capability):
+            self.calls.append((parent, capability))
+            if len(self.calls) == 1:
+                return DerivedLaunchDecision(
+                    ProviderAdmissionState.GRANTED,
+                    "first_child_allowed_by_batch_test",
+                    audit_id=f"audit-first-{backend}",
+                )
+            return DerivedLaunchDecision(
+                ProviderAdmissionState.DENIED,
+                "second_child_denied_by_batch_test",
+                audit_id=f"audit-second-{backend}",
+            )
+
+    agent = _make_agent(tmp_path, {"daemon": {"manager_pool_size": 0}})
+    if backend == "lingtai":
+        _enable_detached_fake_llm(agent, monkeypatch)
+    port = _GrantThenDenyPort()
+    agent._derived_launch_admission_port = port
+    install_fake_detached_owner(monkeypatch)
+    input_path = agent._working_dir / "batch-sensitive-input.txt"
+    input_path.write_text("sensitive batch task input\n", encoding="utf-8")
+
+    root = RootProviderAdmission(
+        f"root-daemon-later-denial-{backend}", RUNTIME_POLICY.policy_version
+    )
+    token = bind_provider_admission(root)
+    try:
+        request = {
+            "action": "emanate",
+            "tasks": [
+                {
+                    "task": "first",
+                    "tools": [],
+                    "task_files": [{"path": "batch-sensitive-input.txt"}],
+                },
+                {"task": "second", "tools": []},
+            ],
+        }
+        if backend != "lingtai":
+            request["backend"] = backend
+        result = agent.get_capability("daemon").handle(request)
+    finally:
+        clear_provider_admission(token)
+
+    assert result["reason_code"] == "second_child_denied_by_batch_test"
+    assert port.calls == [(root, DerivedLaunchCapability.DAEMON)] * 2
+    daemon_root = agent._working_dir / "daemons"
+    assert not (daemon_root / "_task_files").exists()
+    assert not daemon_root.exists() or not any(
+        path.is_dir() and path.name.startswith("em-")
+        for path in daemon_root.iterdir()
+    )
+
+
 def test_profile_external_cli_daemon_launch_reaches_admission_before_supervisor(
     tmp_path, monkeypatch
 ):
@@ -1505,13 +1639,19 @@ def test_profile_external_cli_daemon_launch_reaches_admission_before_supervisor(
     monkeypatch.setattr(agent, "_log", lambda event, **fields: audit.append((event, fields)))
 
     root = RootProviderAdmission("root-external-cli-2a", RUNTIME_POLICY.policy_version)
+    sensitive_input = agent._working_dir / "sensitive-input.txt"
+    sensitive_input.write_text("sensitive task input\n", encoding="utf-8")
     token = bind_provider_admission(root)
     try:
         result = agent.get_capability("daemon").handle(
             {
                 "action": "emanate",
                 "backend": "codex",
-                "tasks": [{"task": "test", "tools": []}],
+                "tasks": [{
+                    "task": "test",
+                    "tools": [],
+                    "task_files": [{"path": "sensitive-input.txt"}],
+                }],
             }
         )
     finally:
@@ -1530,6 +1670,7 @@ def test_profile_external_cli_daemon_launch_reaches_admission_before_supervisor(
         path.is_dir() and path.name.startswith("em-")
         for path in daemon_root.iterdir()
     )
+    assert not (daemon_root / "_task_files").exists()
     decisions = [row for row in audit if row[0] == "derived_launch_admission_decision"]
     assert decisions == [
         (

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1405,12 +1405,11 @@ def test_profile_daemon_launch_reaches_structured_admission_before_supervisor(
         agent._working_dir, full_history=True
     ).records == ()
     assert daemon_dispatch.recovery_markers(agent._working_dir) == []
-    run_dirs = [
-        path for path in (agent._working_dir / "daemons").iterdir()
-        if path.is_dir() and path.name.startswith("em-")
-    ]
-    assert len(run_dirs) == 1
-    assert DaemonRunDir.read_state_from_disk(run_dirs[0]).get("dispatch_sequence") is None
+    daemon_root = agent._working_dir / "daemons"
+    assert not daemon_root.exists() or not any(
+        path.is_dir() and path.name.startswith("em-")
+        for path in daemon_root.iterdir()
+    )
     decisions = [row for row in audit if row[0] == "derived_launch_admission_decision"]
     assert decisions == [
         (
@@ -1521,9 +1520,16 @@ def test_profile_external_cli_daemon_launch_reaches_admission_before_supervisor(
     assert result == {
         "status": "error",
         "message": "derived launch was not admitted: derived_launch_denied_by_test",
+        "reason_code": "derived_launch_denied_by_test",
+        "audit_id": "audit-external-cli-2a",
     }
     assert port.calls == [(root, DerivedLaunchCapability.DAEMON)]
     assert supervisor_calls == []
+    daemon_root = agent._working_dir / "daemons"
+    assert not daemon_root.exists() or not any(
+        path.is_dir() and path.name.startswith("em-")
+        for path in daemon_root.iterdir()
+    )
     decisions = [row for row in audit if row[0] == "derived_launch_admission_decision"]
     assert decisions == [
         (


### PR DESCRIPTION
## Summary
- authorize native and external daemon launches before creating any per-run artifacts
- leave denied launches with no run directory while preserving structured refusal evidence
- return `reason_code` and `audit_id` for external refusal results

## Verification
- `python3 -m py_compile src/lingtai/tools/daemon/__init__.py tests/test_daemon.py`
- AST ordering check: authorization precedes `DaemonRunDir` and dispatch in both paths
- `git diff --check`

Focused pytest could not run in this environment because `pytest` is not installed; independent reviewer will run the acceptance suite.