### PR TITLE
fix(wechat): accept optional ret acknowledgements

### DIFF
--- a/src/lingtai/mcp_servers/wechat/SKILL.md
+++ b/src/lingtai/mcp_servers/wechat/SKILL.md
@@ -7,8 +7,8 @@ description: |
   contacts/accounts basics, read-only settings inventory and owner procedures,
   and external-delivery side-effect caveats. Pulled on demand via action='manual';
   you do not need to call it before every send.
-version: 1.4.0
-last_changed_at: "2026-08-29T00:00:00-07:00"
+version: 1.4.1
+last_changed_at: "2026-08-31T00:00:00-07:00"
 related_files:
 - src/lingtai/mcp_servers/wechat/manager.py
 - src/lingtai/mcp_servers/wechat/server.py
@@ -222,10 +222,12 @@ recipient IDs passed to messaging actions.
 
 - `send` and `reply` deliver to real users — external side effects. Confirm
   recipient and content before sending unsolicited messages.
-- A successful provider response requires an explicit integer `ret: 0`. The
-  result then says `delivery_status: provider_accepted` and
-  `delivery_confirmed: false`: iLink accepted the request, but recipient delivery
-  is not proven. Do not automatically replay an accepted request.
+- A provider response is accepted when `ret` is missing/null or an explicit
+  integer zero, provided `errcode` is absent or an integer zero. Explicit
+  nonzero/noninteger `ret` or `errcode` remains a failure. An accepted result
+  says `delivery_status: provider_accepted` and `delivery_confirmed: false`:
+  iLink accepted the request, but recipient delivery is not proven. Do not
+  automatically replay an accepted request.
 - For text-plus-media partial outcomes, legacy `partial_delivery: true` is only a
   replay-compatibility flag that a recipient-visible side effect may have occurred;
   `partial_provider_acceptance` and `delivery_confirmed: false` carry the precise

--- a/src/lingtai/mcp_servers/wechat/api.py
+++ b/src/lingtai/mcp_servers/wechat/api.py
@@ -190,12 +190,18 @@ def _ack_code(value: object) -> bool:
 # Only fixed diagnostic field names can enter telemetry. Arbitrary provider
 # keys and opaque values are never copied, traversed, or serialized.
 _SAFE_ACK_DIAGNOSTIC_KEYS = ("ret", "errcode")
+_SAFE_ACK_INT_MIN = -(1 << 63)
+_SAFE_ACK_INT_MAX = (1 << 63) - 1
 
 
 def _safe_ack_diagnostic(value: object) -> object:
     """Return bounded metadata for one fixed acknowledgement diagnostic."""
-    if value is None or _ack_code(value):
-        return value
+    if value is None:
+        return None
+    if _ack_code(value):
+        if _SAFE_ACK_INT_MIN <= value <= _SAFE_ACK_INT_MAX:
+            return value
+        return f"<int:{value.bit_length()}bits>"
     if isinstance(value, str):
         return f"<str:{len(value)}>"
     return f"<{type(value).__name__}>"
@@ -251,7 +257,9 @@ def _parse_send_acknowledgement(resp: "httpx.Response") -> dict[str, int]:
     if "errcode" in body:
         errcode = body.get("errcode")
         if not _ack_code(errcode) or errcode != 0:
-            detail = errcode if _ack_code(errcode) else "<invalid>"
+            detail = (
+                _safe_ack_diagnostic(errcode) if _ack_code(errcode) else "<invalid>"
+            )
             _log_ack_warning(
                 "iLink send_message returned non-zero/invalid errcode;", body
             )
@@ -278,11 +286,12 @@ def _parse_send_acknowledgement(resp: "httpx.Response") -> dict[str, int]:
         )
 
     if ret != 0:
+        detail = _safe_ack_diagnostic(ret)
         _log_ack_warning(
             "iLink send_message returned non-zero ret;", body
         )
         raise RuntimeError(
-            f"iLink send_message returned invalid acknowledgement: ret={ret}"
+            f"iLink send_message returned invalid acknowledgement: ret={detail}"
         )
 
     ack: dict[str, int] = {"ret": 0}

--- a/src/lingtai/mcp_servers/wechat/api.py
+++ b/src/lingtai/mcp_servers/wechat/api.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import base64
+import json
 import logging
 import os
 import struct
@@ -162,7 +163,8 @@ async def send_message(
 ) -> dict[str, int]:
     """Submit one recipient-visible request and return a safe provider ack.
 
-    Success requires an explicit non-boolean integer ``ret == 0``.  This is
+    Success accepts a missing/null ``ret`` or an explicit non-boolean integer
+    ``ret == 0`` only when ``errcode`` is absent or an integer zero. This is
     provider acceptance only; it does not confirm recipient delivery.
     """
     url = _ensure_trailing_slash(base_url) + "ilink/bot/sendmessage"
@@ -185,8 +187,54 @@ def _ack_code(value: object) -> bool:
     return isinstance(value, int) and not isinstance(value, bool)
 
 
+# Only fixed diagnostic field names can enter telemetry. Arbitrary provider
+# keys and opaque values are never copied, traversed, or serialized.
+_SAFE_ACK_DIAGNOSTIC_KEYS = ("ret", "errcode")
+
+
+def _safe_ack_diagnostic(value: object) -> object:
+    """Return bounded metadata for one fixed acknowledgement diagnostic."""
+    if value is None or _ack_code(value):
+        return value
+    if isinstance(value, str):
+        return f"<str:{len(value)}>"
+    return f"<{type(value).__name__}>"
+
+
+def _safe_ack_shape(body: dict[str, Any]) -> dict[str, Any]:
+    """Return a bounded, secret-safe description of an acknowledgement body."""
+    shape: dict[str, Any] = {
+        "field_count": len(body),
+        "has_ret": "ret" in body,
+        "has_errcode": "errcode" in body,
+    }
+    for key in _SAFE_ACK_DIAGNOSTIC_KEYS:
+        if key in body:
+            shape[key] = _safe_ack_diagnostic(body[key])
+    return shape
+
+
+def _log_ack_warning(message: str, body: dict[str, Any]) -> None:
+    """Log one bounded acknowledgement warning only when it will be emitted."""
+    if not log.isEnabledFor(logging.WARNING):
+        return
+    log.warning(
+        "%s response_shape=%s",
+        message,
+        json.dumps(_safe_ack_shape(body), ensure_ascii=False, separators=(",", ":")),
+    )
+
+
 def _parse_send_acknowledgement(resp: "httpx.Response") -> dict[str, int]:
-    """Require a strict JSON-object acknowledgement with explicit ``ret=0``."""
+    """Parse iLink sendmessage acknowledgement.
+
+    Mirrors the official OpenClaw/Tencent client: a missing or null ``ret``
+    field is treated as provider acceptance (the protocol declares it
+    optional). Any non-zero integer or non-integer ``ret`` is still a failure.
+    A nonzero or non-integer ``errcode`` is also a failure, even when ``ret``
+    is missing or null.  Only secret-safe structural telemetry is logged when
+    the acknowledgement deviates from the explicit ``{"ret": 0}`` shape.
+    """
     if not resp.text.strip():
         raise RuntimeError("iLink send_message returned an empty response")
     try:
@@ -197,21 +245,48 @@ def _parse_send_acknowledgement(resp: "httpx.Response") -> dict[str, int]:
         raise RuntimeError("iLink send_message returned non-object JSON")
 
     ret = body.get("ret")
-    if not _ack_code(ret) or ret != 0:
-        detail = ret if _ack_code(ret) else "<missing-or-invalid>"
-        raise RuntimeError(
-            f"iLink send_message returned invalid acknowledgement: ret={detail}"
-        )
 
-    ack = {"ret": 0}
+    # Validate errcode first and independent of ret so that a missing or null
+    # ret never bypasses an explicit nonzero/invalid errcode.
     if "errcode" in body:
         errcode = body.get("errcode")
         if not _ack_code(errcode) or errcode != 0:
             detail = errcode if _ack_code(errcode) else "<invalid>"
+            _log_ack_warning(
+                "iLink send_message returned non-zero/invalid errcode;", body
+            )
             raise RuntimeError(
                 "iLink send_message returned invalid acknowledgement: "
                 f"errcode={detail}"
             )
+
+    if ret is None:
+        _log_ack_warning(
+            "iLink send_message returned missing/null ret; treating as provider "
+            "acceptance per official protocol.",
+            body,
+        )
+        return {"ret": 0}
+
+    if not _ack_code(ret):
+        _log_ack_warning(
+            "iLink send_message returned invalid ret type;", body
+        )
+        raise RuntimeError(
+            "iLink send_message returned invalid acknowledgement: "
+            f"ret=<invalid {type(ret).__name__}>"
+        )
+
+    if ret != 0:
+        _log_ack_warning(
+            "iLink send_message returned non-zero ret;", body
+        )
+        raise RuntimeError(
+            f"iLink send_message returned invalid acknowledgement: ret={ret}"
+        )
+
+    ack: dict[str, int] = {"ret": 0}
+    if "errcode" in body:
         ack["errcode"] = 0
     return ack
 

--- a/tests/test_wechat_media_upload_diagnostics.py
+++ b/tests/test_wechat_media_upload_diagnostics.py
@@ -181,13 +181,51 @@ def test_send_ack_skips_shape_when_warning_disabled(monkeypatch) -> None:
 def test_send_ack_invalid_diagnostic_values_redacted(caplog, body, secret) -> None:
     """Even malformed ret/errcode values are reduced to structural telemetry."""
     import logging
-    with caplog.at_level(logging.WARNING):
-        with pytest.raises(RuntimeError, match="invalid acknowledgement"):
-            api._parse_send_acknowledgement(
-                _send_response(json.dumps(body).encode("utf-8"))
-            )
+    with caplog.at_level(logging.WARNING), pytest.raises(
+        RuntimeError, match="invalid acknowledgement"
+    ):
+        api._parse_send_acknowledgement(
+            _send_response(json.dumps(body).encode("utf-8"))
+        )
     assert secret not in caplog.text
     assert "<str:" in caplog.text
+
+
+def test_safe_ack_diagnostic_keeps_only_signed_64bit_ints() -> None:
+    assert api._safe_ack_diagnostic(-(1 << 63)) == -(1 << 63)
+    assert api._safe_ack_diagnostic((1 << 63) - 1) == (1 << 63) - 1
+    assert api._safe_ack_diagnostic(-(1 << 63) - 1) == "<int:64bits>"
+    assert api._safe_ack_diagnostic(1 << 63) == "<int:64bits>"
+
+
+@pytest.mark.parametrize(("field", "sign"), [
+    ("ret", 1),
+    ("ret", -1),
+    ("errcode", 1),
+    ("errcode", -1),
+])
+def test_send_ack_huge_integer_diagnostics_are_bounded(
+    caplog, field: str, sign: int
+) -> None:
+    """Huge provider integers never escape raw through warnings or errors."""
+    import logging
+    digits = "9" * 4000
+    raw = digits if sign > 0 else f"-{digits}"
+    value = int(raw)
+    body = {"ret": value} if field == "ret" else {"ret": None, "errcode": value}
+
+    with caplog.at_level(logging.WARNING), pytest.raises(RuntimeError) as exc_info:
+        api._parse_send_acknowledgement(
+            _send_response(json.dumps(body).encode("utf-8"))
+        )
+
+    error_text = str(exc_info.value)
+    assert raw not in caplog.text
+    assert raw not in error_text
+    assert "<int:" in caplog.text
+    assert "<int:" in error_text
+    assert len(caplog.text) < 1000
+    assert len(error_text) < 300
 
 
 def test_public_send_result_is_acceptance_not_delivery(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_wechat_media_upload_diagnostics.py
+++ b/tests/test_wechat_media_upload_diagnostics.py
@@ -57,11 +57,49 @@ def test_send_message_uses_tencent_246_identity_and_safe_acceptance(monkeypatch)
     assert ack == {"ret": 0, "errcode": 0}
 
 
-@pytest.mark.parametrize("body", [
-    {}, {"ret": None}, {"errcode": 0}, {"ret": "0"}, {"ret": True},
-    {"ret": 17}, {"ret": 0, "errcode": 9},
+@pytest.mark.parametrize("body, expected", [
+    ({"ret": 0}, {"ret": 0}),
+    ({"ret": 0, "errcode": 0}, {"ret": 0, "errcode": 0}),
+    ({"ret": 0, "errcode": 0, "errmsg": "ok"}, {"ret": 0, "errcode": 0}),
 ])
-def test_send_ack_requires_explicit_integer_zero_ret(body: dict) -> None:
+def test_send_ack_explicit_zero_ret_accepted(body: dict, expected: dict) -> None:
+    response = _send_response(json.dumps(body).encode("utf-8"))
+    assert api._parse_send_acknowledgement(response) == expected
+
+
+@pytest.mark.parametrize("body", [
+    {}, {"ret": None}, {"errcode": 0}, {"ret": None, "errcode": 0},
+])
+def test_send_ack_missing_or_null_ret_accepted(body: dict) -> None:
+    """Missing/null ret is provider acceptance per the official client."""
+    response = _send_response(json.dumps(body).encode("utf-8"))
+    assert api._parse_send_acknowledgement(response) == {"ret": 0}
+
+
+@pytest.mark.parametrize("body", [
+    {"ret": "0"}, {"ret": True}, {"ret": 0.0}, {"ret": []},
+    {"ret": 17}, {"ret": -3},
+    {"ret": 17, "errcode": 0},
+    {"ret": 0.0, "errcode": 0},
+    {"ret": False, "errcode": 0},
+])
+def test_send_ack_invalid_ret_rejected(body: dict) -> None:
+    response = _send_response(json.dumps(body).encode("utf-8"))
+    with pytest.raises(RuntimeError, match="invalid acknowledgement"):
+        api._parse_send_acknowledgement(response)
+
+
+@pytest.mark.parametrize("body", [
+    {"errcode": 9},
+    {"ret": None, "errcode": 9},
+    {"ret": None, "errcode": "9"},
+    {"ret": None, "errcode": True},
+    {"ret": None, "errcode": None},
+    {"ret": None, "errcode": 0.0},
+    {"ret": 0, "errcode": 9},
+])
+def test_send_ack_nonzero_or_invalid_errcode_rejected(body: dict) -> None:
+    """A nonzero/invalid errcode fails even when ret is missing or null."""
     response = _send_response(json.dumps(body).encode("utf-8"))
     with pytest.raises(RuntimeError, match="invalid acknowledgement"):
         api._parse_send_acknowledgement(response)
@@ -71,6 +109,85 @@ def test_send_ack_requires_explicit_integer_zero_ret(body: dict) -> None:
 def test_send_ack_rejects_empty_malformed_or_nonobject(content: bytes) -> None:
     with pytest.raises(RuntimeError):
         api._parse_send_acknowledgement(_send_response(content))
+
+
+def test_send_ack_logs_structural_telemetry_not_raw_body(caplog) -> None:
+    """Warnings contain bounded shape telemetry, never the raw response body."""
+    import logging
+    body = {"ret": None, "errmsg": "something", "private": "secret-value-xyz"}
+    with caplog.at_level(logging.WARNING):
+        api._parse_send_acknowledgement(
+            _send_response(json.dumps(body).encode("utf-8"))
+        )
+    assert "missing/null ret" in caplog.text
+    assert "response_shape=" in caplog.text
+    assert "secret-value-xyz" not in caplog.text
+    assert "something" not in caplog.text
+    assert '"field_count":3' in caplog.text
+    assert '"has_ret":true' in caplog.text
+    assert '"has_errcode":false' in caplog.text
+    assert '"ret":null' in caplog.text
+
+
+def test_send_ack_shape_omits_keys_values_and_nested_topology(caplog) -> None:
+    """Arbitrary key strings and nested payloads cannot leak or amplify logs."""
+    import logging
+    secret_key = "https://provider.invalid/callback?token=secret-in-key"
+    body = {
+        "ret": None,
+        secret_key: [{"nested-secret-key": "nested-secret-value"}] * 1000,
+        "password_is_correct": True,
+    }
+    with caplog.at_level(logging.WARNING):
+        api._parse_send_acknowledgement(
+            _send_response(json.dumps(body).encode("utf-8"))
+        )
+    assert "response_shape=" in caplog.text
+    assert secret_key not in caplog.text
+    assert "nested-secret-key" not in caplog.text
+    assert "nested-secret-value" not in caplog.text
+    assert '"password_is_correct":true' not in caplog.text
+    assert '"field_count":3' in caplog.text
+    assert len(caplog.text) < 1000
+
+
+def test_safe_ack_shape_does_not_traverse_deep_unknown_fields() -> None:
+    nested: object = "leaf-secret"
+    for _ in range(2000):
+        nested = {"secret-key": nested}
+    assert api._safe_ack_shape({"ret": None, "opaque": nested}) == {
+        "field_count": 2,
+        "has_ret": True,
+        "has_errcode": False,
+        "ret": None,
+    }
+
+
+def test_send_ack_skips_shape_when_warning_disabled(monkeypatch) -> None:
+    monkeypatch.setattr(api.log, "isEnabledFor", lambda level: False)
+    monkeypatch.setattr(
+        api,
+        "_safe_ack_shape",
+        lambda body: pytest.fail("shape must not be built when warning is disabled"),
+    )
+    response = _send_response(b'{"ret":null,"opaque":{"secret":"value"}}')
+    assert api._parse_send_acknowledgement(response) == {"ret": 0}
+
+
+@pytest.mark.parametrize(("body", "secret"), [
+    ({"ret": "ret-secret-value"}, "ret-secret-value"),
+    ({"ret": None, "errcode": "errcode-secret-value"}, "errcode-secret-value"),
+])
+def test_send_ack_invalid_diagnostic_values_redacted(caplog, body, secret) -> None:
+    """Even malformed ret/errcode values are reduced to structural telemetry."""
+    import logging
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(RuntimeError, match="invalid acknowledgement"):
+            api._parse_send_acknowledgement(
+                _send_response(json.dumps(body).encode("utf-8"))
+            )
+    assert secret not in caplog.text
+    assert "<str:" in caplog.text
 
 
 def test_public_send_result_is_acceptance_not_delivery(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- accept a missing or JSON-null top-level `ret` as provider acceptance only when `errcode` is absent or integer zero
- continue rejecting nonzero and noninteger `ret` / `errcode` values, including booleans and equality-to-zero floats
- emit bounded warning telemetry using only fixed diagnostic field names, field counts, presence flags, and redacted diagnostic types/lengths; arbitrary keys and nested values are never traversed or logged
- align the public `send_message` docstring and bundled WeChat manual with the optional-`ret` behavior and the existing `delivery_confirmed: false` boundary

## Validation

- [x] `git diff --check`
- [x] final regression file: `43 passed`
- [x] full adjacent WeChat surface: `210 passed`
- [x] curated MCP manual suite: `24 passed`
- [x] Ruff 0.16.5 `--select SIM117` passes; its remaining four full-check findings match exact base, while Ruff 0.15.17 reports both changed files clean
- [x] `py_compile` for the changed Python files
- [x] fail-first proof on exact base `a4c253b2ce8abd6044d02d51dba2f4c621454107`: original regression file reports `10 failed, 28 passed`
- [x] follow-up fail-first proof on prior Draft head `d549f7787061ab180f8e0a258d567e8d88d96ce4`: final regression file reports `5 failed, 38 passed`; repaired head reports `43 passed`
- [x] no new architecture-document failure: candidate and exact base both report the same two pre-existing failures (`2 failed, 2 passed`) for duplicate LLM Anatomy metadata and the existing Bash Anatomy/Contract ownership state

## Notes

- An accepted acknowledgement remains **provider acceptance only**. It does not prove recipient delivery, and automatic retry remains disabled.
- An independent read-only review found an unbounded/raw-key telemetry path and stale documentation in the first candidate; both were corrected before commit, with dedicated deep/wide payload, secret-in-key, disabled-warning, and edge-case regressions.
- A second exact-head review found raw 4,000-digit integer diagnostics and one Ruff SIM117; the follow-up bounds exact integers to signed 64-bit, renders larger values as `<int:NNbits>` in warnings and errors, adds positive/negative huge `ret`/`errcode` tests with message caps, and removes SIM117.
- No live WeChat runtime, selector, agent configuration, context setting, credential, or external message was changed or exercised while authoring this PR.
- Logs, fixtures, and examples contain only synthetic values; no credentials or raw provider response bodies are included.

Telegram: @wangrunyuansecbot | Nickname: 一心
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
