### PR TITLE
fix(daemon): bound filtered list hydration

### DIFF
--- a/src/lingtai/tools/daemon/__init__.py
+++ b/src/lingtai/tools/daemon/__init__.py
@@ -6153,13 +6153,13 @@ class DaemonManager:
         limit_int: int,
     ) -> dict:
         """Build list from append-order ledger, never historical directories."""
-        # Filters/search are explicit queries and may stream the ledger.  The
-        # ordinary list reads an EOF tail only; created_at is never re-sorted.
-        full_history = bool(query or (wanted_status and wanted_status != "all") or not include_done)
+        # Every list/filter path reads one caller-selected bounded ledger window;
+        # filters never promote the default EOF tail into full-history hydration.
+        # created_at is never re-sorted.
         _ledger, rows, warnings = dispatch_ledger.read_recent_daemon_states(
             self._workdir.path,
             limit=limit_int,
-            full_history=full_history,
+            full_history=False,
         )
         entries: list[dict] = []
         known_run_ids: set[str] = set()

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -2864,11 +2864,24 @@ def test_handle_list_defaults_to_newest_1000_and_materializes_only_ledger_page(t
     assert default_listing["emanations"][0]["run_id"] == "em-history-1004"
     assert default_listing["emanations"][-1]["run_id"] == "em-history-0005"
 
+    # An explicit last=N grows the bounded window to N, even with a filter.
     materialized.clear()
-    expanded_listing = mgr._handle_list(limit=total)
+    expanded_listing = mgr._handle_list(contains="history", limit=total)
     assert expanded_listing["showing"] == total
     assert len(materialized) == total
     assert expanded_listing["emanations"][0]["run_id"] == "em-history-1004"
+
+    # Query, status, and include_done filters must not silently turn the default
+    # newest-1000 window into a full-history ledger/state hydration pass.
+    for kwargs, expected_showing in (
+        ({"contains": "history"}, 1000),
+        ({"status_filter": "done"}, 1000),
+        ({"include_done": False}, 0),
+    ):
+        materialized.clear()
+        filtered_listing = mgr._handle_list(**kwargs)
+        assert filtered_listing["showing"] == expected_showing
+        assert len(materialized) == 1000
 
 
 def test_handle_list_uses_only_ledger_history_and_explicit_filters(tmp_path):


### PR DESCRIPTION
## Summary
- Keep every `daemon list` path ledger-backed and bounded by the caller-selected window.
- Prevent `query`, non-`all` status, or `include_done=false` from silently upgrading the default newest-1000 window into full-history state hydration.
- Add a regression proving all three default filtered modes materialize only 1,000 entries while explicit `last=N` still selects N.

## Validation
- `PYTHONPATH="$WT/src" /Users/huangzesen/work/GitHub/lingtai-kernel/.venv/bin/python -m pytest -q` for 4 relevant daemon-list tests — **4 passed in 8.59s**.
- `git diff --check` — **PASS**.
- Full `tests/test_daemon.py -x` is **not green**: it reached 89 passes then stopped at pre-existing/unrelated `test_handle_emanate_dispatches_and_returns_ids` (`status='error'` instead of `dispatched`). This PR does not touch emanate/dispatch code and does not claim that test as passing.

## Scope
No daemon directory scan, data migration, runtime/configuration change, or target-agent process action.

Telegram: @lingtaidev2bot | Nickname: N/A
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai