### PR TITLE
fix(daemon): fail closed before Driver lease handoff

### DIFF
--- a/src/lingtai/adapters/acp/CONTRACT.md
+++ b/src/lingtai/adapters/acp/CONTRACT.md
@@ -319,6 +319,8 @@ or optional-dependencies section for this standard-library slice.
 admission protocol. Every hello and decision request carries a fresh `call_id`;
 a missing or mismatched response id closes the transport and fails closed.
 Granted derived-launch endpoints are opaque, one-use leases and remain within
-this adapter layer. This module does **not** compose ACP profiles or launch
+the typed in-memory launch decision only. `DriverDerivedLaunchAdmissionAdapter`
+performs that narrow projection; it does not serialize, consume, or otherwise
+hand off the lease. This module does **not** compose ACP profiles or launch
 daemons, avatars, supervisors, or managers; those consumers belong to separate
 layers.

--- a/src/lingtai/adapters/acp/driver_authority.py
+++ b/src/lingtai/adapters/acp/driver_authority.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from lingtai.kernel.provider_admission import (
     DerivedLaunchCapability,
+    DerivedLaunchDecision,
     DerivedProviderAdmission,
     ProviderAdmissionParent,
     ProviderAdmissionState,
@@ -90,6 +91,33 @@ class DriverDerivedLaunchGrant:
     reason_code: str
     audit_id: str | None = None
     child_endpoint_lease: DriverChildEndpointLease | None = None
+
+
+class DriverDerivedLaunchAdmissionAdapter:
+    """Project one Driver grant into Core's derived-launch decision port.
+
+    This adapter owns no daemon, manager, supervisor, or child startup.  It
+    only preserves the Driver's opaque one-use lease alongside the typed Core
+    decision until a later consumer can either hand it off or close it.
+    """
+
+    __slots__ = ("_authority",)
+
+    def __init__(self, authority: "DriverAuthorityClient") -> None:
+        self._authority = authority
+
+    def authorize_derived_launch(
+        self,
+        parent: RootProviderAdmission,
+        capability: DerivedLaunchCapability,
+    ) -> DerivedLaunchDecision:
+        grant = self._authority.request_derived_launch(parent, capability)
+        return DerivedLaunchDecision(
+            grant.state,
+            grant.reason_code,
+            audit_id=grant.audit_id,
+            child_endpoint_lease=grant.child_endpoint_lease,
+        )
 
 
 class DriverAuthorityClient(ProviderCallAdmissionPort):
@@ -330,3 +358,15 @@ class DriverAuthorityClient(ProviderCallAdmissionPort):
         endpoint_capability = DerivedLaunchCapability(self._identity.capability)
         endpoint_call_class = ProviderCallClass.DAEMON if endpoint_capability is DerivedLaunchCapability.DAEMON else ProviderCallClass.AVATAR_CHILD
         return call_class is endpoint_call_class
+
+
+__all__ = [
+    "DRIVER_AUTHORITY_FD_ENV",
+    "DriverAuthorityClient",
+    "DriverAuthorityEndpointBindingMismatch",
+    "DriverAuthorityIdentity",
+    "DriverAuthorityTransportError",
+    "DriverChildEndpointLease",
+    "DriverDerivedLaunchAdmissionAdapter",
+    "DriverDerivedLaunchGrant",
+]

--- a/src/lingtai/adapters/tool_plugin_host.py
+++ b/src/lingtai/adapters/tool_plugin_host.py
@@ -672,6 +672,7 @@ class AgentDaemonRuntimeAdapter:
         "_read_language",
         "_read_max_aed_attempts",
         "_read_tool_call_guard",
+        "_requires_derived_launch_admission",
         "_authorize_derived_launch",
         "_manager_options",
         "_setup_preset_capability",
@@ -694,6 +695,7 @@ class AgentDaemonRuntimeAdapter:
         read_language: Callable[[], str],
         read_max_aed_attempts: Callable[[], int],
         read_tool_call_guard: Callable[[], Any],
+        requires_derived_launch_admission: Callable[[], bool],
         authorize_derived_launch: Callable[[Any], Any],
         manager_options: Mapping[str, Any],
         setup_preset_capability: Callable[[str, Mapping[str, Any]], tuple[dict[str, Any], dict[str, Callable[[dict], dict]]]],
@@ -711,6 +713,7 @@ class AgentDaemonRuntimeAdapter:
         self._read_language = read_language
         self._read_max_aed_attempts = read_max_aed_attempts
         self._read_tool_call_guard = read_tool_call_guard
+        self._requires_derived_launch_admission = requires_derived_launch_admission
         self._authorize_derived_launch = authorize_derived_launch
         self._manager_options = dict(manager_options)
         self._setup_preset_capability = setup_preset_capability
@@ -749,6 +752,10 @@ class AgentDaemonRuntimeAdapter:
     @property
     def tool_call_guard(self) -> Any:
         return self._read_tool_call_guard()
+
+    @property
+    def requires_derived_launch_admission(self) -> bool:
+        return self._requires_derived_launch_admission()
 
     def authorize_derived_launch(self, capability: Any) -> Any:
         return self._authorize_derived_launch(capability)
@@ -911,6 +918,9 @@ def daemon_runtime_for_agent(
         read_language=_read_language,
         read_max_aed_attempts=_read_max_aed_attempts,
         read_tool_call_guard=lambda: getattr(agent, "_tool_call_guard", None),
+        requires_derived_launch_admission=lambda: bool(
+            getattr(agent, "_requires_derived_launch_admission_port", False)
+        ),
         authorize_derived_launch=_authorize_derived_launch,
         manager_options=manager_options,
         setup_preset_capability=_setup_preset_capability,

--- a/src/lingtai/kernel/provider_admission.py
+++ b/src/lingtai/kernel/provider_admission.py
@@ -146,6 +146,12 @@ class DerivedLaunchDecision:
     state: ProviderAdmissionState
     reason_code: str
     audit_id: str | None = None
+    # An adapter-owned, non-serializable, one-use child handoff.  Core neither
+    # inspects nor reconstructs it; a consumer must either hand it to the
+    # exact supported process boundary or release it before returning.
+    child_endpoint_lease: object | None = field(
+        default=None, repr=False, compare=False
+    )
 
     @property
     def allowed(self) -> bool:

--- a/src/lingtai/kernel/tool_plugin/__init__.py
+++ b/src/lingtai/kernel/tool_plugin/__init__.py
@@ -392,6 +392,15 @@ class DaemonRuntimePort(Protocol):
     def manager_options(self) -> Mapping[str, Any]:
         """Resolved construction options for this daemon manager binding."""
 
+    @property
+    def requires_derived_launch_admission(self) -> bool:
+        """Whether this binding must fail closed for derived launches.
+
+        This is policy state, not an authority decision or a grant.  Daemon
+        uses it to reject external CLI execution before it can ask Driver for
+        an endpoint that this backend cannot consume.
+        """
+
     def authorize_derived_launch(self, capability: Any) -> Any:
         """Decide one daemon-derived process launch before side effects."""
 

--- a/src/lingtai/tools/daemon/CONTRACT.md
+++ b/src/lingtai/tools/daemon/CONTRACT.md
@@ -983,6 +983,14 @@ This requirement flag is not a grant, parent identity, or bearer. A future
 Driver authority bridge must supply those separately before any legitimate
 derived launch can be allowed.
 
+Until the POSIX manager's child-endpoint transport is available, a root Driver
+batch that receives one or more child endpoint leases is also refused before
+task-file materialization, run-directory creation, durable enqueue, or spawn;
+every already-issued lease is closed. An external CLI backend is refused even
+earlier, before it asks Driver for a lease it cannot consume. These are
+deliberately fail-closed transition rules, not successful Driver daemon
+dispatch: the later supervisor/manager FD handoff owns that transition.
+
 ## Acceptance Gate
 
 Any new daemon backend, backend-family reuse, or contract-impacting daemon

--- a/src/lingtai/tools/daemon/__init__.py
+++ b/src/lingtai/tools/daemon/__init__.py
@@ -5655,6 +5655,22 @@ class DaemonManager:
         ):
             return {"status": "error", "message": f"Unknown CLI backend: {backend}"}
 
+        # A constrained Driver profile grants a one-use endpoint for a
+        # LingTai-owned child.  An external CLI has no contract for that
+        # endpoint.  Reject before asking the authority, materializing task
+        # files, creating a run directory, or queuing work: requesting a grant
+        # first would create a misleading Driver audit event for a backend that
+        # can never consume it.
+        if self._runtime.requires_derived_launch_admission:
+            return {
+                "status": "error",
+                "message": (
+                    "external CLI daemon backends are unavailable under Driver admission"
+                ),
+                "reason_code": "driver_external_cli_backend_unsupported",
+                "audit_id": None,
+            }
+
         # Pre-flight: validate per-task backend_options BEFORE creating any
         # run_dir or scheduling work, so a single bad spec refuses the whole
         # batch with a clear message instead of leaving half-spawned daemons.

--- a/src/lingtai/tools/daemon/__init__.py
+++ b/src/lingtai/tools/daemon/__init__.py
@@ -5408,6 +5408,9 @@ class DaemonManager:
             )
         except DerivedLaunchAdmissionError as error:
             return self._admission_error_result(error)
+        if self._has_unhandoffable_driver_leases(launch_decisions):
+            self._close_unconsumed_derived_launch_decisions(launch_decisions)
+            return self._driver_handoff_unavailable_result()
 
         ids = []
         group_id = DaemonRunDir.new_group_id()
@@ -5735,6 +5738,9 @@ class DaemonManager:
             )
         except DerivedLaunchAdmissionError as error:
             return self._admission_error_result(error)
+        if self._has_unhandoffable_driver_leases(launch_decisions):
+            self._close_unconsumed_derived_launch_decisions(launch_decisions)
+            return self._driver_handoff_unavailable_result()
 
         ids = []
         group_id = DaemonRunDir.new_group_id()
@@ -9568,20 +9574,50 @@ class DaemonManager:
         }
 
     @staticmethod
-    def _close_unconsumed_derived_launch_decisions(decisions: list[object]) -> None:
+    def _close_unconsumed_derived_launch_decisions(
+        decisions: list["DerivedLaunchDecision"],
+    ) -> None:
         """Release pre-authorized decisions that have not reached a child yet.
 
-        This base layer has no resource-bearing decisions. The Driver adapter
-        layer supplies a child endpoint lease per decision and replaces this
-        hook with deterministic release before it can use batch pre-admission.
+        A later denial or unavailable handoff occurs before any child can
+        consume earlier Driver grants.  Close every known lease in that batch
+        before exposing the refusal; generic Core decisions carry ``None``.
         """
-        return None
+        for decision in decisions:
+            lease = decision.child_endpoint_lease
+            if lease is not None:
+                try:
+                    lease.close()
+                except Exception:
+                    pass
+
+    @staticmethod
+    def _has_unhandoffable_driver_leases(
+        decisions: list["DerivedLaunchDecision"],
+    ) -> bool:
+        """Detect Driver grants before their lease can reach durable state.
+
+        B5's central manager transports capsules as JSON, so it cannot carry a
+        live child endpoint.  B8 will add the SCM_RIGHTS transport and its
+        restart invalidation rule.  Until then, a valid Driver grant fails
+        closed rather than being queued without its authority endpoint.
+        """
+        return any(decision.child_endpoint_lease is not None for decision in decisions)
+
+    @staticmethod
+    def _driver_handoff_unavailable_result() -> dict[str, str | None]:
+        return {
+            "status": "error",
+            "message": "Driver child-endpoint handoff is unavailable",
+            "reason_code": "driver_child_endpoint_handoff_unavailable",
+            "audit_id": None,
+        }
 
     def _authorize_derived_launch_batch(
         self, capability_name: str, task_count: int
-    ) -> list[object]:
+    ) -> list["DerivedLaunchDecision"]:
         """Authorize every child in a batch before any durable batch write."""
-        decisions: list[object] = []
+        decisions = []
         try:
             for _ in range(task_count):
                 decisions.append(self._authorize_derived_launch(capability_name))
@@ -9590,11 +9626,14 @@ class DaemonManager:
             raise
         return decisions
 
-    def _authorize_derived_launch(self, capability_name: str) -> object:
+    def _authorize_derived_launch(
+        self, capability_name: str
+    ) -> "DerivedLaunchDecision":
         """Reach the host decision seam before a daemon launch side effect."""
         from lingtai.kernel.provider_admission import (
             DerivedLaunchAdmissionError,
             DerivedLaunchCapability,
+            DerivedLaunchDecision,
         )
 
         capability = DerivedLaunchCapability(capability_name)

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1685,6 +1685,107 @@ def test_profile_external_cli_daemon_launch_reaches_admission_before_supervisor(
     ]
 
 
+def test_profile_external_cli_default_manager_queues_only_after_granted_admission(
+    tmp_path, monkeypatch
+):
+    """The default POSIX manager retains its 100-worker cap after admission."""
+    from lingtai.adapters.acp.puffo_v0 import RUNTIME_POLICY
+    from lingtai.adapters.posix.daemon_supervisor import PosixDaemonSupervisorAdapter
+
+    class _GrantingPort:
+        def authorize_derived_launch(self, _parent, _capability):
+            return DerivedLaunchDecision(
+                ProviderAdmissionState.GRANTED,
+                "derived_launch_allowed_by_test",
+                audit_id="audit-default-manager-grant",
+            )
+
+    agent = _make_agent(tmp_path, ["daemon"])
+    agent._derived_launch_admission_port = _GrantingPort()
+    queued = []
+    direct_supervisor_calls = []
+    monkeypatch.setattr(
+        "lingtai.adapters.posix.daemon_manager.enqueue_manager_run",
+        lambda **kwargs: queued.append(kwargs),
+    )
+    monkeypatch.setattr(
+        PosixDaemonSupervisorAdapter,
+        "spawn_detached",
+        lambda *_args, **_kwargs: direct_supervisor_calls.append(True),
+    )
+
+    root = RootProviderAdmission(
+        "root-external-cli-default-manager", RUNTIME_POLICY.policy_version
+    )
+    token = bind_provider_admission(root)
+    try:
+        result = agent.get_capability("daemon").handle(
+            {
+                "action": "emanate",
+                "backend": "codex",
+                "tasks": [{"task": "test", "tools": []}],
+            }
+        )
+    finally:
+        clear_provider_admission(token)
+
+    assert result["status"] == "dispatched"
+    assert len(queued) == 1
+    assert queued[0]["pool_size"] == 100
+    assert direct_supervisor_calls == []
+
+
+def test_profile_external_cli_indeterminate_admission_never_queues_default_manager(
+    tmp_path, monkeypatch
+):
+    """An unavailable external-CLI authority leaves no queue or run artifact."""
+    from lingtai.adapters.acp.puffo_v0 import RUNTIME_POLICY
+
+    class _IndeterminatePort:
+        def authorize_derived_launch(self, _parent, _capability):
+            return DerivedLaunchDecision(
+                ProviderAdmissionState.INDETERMINATE,
+                "driver_authority_unavailable",
+            )
+
+    agent = _make_agent(tmp_path, ["daemon"])
+    agent._derived_launch_admission_port = _IndeterminatePort()
+    queued = []
+    monkeypatch.setattr(
+        "lingtai.adapters.posix.daemon_manager.enqueue_manager_run",
+        lambda **kwargs: queued.append(kwargs),
+    )
+
+    root = RootProviderAdmission(
+        "root-external-cli-indeterminate", RUNTIME_POLICY.policy_version
+    )
+    token = bind_provider_admission(root)
+    try:
+        result = agent.get_capability("daemon").handle(
+            {
+                "action": "emanate",
+                "backend": "codex",
+                "tasks": [{"task": "test", "tools": []}],
+            }
+        )
+    finally:
+        clear_provider_admission(token)
+
+    assert result == {
+        "status": "error",
+        "message": "derived launch was not admitted: driver_authority_unavailable",
+        "reason_code": "driver_authority_unavailable",
+        "audit_id": None,
+    }
+    assert queued == []
+    daemon_root = agent._working_dir / "daemons"
+    assert not daemon_root.exists() or not any(
+        path.is_dir() and path.name.startswith("em-")
+        for path in daemon_root.iterdir()
+    )
+    assert not (daemon_root / "_task_files").exists()
+
+
 def test_task_skills_render_compact_catalog_from_dir_and_file(tmp_path):
     """Task skills accept either a skill directory or a direct SKILL.md path."""
     agent = _make_agent(tmp_path, ["daemon"])

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -4,6 +4,7 @@ import json
 import os
 import queue
 import re
+import socket
 import threading
 import time
 from pathlib import Path
@@ -1836,6 +1837,184 @@ def test_profile_external_cli_rejects_before_requesting_driver_admission(
         for path in daemon_root.iterdir()
     )
     assert not (daemon_root / "_task_files").exists()
+
+
+def test_profile_driver_grant_batch_fails_closed_until_manager_handoff_exists(
+    tmp_path, monkeypatch
+):
+    """A valid Driver batch never queues while its leases lack an FD transport."""
+    from lingtai.adapters.acp.driver_authority import (
+        DriverChildEndpointLease,
+        DriverDerivedLaunchAdmissionAdapter,
+        DriverDerivedLaunchGrant,
+    )
+    from lingtai.adapters.acp.puffo_v0 import RUNTIME_POLICY
+
+    class _GrantingAuthority:
+        def __init__(self, grants):
+            self.grants = list(grants)
+            self.calls = []
+
+        def request_derived_launch(self, parent, capability):
+            self.calls.append((parent, capability))
+            return self.grants.pop(0)
+
+    first_child, first_peer = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+    second_child, second_peer = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+    first_lease = DriverChildEndpointLease(first_child)
+    second_lease = DriverChildEndpointLease(second_child)
+    authority = _GrantingAuthority([
+        DriverDerivedLaunchGrant(
+            ProviderAdmissionState.GRANTED,
+            "first_driver_grant",
+            audit_id="audit-driver-first",
+            child_endpoint_lease=first_lease,
+        ),
+        DriverDerivedLaunchGrant(
+            ProviderAdmissionState.GRANTED,
+            "second_driver_grant",
+            audit_id="audit-driver-second",
+            child_endpoint_lease=second_lease,
+        ),
+    ])
+    agent = _make_agent(tmp_path, ["daemon"])
+    agent._requires_derived_launch_admission_port = True
+    agent._derived_launch_admission_port = DriverDerivedLaunchAdmissionAdapter(
+        authority
+    )
+    queued = []
+    monkeypatch.setattr(
+        "lingtai.adapters.posix.daemon_manager.enqueue_manager_run",
+        lambda **kwargs: queued.append(kwargs),
+    )
+    source = agent._working_dir / "driver-sensitive-input.txt"
+    source.write_text("sensitive driver task input\n", encoding="utf-8")
+
+    root = RootProviderAdmission("root-driver-batch", RUNTIME_POLICY.policy_version)
+    token = bind_provider_admission(root)
+    try:
+        result = agent.get_capability("daemon").handle(
+            {
+                "action": "emanate",
+                "tasks": [
+                    {
+                        "task": "first",
+                        "tools": [],
+                        "task_files": [{"path": "driver-sensitive-input.txt"}],
+                    },
+                    {"task": "second", "tools": []},
+                ],
+            }
+        )
+    finally:
+        clear_provider_admission(token)
+
+    try:
+        assert result == {
+            "status": "error",
+            "message": "Driver child-endpoint handoff is unavailable",
+            "reason_code": "driver_child_endpoint_handoff_unavailable",
+            "audit_id": None,
+        }
+        assert authority.calls == [(root, DerivedLaunchCapability.DAEMON)] * 2
+        assert queued == []
+        for peer in (first_peer, second_peer):
+            peer.settimeout(2)
+            assert peer.recv(1) == b""
+        daemon_root = agent._working_dir / "daemons"
+        assert not (daemon_root / "_task_files").exists()
+        assert not daemon_root.exists() or not any(
+            path.is_dir() and path.name.startswith("em-")
+            for path in daemon_root.iterdir()
+        )
+    finally:
+        first_lease.close()
+        second_lease.close()
+        first_peer.close()
+        second_peer.close()
+
+
+def test_profile_driver_later_batch_denial_closes_earlier_lease_before_writes(
+    tmp_path, monkeypatch
+):
+    """A later Driver denial releases earlier grants with no durable residue."""
+    from lingtai.adapters.acp.driver_authority import (
+        DriverChildEndpointLease,
+        DriverDerivedLaunchAdmissionAdapter,
+        DriverDerivedLaunchGrant,
+    )
+    from lingtai.adapters.acp.puffo_v0 import RUNTIME_POLICY
+
+    class _SequencedAuthority:
+        def __init__(self, grants):
+            self.grants = list(grants)
+            self.calls = []
+
+        def request_derived_launch(self, parent, capability):
+            self.calls.append((parent, capability))
+            return self.grants.pop(0)
+
+    child, peer = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+    lease = DriverChildEndpointLease(child)
+    authority = _SequencedAuthority([
+        DriverDerivedLaunchGrant(
+            ProviderAdmissionState.GRANTED,
+            "first_driver_grant",
+            audit_id="audit-driver-first",
+            child_endpoint_lease=lease,
+        ),
+        DriverDerivedLaunchGrant(
+            ProviderAdmissionState.DENIED,
+            "second_driver_denied",
+            audit_id="audit-driver-second",
+        ),
+    ])
+    agent = _make_agent(tmp_path, ["daemon"])
+    agent._requires_derived_launch_admission_port = True
+    agent._derived_launch_admission_port = DriverDerivedLaunchAdmissionAdapter(
+        authority
+    )
+    queued = []
+    monkeypatch.setattr(
+        "lingtai.adapters.posix.daemon_manager.enqueue_manager_run",
+        lambda **kwargs: queued.append(kwargs),
+    )
+
+    root = RootProviderAdmission("root-driver-denial", RUNTIME_POLICY.policy_version)
+    token = bind_provider_admission(root)
+    try:
+        result = agent.get_capability("daemon").handle(
+            {
+                "action": "emanate",
+                "tasks": [
+                    {"task": "first", "tools": []},
+                    {"task": "second", "tools": []},
+                ],
+            }
+        )
+    finally:
+        clear_provider_admission(token)
+
+    try:
+        assert result == {
+            "status": "error",
+            "message": "derived launch was not admitted: second_driver_denied",
+            "reason_code": "second_driver_denied",
+            "audit_id": "audit-driver-second",
+        }
+        assert authority.calls == [(root, DerivedLaunchCapability.DAEMON)] * 2
+        assert queued == []
+        peer.settimeout(2)
+        assert peer.recv(1) == b""
+        daemon_root = agent._working_dir / "daemons"
+        assert not (daemon_root / "_task_files").exists()
+        assert not daemon_root.exists() or not any(
+            path.is_dir() and path.name.startswith("em-")
+            for path in daemon_root.iterdir()
+        )
+    finally:
+        lease.close()
+        peer.close()
 
 
 def test_task_skills_render_compact_catalog_from_dir_and_file(tmp_path):

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1685,11 +1685,10 @@ def test_profile_external_cli_daemon_launch_reaches_admission_before_supervisor(
     ]
 
 
-def test_profile_external_cli_default_manager_queues_only_after_granted_admission(
+def test_external_cli_default_manager_queues_in_legacy_admission_mode(
     tmp_path, monkeypatch
 ):
-    """The default POSIX manager retains its 100-worker cap after admission."""
-    from lingtai.adapters.acp.puffo_v0 import RUNTIME_POLICY
+    """The generic, non-profile path retains the default manager bound."""
     from lingtai.adapters.posix.daemon_supervisor import PosixDaemonSupervisorAdapter
 
     class _GrantingPort:
@@ -1714,9 +1713,7 @@ def test_profile_external_cli_default_manager_queues_only_after_granted_admissio
         lambda *_args, **_kwargs: direct_supervisor_calls.append(True),
     )
 
-    root = RootProviderAdmission(
-        "root-external-cli-default-manager", RUNTIME_POLICY.policy_version
-    )
+    root = RootProviderAdmission("root-external-cli-default-manager", "test-policy")
     token = bind_provider_admission(root)
     try:
         result = agent.get_capability("daemon").handle(
@@ -1735,11 +1732,10 @@ def test_profile_external_cli_default_manager_queues_only_after_granted_admissio
     assert direct_supervisor_calls == []
 
 
-def test_profile_external_cli_indeterminate_admission_never_queues_default_manager(
+def test_external_cli_indeterminate_admission_never_queues_default_manager(
     tmp_path, monkeypatch
 ):
-    """An unavailable external-CLI authority leaves no queue or run artifact."""
-    from lingtai.adapters.acp.puffo_v0 import RUNTIME_POLICY
+    """A configured generic authority still fails closed before queueing."""
 
     class _IndeterminatePort:
         def authorize_derived_launch(self, _parent, _capability):
@@ -1756,9 +1752,7 @@ def test_profile_external_cli_indeterminate_admission_never_queues_default_manag
         lambda **kwargs: queued.append(kwargs),
     )
 
-    root = RootProviderAdmission(
-        "root-external-cli-indeterminate", RUNTIME_POLICY.policy_version
-    )
+    root = RootProviderAdmission("root-external-cli-indeterminate", "test-policy")
     token = bind_provider_admission(root)
     try:
         result = agent.get_capability("daemon").handle(
@@ -1777,6 +1771,64 @@ def test_profile_external_cli_indeterminate_admission_never_queues_default_manag
         "reason_code": "driver_authority_unavailable",
         "audit_id": None,
     }
+    assert queued == []
+    daemon_root = agent._working_dir / "daemons"
+    assert not daemon_root.exists() or not any(
+        path.is_dir() and path.name.startswith("em-")
+        for path in daemon_root.iterdir()
+    )
+
+
+def test_profile_external_cli_rejects_before_requesting_driver_admission(
+    tmp_path, monkeypatch
+):
+    """A constrained profile never asks Driver for an unusable CLI grant."""
+    from lingtai.adapters.acp.puffo_v0 import RUNTIME_POLICY
+
+    class _CountingPort:
+        def __init__(self):
+            self.calls = []
+
+        def authorize_derived_launch(self, parent, capability):
+            self.calls.append((parent, capability))
+            return DerivedLaunchDecision(
+                ProviderAdmissionState.GRANTED,
+                "grant_must_not_be_requested_for_external_cli",
+                audit_id="audit-must-not-exist",
+            )
+
+    agent = _make_agent(tmp_path, ["daemon"])
+    agent._requires_derived_launch_admission_port = True
+    port = _CountingPort()
+    agent._derived_launch_admission_port = port
+    queued = []
+    monkeypatch.setattr(
+        "lingtai.adapters.posix.daemon_manager.enqueue_manager_run",
+        lambda **kwargs: queued.append(kwargs),
+    )
+
+    root = RootProviderAdmission(
+        "root-profile-external-cli", RUNTIME_POLICY.policy_version
+    )
+    token = bind_provider_admission(root)
+    try:
+        result = agent.get_capability("daemon").handle(
+            {
+                "action": "emanate",
+                "backend": "codex",
+                "tasks": [{"task": "test", "tools": []}],
+            }
+        )
+    finally:
+        clear_provider_admission(token)
+
+    assert result == {
+        "status": "error",
+        "message": "external CLI daemon backends are unavailable under Driver admission",
+        "reason_code": "driver_external_cli_backend_unsupported",
+        "audit_id": None,
+    }
+    assert port.calls == []
     assert queued == []
     daemon_root = agent._working_dir / "daemons"
     assert not daemon_root.exists() or not any(

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1807,6 +1807,8 @@ def test_profile_external_cli_rejects_before_requesting_driver_admission(
         "lingtai.adapters.posix.daemon_manager.enqueue_manager_run",
         lambda **kwargs: queued.append(kwargs),
     )
+    source = agent._working_dir / "external-cli-sensitive-input.txt"
+    source.write_text("sensitive external CLI task input\n", encoding="utf-8")
 
     root = RootProviderAdmission(
         "root-profile-external-cli", RUNTIME_POLICY.policy_version
@@ -1817,7 +1819,15 @@ def test_profile_external_cli_rejects_before_requesting_driver_admission(
             {
                 "action": "emanate",
                 "backend": "codex",
-                "tasks": [{"task": "test", "tools": []}],
+                "tasks": [
+                    {
+                        "task": "test",
+                        "tools": [],
+                        "task_files": [
+                            {"path": "external-cli-sensitive-input.txt"}
+                        ],
+                    }
+                ],
             }
         )
     finally:
@@ -1997,6 +2007,8 @@ def test_profile_driver_later_batch_denial_closes_earlier_lease_before_writes(
         "spawn_detached",
         lambda *_args, **_kwargs: supervisor_calls.append(True),
     )
+    source = agent._working_dir / "driver-denial-sensitive-input.txt"
+    source.write_text("sensitive denied driver task input\n", encoding="utf-8")
 
     root = RootProviderAdmission("root-driver-denial", RUNTIME_POLICY.policy_version)
     token = bind_provider_admission(root)
@@ -2005,7 +2017,13 @@ def test_profile_driver_later_batch_denial_closes_earlier_lease_before_writes(
             {
                 "action": "emanate",
                 "tasks": [
-                    {"task": "first", "tools": []},
+                    {
+                        "task": "first",
+                        "tools": [],
+                        "task_files": [
+                            {"path": "driver-denial-sensitive-input.txt"}
+                        ],
+                    },
                     {"task": "second", "tools": []},
                 ],
             }

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1849,6 +1849,7 @@ def test_profile_driver_grant_batch_fails_closed_until_manager_handoff_exists(
         DriverDerivedLaunchGrant,
     )
     from lingtai.adapters.acp.puffo_v0 import RUNTIME_POLICY
+    from lingtai.adapters.posix.daemon_supervisor import PosixDaemonSupervisorAdapter
 
     class _GrantingAuthority:
         def __init__(self, grants):
@@ -1883,9 +1884,15 @@ def test_profile_driver_grant_batch_fails_closed_until_manager_handoff_exists(
         authority
     )
     queued = []
+    supervisor_calls = []
     monkeypatch.setattr(
         "lingtai.adapters.posix.daemon_manager.enqueue_manager_run",
         lambda **kwargs: queued.append(kwargs),
+    )
+    monkeypatch.setattr(
+        PosixDaemonSupervisorAdapter,
+        "spawn_detached",
+        lambda *_args, **_kwargs: supervisor_calls.append(True),
     )
     source = agent._working_dir / "driver-sensitive-input.txt"
     source.write_text("sensitive driver task input\n", encoding="utf-8")
@@ -1918,6 +1925,10 @@ def test_profile_driver_grant_batch_fails_closed_until_manager_handoff_exists(
         }
         assert authority.calls == [(root, DerivedLaunchCapability.DAEMON)] * 2
         assert queued == []
+        assert supervisor_calls == []
+        assert daemon_dispatch.read_dispatches(
+            agent._working_dir, full_history=True
+        ).records == ()
         for peer in (first_peer, second_peer):
             peer.settimeout(2)
             assert peer.recv(1) == b""
@@ -1944,6 +1955,7 @@ def test_profile_driver_later_batch_denial_closes_earlier_lease_before_writes(
         DriverDerivedLaunchGrant,
     )
     from lingtai.adapters.acp.puffo_v0 import RUNTIME_POLICY
+    from lingtai.adapters.posix.daemon_supervisor import PosixDaemonSupervisorAdapter
 
     class _SequencedAuthority:
         def __init__(self, grants):
@@ -1975,9 +1987,15 @@ def test_profile_driver_later_batch_denial_closes_earlier_lease_before_writes(
         authority
     )
     queued = []
+    supervisor_calls = []
     monkeypatch.setattr(
         "lingtai.adapters.posix.daemon_manager.enqueue_manager_run",
         lambda **kwargs: queued.append(kwargs),
+    )
+    monkeypatch.setattr(
+        PosixDaemonSupervisorAdapter,
+        "spawn_detached",
+        lambda *_args, **_kwargs: supervisor_calls.append(True),
     )
 
     root = RootProviderAdmission("root-driver-denial", RUNTIME_POLICY.policy_version)
@@ -2004,6 +2022,10 @@ def test_profile_driver_later_batch_denial_closes_earlier_lease_before_writes(
         }
         assert authority.calls == [(root, DerivedLaunchCapability.DAEMON)] * 2
         assert queued == []
+        assert supervisor_calls == []
+        assert daemon_dispatch.read_dispatches(
+            agent._working_dir, full_history=True
+        ).records == ()
         peer.settimeout(2)
         assert peer.recv(1) == b""
         daemon_root = agent._working_dir / "daemons"


### PR DESCRIPTION
## Summary
- reject constrained external CLI daemon backends before Driver admission
- project Driver grants into opaque derived-launch decisions and close unhanded leases before durable daemon side effects
- cover zero queue/spawn/dispatch/task-file/run-dir residue and verify the legacy path is observably unsafe

## Validation
- 5 targeted B5 tests: 5 passed
- legacy main-red repro confirmed the pre-B5 implementation left task-file artifacts
- `python3 -m py_compile` on changed Python files
- `git diff --check`

## Scope
This is the B5 safety transition: the default Driver path fails cleanly until B8 adds the SCM_RIGHTS child-endpoint handoff. It does not make the endpoint path usable yet.