### PR TITLE
fix(avatar): hand off driver child endpoint leases

### DIFF
--- a/src/lingtai/adapters/acp/driver_authority.py
+++ b/src/lingtai/adapters/acp/driver_authority.py
@@ -83,6 +83,18 @@ class DriverChildEndpointLease:
         self.close()
 
 
+def consume_posix_child_endpoint_lease(lease: object) -> int:
+    """Transfer the one Driver child endpoint into the POSIX spawn adapter.
+
+    The opaque Core field may only be interpreted at this concrete adapter
+    boundary.  Rejecting another object here keeps the Driver handoff format
+    out of Avatar/Core while preserving the lease's one-use semantics.
+    """
+    if not isinstance(lease, DriverChildEndpointLease):
+        raise TypeError("expected a DriverChildEndpointLease for POSIX spawn")
+    return lease.consume_for_posix_spawn()
+
+
 @dataclass(frozen=True, slots=True)
 class DriverDerivedLaunchGrant:
     """A Driver result kept private until a later Kernel consumer owns it."""
@@ -367,6 +379,7 @@ __all__ = [
     "DriverAuthorityIdentity",
     "DriverAuthorityTransportError",
     "DriverChildEndpointLease",
+    "consume_posix_child_endpoint_lease",
     "DriverDerivedLaunchAdmissionAdapter",
     "DriverDerivedLaunchGrant",
 ]

--- a/src/lingtai/adapters/posix/ANATOMY.md
+++ b/src/lingtai/adapters/posix/ANATOMY.md
@@ -174,7 +174,10 @@ co-located owning ANATOMY.md files.
 - `PosixAvatarLauncherAdapter` implements the avatar-local launcher Port with
   inherited cwd/environment, disconnected stdio, binary-write stderr,
   `start_new_session`, exact `poll()` truth, one-process TERM/KILL, and
-  non-killing release (`src/lingtai/adapters/posix/avatar_launcher.py`).
+  non-killing release. For a Driver-approved avatar only, it consumes the
+  opaque one-shot AF_UNIX child endpoint, passes exactly that descriptor with
+  `close_fds=True`, then closes its parent copy
+  (`src/lingtai/adapters/posix/avatar_launcher.py`).
 
 ## Connections
 

--- a/src/lingtai/adapters/posix/avatar_launcher.py
+++ b/src/lingtai/adapters/posix/avatar_launcher.py
@@ -12,17 +12,34 @@ class PosixAvatarLauncherAdapter:
     def launch(self, request: AvatarLaunchRequest) -> AvatarLaunchReceipt:
         request.stderr_path.parent.mkdir(parents=True, exist_ok=True)
         stderr_fh = request.stderr_path.open("wb")
+        authority_fd = None
         try:
             kwargs = {
                 "stdin": subprocess.DEVNULL,
                 "stdout": subprocess.DEVNULL,
                 "stderr": stderr_fh,
                 "start_new_session": True,
+                "close_fds": True,
             }
-            if request.environment is not None:
-                kwargs["env"] = {**os.environ, **request.environment}
+            environment = dict(request.environment or {})
+            if request.authority_lease is not None:
+                from lingtai.adapters.acp.driver_authority import (
+                    DRIVER_AUTHORITY_FD_ENV,
+                    consume_posix_child_endpoint_lease,
+                )
+
+                authority_fd = consume_posix_child_endpoint_lease(request.authority_lease)
+                environment[DRIVER_AUTHORITY_FD_ENV] = str(authority_fd)
+                kwargs["pass_fds"] = (authority_fd,)
+            if environment:
+                kwargs["env"] = {**os.environ, **environment}
             process = subprocess.Popen(list(request.argv), **kwargs)
         finally:
+            if authority_fd is not None:
+                try:
+                    os.close(authority_fd)
+                except OSError:
+                    pass
             stderr_fh.close()
         return AvatarLaunchReceipt(process.pid, process)
 

--- a/src/lingtai/adapters/windows/ANATOMY.md
+++ b/src/lingtai/adapters/windows/ANATOMY.md
@@ -89,7 +89,9 @@ only method execution requires Windows.
   (`src/lingtai/adapters/windows/process_scan.py`).
 - `WindowsAvatarLauncherAdapter` — avatar spawn with the shared creation
   flags; `terminate`/`force_terminate` are both documented-forceful
-  `TerminateProcess` (`src/lingtai/adapters/windows/avatar_launcher.py`).
+  `TerminateProcess`. The Driver avatar child-endpoint handoff is POSIX-only;
+  Windows closes and rejects such a lease rather than launching a child
+  without it (`src/lingtai/adapters/windows/avatar_launcher.py`).
 - `WindowsDaemonSupervisorAdapter` — detached daemon supervisor spawn with the
   inherited-handle one-shot capsule wire (`handle_list` +
   `LINGTAI_DAEMON_CAPSULE_HANDLE`), plus execution-child and resume-owner

--- a/src/lingtai/adapters/windows/avatar_launcher.py
+++ b/src/lingtai/adapters/windows/avatar_launcher.py
@@ -7,6 +7,10 @@ plus the opaque ``Popen`` handle. Detachment uses
 ``creationflags=_win32.DETACHED_CREATIONFLAGS`` (new process group + no window)
 and ``close_fds=True`` instead of the POSIX ``start_new_session=True``.
 
+The Driver's avatar child-endpoint wire is currently POSIX-only. A request that
+carries that opaque one-shot lease closes it and fails before process creation
+on Windows, instead of silently dropping its endpoint.
+
 Honest termination tier (owner decision U7): on Windows both
 ``subprocess.Popen.terminate()`` and ``.kill()`` call ``TerminateProcess`` —
 there is no graceful signal to send. This adapter therefore does **not** pretend
@@ -25,6 +29,19 @@ from lingtai.tools.avatar._launcher import AvatarLaunchReceipt, AvatarLaunchRequ
 
 class WindowsAvatarLauncherAdapter:
     def launch(self, request: AvatarLaunchRequest) -> AvatarLaunchReceipt:
+        if request.authority_lease is not None:
+            # The Driver child endpoint is an AF_UNIX descriptor handoff.
+            # Windows has no corresponding avatar-launch boundary yet, so
+            # never start a child that silently lost its approved endpoint.
+            close = getattr(request.authority_lease, "close", None)
+            if callable(close):
+                try:
+                    close()
+                except OSError:
+                    pass
+            raise RuntimeError(
+                "Driver avatar child endpoint handoff is only supported on POSIX"
+            )
         request.stderr_path.parent.mkdir(parents=True, exist_ok=True)
         stderr_fh = request.stderr_path.open("wb")
         try:

--- a/src/lingtai/adapters/windows/avatar_launcher.py
+++ b/src/lingtai/adapters/windows/avatar_launcher.py
@@ -33,12 +33,10 @@ class WindowsAvatarLauncherAdapter:
             # The Driver child endpoint is an AF_UNIX descriptor handoff.
             # Windows has no corresponding avatar-launch boundary yet, so
             # never start a child that silently lost its approved endpoint.
-            close = getattr(request.authority_lease, "close", None)
-            if callable(close):
-                try:
-                    close()
-                except OSError:
-                    pass
+            try:
+                request.authority_lease.close()
+            except OSError:
+                pass
             raise RuntimeError(
                 "Driver avatar child endpoint handoff is only supported on POSIX"
             )

--- a/src/lingtai/kernel/provider_admission.py
+++ b/src/lingtai/kernel/provider_admission.py
@@ -44,6 +44,12 @@ class ProviderAdmissionState(str, Enum):
     INDETERMINATE = "indeterminate"
 
 
+class DerivedLaunchEndpointLease(Protocol):
+    """Opaque one-use child handoff with exactly one required cleanup action."""
+
+    def close(self) -> None: ...
+
+
 @dataclass(frozen=True, slots=True)
 class RootProviderAdmission:
     """Core-private context for one admitted root turn.
@@ -149,7 +155,7 @@ class DerivedLaunchDecision:
     # An adapter-owned, non-serializable, one-use child handoff.  Core neither
     # inspects nor reconstructs it; a consumer must either hand it to the
     # exact supported process boundary or release it before returning.
-    child_endpoint_lease: object | None = field(
+    child_endpoint_lease: DerivedLaunchEndpointLease | None = field(
         default=None, repr=False, compare=False
     )
 
@@ -224,10 +230,10 @@ def _discard_derived_launch_decision(
     """
 
     if isinstance(decision, DerivedLaunchDecision):
-        close = getattr(decision.child_endpoint_lease, "close", None)
-        if callable(close):
+        lease = decision.child_endpoint_lease
+        if lease is not None:
             try:
-                close()
+                lease.close()
             except OSError:
                 pass
     return DerivedLaunchDecision(ProviderAdmissionState.INDETERMINATE, reason_code)
@@ -471,6 +477,7 @@ __all__ = [
     "DerivedLaunchAdmissionPort",
     "DerivedLaunchCapability",
     "DerivedLaunchDecision",
+    "DerivedLaunchEndpointLease",
     "ProviderAdmissionError",
     "ProviderAdmissionParent",
     "ProviderAdmissionState",

--- a/src/lingtai/kernel/provider_admission.py
+++ b/src/lingtai/kernel/provider_admission.py
@@ -295,6 +295,11 @@ def require_derived_launch_admission(
         )
     try:
         decision = port.authorize_derived_launch(parent, capability)
+    except DerivedLaunchAdmissionError:
+        # A structured adapter denial can carry an opaque child-endpoint
+        # lease.  Preserve it for the concrete launch consumer, which owns
+        # releasing that lease before surfacing the failure.
+        raise
     except Exception:
         decision = DerivedLaunchDecision(
             ProviderAdmissionState.INDETERMINATE,

--- a/src/lingtai/kernel/provider_admission.py
+++ b/src/lingtai/kernel/provider_admission.py
@@ -211,6 +211,28 @@ class DerivedLaunchAdmissionError(PermissionError):
         super().__init__(f"derived launch was not admitted: {decision.reason_code}")
 
 
+def _discard_derived_launch_decision(
+    decision: object,
+    *,
+    reason_code: str,
+) -> DerivedLaunchDecision:
+    """Replace an untrusted Port decision without stranding its lease.
+
+    Core does not inspect or reconstruct the opaque child endpoint.  It does,
+    however, own the last reference when it rejects an adapter decision before
+    a concrete launch consumer can receive it.
+    """
+
+    if isinstance(decision, DerivedLaunchDecision):
+        close = getattr(decision.child_endpoint_lease, "close", None)
+        if callable(close):
+            try:
+                close()
+            except OSError:
+                pass
+    return DerivedLaunchDecision(ProviderAdmissionState.INDETERMINATE, reason_code)
+
+
 _current_parent: ContextVar[ProviderAdmissionParent | None] = ContextVar(
     "lingtai_current_provider_admission", default=None
 )
@@ -315,9 +337,9 @@ def require_derived_launch_admission(
             and (not isinstance(decision.audit_id, str) or not decision.audit_id)
         )
     ):
-        decision = DerivedLaunchDecision(
-            ProviderAdmissionState.INDETERMINATE,
-            "malformed_derived_launch_admission_decision",
+        decision = _discard_derived_launch_decision(
+            decision,
+            reason_code="malformed_derived_launch_admission_decision",
         )
     if not decision.allowed:
         raise DerivedLaunchAdmissionError(decision)

--- a/src/lingtai/tools/avatar/ANATOMY.md
+++ b/src/lingtai/tools/avatar/ANATOMY.md
@@ -40,8 +40,8 @@ maintenance: |
 Avatar capability — spawn independent peer agents (分身) as fully detached
 processes. Two modes:
 
-- **Shallow (初生):** Copy `init.json`, write restrictive
-  `.lingtai-derived-child.json` to a new working dir, strip identity, launch.
+- **Shallow (初生):** Copy `init.json`, strip identity, launch. A Driver
+  lease additionally writes restrictive `.lingtai-derived-child.json`.
   The avatar gets the same LLM config + capabilities but no history.
 - **Deep (二重身):** Copy identity and durable knowledge (`system/`, `knowledge/`, `exports/`)
   plus `init.json`, strip name + history. The avatar is a doppelgänger — same
@@ -165,16 +165,18 @@ avatar/__init__.py
 - **Relative path re-rooting:** Preset paths (`default`, `active`, `allowed`) that are relative are re-rooted against the parent's working dir so they remain valid from the avatar's different directory.
 - **Liveness check:** Before spawning, existing ledger entries are observed through a target-bound `PosixAgentPresenceStoreAdapter` and Core `observe_alive()` policy. If a live avatar with the same name exists, the spawn is refused with `already_active`.
 - **Boot verification:** After launching, `_wait_for_boot()` polls for `.agent.heartbeat` or Port exit truth within 5 seconds. If the process exits before handshaking, stderr is captured and the failure is reported. Port release after observation never kills a live slow avatar.
-- **Derived child requirement:** `_spawn()` atomically writes
-  `.lingtai-derived-child.json` before launch, outside the child-managed
-  `system/` namespace. The shared probe also treats a legacy
+- **Derived child requirement:** only a Driver-granted child-endpoint lease
+  makes `_spawn()` atomically write `.lingtai-derived-child.json` before
+  launch, outside the child-managed `system/` namespace. The shared probe also treats a legacy
   `system/derived_child.json` as restrictive so existing children retain their
   requirement after upgrade; only both locations being missing is absence.
   `cli.run()` reads that durable state on every boot and turns it into the
   restrictive requirement that any nested daemon/avatar launch has authority.
   The launcher also adds
   `LINGTAI_DERIVED_AVATAR_EXECUTION=1` as redundant immediate-launch defense.
-  Neither form carries a parent, grant, or authority bearer.
+  Neither marker nor environment form carries a parent, grant, or authority
+  bearer; the opaque lease is handed only to the POSIX launcher, or closed if
+  launch does not reach that Port.
 - **Deep copy scope guard:** `_prepare_deep()` asserts `dst.parent == src.parent` to prevent rmtree from reaching outside the network root.
 - **Mission-quality gate (issue #33):** Before any filesystem mutation, `_spawn` runs `_mission_looks_unsafe(reasoning)` — empty / sub-20-char / debug-placeholder missions return `{"status": "confirmation_needed", ...}` unless `confirm=true`. The dry-run path is exempt (its purpose is preview without commitment).
 - **Dry-run (issue #33):** `dry_run=true` short-circuits after parent `init.json` is loaded and before any working dir is created or process launched, returning `{"status": "dry_run", "preview": {...}}`. The preview includes whether the mission would have tripped the quality gate.
@@ -203,6 +205,7 @@ avatar/__init__.py
   capability blacklists `avatar` to prevent avatar-in-daemon recursion and rules
   mutation from emanations.
 
-Platform process mechanics are in `adapters/avatar_launcher.py` and the
-POSIX reference adapter. Unsupported Windows selection fails loudly; a future
-Windows adapter and native acceptance remain outside this re-cut.
+Platform process mechanics are in `adapters/avatar_launcher.py` plus the POSIX
+and Windows adapters. A Driver child-endpoint handoff is POSIX-only: the POSIX
+adapter inherits exactly the one-shot endpoint, while the Windows adapter
+closes and rejects that lease rather than dropping it.

--- a/src/lingtai/tools/avatar/CONTRACT.md
+++ b/src/lingtai/tools/avatar/CONTRACT.md
@@ -1,7 +1,7 @@
 ---
 name: avatar-contract
 tool: avatar
-contract_version: 6
+contract_version: 7
 related_files:
   - src/lingtai/tools/avatar/BEHAVIORS.md
   - src/lingtai/tools/avatar/__init__.py
@@ -80,9 +80,9 @@ per-action `input` object, and the model-facing root is exactly `action`,
   root `summarize` boolean it advertises is honored by the single central
   summarizer rather than silently ignored.
 
-**contract_version 6**: each spawned avatar persists a restrictive
-`.lingtai-derived-child.json` marker before it is launched, outside the
-child-managed `system/` namespace. This makes the
+**contract_version 7**: only an avatar spawn approved with a Driver child
+endpoint lease persists a restrictive `.lingtai-derived-child.json` marker
+before it is launched, outside the child-managed `system/` namespace. This makes the
 requirement for nested derived-launch authority survive a direct restart of the
 same child directory; the launch environment marker is redundant only. It does
 not carry, create, or validate authority, and it does not claim to withstand a
@@ -297,7 +297,7 @@ the network root (`<parent>/..`):
   .rules                          # distributed rules signal
   logs/spawn.stderr               # captured child stderr for boot diagnosis
   logs/agent.log                  # rotating stdlib logging (boot + runtime warnings)
-  .lingtai-derived-child.json     # durable restrictive derived-child state
+  .lingtai-derived-child.json     # Driver-derived child state only
   knowledge/ exports/ combo.json  # deep mode only (system/ also has deep state)
 ```
 
@@ -314,8 +314,9 @@ live descendant.
 
 ## Cross-platform launcher contract
 
-- `AvatarManager` writes `.lingtai-derived-child.json` before process launch.
-  Its presence is the authoritative restrictive state: every later
+- `AvatarManager` writes `.lingtai-derived-child.json` before process launch
+  only for a Driver-approved decision that carries a child endpoint lease. Its
+  presence is the authoritative restrictive state: every later
   `lingtai run <dir>` treats that directory as derived and requires authority
   before a nested daemon/avatar launch. Malformed or unexpected marker state
   remains restrictive. For upgrade compatibility, the former
@@ -330,7 +331,9 @@ live descendant.
   `logs/spawn.stderr` to the avatar-local Port. Cwd is inherited. The
   `LINGTAI_DERIVED_AVATAR_EXECUTION=1` environment override is redundant
   immediate-launch defense only; it is non-secret and never carries an
-  authority bearer.
+  authority bearer. The opaque one-use lease travels with that same Driver
+  decision to the POSIX launcher, which alone consumes it into the child's
+  `pass_fds`; any early return or setup failure closes the unconsumed lease.
 - The Port returns a positive PID and an opaque adapter handle. `poll()` is
   nonblocking and returns the exact integer child return code or `None`.
 - Production adapters disconnect stdin/stdout and own a binary-write stderr
@@ -351,7 +354,9 @@ live descendant.
   `TerminateProcess` — there is no graceful signal. The Windows adapter does not
   pretend a graceful tier exists: `terminate()` and `force_terminate()` are
   **both** forceful, immediate termination of exactly the owned process, never a
-  tree kill.
+  tree kill. The Driver child-endpoint handoff is currently POSIX-only: Windows
+  closes and rejects a supplied lease rather than launching a child without its
+  approved endpoint.
 - The selector `select_avatar_launcher()` returns the Windows adapter when
   `os.name == "nt"` (lazy import) and the POSIX adapter when `os.name ==
   "posix"`, both via lazy imports so each mechanism module loads only on its

--- a/src/lingtai/tools/avatar/__init__.py
+++ b/src/lingtai/tools/avatar/__init__.py
@@ -115,6 +115,7 @@ def _mission_looks_unsafe(mission: str) -> tuple[bool, str]:
 
 if TYPE_CHECKING:
     from lingtai.kernel.base_agent import BaseAgent
+    from lingtai.kernel.provider_admission import DerivedLaunchEndpointLease
     from lingtai.kernel.tool_plugin import ToolPluginHost
 
 PROVIDERS = {"providers": [], "default": "builtin"}
@@ -912,7 +913,7 @@ class AvatarManager:
         self,
         working_dir: Path,
         *,
-        authority_lease: object | None = None,
+        authority_lease: "DerivedLaunchEndpointLease | None" = None,
         derived_child: bool = False,
     ) -> tuple[AvatarLaunchReceipt, Path]:
         """Launch `lingtai-agent run <dir>` as a fully detached process.
@@ -958,10 +959,10 @@ class AvatarManager:
     @staticmethod
     def _close_unconsumed_launch_lease(decision: "DerivedLaunchDecision") -> None:
         """Close a Driver endpoint unless ownership reached the launcher Port."""
-        close = getattr(decision.child_endpoint_lease, "close", None)
-        if callable(close):
+        lease = decision.child_endpoint_lease
+        if lease is not None:
             try:
-                close()
+                lease.close()
             except OSError:
                 pass
 

--- a/src/lingtai/tools/avatar/__init__.py
+++ b/src/lingtai/tools/avatar/__init__.py
@@ -972,12 +972,24 @@ class AvatarManager:
             DerivedLaunchCapability,
         )
 
+        decision: DerivedLaunchDecision | None = None
+        transferred = False
         try:
-            decision = self._host.avatar_parent.authorize_derived_launch(
-                DerivedLaunchCapability.AVATAR
-            )
-        except DerivedLaunchAdmissionError as exc:
-            decision = exc.decision
+            try:
+                decision = self._host.avatar_parent.authorize_derived_launch(
+                    DerivedLaunchCapability.AVATAR
+                )
+            except DerivedLaunchAdmissionError as exc:
+                decision = exc.decision
+                self._append_ledger(
+                    "avatar_admission_decision",
+                    peer_name,
+                    capability=DerivedLaunchCapability.AVATAR.value,
+                    state=decision.state.value,
+                    reason_code=decision.reason_code,
+                    audit_id=decision.audit_id,
+                )
+                raise
             self._append_ledger(
                 "avatar_admission_decision",
                 peer_name,
@@ -986,18 +998,13 @@ class AvatarManager:
                 reason_code=decision.reason_code,
                 audit_id=decision.audit_id,
             )
-            raise
-        self._append_ledger(
-            "avatar_admission_decision",
-            peer_name,
-            capability=DerivedLaunchCapability.AVATAR.value,
-            state=decision.state.value,
-            reason_code=decision.reason_code,
-            audit_id=decision.audit_id,
-        )
-        if not decision.allowed:
-            raise DerivedLaunchAdmissionError(decision)
-        return decision
+            if not decision.allowed:
+                raise DerivedLaunchAdmissionError(decision)
+            transferred = True
+            return decision
+        finally:
+            if decision is not None and not transferred:
+                self._close_unconsumed_launch_lease(decision)
 
     # ------------------------------------------------------------------
     # Ledger reading

--- a/src/lingtai/tools/avatar/__init__.py
+++ b/src/lingtai/tools/avatar/__init__.py
@@ -542,100 +542,103 @@ class AvatarManager:
                 "message": "Dry run — no process spawned, no files written.",
             }
 
-        self._authorize_derived_launch(peer_name)
+        launch_decision = self._authorize_derived_launch(peer_name)
+        lease_handed_to_launcher = False
+        try:
 
         # Working dir: sibling of parent, named after the avatar. Defense-in-depth
         # scope check — resolve and assert the target's parent equals the network
         # root, so even if peer_name validation is ever loosened, this still
         # prevents writing outside .lingtai/<siblings>/.
-        avatar_working_dir = parent_working_dir.parent / peer_name
-        network_root = parent_working_dir.parent.resolve()
-        try:
-            resolved = avatar_working_dir.resolve(strict=False)
-        except (OSError, RuntimeError) as e:
-            return {"error": f"Cannot resolve avatar path: {e}"}
-        if resolved.parent != network_root:
-            return {
-                "error": (
-                    f"Avatar path '{avatar_working_dir}' escapes the network root "
-                    f"'{network_root}' — rejected."
-                )
-            }
-        if avatar_working_dir.exists():
-            return {"error": f"Directory '{peer_name}' already exists. Choose another name."}
+            avatar_working_dir = parent_working_dir.parent / peer_name
+            network_root = parent_working_dir.parent.resolve()
+            try:
+                resolved = avatar_working_dir.resolve(strict=False)
+            except (OSError, RuntimeError) as e:
+                return {"error": f"Cannot resolve avatar path: {e}"}
+            if resolved.parent != network_root:
+                return {
+                    "error": (
+                        f"Avatar path '{avatar_working_dir}' escapes the network root "
+                        f"'{network_root}' — rejected."
+                    )
+                }
+            if avatar_working_dir.exists():
+                return {"error": f"Directory '{peer_name}' already exists. Choose another name."}
 
         # Prepare the avatar's working directory
-        parent_name = self._host.avatar_parent.parent_name or parent_working_dir.name
+            parent_name = self._host.avatar_parent.parent_name or parent_working_dir.name
 
         # Copy init.json and launch lingtai
-        if avatar_type == "deep":
-            self._prepare_deep(parent_working_dir, avatar_working_dir)
-        else:
-            avatar_working_dir.mkdir(parents=True, exist_ok=True)
+            if avatar_type == "deep":
+                self._prepare_deep(parent_working_dir, avatar_working_dir)
+            else:
+                avatar_working_dir.mkdir(parents=True, exist_ok=True)
 
         # Resolve relative file paths to absolute so avatar can find them.
         # Only active prompt-contract file fields are re-rooted: env_file plus
         # the externally changeable prompt surfaces (covenant / base_prompt /
         # comment). Retired override file fields (principle_file / substrate_file
         # / brief_file / procedures_file) are not inherited as live paths.
-        for key in ("env_file", "covenant_file",
-                    "base_prompt_file", "comment_file"):
-            val = parent_init.get(key)
-            if val and not os.path.isabs(val):
-                resolved = parent_working_dir / val
-                if resolved.is_file():
-                    parent_init[key] = str(resolved)
+            for key in ("env_file", "covenant_file",
+                        "base_prompt_file", "comment_file"):
+                val = parent_init.get(key)
+                if val and not os.path.isabs(val):
+                    resolved = parent_working_dir / val
+                    if resolved.is_file():
+                        parent_init[key] = str(resolved)
 
         # Inherit the parent runtime location through Avatar's narrow host port.
-        venv_path = self._host.avatar_parent.venv_path
-        if venv_path:
-            parent_init["venv_path"] = venv_path
+            venv_path = self._host.avatar_parent.venv_path
+            if venv_path:
+                parent_init["venv_path"] = venv_path
 
         # Clean stale signal files before launch
-        for sig in (".suspend", ".sleep", ".interrupt"):
-            sig_file = avatar_working_dir / sig
-            if sig_file.is_file():
-                sig_file.unlink(missing_ok=True)
+            for sig in (".suspend", ".sleep", ".interrupt"):
+                sig_file = avatar_working_dir / sig
+                if sig_file.is_file():
+                    sig_file.unlink(missing_ok=True)
 
         # Seed the avatar's first turn with a parent-identity prompt + the
         # caller's reasoning (task brief). Written to the avatar's `.prompt`
         # file — picked up by the kernel's signal-file watcher on first poll
         # and delivered as a one-shot system message (consumed-once via unlink).
-        parent_address = parent_working_dir.name
-        avatar_lang = parent_init.get("manifest", {}).get("language", "en")
-        parent_prompt = t(
-            avatar_lang, "avatar.parent_prompt",
-            parent_name=parent_name,
-            parent_address=parent_address,
-        )
-        first_prompt = parent_prompt
-        if reasoning and reasoning.strip():
-            first_prompt = f"{parent_prompt}\n\n{reasoning.strip()}"
+            parent_address = parent_working_dir.name
+            avatar_lang = parent_init.get("manifest", {}).get("language", "en")
+            parent_prompt = t(
+                avatar_lang, "avatar.parent_prompt",
+                parent_name=parent_name,
+                parent_address=parent_address,
+            )
+            first_prompt = parent_prompt
+            if reasoning and reasoning.strip():
+                first_prompt = f"{parent_prompt}\n\n{reasoning.strip()}"
 
         # Write avatar's init.json (modified copy of parent's).
-        avatar_comment = args.get("comment", SPAWN_COMMENT_DEFAULT)
-        avatar_init = self._make_avatar_init(
-            parent_init, peer_name, comment=avatar_comment,
-            parent_working_dir=parent_working_dir,
-        )
-        (avatar_working_dir / "init.json").write_text(
-            json.dumps(avatar_init, indent=2, ensure_ascii=False),
-            encoding="utf-8"
-        )
+            avatar_comment = args.get("comment", SPAWN_COMMENT_DEFAULT)
+            avatar_init = self._make_avatar_init(
+                parent_init, peer_name, comment=avatar_comment,
+                parent_working_dir=parent_working_dir,
+            )
+            (avatar_working_dir / "init.json").write_text(
+                json.dumps(avatar_init, indent=2, ensure_ascii=False),
+                encoding="utf-8"
+            )
 
-        # Derived status belongs to the child directory, not this particular
-        # process invocation.  A later ``lingtai run <dir>`` therefore keeps
-        # the restrictive nested-launch requirement even if a wrapper drops
-        # the redundant environment marker.
-        atomic_write_json(
-            derived_avatar_state_path(avatar_working_dir),
-            DERIVED_AVATAR_STATE,
-            sort_keys=True,
-        )
+            # Only a Driver-granted child endpoint makes this avatar derived.
+            # Generic LingTai's historical grant contains no endpoint lease and
+            # therefore keeps its existing boot behavior.
+            derived_child = launch_decision.child_endpoint_lease is not None
+            if derived_child:
+                atomic_write_json(
+                    derived_avatar_state_path(avatar_working_dir),
+                    DERIVED_AVATAR_STATE,
+                    sort_keys=True,
+                )
 
         # Drop the spawn prompt as a `.prompt` signal file — the avatar's
         # kernel watcher consumes it on first poll and delivers it once.
-        (avatar_working_dir / ".prompt").write_text(first_prompt, encoding="utf-8")
+            (avatar_working_dir / ".prompt").write_text(first_prompt, encoding="utf-8")
 
         # Launch as detached process and wait briefly for the child to either
         # write its handshake (.agent.heartbeat) or exit. If the child exits
@@ -644,66 +647,74 @@ class AvatarManager:
         # avatar capability returns "ok" the instant a child forks, even if the
         # child crashes 50ms later (e.g. invalid init.json), and the parent's
         # LLM has no idea anything went wrong.
-        proc, stderr_path = self._launch(avatar_working_dir)
-        pid = proc.pid
-
-        try:
-            boot_status, boot_error = self._wait_for_boot(
-                avatar_working_dir, proc, stderr_path,
+            proc, stderr_path = self._launch(
+                avatar_working_dir,
+                authority_lease=launch_decision.child_endpoint_lease,
+                derived_child=derived_child,
             )
-        finally:
-            self._launcher.release(proc.handle)
+            lease_handed_to_launcher = True
+            pid = proc.pid
+
+            try:
+                boot_status, boot_error = self._wait_for_boot(
+                    avatar_working_dir, proc, stderr_path,
+                )
+            finally:
+                self._launcher.release(proc.handle)
 
         # Record in ledger — include boot status so post-mortem can distinguish
         # successful spawns from failed ones without re-checking the filesystem.
-        ledger_extra = {"boot_status": boot_status}
-        if boot_error:
-            ledger_extra["boot_error"] = boot_error
-        self._append_ledger(
-            "avatar", peer_name,
-            working_dir=avatar_working_dir.name,
-            mission=reasoning or "",
-            type=avatar_type,
-            pid=pid,
-            **ledger_extra,
-        )
+            ledger_extra = {"boot_status": boot_status}
+            if boot_error:
+                ledger_extra["boot_error"] = boot_error
+            self._append_ledger(
+                "avatar", peer_name,
+                working_dir=avatar_working_dir.name,
+                mission=reasoning or "",
+                type=avatar_type,
+                pid=pid,
+                **ledger_extra,
+            )
 
-        if boot_status == "failed":
-            return {
-                "error": (
-                    f"avatar {peer_name!r} failed to boot: {boot_error}. "
-                    f"See {stderr_path} for details."
-                ),
-                "address": avatar_working_dir.name,
-                "agent_name": peer_name,
-                "pid": pid,
-            }
+            if boot_status == "failed":
+                return {
+                    "error": (
+                        f"avatar {peer_name!r} failed to boot: {boot_error}. "
+                        f"See {stderr_path} for details."
+                    ),
+                    "address": avatar_working_dir.name,
+                    "agent_name": peer_name,
+                    "pid": pid,
+                }
 
         # Auto-distribute rules to all descendants (including newborn) — read from canonical system/rules.md
-        parent_rules_md = parent_working_dir / "system" / "rules.md"
-        if parent_rules_md.is_file():
-            try:
-                rules_content = parent_rules_md.read_text(encoding="utf-8")
-            except OSError:
-                rules_content = ""
-            if rules_content.strip():
-                self._distribute_rules_to_descendants(rules_content, parent_working_dir)
+            parent_rules_md = parent_working_dir / "system" / "rules.md"
+            if parent_rules_md.is_file():
+                try:
+                    rules_content = parent_rules_md.read_text(encoding="utf-8")
+                except OSError:
+                    rules_content = ""
+                if rules_content.strip():
+                    self._distribute_rules_to_descendants(rules_content, parent_working_dir)
 
-        result = {
-            "status": "ok",
-            "address": avatar_working_dir.name,
-            "agent_name": peer_name,
-            "type": avatar_type,
-            "pid": pid,
-        }
-        if boot_status == "slow":
-            # Process is still alive but didn't finish handshaking in the
-            # window — surface a warning so the caller knows to monitor it.
-            result["warning"] = (
-                f"avatar still booting after {self._BOOT_WAIT_SECS}s — "
-                f"check .agent.heartbeat freshness before relying on it"
-            )
-        return result
+            result = {
+                "status": "ok",
+                "address": avatar_working_dir.name,
+                "agent_name": peer_name,
+                "type": avatar_type,
+                "pid": pid,
+            }
+            if boot_status == "slow":
+                # Process is still alive but didn't finish handshaking in the
+                # window — surface a warning so the caller knows to monitor it.
+                result["warning"] = (
+                    f"avatar still booting after {self._BOOT_WAIT_SECS}s — "
+                    f"check .agent.heartbeat freshness before relying on it"
+                )
+            return result
+        finally:
+            if not lease_handed_to_launcher:
+                self._close_unconsumed_launch_lease(launch_decision)
 
     def _wait_for_boot(
         self, working_dir: Path, proc: AvatarLaunchReceipt, stderr_path: Path,
@@ -897,7 +908,13 @@ class AvatarManager:
     _BOOT_WAIT_SECS = BOOT_WAIT_SECONDS
     _BOOT_POLL_INTERVAL = BOOT_POLL_INTERVAL_SECONDS
 
-    def _launch(self, working_dir: Path) -> tuple[AvatarLaunchReceipt, Path]:
+    def _launch(
+        self,
+        working_dir: Path,
+        *,
+        authority_lease: object | None = None,
+        derived_child: bool = False,
+    ) -> tuple[AvatarLaunchReceipt, Path]:
         """Launch `lingtai-agent run <dir>` as a fully detached process.
 
         Captures stderr to ``logs/spawn.stderr`` so a child that exits before
@@ -928,15 +945,27 @@ class AvatarManager:
             AvatarLaunchRequest(
                 argv=cmd,
                 stderr_path=stderr_path,
-                # Redundant boot signal only. The durable child state written
-                # during _spawn is authoritative for subsequent/restarted
-                # launches and never carries a grant or authority bearer.
-                environment={DERIVED_AVATAR_EXECUTION_ENV: "1"},
+                # Redundant immediate-launch signal only. The durable child
+                # state is authoritative for restarts and carries no bearer.
+                environment=(
+                    {DERIVED_AVATAR_EXECUTION_ENV: "1"} if derived_child else None
+                ),
+                authority_lease=authority_lease,
             )
         )
         return receipt, stderr_path
 
-    def _authorize_derived_launch(self, peer_name: str) -> None:
+    @staticmethod
+    def _close_unconsumed_launch_lease(decision: "DerivedLaunchDecision") -> None:
+        """Close a Driver endpoint unless ownership reached the launcher Port."""
+        close = getattr(decision.child_endpoint_lease, "close", None)
+        if callable(close):
+            try:
+                close()
+            except OSError:
+                pass
+
+    def _authorize_derived_launch(self, peer_name: str) -> "DerivedLaunchDecision":
         """Reach the host decision seam before avatar filesystem/process effects."""
         from lingtai.kernel.provider_admission import (
             DerivedLaunchAdmissionError,
@@ -968,6 +997,7 @@ class AvatarManager:
         )
         if not decision.allowed:
             raise DerivedLaunchAdmissionError(decision)
+        return decision
 
     # ------------------------------------------------------------------
     # Ledger reading

--- a/src/lingtai/tools/avatar/_launcher.py
+++ b/src/lingtai/tools/avatar/_launcher.py
@@ -71,11 +71,17 @@ def probe_derived_avatar_state(working_dir: Path) -> DerivedAvatarState:
 
 @dataclass(frozen=True)
 class AvatarLaunchRequest:
-    """The complete launch input; cwd is inherited and env overrides are explicit."""
+    """The complete launch input; cwd is inherited and env overrides are explicit.
+
+    ``authority_lease`` is opaque adapter-owned state.  Avatar Core carries it
+    from one approved derived-launch decision to its launcher Port, but never
+    inspects it as an FD or treats it as authority itself.
+    """
 
     argv: tuple[str, ...]
     stderr_path: Path
     environment: Mapping[str, str] | None = None
+    authority_lease: object | None = None
 
 
 @dataclass(frozen=True)

--- a/src/lingtai/tools/avatar/_launcher.py
+++ b/src/lingtai/tools/avatar/_launcher.py
@@ -6,6 +6,8 @@ from enum import Enum
 from pathlib import Path
 from typing import Mapping, Protocol
 
+from lingtai.kernel.provider_admission import DerivedLaunchEndpointLease
+
 
 # This is deliberately a restrictive boot marker, never an authority bearer:
 # a child that forges it can only make its own nested derived launch fail closed.
@@ -81,7 +83,7 @@ class AvatarLaunchRequest:
     argv: tuple[str, ...]
     stderr_path: Path
     environment: Mapping[str, str] | None = None
-    authority_lease: object | None = None
+    authority_lease: DerivedLaunchEndpointLease | None = None
 
 
 @dataclass(frozen=True)

--- a/src/lingtai/tools/daemon/__init__.py
+++ b/src/lingtai/tools/daemon/__init__.py
@@ -9588,7 +9588,7 @@ class DaemonManager:
             if lease is not None:
                 try:
                     lease.close()
-                except Exception:
+                except OSError:
                     pass
 
     @staticmethod

--- a/src/lingtai/tools/daemon/__init__.py
+++ b/src/lingtai/tools/daemon/__init__.py
@@ -9637,10 +9637,21 @@ class DaemonManager:
         )
 
         capability = DerivedLaunchCapability(capability_name)
+        decision: DerivedLaunchDecision | None = None
+        transferred = False
         try:
-            decision = self._runtime.authorize_derived_launch(capability)
-        except DerivedLaunchAdmissionError as exc:
-            decision = exc.decision
+            try:
+                decision = self._runtime.authorize_derived_launch(capability)
+            except DerivedLaunchAdmissionError as exc:
+                decision = exc.decision
+                self._log(
+                    "derived_launch_admission_decision",
+                    capability=capability.value,
+                    state=decision.state.value,
+                    reason_code=decision.reason_code,
+                    audit_id=decision.audit_id,
+                )
+                raise
             self._log(
                 "derived_launch_admission_decision",
                 capability=capability.value,
@@ -9648,17 +9659,13 @@ class DaemonManager:
                 reason_code=decision.reason_code,
                 audit_id=decision.audit_id,
             )
-            raise
-        self._log(
-            "derived_launch_admission_decision",
-            capability=capability.value,
-            state=decision.state.value,
-            reason_code=decision.reason_code,
-            audit_id=decision.audit_id,
-        )
-        if not decision.allowed:
-            raise DerivedLaunchAdmissionError(decision)
-        return decision
+            if not decision.allowed:
+                raise DerivedLaunchAdmissionError(decision)
+            transferred = True
+            return decision
+        finally:
+            if decision is not None and not transferred:
+                self._close_unconsumed_derived_launch_decisions([decision])
 
 
 # Pair of the ``DEFAULT_MAX_TURNS`` assertion above: ``_tool_family``'s

--- a/tests/test_avatar_launcher.py
+++ b/tests/test_avatar_launcher.py
@@ -1,7 +1,11 @@
 """Focused Contract tests for the avatar-local launcher boundary."""
+import os
+import socket
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from lingtai.tools.avatar import AvatarManager
 from lingtai.tools.avatar._launcher import (
@@ -107,8 +111,20 @@ def test_unreadable_legacy_derived_marker_keeps_cli_boot_restrictive(
     assert cli._derived_avatar_requires_admission(tmp_path) is True
 
 
-def test_manager_marks_avatar_child_as_requiring_derived_authority(tmp_path):
-    """The production avatar launch request carries no authority bearer."""
+def test_manager_marks_driver_derived_avatar_child_as_requiring_authority(tmp_path):
+    """A Driver-derived avatar launch carries only a restrictive boot hint."""
+    launcher = MagicMock()
+    launcher.launch.return_value = AvatarLaunchReceipt(419, object())
+    manager = AvatarManager(SimpleNamespace(), launcher=launcher)
+    with patch("lingtai.venv_resolve.resolve_venv", return_value=tmp_path), patch(
+        "lingtai.venv_resolve.venv_python", return_value=tmp_path / "python"
+    ):
+        manager._launch(tmp_path, derived_child=True)
+    request = launcher.launch.call_args.args[0]
+    assert request.environment == {"LINGTAI_DERIVED_AVATAR_EXECUTION": "1"}
+
+
+def test_manager_keeps_generic_avatar_launch_free_of_driver_hints(tmp_path):
     launcher = MagicMock()
     launcher.launch.return_value = AvatarLaunchReceipt(419, object())
     manager = AvatarManager(SimpleNamespace(), launcher=launcher)
@@ -117,7 +133,59 @@ def test_manager_marks_avatar_child_as_requiring_derived_authority(tmp_path):
     ):
         manager._launch(tmp_path)
     request = launcher.launch.call_args.args[0]
-    assert request.environment == {"LINGTAI_DERIVED_AVATAR_EXECUTION": "1"}
+    assert request.environment is None
+    assert request.authority_lease is None
+
+
+def test_posix_launch_passes_only_the_one_shot_driver_child_endpoint(tmp_path):
+    """The child receives a lease endpoint, never a root authority descriptor."""
+    from lingtai.adapters.acp.driver_authority import DriverChildEndpointLease
+
+    process = MagicMock(pid=419, poll=MagicMock(return_value=None))
+    client, driver = socket.socketpair()
+    request = AvatarLaunchRequest(
+        ("python", "-m", "lingtai", "run", "/avatar"),
+        tmp_path / "logs" / "spawn.stderr",
+        authority_lease=DriverChildEndpointLease(client),
+    )
+    try:
+        with patch(
+            "lingtai.adapters.posix.avatar_launcher.subprocess.Popen",
+            return_value=process,
+        ) as popen:
+            PosixAvatarLauncherAdapter().launch(request)
+        kwargs = popen.call_args.kwargs
+        child_fd = kwargs["pass_fds"]
+        assert len(child_fd) == 1
+        assert kwargs["env"]["LINGTAI_DRIVER_AUTHORITY_FD"] == str(child_fd[0])
+        assert kwargs["close_fds"] is True
+        with pytest.raises(OSError):
+            os.fstat(child_fd[0])
+    finally:
+        driver.close()
+
+
+def test_posix_launch_closes_driver_endpoint_when_popen_fails(tmp_path):
+    """A consumed endpoint is still released if process creation aborts."""
+    from lingtai.adapters.acp.driver_authority import DriverChildEndpointLease
+
+    client, driver = socket.socketpair()
+    driver.settimeout(1)
+    request = AvatarLaunchRequest(
+        ("python", "-m", "lingtai", "run", "/avatar"),
+        tmp_path / "logs" / "spawn.stderr",
+        authority_lease=DriverChildEndpointLease(client),
+    )
+    try:
+        with patch(
+            "lingtai.adapters.posix.avatar_launcher.subprocess.Popen",
+            side_effect=OSError("launch failed"),
+        ):
+            with pytest.raises(OSError, match="launch failed"):
+                PosixAvatarLauncherAdapter().launch(request)
+        assert driver.recv(1) == b""
+    finally:
+        driver.close()
 
 
 def test_manager_boot_policy_uses_opaque_port_and_preserves_precedence(tmp_path):

--- a/tests/test_avatar_launcher_windows.py
+++ b/tests/test_avatar_launcher_windows.py
@@ -83,6 +83,27 @@ def test_windows_launch_propagates_explicit_derived_child_requirement(tmp_path):
     assert popen.call_args.kwargs["env"]["LINGTAI_DERIVED_AVATAR_EXECUTION"] == "1"
 
 
+def test_windows_rejects_and_closes_posix_driver_child_endpoint(tmp_path):
+    """A Windows launch must not discard the Driver's one-shot endpoint."""
+    class Lease:
+        closed = False
+
+        def close(self):
+            self.closed = True
+
+    lease = Lease()
+    request = AvatarLaunchRequest(
+        ("python", "-m", "lingtai", "run", "/avatar"),
+        tmp_path / "logs" / "spawn.stderr",
+        authority_lease=lease,
+    )
+    with patch("lingtai.adapters.windows.avatar_launcher.subprocess.Popen") as popen:
+        with pytest.raises(RuntimeError, match="only supported on POSIX"):
+            WindowsAvatarLauncherAdapter().launch(request)
+    assert lease.closed is True
+    popen.assert_not_called()
+
+
 def test_windows_terminate_and_force_terminate_both_forceful():
     """Owner decision U7: both map to the handle's forceful kill/terminate;
     the adapter never pretends a graceful tier exists."""

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -14,6 +14,7 @@ import pytest
 
 from lingtai.kernel.config import AgentConfig
 from lingtai.kernel.provider_admission import (
+    DerivedLaunchAdmissionError,
     DerivedLaunchCapability,
     DerivedLaunchDecision,
     ProviderAdmissionState,
@@ -1606,6 +1607,66 @@ def test_profile_daemon_later_batch_denial_leaves_no_task_file_store_or_run(
         path.is_dir() and path.name.startswith("em-")
         for path in daemon_root.iterdir()
     )
+
+
+@pytest.mark.parametrize("rejection_origin", ["returned", "raised"])
+def test_profile_daemon_closes_current_rejection_lease(
+    tmp_path, rejection_origin,
+):
+    """Every current rejection closes its lease before Daemon surfaces it."""
+    from lingtai.adapters.acp.puffo_v0 import RUNTIME_POLICY
+
+    class _Lease:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    prior_lease = _Lease()
+    rejected_lease = _Lease()
+    rejected_decision = DerivedLaunchDecision(
+        ProviderAdmissionState.DENIED,
+        f"{rejection_origin}_child_denied",
+        child_endpoint_lease=rejected_lease,
+    )
+
+    class _RejectingPort:
+        def __init__(self):
+            self.calls = 0
+
+        def authorize_derived_launch(self, _parent, _capability):
+            self.calls += 1
+            if self.calls == 1:
+                return DerivedLaunchDecision(
+                    ProviderAdmissionState.GRANTED,
+                    "first_child_allowed",
+                    child_endpoint_lease=prior_lease,
+                )
+            if rejection_origin == "raised":
+                raise DerivedLaunchAdmissionError(rejected_decision)
+            return rejected_decision
+
+    agent = _make_agent(tmp_path, ["daemon"])
+    port = _RejectingPort()
+    agent._derived_launch_admission_port = port
+    token = bind_provider_admission(
+        RootProviderAdmission("root-daemon-lease", RUNTIME_POLICY.policy_version)
+    )
+    try:
+        result = agent.get_capability("daemon").handle({
+            "action": "emanate",
+            "tasks": [
+                {"task": "first", "tools": []},
+                {"task": "second", "tools": []},
+            ],
+        })
+    finally:
+        clear_provider_admission(token)
+
+    assert result["reason_code"] == f"{rejection_origin}_child_denied"
+    assert rejected_lease.closed is True
+    assert prior_lease.closed is True
 
 
 def test_profile_external_cli_daemon_launch_reaches_admission_before_supervisor(

--- a/tests/test_layers_avatar.py
+++ b/tests/test_layers_avatar.py
@@ -99,13 +99,10 @@ class TestAvatarManager:
         assert "avatar" in child_caps
 
     @pytest.mark.parametrize("avatar_type", ["shallow", "deep"])
-    def test_spawn_persists_restrictive_derived_child_state(self, tmp_path, avatar_type):
-        """Every spawn mode keeps the child directory derived after copying."""
+    def test_generic_spawn_does_not_persist_driver_derived_child_state(self, tmp_path, avatar_type):
+        """A legacy avatar spawn must not become Driver-derived by itself."""
         from lingtai.agent import Agent
-        from lingtai.tools.avatar._launcher import (
-            DERIVED_AVATAR_STATE,
-            derived_avatar_state_path,
-        )
+        from lingtai.tools.avatar._launcher import derived_avatar_state_path
 
         parent = Agent(
             service=make_mock_service(),
@@ -121,11 +118,7 @@ class TestAvatarManager:
         )
 
         assert result["status"] == "ok"
-        assert json.loads(
-            derived_avatar_state_path(parent._working_dir.parent / "child").read_text(
-                encoding="utf-8"
-            )
-        ) == DERIVED_AVATAR_STATE
+        assert not derived_avatar_state_path(parent._working_dir.parent / "child").exists()
 
     def test_spawn_inherits_covenant(self, tmp_path):
         """Spawned agent should inherit parent's covenant."""
@@ -286,6 +279,8 @@ class TestAvatarManager:
         )
         from lingtai.agent import Agent
 
+        lease = object()
+
         class _GrantingPort:
             def __init__(self):
                 self.calls = []
@@ -296,6 +291,7 @@ class TestAvatarManager:
                     ProviderAdmissionState.GRANTED,
                     "derived_launch_allowed_by_test",
                     audit_id="audit-avatar-positive-2a",
+                    child_endpoint_lease=lease,
                 )
 
         launch_calls = []
@@ -309,8 +305,8 @@ class TestAvatarManager:
             launch_patch.setattr(
                 AvatarManager,
                 "_launch",
-                lambda _self, working_dir: (
-                    launch_calls.append(working_dir)
+                lambda _self, working_dir, **kwargs: (
+                    launch_calls.append((working_dir, kwargs))
                     or (receipt, Path("/tmp/avatar-positive-2a.stderr"))
                 ),
             )
@@ -334,7 +330,14 @@ class TestAvatarManager:
 
         assert result["status"] == "ok"
         assert port.calls == [(root, DerivedLaunchCapability.AVATAR)]
-        assert launch_calls == [parent._working_dir.parent / "child"]
+        assert launch_calls == [
+            (
+                parent._working_dir.parent / "child",
+                {"authority_lease": lease, "derived_child": True},
+            )
+        ]
+        from lingtai.tools.avatar._launcher import derived_avatar_state_path
+        assert derived_avatar_state_path(parent._working_dir.parent / "child").is_file()
         records = [
             json.loads(line)
             for line in (parent._working_dir / "delegates" / "ledger.jsonl")
@@ -344,6 +347,59 @@ class TestAvatarManager:
         assert records[0]["event"] == "avatar_admission_decision"
         assert records[0]["state"] == "granted"
         assert records[0]["audit_id"] == "audit-avatar-positive-2a"
+
+    def test_profile_avatar_early_return_closes_unhanded_driver_lease(self, tmp_path):
+        """A Driver lease is closed when spawn aborts before the launcher Port."""
+        from lingtai.adapters.acp.puffo_v0 import RUNTIME_POLICY
+        from lingtai.kernel.provider_admission import (
+            DerivedLaunchDecision,
+            ProviderAdmissionState,
+            RootProviderAdmission,
+            bind_provider_admission,
+            clear_provider_admission,
+        )
+        from lingtai.agent import Agent
+
+        class _Lease:
+            def __init__(self):
+                self.closed = False
+
+            def close(self):
+                self.closed = True
+
+        class _GrantingPort:
+            def __init__(self, lease):
+                self.lease = lease
+
+            def authorize_derived_launch(self, _parent, _capability):
+                return DerivedLaunchDecision(
+                    ProviderAdmissionState.GRANTED,
+                    "derived_launch_allowed_by_test",
+                    child_endpoint_lease=self.lease,
+                )
+
+        lease = _Lease()
+        parent = Agent(
+            service=make_mock_service(),
+            agent_name="parent",
+            working_dir=tmp_path / "parent",
+            capabilities=["avatar"],
+            _turn_origin_policy=RUNTIME_POLICY,
+            derived_launch_admission_port=_GrantingPort(lease),
+        )
+        (parent._working_dir.parent / "child").mkdir()
+        token = bind_provider_admission(
+            RootProviderAdmission("root-avatar-lease-close", RUNTIME_POLICY.policy_version)
+        )
+        try:
+            result = parent.get_capability("avatar").handle(
+                {"action": "spawn", "input": {"name": "child", "confirm": True}}
+            )
+        finally:
+            clear_provider_admission(token)
+
+        assert result == {"error": "Directory 'child' already exists. Choose another name."}
+        assert lease.closed is True
 
 
 class TestMissionQualityGate:

--- a/tests/test_layers_avatar.py
+++ b/tests/test_layers_avatar.py
@@ -213,6 +213,13 @@ class TestAvatarManager:
         )
         from lingtai.agent import Agent
 
+        class _Lease:
+            def __init__(self):
+                self.closed = False
+
+            def close(self):
+                self.closed = True
+
         class _DenyingPort:
             def __init__(self):
                 self.calls = []
@@ -223,8 +230,10 @@ class TestAvatarManager:
                     ProviderAdmissionState.DENIED,
                     "derived_launch_denied_by_test",
                     audit_id="audit-avatar-2a",
+                    child_endpoint_lease=lease,
                 )
 
+        lease = _Lease()
         parent = Agent(
             service=make_mock_service(),
             agent_name="parent",
@@ -244,6 +253,7 @@ class TestAvatarManager:
             clear_provider_admission(token)
 
         assert "derived_launch_denied_by_test" in result["error"]
+        assert lease.closed is True
         assert port.calls == [(root, DerivedLaunchCapability.AVATAR)]
         assert not (parent._working_dir.parent / "child").exists()
         records = [
@@ -263,6 +273,109 @@ class TestAvatarManager:
                 "audit_id": "audit-avatar-2a",
             }
         ]
+
+    def test_profile_avatar_admission_error_closes_untransferred_lease(self, tmp_path):
+        """A port-raised rejection releases the lease before Avatar returns."""
+        from lingtai.adapters.acp.puffo_v0 import RUNTIME_POLICY
+        from lingtai.kernel.provider_admission import (
+            DerivedLaunchAdmissionError,
+            DerivedLaunchDecision,
+            ProviderAdmissionState,
+            RootProviderAdmission,
+            bind_provider_admission,
+            clear_provider_admission,
+        )
+        from lingtai.agent import Agent
+
+        class _Lease:
+            def __init__(self):
+                self.closed = False
+
+            def close(self):
+                self.closed = True
+
+        lease = _Lease()
+
+        class _RaisingPort:
+            def authorize_derived_launch(self, _parent, _capability):
+                raise DerivedLaunchAdmissionError(
+                    DerivedLaunchDecision(
+                        ProviderAdmissionState.INDETERMINATE,
+                        "driver_unavailable",
+                        child_endpoint_lease=lease,
+                    )
+                )
+
+        parent = Agent(
+            service=make_mock_service(),
+            agent_name="parent",
+            working_dir=tmp_path / "parent",
+            capabilities=["avatar"],
+            _turn_origin_policy=RUNTIME_POLICY,
+            derived_launch_admission_port=_RaisingPort(),
+        )
+        token = bind_provider_admission(
+            RootProviderAdmission("root-avatar-raised-lease", RUNTIME_POLICY.policy_version)
+        )
+        try:
+            result = parent.get_capability("avatar").handle(
+                {"action": "spawn", "input": {"name": "child", "confirm": True}}
+            )
+        finally:
+            clear_provider_admission(token)
+
+        assert "driver_unavailable" in result["error"]
+        assert lease.closed is True
+
+    def test_profile_avatar_ledger_failure_closes_untransferred_lease(self, tmp_path, monkeypatch):
+        """Ledger I/O cannot strand a grant before spawn owns its lease."""
+        from lingtai.adapters.acp.puffo_v0 import RUNTIME_POLICY
+        from lingtai.kernel.provider_admission import (
+            DerivedLaunchDecision,
+            ProviderAdmissionState,
+            RootProviderAdmission,
+            bind_provider_admission,
+            clear_provider_admission,
+        )
+        from lingtai.agent import Agent
+
+        class _Lease:
+            def __init__(self):
+                self.closed = False
+
+            def close(self):
+                self.closed = True
+
+        lease = _Lease()
+
+        class _GrantingPort:
+            def authorize_derived_launch(self, _parent, _capability):
+                return DerivedLaunchDecision(
+                    ProviderAdmissionState.GRANTED,
+                    "allowed",
+                    child_endpoint_lease=lease,
+                )
+
+        parent = Agent(
+            service=make_mock_service(),
+            agent_name="parent",
+            working_dir=tmp_path / "parent",
+            capabilities=["avatar"],
+            _turn_origin_policy=RUNTIME_POLICY,
+            derived_launch_admission_port=_GrantingPort(),
+        )
+        manager = parent.get_capability("avatar")
+        monkeypatch.setattr(manager, "_append_ledger", MagicMock(side_effect=OSError("disk full")))
+        token = bind_provider_admission(
+            RootProviderAdmission("root-avatar-ledger-lease", RUNTIME_POLICY.policy_version)
+        )
+        try:
+            with pytest.raises(OSError, match="disk full"):
+                manager._authorize_derived_launch("child")
+        finally:
+            clear_provider_admission(token)
+
+        assert lease.closed is True
 
     def test_profile_avatar_grant_reaches_the_same_launch_recorder(
         self, tmp_path, monkeypatch

--- a/tests/test_provider_admission.py
+++ b/tests/test_provider_admission.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import ast
+import socket
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from types import SimpleNamespace
@@ -739,6 +740,109 @@ def test_derived_launch_port_preserves_a_structured_adapter_error_decision():
     assert raised.value.decision is decision
     assert raised.value.decision.reason_code == "driver_unavailable"
     assert raised.value.decision.child_endpoint_lease is lease
+
+
+def test_malformed_derived_launch_decision_releases_its_lease_before_replacement():
+    """Core owns the opaque lease when it discards an untrusted Port result."""
+
+    class _Lease:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    lease = _Lease()
+
+    class _Port:
+        def authorize_derived_launch(self, _parent, _capability):
+            return DerivedLaunchDecision(
+                ProviderAdmissionState.GRANTED,
+                "",
+                child_endpoint_lease=lease,
+            )
+
+    root = RootProviderAdmission("turn-malformed-lease", RUNTIME_POLICY.policy_version)
+    token = bind_provider_admission(root)
+    try:
+        with pytest.raises(
+            DerivedLaunchAdmissionError,
+            match="malformed_derived_launch_admission_decision",
+        ) as raised:
+            require_derived_launch_admission(_Port(), DerivedLaunchCapability.AVATAR)
+    finally:
+        clear_provider_admission(token)
+
+    assert lease.closed is True
+    assert raised.value.decision.reason_code == "malformed_derived_launch_admission_decision"
+
+
+def test_malformed_derived_launch_audit_id_releases_its_lease_before_replacement():
+    """Every malformed-decision variant uses the same discard ownership path."""
+
+    class _Lease:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    lease = _Lease()
+
+    class _Port:
+        def authorize_derived_launch(self, _parent, _capability):
+            return DerivedLaunchDecision(
+                ProviderAdmissionState.GRANTED,
+                "allowed",
+                audit_id="",
+                child_endpoint_lease=lease,
+            )
+
+    root = RootProviderAdmission("turn-malformed-audit-lease", RUNTIME_POLICY.policy_version)
+    token = bind_provider_admission(root)
+    try:
+        with pytest.raises(
+            DerivedLaunchAdmissionError,
+            match="malformed_derived_launch_admission_decision",
+        ):
+            require_derived_launch_admission(_Port(), DerivedLaunchCapability.AVATAR)
+    finally:
+        clear_provider_admission(token)
+
+    assert lease.closed is True
+
+
+def test_malformed_derived_launch_decision_closes_a_real_driver_endpoint_lease():
+    """Discarding a malformed Driver grant closes the underlying socket peer."""
+    from lingtai.adapters.acp.driver_authority import DriverChildEndpointLease
+
+    endpoint, peer = socket.socketpair()
+    peer.settimeout(1)
+    lease = DriverChildEndpointLease(endpoint)
+
+    class _Port:
+        def authorize_derived_launch(self, _parent, _capability):
+            return DerivedLaunchDecision(
+                ProviderAdmissionState.GRANTED,
+                "",
+                child_endpoint_lease=lease,
+            )
+
+    root = RootProviderAdmission("turn-real-malformed-lease", RUNTIME_POLICY.policy_version)
+    token = bind_provider_admission(root)
+    try:
+        with pytest.raises(
+            DerivedLaunchAdmissionError,
+            match="malformed_derived_launch_admission_decision",
+        ):
+            require_derived_launch_admission(_Port(), DerivedLaunchCapability.AVATAR)
+    finally:
+        clear_provider_admission(token)
+
+    try:
+        assert peer.recv(1) == b""
+    finally:
+        peer.close()
 
 
 def test_required_derived_launch_port_cannot_fall_back_to_legacy_default():

--- a/tests/test_provider_admission.py
+++ b/tests/test_provider_admission.py
@@ -710,6 +710,37 @@ def test_derived_launch_port_is_fail_closed_when_unconnected_or_indeterminate():
     assert raised.value.decision.state is ProviderAdmissionState.INDETERMINATE
 
 
+def test_derived_launch_port_preserves_a_structured_adapter_error_decision():
+    """The launch consumer must receive the original opaque lease decision."""
+
+    class _Lease:
+        def close(self):
+            pass
+
+    lease = _Lease()
+    decision = DerivedLaunchDecision(
+        ProviderAdmissionState.INDETERMINATE,
+        "driver_unavailable",
+        child_endpoint_lease=lease,
+    )
+
+    class _Port:
+        def authorize_derived_launch(self, _parent, _capability):
+            raise DerivedLaunchAdmissionError(decision)
+
+    root = RootProviderAdmission("turn-a", RUNTIME_POLICY.policy_version)
+    token = bind_provider_admission(root)
+    try:
+        with pytest.raises(DerivedLaunchAdmissionError) as raised:
+            require_derived_launch_admission(_Port(), DerivedLaunchCapability.AVATAR)
+    finally:
+        clear_provider_admission(token)
+
+    assert raised.value.decision is decision
+    assert raised.value.decision.reason_code == "driver_unavailable"
+    assert raised.value.decision.child_endpoint_lease is lease
+
+
 def test_required_derived_launch_port_cannot_fall_back_to_legacy_default():
     """A constrained composition must expose a missing Driver seam."""
 

--- a/tests/test_provider_admission.py
+++ b/tests/test_provider_admission.py
@@ -742,7 +742,14 @@ def test_derived_launch_port_preserves_a_structured_adapter_error_decision():
     assert raised.value.decision.child_endpoint_lease is lease
 
 
-def test_malformed_derived_launch_decision_releases_its_lease_before_replacement():
+@pytest.mark.parametrize("capability", list(DerivedLaunchCapability))
+@pytest.mark.parametrize(
+    ("reason_code", "audit_id"),
+    [("", None), ("allowed", "")],
+)
+def test_malformed_derived_launch_decision_releases_its_lease_before_replacement(
+    capability, reason_code, audit_id
+):
     """Core owns the opaque lease when it discards an untrusted Port result."""
 
     class _Lease:
@@ -758,7 +765,8 @@ def test_malformed_derived_launch_decision_releases_its_lease_before_replacement
         def authorize_derived_launch(self, _parent, _capability):
             return DerivedLaunchDecision(
                 ProviderAdmissionState.GRANTED,
-                "",
+                reason_code,
+                audit_id=audit_id,
                 child_endpoint_lease=lease,
             )
 
@@ -769,7 +777,7 @@ def test_malformed_derived_launch_decision_releases_its_lease_before_replacement
             DerivedLaunchAdmissionError,
             match="malformed_derived_launch_admission_decision",
         ) as raised:
-            require_derived_launch_admission(_Port(), DerivedLaunchCapability.AVATAR)
+            require_derived_launch_admission(_Port(), capability)
     finally:
         clear_provider_admission(token)
 
@@ -777,42 +785,8 @@ def test_malformed_derived_launch_decision_releases_its_lease_before_replacement
     assert raised.value.decision.reason_code == "malformed_derived_launch_admission_decision"
 
 
-def test_malformed_derived_launch_audit_id_releases_its_lease_before_replacement():
-    """Every malformed-decision variant uses the same discard ownership path."""
-
-    class _Lease:
-        def __init__(self):
-            self.closed = False
-
-        def close(self):
-            self.closed = True
-
-    lease = _Lease()
-
-    class _Port:
-        def authorize_derived_launch(self, _parent, _capability):
-            return DerivedLaunchDecision(
-                ProviderAdmissionState.GRANTED,
-                "allowed",
-                audit_id="",
-                child_endpoint_lease=lease,
-            )
-
-    root = RootProviderAdmission("turn-malformed-audit-lease", RUNTIME_POLICY.policy_version)
-    token = bind_provider_admission(root)
-    try:
-        with pytest.raises(
-            DerivedLaunchAdmissionError,
-            match="malformed_derived_launch_admission_decision",
-        ):
-            require_derived_launch_admission(_Port(), DerivedLaunchCapability.AVATAR)
-    finally:
-        clear_provider_admission(token)
-
-    assert lease.closed is True
-
-
-def test_malformed_derived_launch_decision_closes_a_real_driver_endpoint_lease():
+@pytest.mark.parametrize("capability", list(DerivedLaunchCapability))
+def test_malformed_derived_launch_decision_closes_a_real_driver_endpoint_lease(capability):
     """Discarding a malformed Driver grant closes the underlying socket peer."""
     from lingtai.adapters.acp.driver_authority import DriverChildEndpointLease
 
@@ -835,7 +809,7 @@ def test_malformed_derived_launch_decision_closes_a_real_driver_endpoint_lease()
             DerivedLaunchAdmissionError,
             match="malformed_derived_launch_admission_decision",
         ):
-            require_derived_launch_admission(_Port(), DerivedLaunchCapability.AVATAR)
+            require_derived_launch_admission(_Port(), capability)
     finally:
         clear_provider_admission(token)
 


### PR DESCRIPTION
## Summary
- carry Driver child endpoint leases through admission and Avatar launch without Core inspecting endpoint internals
- consume POSIX leases exactly once at the process boundary; reject and close unsupported Windows handoffs
- centralize malformed decision cleanup with a typed close contract across Core, Avatar, Windows, and Daemon

## Verification
- independent review: focused admission 74 passed / 1 skipped; Avatar 60 passed / 1 skipped
- malformed decisions parameterized across all `DerivedLaunchCapability` values, including real `DriverChildEndpointLease` socket EOF probes
- `py_compile`, `git diff --check`, clean-worktree and scope audit passed
- one unrelated pre-existing provider-admission concurrency source-line inventory failure remains separately owned

Exact reviewed head: `b864ed5f7295b4533a46b7a6bc2692498400bd79`.