### PR TITLE
fix(anatomy): remove duplicate llm reference

### DIFF
--- a/src/lingtai/kernel/llm/ANATOMY.md
+++ b/src/lingtai/kernel/llm/ANATOMY.md
@@ -7,7 +7,6 @@ related_files:
   - src/lingtai/kernel/llm/base.py
   - src/lingtai/kernel/llm/reasoning_effort.py
   - src/lingtai/kernel/llm/interface.py
-  - src/lingtai/kernel/llm/reasoning_effort.py
   - src/lingtai/kernel/llm/service.py
   - src/lingtai/kernel/llm/streaming.py
   - tests/test_llm_service.py


### PR DESCRIPTION
## Summary

- Remove the duplicate `src/lingtai/kernel/llm/reasoning_effort.py` edge from `src/lingtai/kernel/llm/ANATOMY.md`.
- Preserve the one real navigation edge; this is a one-file documentation-graph repair with no runtime, contract, configuration, or release behavior change.

## Validation

- Repository duplicate-free assertion against the changed anatomy — passed: `related_files=13`, `unique=13`, `reasoning_effort_count=1`.
- `scripts/check_docs_governance.py --check` — the candidate removes the LLM duplicate finding; it remains non-green only for pre-existing `IMPLEMENTATION_REPORT.md` missing frontmatter, reproduced on clean exact-base control.
- `src/lingtai/intrinsic_skills/lingtai-kernel-anatomy/scripts/check_anatomy_drift.py --check` — three pre-existing out-of-range citations, reproduced identically on clean exact-base control.
- `python -m pytest -q tests/test_architecture_documents.py` — not green: after this repair it exposes 23 pre-existing orphan files and an existing `tools/bash` Contract/Anatomy pairing failure. The clean exact-base control instead stops first on this PR's duplicate LLM reference plus the same bash pairing issue.
- `git diff --check` — passed.

## Notes

- Human-directed repair context: Jason Telegram `12795` / `12797` directs autonomous repair of the accumulated release-blocking baseline failures. This PR intentionally repairs only the first verified root cause.
- Exact base/head at PR creation: `a10f0e4a` / `c02c4141`.
- This PR does not merge, tag, upload, publish, create a GitHub release, dispatch CI, change configuration/authentication, or perform any other release side effect.
- Telegram: @lingtaidev2bot | Nickname: 观一
- Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
