### PR TITLE
fix(contracts): govern bash capability

### DIFF
--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -14,6 +14,7 @@ related_files:
   - src/lingtai/kernel/lifecycle_clock/CONTRACT.md
   - src/lingtai/kernel/project/CONTRACT.md
   - src/lingtai/kernel/refresh_watcher/CONTRACT.md
+  - src/lingtai/tools/bash/CONTRACT.md
   - src/lingtai/tools/notification/CONTRACT.md
   - src/lingtai/tools/pad/CONTRACT.md
   - src/lingtai/tools/lingtai/CONTRACT.md

--- a/src/lingtai/tools/CONTRACT.md
+++ b/src/lingtai/tools/CONTRACT.md
@@ -5,6 +5,7 @@ root_contract: CONTRACT.md
 related_files:
   - src/lingtai/tools/ANATOMY.md
   - src/lingtai/kernel/tool_plugin/CONTRACT.md
+  - src/lingtai/tools/bash/CONTRACT.md
   - src/lingtai/tools/BEHAVIORS.md
   - src/lingtai/tools/registry.py
   - src/lingtai/kernel/base_agent/tools.py

--- a/src/lingtai/tools/bash/CONTRACT.md
+++ b/src/lingtai/tools/bash/CONTRACT.md
@@ -2,6 +2,7 @@
 name: bash-contract
 tool: shell
 contract_version: 7
+root_contract: CONTRACT.md
 related_files:
   - src/lingtai/tools/bash/__init__.py
   - src/lingtai/kernel/execution_workspace.py


### PR DESCRIPTION
## Summary

- Register the already-existing Bash capability Contract as a root-governed child.
- Declare its `root_contract` and restore the missing reciprocal Tools Contract link.
- Resolve the Bash Contract/Anatomy ownership ambiguity without changing shell runtime behavior, contract semantics, configuration, or release flow.

## Validation

- `python -m pytest -q tests/test_architecture_documents.py::test_governed_child_contracts_have_reciprocal_anatomy_pairs tests/test_architecture_documents.py::test_governed_cross_document_links_are_reciprocal` — 2 passed.
- Direct graph proof — root Bash Contract count `1`; Bash `root_contract=CONTRACT.md`; Tools Contract reciprocal count `1`.
- `git diff --check` — passed.
- Full `tests/test_architecture_documents.py` remains non-green only because this unstacked exact-main candidate still hits the independently repaired LLM duplicate edge first (PR #1595); after that, the known orphan-path batch remains. This PR does not claim a green suite.
- `scripts/check_docs_governance.py --check` and the anatomy drift checker remain blocked by pre-existing baseline findings documented in the release-repair task state.

## Notes

- Human-directed repair context: Jason Telegram `12795` / `12797` directs autonomous minimal root-cause repairs of the accumulated release-blocking baseline failures.
- Exact base/head at PR creation: `a10f0e4a` / `cd2559d6`.
- This PR does not merge, tag, upload, publish, create a GitHub release, dispatch CI, change runtime/configuration/authentication, or perform any deletion.
- Telegram: @lingtaidev2bot | Nickname: 观一
- Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
