### PR TITLE
fix(anatomy): map acp driver authority

### DIFF
--- a/src/lingtai/adapters/acp/ANATOMY.md
+++ b/src/lingtai/adapters/acp/ANATOMY.md
@@ -5,6 +5,7 @@ related_files:
   - src/lingtai/adapters/acp/BEHAVIORS.md
   - src/lingtai/adapters/acp/MANUAL.md
   - src/lingtai/adapters/acp/__init__.py
+  - src/lingtai/adapters/acp/driver_authority.py
   - src/lingtai/adapters/acp/puffo_v0.py
   - src/lingtai/adapters/acp/server.py
   - src/lingtai/cli_acp.py


### PR DESCRIPTION
## Summary

- Add the orphaned `src/lingtai/adapters/acp/driver_authority.py` to its already-existing ACP Anatomy `related_files` list.
- Match the Anatomy’s existing component/state documentation for the local Driver authority transport; no source behavior or contract changes.

## Validation

- Direct root → `src/lingtai/ANATOMY.md` → ACP Anatomy path proof — passed.
- ACP Anatomy related-files check — passed; `driver_authority.py` appears exactly once.
- `git diff --check` — passed.
- Full graph remains independently blocked by the unstacked LLM duplicate repair (#1595) and the remaining orphan-owner batches; this PR does not claim green.

## Notes

- Human-directed repair context: Jason Telegram `12795` / `12797` directs autonomous minimal root-cause repairs for the urgent release baseline.
- Exact base/head at PR creation: `a10f0e4a` / `e61a663d`.
- This PR does not merge, tag, upload, publish, create a GitHub release, dispatch CI, change runtime/configuration/authentication, or delete anything.
- Telegram: @lingtaidev2bot | Nickname: 观一
- Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
