### PR TITLE
docs: map remaining Anatomy graph orphans

### DIFF
--- a/src/lingtai/intrinsic_skills/ANATOMY.md
+++ b/src/lingtai/intrinsic_skills/ANATOMY.md
@@ -37,6 +37,8 @@ related_files:
   - tests/test_intrinsic_manual_actions.py
   - tests/test_lingtai_doctor.py
   - tests/test_override_intrinsic.py
+  - src/lingtai/intrinsic_skills/system-manual/reference/external-attach-diagnostic/SKILL.md
+  - src/lingtai/intrinsic_skills/system-manual/reference/external-attach-diagnostic/scripts/external_attach_diagnostic.py
 maintenance: |
   Keep related_files repo-relative, duplicate-free, and linked to real files.
   This package is a bundle of shipped documentation, not a code layer, so it

--- a/src/lingtai/mcp_servers/ANATOMY.md
+++ b/src/lingtai/mcp_servers/ANATOMY.md
@@ -148,6 +148,10 @@ related_files:
   - src/lingtai/mcp_servers/whatsapp/redaction.py
   - src/lingtai/mcp_servers/whatsapp/resources.py
   - src/lingtai/mcp_servers/whatsapp/server.py
+  - src/lingtai/mcp_servers/cloud_mail/plugin.py
+  - src/lingtai/mcp_servers/feishu/settings.py
+  - src/lingtai/mcp_servers/wechat/settings.py
+  - src/lingtai/mcp_servers/whatsapp/settings.py
 maintenance: |
   Keep related_files as repo-relative paths to real files. Include neighboring
   ANATOMY.md files so the anatomy graph stays connected rather than isolated;

--- a/src/lingtai/tools/mcp/ANATOMY.md
+++ b/src/lingtai/tools/mcp/ANATOMY.md
@@ -34,6 +34,10 @@ related_files:
   - src/lingtai/tools/mcp/skills/mcp-manual/scripts/find_readme.py
   - src/lingtai/tools/mcp/manual/scripts/find_readme.py
   - src/lingtai/tools/ANATOMY.md
+  - src/lingtai/tools/mcp/manual/SKILL.md
+  - src/lingtai/tools/mcp/manual/reference/curated-addons.md
+  - src/lingtai/tools/mcp/manual/reference/third-party-and-legacy.md
+  - src/lingtai/tools/mcp/manual/reference/troubleshooting.md
 maintenance: |
   Keep related_files as repo-relative paths to real files. Include neighboring
   ANATOMY.md files so the anatomy graph stays connected rather than isolated;

--- a/src/lingtai/tools/notification/ANATOMY.md
+++ b/src/lingtai/tools/notification/ANATOMY.md
@@ -22,6 +22,9 @@ related_files:
   - tests/test_notification_tool.py
   - tests/test_notification_delay_alarm.py
   - tests/test_notification_sync.py
+  - src/lingtai/tools/notification/glossary-en.md
+  - src/lingtai/tools/notification/glossary-wen.md
+  - src/lingtai/tools/notification/glossary-zh.md
 maintenance: |
   Notification is an official declared host-plugin slice. Keep this Anatomy
   reciprocal with CONTRACT.md and BEHAVIORS.md and update the kernel Port,

--- a/tests/ANATOMY.md
+++ b/tests/ANATOMY.md
@@ -466,6 +466,15 @@ related_files:
   - tests/unit/__init__.py
   - tests/unit/auth/__init__.py
   - tests/unit/auth/test_codex_auth.py
+  - tests/_tool_plugin_helpers.py
+  - tests/test_cli_liveness.py
+  - tests/test_daemon_notification_channel.py
+  - tests/test_daemon_task_files.py
+  - tests/test_driver_authority_adapter.py
+  - tests/test_external_attach_diagnostic.py
+  - tests/test_feishu_settings.py
+  - tests/test_platform_workflow_release_gating.py
+  - tests/test_system_runtime_policy.py
 maintenance: |
   Keep related_files repo-relative, duplicate-free, and linked to real files.
   This is a navigation-only inventory anatomy: tests/ is a validation surface,


### PR DESCRIPTION
## Summary

- Maps the remaining 22 known tracked files into the five nearest natural `ANATOMY.md` owners: intrinsic skills (2), MCP servers (4), MCP manual (4), notification (3), and tests (9).
- This is the single consolidated follow-up PR requested by Jason instead of further owner-by-owner PR splitting.
- Documentation metadata only; no runtime behavior changes.

## Validation

- Direct production-graph proof: all 22 added paths occur exactly once in their intended owner metadata; the only remaining graph orphan is `src/lingtai/adapters/acp/driver_authority.py`, already covered by still-open #1597.
- `PYTHONPATH=<candidate>/src <repo>/.venv/bin/python -m pytest tests/test_external_attach_diagnostic.py -q` — 7 passed.
- `git diff --check` passed.
- The direct repository architecture test currently stops earlier on the pre-existing duplicate LLM entry that still-open #1595 removes; this PR does not claim the unmerged aggregate graph is green.

## Scope boundary

- Based on `a10f0e4a`; candidate head `de5f40b6`.
- Deliberately does not merge, close, or rewrite #1595–#1597, and does not include the ACP `driver_authority.py` mapping from #1597.
- No tag, upload, publish, GitHub release, CI dispatch, runtime/config/auth action, or deletion.

Telegram: @lingtaidev2bot | Nickname: 观一
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
