### PR TITLE
test: fix malformed async invocation fixture

### DIFF
--- a/tests/test_bash_async.py
+++ b/tests/test_bash_async.py
@@ -51,7 +51,9 @@ class TestBashAsync:
             lambda state: state.pop("invocation"),
             lambda state: state.update({"invocation": {"script": 42}}),
             lambda state: state.update({
-                "invocation": {**state["invocation"], "argv": ["-Command"]},
+                "invocation": {
+                    **state["invocation"], "executable": None, "argv": ["-Command"],
+                },
             }),
             lambda state: state.update({
                 "invocation": {**state["invocation"], "unknown": True},


### PR DESCRIPTION
## Summary

- Corrects one stale async-state test fixture so its `argv-without-executable` case actually removes the separately serialized `executable` field.
- The test now accurately exercises the existing `_invocation_from_state()` rejection path before any process-adapter selection.
- Test-only: no production, raw-fallback, adapter, or runtime behavior change.

## Validation

- `PYTHONPATH=<candidate>/src <repo>/.venv/bin/python -m pytest tests/test_bash_async.py::TestBashAsync::test_malformed_new_state_is_unrecoverable_without_raw_fallback -q -p no:cacheprovider --basetemp <task scratch>` — 5 passed in 0.28s.
- `git diff --check` passed.

## Release status

This Draft PR does **not** establish a green release baseline. Fresh current-main full pytest is still non-green (ordinary failures plus a later `WindowsPath` report-stage internal error); no release/tag/upload/publish action is requested or performed.

Telegram: @lingtaidev2bot | Nickname: 观一
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
