### PR TITLE
feat(acp): configure Puffo driver authority

### DIFF
--- a/ENVIRONMENT_VARIABLES.md
+++ b/ENVIRONMENT_VARIABLES.md
@@ -3,7 +3,7 @@ name: environment-variable-registry
 description: >
   Canonical registry for environment variables consumed by LingTai source,
   bundled MCPs, adapters, daemon composition, and focused tests.
-version: 1.8.1
+version: 1.9.0
 last_changed_at: "2026-09-01"
 related_files:
 - ANATOMY.md
@@ -12,8 +12,11 @@ related_files:
 - src/lingtai/ANATOMY.md
 - src/lingtai/CONTRACT.md
 - src/lingtai/adapters/posix/ANATOMY.md
-- src/lingtai/adapters/acp/ANATOMY.md
 - src/lingtai/adapters/windows/ANATOMY.md
+- src/lingtai/adapters/acp/ANATOMY.md
+- src/lingtai/adapters/acp/CONTRACT.md
+- src/lingtai/adapters/acp/driver_authority.py
+- src/lingtai/cli_acp.py
 - src/lingtai/auth/ANATOMY.md
 - src/lingtai/intrinsic_skills/ANATOMY.md
 - src/lingtai/kernel/ANATOMY.md
@@ -87,6 +90,7 @@ reports, prompts, or this registry.
 | `LINGTAI_CONTEXT_LIMIT` | unset; valid v2 `settings/system.json` `context_limit`, else the service's conservative window / `AgentConfig.context_limit = None` | Positive integer string of context tokens; one agent/process | Highest-precedence source for the effective context window given to `LLMService` and `AgentConfig.context_limit` | Resolved once per CLI boot (before the first service is built) and once per `_setup_from_init` refresh; an `env_file` edit needs refresh | Missing, blank, non-integer, zero, or negative values fall through to the System file, then the fixed default | `src/lingtai/tools/system/settings.py` via `resolve_runtime_policy`, applied by `src/lingtai/cli.py` and `src/lingtai/agent.py` | Sizing only; the kernel-fixed 0.85/1.0/3-round/0.75 context-pressure thresholds are never configurable through it |
 | `LINGTAI_MAX_RPM` | unset; valid v2 `settings/system.json` `max_rpm`, else `60` | Non-negative integer string; `0` disables API-rate gating | Highest-precedence source for the provider requests-per-minute cap threaded into provider defaults and `AgentConfig.max_rpm` | Same boot/refresh resolution as `LINGTAI_CONTEXT_LIMIT`; a changed value rebuilds the LLM service on refresh | Missing, blank, non-integer, or negative values fall through to the System file, then `60` | `src/lingtai/tools/system/settings.py`, `src/lingtai/cli.py`, `src/lingtai/agent.py` | Rate tuning only; it grants no capability |
 | `LINGTAI_STREAMING` | unset; valid v2 `settings/system.json` `streaming`, else `false` | `1`/`0`, `true`/`false`, `yes`/`no`, `on`/`off` (case-insensitive) | Highest-precedence source for the session's streaming send path | Resolved at boot and installed on the `SessionManager` on every `_setup_from_init` refresh; the next request uses the new path | Unrecognized values fall through to the System file, then `false` | `src/lingtai/tools/system/settings.py`, `src/lingtai/cli.py`, `src/lingtai/agent.py`, `src/lingtai/kernel/session.py` | Transport mode only; not an authorization boundary |
+| `LINGTAI_DRIVER_AUTHORITY_FD` | unset; launcher-injected only | Non-negative inherited POSIX AF_UNIX stream descriptor number | One `lingtai-agent acp --profile puffo-v0` process | Consumed and removed from the environment during constrained ACP composition, before Agent construction; never reloaded | Missing, malformed, unusable, or derived-role endpoint installs a fail-closed provider/derived-launch Port pair | `src/lingtai/adapters/acp/driver_authority.py`, `src/lingtai/cli_acp.py` | One-time local descriptor locator, never a serialized credential; do not forward it to child processes or expose its number |
 | `LINGTAI_AED_TIMEOUT` | unset; valid v2 `settings/system.json` `aed_timeout`, else `360` seconds | Finite positive number of seconds | Highest-precedence source for `AgentConfig.aed_timeout` (max seconds in STUCK before ASLEEP) | Boot and every `_setup_from_init` refresh; a live STUCK turn observes the new value on its next heartbeat | Missing, blank, non-numeric, non-finite, zero, or negative values fall through to the System file, then `360` | `src/lingtai/tools/system/settings.py`, `src/lingtai/agent.py` | Availability tuning only; it grants no capability |
 | `LINGTAI_MAX_AED_ATTEMPTS` | unset; valid v2 `settings/system.json` `max_aed_attempts`, else `3` | Integer string `>= 1` | Highest-precedence source for `AgentConfig.max_aed_attempts` | Boot and every `_setup_from_init` refresh | Missing, blank, non-integer, or `< 1` values fall through to the System file, then `3`; the `AgentConfig` clamp to `>= 1` is retained | `src/lingtai/tools/system/settings.py`, `src/lingtai/agent.py` | Recovery tuning only; it grants no capability |
 | `LINGTAI_SNAPSHOT_INTERVAL` | unset; valid v2 `settings/system.json` `snapshot_interval`, else off | Finite positive number of seconds, or `off` (case-insensitive) to disable | Highest-precedence source for `AgentConfig.snapshot_interval` (git Time Machine cadence) | Boot and every `_setup_from_init` refresh; enabling on a started agent initializes the snapshot port before the new cadence becomes visible to the heartbeat, and an initialization failure keeps snapshots off with a `snapshot_initialize_failed` log | Missing, blank, non-numeric, non-finite, zero, or negative values fall through to the System file, then off | `src/lingtai/tools/system/settings.py`, `src/lingtai/agent.py`, `src/lingtai/kernel/base_agent/lifecycle.py` | Local snapshot cadence only; it grants no capability |

--- a/src/lingtai/adapters/acp/ANATOMY.md
+++ b/src/lingtai/adapters/acp/ANATOMY.md
@@ -9,7 +9,6 @@ related_files:
   - src/lingtai/adapters/acp/driver_authority.py
   - src/lingtai/adapters/acp/puffo_v0.py
   - src/lingtai/adapters/acp/server.py
-  - ENVIRONMENT_VARIABLES.md
   - src/lingtai/cli_acp.py
   - src/lingtai/cli_puffo_v0.py
   - src/lingtai/cli.py

--- a/src/lingtai/adapters/acp/ANATOMY.md
+++ b/src/lingtai/adapters/acp/ANATOMY.md
@@ -9,6 +9,7 @@ related_files:
   - src/lingtai/adapters/acp/driver_authority.py
   - src/lingtai/adapters/acp/puffo_v0.py
   - src/lingtai/adapters/acp/server.py
+  - ENVIRONMENT_VARIABLES.md
   - src/lingtai/cli_acp.py
   - src/lingtai/cli_puffo_v0.py
   - src/lingtai/cli.py
@@ -25,6 +26,7 @@ related_files:
   - src/lingtai/kernel/base_agent/CONTRACT.md
   - tests/test_acp_stdio.py
   - tests/test_puffo_v0_profile.py
+  - tests/test_driver_authority_adapter.py
   - tests/test_correlated_turns.py
   - tests/test_execution_workspace.py
   - tests/test_turn_events.py
@@ -78,6 +80,8 @@ co-located [`CONTRACT.md`](CONTRACT.md), and its operator/developer procedure is
   quarantines Python application stdout to stderr before Agent construction,
   composes the existing Agent, consumes the typed bounded stop proof, and hard-
   exits on incomplete quiescence so no later Python state write can race teardown.
+  For `puffo-v0`, it consumes the one launcher-injected Driver authority
+  descriptor and composes either its root Port pair or a fail-closed pair.
   Shared poisoned-worker exit logging is lease-aware: retained ownership may log,
   while a successful `STOPPED` release skips every later workdir append and still
   reaches the unconditional process exit.
@@ -110,7 +114,10 @@ adapter origin to provider dispatch. This controls turn initiation, not what
 state the eventual turn can read. The composition root re-resolves a profile
 runtime immediately before Agent composition so a normal resolve-to-start drift
 fails closed; host-principal filesystem replacement after that check remains
-outside this profile's trust boundary. Outbound: the Adapter calls only the
+outside this profile's trust boundary. The same composition root consumes and
+removes `LINGTAI_DRIVER_AUTHORITY_FD`; only a valid root endpoint becomes the
+profile's provider and derived-launch Port pair, while every other outcome is
+typed fail-closed. Outbound: the Adapter calls only the
 protocol-neutral `BaseAgent.submit_turn`/`TurnHandle` boundary with an optional
 turn-scoped tool observer. The CLI root
 reuses `cli.load_init`, `cli.build_agent`, venv resolution, logging, lifecycle,
@@ -135,7 +142,9 @@ through physical terminal-batch completion, close invalidation, or fatal abort.
 ACP session/correlation identifiers are not persisted. `puffo-v0` additionally
 reads an operator-managed local registry at spawn time; it neither creates a
 durable ACP session nor changes the Agent's own durable identity state. Durable
-agent state remains owned by the existing Agent/workdir lifecycle. Closing requests active cancellation
+agent state remains owned by the existing Agent/workdir lifecycle. The one-time
+Driver authority environment locator is removed at composition and is not
+retained as process state. Closing requests active cancellation
 and suppresses prompt frames that have not crossed the writer start check; typed
 Agent stop retains services/heartbeat/lease until execution quiescence is proven.
 

--- a/src/lingtai/adapters/acp/BEHAVIORS.md
+++ b/src/lingtai/adapters/acp/BEHAVIORS.md
@@ -1,6 +1,6 @@
 ---
 name: acp-local-stdio-behavior-tests
-behavior_version: 2
+behavior_version: 3
 labt_version: 2
 contract: CONTRACT.md
 anatomy: ANATOMY.md
@@ -8,8 +8,10 @@ related_files:
   - src/lingtai/adapters/acp/CONTRACT.md
   - src/lingtai/adapters/acp/ANATOMY.md
   - src/lingtai/adapters/acp/MANUAL.md
+  - src/lingtai/adapters/acp/driver_authority.py
   - src/lingtai/adapters/acp/server.py
   - src/lingtai/cli_acp.py
+  - ENVIRONMENT_VARIABLES.md
   - src/lingtai/kernel/turns.py
   - src/lingtai/kernel/execution_workspace.py
   - src/lingtai/kernel/turn_events.py
@@ -18,6 +20,7 @@ related_files:
   - src/lingtai/services/session_mcp.py
   - src/lingtai/kernel/base_agent/lifecycle.py
   - tests/test_acp_stdio.py
+  - tests/test_driver_authority_adapter.py
   - tests/test_correlated_turns.py
   - tests/test_execution_workspace.py
   - tests/test_turn_events.py
@@ -102,14 +105,21 @@ the evidence trail in the task report.
 
 1. Run `python -m pytest -q -x tests/test_puffo_v0_profile.py`.
 2. Inspect the registry cases: only an active, entry-digest-valid opaque id
-   with its original directory identity resolves; tampered, retargeted, or
-   revoked entries, including a missing required revocation log, fail before
-   composition. An active identity and workspace cannot be bound twice.
+  with its original directory identity resolves; tampered, retargeted, or
+  revoked entries, including a missing required revocation log, fail before
+  composition. An active identity and workspace cannot be bound twice.
 3. Inspect the profile session and turn-origin cases: another workspace and
    every non-empty `mcpServers` input fail; the operator-managed tool surface is
    retained, but legacy/inbox/internal events cannot queue or dispatch any
    provider/model turn. A direct ACP prompt carries the authenticated-adapter
    origin.
+4. Inspect Driver authority composition: the launcher supplies exactly one
+   inherited root AF_UNIX-stream descriptor in `LINGTAI_DRIVER_AUTHORITY_FD`.
+   The profile consumes and removes the locator before Agent construction,
+   passes the resulting Driver client to the root provider-call Port, and
+   projects that same client to the derived-launch Port. Missing, malformed,
+   unusable, or derived-role endpoints install the typed fail-closed pair;
+   they never select the generic runtime policy as a substitute.
 
 ### Expected evidence
 
@@ -117,6 +127,9 @@ the evidence trail in the task report.
   launch through the profile.
 - [ ] The profile denies unavailable identities and every non-ACP origin before
   provider dispatch, while preserving the configured local tool surface.
+- [ ] Root provider calls and derived-launch requests use the consumed Driver
+  endpoint, or both return `driver_authority_unavailable`; the environment
+  locator is absent before Agent construction and cannot reach descendants.
 - [ ] The host-boundary non-guarantee remains documented.
 
 ### Pass / Fail
@@ -124,7 +137,8 @@ the evidence trail in the task report.
 Pass when the focused tests prove every profile startup field comes from the
 local registry and constrained session policy. Fail on a remote-controlled
 workspace/MCP input, a non-ACP event that reaches provider dispatch, accepted
-revoked id, or any claim that this controlled entrypoint isolates a same-OS
-principal or contains full-tool runtime behavior.
+revoked id, a missing/invalid/non-root Driver endpoint that falls back to a
+generic admission policy, or any claim that this controlled entrypoint isolates
+a same-OS principal or contains full-tool runtime behavior.
 This behavior is a registry/session-policy foundation: its entry digest does
 not by itself prove a complete effective tool/action or launch-security policy.

--- a/src/lingtai/adapters/acp/CONTRACT.md
+++ b/src/lingtai/adapters/acp/CONTRACT.md
@@ -1,17 +1,19 @@
 ---
 name: acp-local-stdio
-contract_version: 2
+contract_version: 3
 root_contract: CONTRACT.md
 related_files:
   - src/lingtai/adapters/acp/ANATOMY.md
   - src/lingtai/adapters/acp/BEHAVIORS.md
   - src/lingtai/adapters/acp/MANUAL.md
   - src/lingtai/adapters/acp/__init__.py
+  - src/lingtai/adapters/acp/driver_authority.py
   - src/lingtai/adapters/acp/puffo_v0.py
   - src/lingtai/adapters/acp/server.py
   - src/lingtai/cli_acp.py
   - src/lingtai/cli_puffo_v0.py
   - src/lingtai/cli.py
+  - ENVIRONMENT_VARIABLES.md
   - src/lingtai/kernel/turns.py
   - src/lingtai/kernel/execution_workspace.py
   - src/lingtai/kernel/turn_events.py
@@ -25,6 +27,7 @@ related_files:
   - pyproject.toml
   - tests/test_acp_stdio.py
   - tests/test_puffo_v0_profile.py
+  - tests/test_driver_authority_adapter.py
   - tests/test_correlated_turns.py
   - tests/test_execution_workspace.py
   - tests/test_turn_events.py
@@ -235,17 +238,17 @@ argv, environment, or MCP command from the remote caller.
     `mcpServers: []`; it never starts a client-supplied process. This is an
     identity/workspace-bound **full-tool** profile: operator-managed LingTai
     capabilities remain available, including after refresh. Its capability
-    boundary is provider-turn initiation: the current PR2 Core slice enforces
-    direct authenticated ACP root prompts at the actual root provider request,
-    while inbox, task-card, alarm, mail/MCP wake, and other independent root
-    events are denied before provider dispatch. Daemon and avatar still use
-    their historical independent execution routes and remain outside this
-    root-only gate. A future route that binds a derived parent before its host
-    transport is connected will receive explicit
-    `derived_admission_port_unconnected` and reject before provider I/O. The
-    separate driver-mediated derived-admission transport must wire those
-    historical routes before this profile can claim all provider/model turns
-    are covered. This controls who may start a root
+    boundary is provider-turn initiation: the profile consumes one
+    launcher-injected `LINGTAI_DRIVER_AUTHORITY_FD` root endpoint before Agent
+    construction and uses its Driver-backed Port for each root provider request
+    and derived-launch decision. The locator is removed immediately and is not
+    forwarded to a child process. Missing, malformed, unusable, or derived-role
+    endpoints install a typed fail-closed Port pair, so no generic profile
+    policy can accidentally authorize provider I/O or a launch. Inbox,
+    task-card, alarm, mail/MCP wake, and other independent root events remain
+    denied before provider dispatch. This slice configures only the root ACP
+    process; daemon/avatar child endpoint adoption and supervisor lifecycle are
+    separate layers. This controls who may start a root
     turn, not what state a later admitted turn may read: non-ACP sources may
     still write state. The profile adds no `external_send` approval
     boundary and does not promise workspace-only writes, process containment,
@@ -290,7 +293,9 @@ and CLI Python-stdout quarantine/hard-exit ownership.
 `tests/test_puffo_v0_profile.py` pins opaque-id provisioning/resolution,
 tamper/revocation rejection, full-tool composition, fixed-workspace and
 empty-session-MCP rejection, authenticated-adapter admission, and profile CLI
-composition. `tests/test_correlated_turns.py` independently proves an
+composition. `tests/test_driver_authority_adapter.py` pins the inherited root
+endpoint configuration and its fail-closed missing/malformed/derived-role
+outcomes. `tests/test_correlated_turns.py` independently proves an
 untrusted inbox event cannot reach provider dispatch under this profile policy.
 `tests/test_provider_admission.py` independently proves a missing, denied, or
 indeterminate provider admission cannot reach the underlying provider service;
@@ -316,7 +321,11 @@ or optional-dependencies section for this standard-library slice.
 ## Driver authority client
 
 `driver_authority.py` is an isolated AF_UNIX client for the Puffo Driver
-admission protocol. Every hello and decision request carries a fresh `call_id`;
+admission protocol. `puffo-v0` composition may consume exactly one
+`LINGTAI_DRIVER_AUTHORITY_FD` locator and must install a fail-closed Port pair
+when it is absent, invalid, or not a root endpoint; this does not give the
+protocol client ownership of profile composition. Every hello and decision
+request carries a fresh `call_id`;
 a missing or mismatched response id closes the transport and fails closed.
 Granted derived-launch endpoints are opaque, one-use leases and remain within
 the typed in-memory launch decision only. `DriverDerivedLaunchAdmissionAdapter`

--- a/src/lingtai/adapters/acp/MANUAL.md
+++ b/src/lingtai/adapters/acp/MANUAL.md
@@ -3,10 +3,12 @@ related_files:
   - src/lingtai/adapters/acp/CONTRACT.md
   - src/lingtai/adapters/acp/ANATOMY.md
   - src/lingtai/adapters/acp/BEHAVIORS.md
+  - src/lingtai/adapters/acp/driver_authority.py
   - src/lingtai/adapters/acp/puffo_v0.py
   - src/lingtai/adapters/acp/server.py
   - src/lingtai/cli_acp.py
   - src/lingtai/cli_puffo_v0.py
+  - ENVIRONMENT_VARIABLES.md
   - src/lingtai/kernel/turns.py
   - src/lingtai/kernel/execution_workspace.py
   - src/lingtai/kernel/turn_events.py
@@ -195,6 +197,17 @@ The Puffo OpenCode driver is explicitly outside this trust path. It must not
 launch a `puffo-v0` bound identity or be presented as an alternative identity
 binding entrypoint; only the ACP driver participates in this profile.
 
+For each `puffo-v0` process, that ACP driver also passes exactly one already
+open root Driver-authority AF_UNIX stream descriptor through
+`LINGTAI_DRIVER_AUTHORITY_FD`. LingTai consumes and removes this descriptor
+locator before constructing the Agent. A usable root endpoint becomes the
+profile's provider-call Port and is projected to its derived-launch Port.
+Missing, malformed, unavailable, or derived-role endpoints instead install the
+typed `driver_authority_unavailable` fail-closed pair; the profile never falls
+back to generic runtime policy for either boundary. This B7 configuration step
+does not supervise a process or transfer a derived child endpoint: B8 owns
+supervisor and child-FD lifetime.
+
 ## Wire sequence
 
 A minimal client sequence is:
@@ -321,8 +334,12 @@ one.
 
 ## Driver authority protocol client
 
-This repository's client accepts an already-open AF_UNIX descriptor from a
-future composition layer. It has no environment/profile wiring in this slice.
+The `puffo-v0` ACP composition consumes one launcher-injected
+`LINGTAI_DRIVER_AUTHORITY_FD` descriptor before Agent construction. It removes
+that locator from the environment immediately; the descriptor is never a
+serializable credential. A missing, malformed, unusable, or derived-role
+endpoint installs a fail-closed admission Port instead of falling back to the
+generic profile policy. Other composition layers do not read this variable.
 The peer must reply to hello and every request with the exact request `call_id`.
 Any timeout, malformed frame, unexpected descriptor, or correlation mismatch
 invalidates the stream; recreate the client rather than retrying it. A derived

--- a/src/lingtai/adapters/acp/driver_authority.py
+++ b/src/lingtai/adapters/acp/driver_authority.py
@@ -196,9 +196,22 @@ class DriverAuthorityClient(ProviderCallAdmissionPort):
     def from_inherited_fd(cls, fd: int, *, timeout: float = _DEFAULT_TIMEOUT_SECONDS) -> "DriverAuthorityClient":
         if not isinstance(fd, int) or isinstance(fd, bool) or fd < 0:
             raise DriverAuthorityTransportError("authority fd is invalid")
+        endpoint: socket.socket | None = None
         try:
-            return cls(socket.socket(fileno=fd), timeout=timeout)
-        except OSError as exc:
+            endpoint = socket.socket(fileno=fd)
+            return cls(endpoint, timeout=timeout)
+        except (OSError, OverflowError) as exc:
+            # ``fileno=`` can reject a live non-socket descriptor before a
+            # socket object owns it.  This is still an inherited authority
+            # locator, so consume it on every rejected path rather than
+            # leaving it open (or inheritable) for a later child.
+            try:
+                if endpoint is None:
+                    os.close(fd)
+                else:
+                    endpoint.close()
+            except (OSError, OverflowError):
+                pass
             raise DriverAuthorityTransportError("authority fd is unavailable") from exc
 
     @property
@@ -425,7 +438,7 @@ def authority_adapter_from_environment(
             authority.close()
             raise DriverAuthorityTransportError("ACP profile requires a root authority endpoint")
         return authority
-    except (TypeError, ValueError, DriverAuthorityTransportError):
+    except (TypeError, ValueError, OverflowError, DriverAuthorityTransportError):
         return UnavailableDriverAuthorityAdapter()
 
 

--- a/src/lingtai/adapters/acp/driver_authority.py
+++ b/src/lingtai/adapters/acp/driver_authority.py
@@ -132,6 +132,38 @@ class DriverDerivedLaunchAdmissionAdapter:
         )
 
 
+class UnavailableDriverAuthorityAdapter:
+    """Fail-closed Port pair used when constrained composition lacks authority.
+
+    This is deliberately a composition result, not a fallback policy.  A
+    ``puffo-v0`` process without a usable inherited Driver endpoint must retain
+    its provider and derived-launch gates rather than reverting to generic
+    LingTai behavior.
+    """
+
+    __slots__ = ()
+
+    def authorize_provider_call(
+        self,
+        _parent: ProviderAdmissionParent,
+        _call_class: ProviderCallClass,
+    ) -> ProviderCallDecision:
+        return ProviderCallDecision(
+            ProviderAdmissionState.INDETERMINATE,
+            "driver_authority_unavailable",
+        )
+
+    def authorize_derived_launch(
+        self,
+        _parent: RootProviderAdmission,
+        _capability: DerivedLaunchCapability,
+    ) -> DerivedLaunchDecision:
+        return DerivedLaunchDecision(
+            ProviderAdmissionState.INDETERMINATE,
+            "driver_authority_unavailable",
+        )
+
+
 class DriverAuthorityClient(ProviderCallAdmissionPort):
     """Authenticated request/response client; no lifecycle integration."""
 
@@ -372,6 +404,31 @@ class DriverAuthorityClient(ProviderCallAdmissionPort):
         return call_class is endpoint_call_class
 
 
+def authority_adapter_from_environment(
+    *, timeout: float = _DEFAULT_TIMEOUT_SECONDS
+) -> DriverAuthorityClient | UnavailableDriverAuthorityAdapter:
+    """Consume the one inherited Driver FD for constrained ACP composition.
+
+    The environment value is merely a one-time local descriptor locator.  It
+    is removed before Agent construction so a child process cannot rediscover
+    authority from inherited configuration.  Any absent, malformed, unusable,
+    or derived-role endpoint becomes a typed fail-closed Port pair.
+    """
+
+    raw_fd = os.environ.pop(DRIVER_AUTHORITY_FD_ENV, None)
+    if raw_fd is None:
+        return UnavailableDriverAuthorityAdapter()
+    try:
+        fd = int(raw_fd)
+        authority = DriverAuthorityClient.from_inherited_fd(fd, timeout=timeout)
+        if authority.identity.role != "root":
+            authority.close()
+            raise DriverAuthorityTransportError("ACP profile requires a root authority endpoint")
+        return authority
+    except (TypeError, ValueError, DriverAuthorityTransportError):
+        return UnavailableDriverAuthorityAdapter()
+
+
 __all__ = [
     "DRIVER_AUTHORITY_FD_ENV",
     "DriverAuthorityClient",
@@ -382,4 +439,6 @@ __all__ = [
     "consume_posix_child_endpoint_lease",
     "DriverDerivedLaunchAdmissionAdapter",
     "DriverDerivedLaunchGrant",
+    "UnavailableDriverAuthorityAdapter",
+    "authority_adapter_from_environment",
 ]

--- a/src/lingtai/cli_acp.py
+++ b/src/lingtai/cli_acp.py
@@ -228,6 +228,11 @@ def handle_acp_command(args) -> None:
         RUNTIME_POLICY,
         resolve_runtime,
     )
+    from lingtai.adapters.acp.driver_authority import (
+        DriverAuthorityClient,
+        DriverDerivedLaunchAdmissionAdapter,
+        authority_adapter_from_environment,
+    )
     from lingtai.kernel.execution_workspace import ExecutionWorkspace
 
     try:
@@ -235,14 +240,20 @@ def handle_acp_command(args) -> None:
     except PuffoV0RegistryError as exc:
         print(f"error: {exc}", file=sys.stderr)
         raise SystemExit(1) from None
+    authority = authority_adapter_from_environment()
+    derived_launch_port = (
+        DriverDerivedLaunchAdmissionAdapter(authority)
+        if isinstance(authority, DriverAuthorityClient)
+        else authority
+    )
     run_acp(
         runtime.agent_dir,
         fixed_execution_workspace=ExecutionWorkspace(runtime.workspace),
         puffo_runtime=runtime,
         turn_origin_policy=RUNTIME_POLICY,
         requires_turn_origin_policy=True,
-        provider_call_admission_port=RUNTIME_POLICY,
-        derived_launch_admission_port=RUNTIME_POLICY,
+        provider_call_admission_port=authority,
+        derived_launch_admission_port=derived_launch_port,
         requires_derived_launch_admission_port=True,
     )
 

--- a/tests/test_driver_authority_adapter.py
+++ b/tests/test_driver_authority_adapter.py
@@ -63,6 +63,15 @@ def _assert_peer_closed(peer):
     assert peer.recv(1) == b""
 
 
+def _assert_fd_closed(fd):
+    try:
+        os.fstat(fd)
+    except OSError as exc:
+        assert exc.errno == 9  # EBADF
+    else:
+        raise AssertionError("rejected inherited descriptor remained open")
+
+
 def _hello(sock, *, role="root", capability=None):
     request = _recv(sock)
     assert request["op"] == "hello"
@@ -117,6 +126,36 @@ def test_profile_authority_configuration_fails_closed_without_a_usable_root_endp
     )
     assert provider.state is ProviderAdmissionState.INDETERMINATE
     assert launch.state is ProviderAdmissionState.INDETERMINATE
+
+
+def test_profile_authority_configuration_closes_rejected_non_socket_descriptors(monkeypatch):
+    read_fd, write_fd = os.pipe()
+    file_fd = os.open(__file__, os.O_RDONLY)
+    try:
+        for fd in (read_fd, file_fd):
+            os.set_inheritable(fd, True)
+            monkeypatch.setenv("LINGTAI_DRIVER_AUTHORITY_FD", str(fd))
+
+            authority = authority_adapter_from_environment()
+
+            assert isinstance(authority, UnavailableDriverAuthorityAdapter)
+            assert "LINGTAI_DRIVER_AUTHORITY_FD" not in os.environ
+            _assert_fd_closed(fd)
+    finally:
+        for fd in (read_fd, write_fd, file_fd):
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+
+def test_profile_authority_configuration_normalizes_an_out_of_range_fd(monkeypatch):
+    monkeypatch.setenv("LINGTAI_DRIVER_AUTHORITY_FD", str(2**63))
+
+    authority = authority_adapter_from_environment()
+
+    assert isinstance(authority, UnavailableDriverAuthorityAdapter)
+    assert "LINGTAI_DRIVER_AUTHORITY_FD" not in os.environ
 
 
 def test_profile_authority_configuration_rejects_a_derived_endpoint(monkeypatch):

--- a/tests/test_driver_authority_adapter.py
+++ b/tests/test_driver_authority_adapter.py
@@ -14,6 +14,8 @@ from unittest.mock import patch
 from lingtai.adapters.acp.driver_authority import (
     DriverAuthorityClient,
     DriverAuthorityTransportError,
+    UnavailableDriverAuthorityAdapter,
+    authority_adapter_from_environment,
 )
 from lingtai.kernel.provider_admission import (
     DerivedLaunchCapability,
@@ -81,6 +83,55 @@ def test_hello_and_provider_request_are_correlated():
     thread.join(2)
     assert not errors
     assert decision.state is ProviderAdmissionState.GRANTED
+
+
+def test_profile_authority_configuration_consumes_a_root_endpoint(monkeypatch):
+    def handler(sock):
+        _hello(sock)
+
+    endpoint, thread, errors = _server(handler)
+    monkeypatch.setenv("LINGTAI_DRIVER_AUTHORITY_FD", str(endpoint.detach()))
+
+    authority = authority_adapter_from_environment()
+
+    thread.join(2)
+    assert not errors
+    assert isinstance(authority, DriverAuthorityClient)
+    assert authority.identity.role == "root"
+    assert "LINGTAI_DRIVER_AUTHORITY_FD" not in os.environ
+    authority.close()
+
+
+def test_profile_authority_configuration_fails_closed_without_a_usable_root_endpoint(monkeypatch):
+    monkeypatch.setenv("LINGTAI_DRIVER_AUTHORITY_FD", "not-a-fd")
+
+    authority = authority_adapter_from_environment()
+
+    assert isinstance(authority, UnavailableDriverAuthorityAdapter)
+    assert "LINGTAI_DRIVER_AUTHORITY_FD" not in os.environ
+    provider = authority.authorize_provider_call(
+        RootProviderAdmission("turn", "v1"), ProviderCallClass.ROOT
+    )
+    launch = authority.authorize_derived_launch(
+        RootProviderAdmission("turn", "v1"), DerivedLaunchCapability.DAEMON
+    )
+    assert provider.state is ProviderAdmissionState.INDETERMINATE
+    assert launch.state is ProviderAdmissionState.INDETERMINATE
+
+
+def test_profile_authority_configuration_rejects_a_derived_endpoint(monkeypatch):
+    def handler(sock):
+        _hello(sock, role="derived", capability="daemon")
+        assert sock.recv(1) == b""
+
+    endpoint, thread, errors = _server(handler)
+    monkeypatch.setenv("LINGTAI_DRIVER_AUTHORITY_FD", str(endpoint.detach()))
+
+    authority = authority_adapter_from_environment()
+
+    thread.join(2)
+    assert not errors
+    assert isinstance(authority, UnavailableDriverAuthorityAdapter)
 
 
 def test_mismatched_call_id_closes_received_endpoint_and_fails_closed():

--- a/tests/test_puffo_v0_profile.py
+++ b/tests/test_puffo_v0_profile.py
@@ -400,6 +400,7 @@ def test_profile_session_rejects_remote_workspace_and_mcp_inputs(tmp_path):
 
 def test_profile_cli_resolves_an_opaque_id_before_composing_acp(monkeypatch, tmp_path):
     import lingtai.cli_acp as cli_acp
+    from lingtai.adapters.acp.driver_authority import UnavailableDriverAuthorityAdapter
     from lingtai.adapters.acp.puffo_v0 import DirectoryBinding, PuffoV0Runtime
 
     agent_dir = tmp_path / "identity"
@@ -415,6 +416,10 @@ def test_profile_cli_resolves_an_opaque_id_before_composing_acp(monkeypatch, tmp
     monkeypatch.setattr(cli_acp, "resolve_runtime", lambda _id: runtime, raising=False)
     # The handler imports from the profile module after parser validation.
     monkeypatch.setattr("lingtai.adapters.acp.puffo_v0.resolve_runtime", lambda _id: runtime)
+    monkeypatch.setattr(
+        "lingtai.adapters.acp.driver_authority.authority_adapter_from_environment",
+        UnavailableDriverAuthorityAdapter,
+    )
     monkeypatch.setattr(cli_acp, "run_acp", lambda directory, **kwargs: observed.update(directory=directory, **kwargs))
 
     cli_acp.handle_acp_command(SimpleNamespace(profile="puffo-v0", runtime_id="runtime-1", agent_dir=None))
@@ -424,10 +429,43 @@ def test_profile_cli_resolves_an_opaque_id_before_composing_acp(monkeypatch, tmp
     assert observed.get("forced_disable") is None
     assert observed["turn_origin_policy"] is RUNTIME_POLICY
     assert observed["requires_turn_origin_policy"] is True
-    assert observed["provider_call_admission_port"] is RUNTIME_POLICY
-    assert observed["derived_launch_admission_port"] is RUNTIME_POLICY
+    assert isinstance(observed["provider_call_admission_port"], UnavailableDriverAuthorityAdapter)
+    assert observed["derived_launch_admission_port"] is observed["provider_call_admission_port"]
     assert observed["requires_derived_launch_admission_port"] is True
     assert observed["puffo_runtime"] == runtime
+
+
+def test_profile_cli_composes_a_root_driver_for_both_admission_boundaries(monkeypatch, tmp_path):
+    import lingtai.cli_acp as cli_acp
+    from lingtai.adapters.acp.driver_authority import (
+        DriverAuthorityClient,
+        DriverDerivedLaunchAdmissionAdapter,
+    )
+    from lingtai.adapters.acp.puffo_v0 import DirectoryBinding, PuffoV0Runtime
+
+    agent_dir = tmp_path / "identity"
+    agent_dir.mkdir()
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    binding = DirectoryBinding(device=1, inode=2, owner=3, group=4)
+    runtime = PuffoV0Runtime(
+        "runtime-1", agent_dir, workspace, "digest", binding, binding,
+        RUNTIME_POLICY.policy_version,
+    )
+    authority = object.__new__(DriverAuthorityClient)
+    observed = {}
+    monkeypatch.setattr("lingtai.adapters.acp.puffo_v0.resolve_runtime", lambda _id: runtime)
+    monkeypatch.setattr(
+        "lingtai.adapters.acp.driver_authority.authority_adapter_from_environment",
+        lambda: authority,
+    )
+    monkeypatch.setattr(cli_acp, "run_acp", lambda directory, **kwargs: observed.update(directory=directory, **kwargs))
+
+    cli_acp.handle_acp_command(SimpleNamespace(profile="puffo-v0", runtime_id="runtime-1", agent_dir=None))
+
+    assert observed["provider_call_admission_port"] is authority
+    assert isinstance(observed["derived_launch_admission_port"], DriverDerivedLaunchAdmissionAdapter)
+    assert observed["derived_launch_admission_port"]._authority is authority
 
 
 def test_constrained_acp_refuses_to_start_without_its_derived_launch_port(tmp_path):


### PR DESCRIPTION
## Summary
- consume the launcher-provided root Driver authority FD only for `acp --profile puffo-v0`
- fail closed for missing, malformed, unavailable, or derived-role endpoints and use the same client for root provider and derived-launch admission
- document the one-time environment locator and B8 supervisor/child-FD-lifecycle boundary

## Validation
- `git diff --check`
- `python3 -m py_compile src/lingtai/adapters/acp/driver_authority.py src/lingtai/cli_acp.py tests/test_driver_authority_adapter.py tests/test_puffo_v0_profile.py`
- direct Driver socket composition smoke test
- direct `puffo-v0` root composition smoke test

## Environment limitations
- `python3 scripts/check_docs_governance.py --check` is blocked because PyYAML is not installed
- focused pytest is unavailable because this checkout has no project venv and the host Python has no pytest