### PR TITLE
test(daemon): guard Windows adopted fd ownership

### DIFF
--- a/tests/test_daemon_windows_supervisor.py
+++ b/tests/test_daemon_windows_supervisor.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import os
+import socket
 import subprocess
 import sys
 import threading
@@ -150,6 +151,55 @@ def test_spawn_detached_guards_against_non_windows_use(tmp_path):
     request = _write_lingtai_manifest(run_dir)
     with pytest.raises(OSError, match="requires Windows"):
         WindowsDaemonSupervisorAdapter().spawn_detached(request)
+
+
+def test_windows_adapter_closes_the_descriptor_it_refuses_to_hand_off(tmp_path):
+    """The refusal must consume the descriptor, not merely decline the work.
+
+    ``adopted_fd`` is a live descriptor the caller has already given up, so a
+    bare ``raise`` would strand it in this process.  The peer's EOF is the
+    assertion rather than ``fstat`` because it proves the open file
+    description was released, which survives descriptor-number reuse.
+    """
+    if os.name == "nt":
+        pytest.skip("the POSIX handoff refusal is only observable off Windows")
+    run_dir = _make_run_dir(tmp_path)
+    request = _write_lingtai_manifest(run_dir)
+    child_endpoint, peer = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+    adopted_fd = child_endpoint.detach()
+    try:
+        with pytest.raises(NotImplementedError, match="POSIX-only"):
+            WindowsDaemonSupervisorAdapter().spawn_detached(
+                request, adopted_fd=adopted_fd
+            )
+        peer.settimeout(1)
+        assert peer.recv(1) == b""
+    finally:
+        peer.close()
+
+
+def test_windows_execution_child_closes_the_descriptor_it_refuses_to_hand_off(
+    tmp_path,
+):
+    if os.name == "nt":
+        pytest.skip("the POSIX handoff refusal is only observable off Windows")
+    run_dir = _make_run_dir(tmp_path)
+    _write_lingtai_manifest(run_dir)
+    child_endpoint, peer = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+    adopted_fd = child_endpoint.detach()
+    try:
+        with pytest.raises(NotImplementedError, match="POSIX-only"):
+            WindowsDaemonSupervisorAdapter().spawn_execution_child(
+                python_executable=sys.executable,
+                manifest_path=str(manifest_path_for(run_dir.path)),
+                run_id=run_dir.run_id,
+                run_dir=run_dir.path,
+                adopted_fd=adopted_fd,
+            )
+        peer.settimeout(1)
+        assert peer.recv(1) == b""
+    finally:
+        peer.close()
 
 
 def test_windows_spawn_detached_exact_handle_wire_shape(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- add regression coverage for the Windows adapter's rejected `adopted_fd` handoff
- prove both detached-supervisor and execution-child rejection paths release the transferred descriptor by observing peer EOF
- keep the change test-only; production behavior and architecture documentation are unchanged

## Validation

- [x] `git diff --check`
- [x] `/tmp/lingtai-windows-adopted-fd-venv/bin/python -m pytest -q -x tests/test_daemon_windows_supervisor.py` (`15 passed, 2 skipped`)
- [x] `/tmp/lingtai-windows-adopted-fd-venv/bin/python -m pytest -q tests/test_docs_governance.py` (`70 passed`)
- [x] directed mutation review: deleting each production close independently fails only its corresponding new test

## Notes

- Follow-up regression coverage after #1602 made the `adopted_fd` parameter available on `main`.
- No logs, screenshots, examples, or secrets are included.