### PR TITLE
fix(nudge): gate kernel version probes by UTC day and installed version

### DIFF
--- a/src/lingtai/kernel/nudge/kernel_version.py
+++ b/src/lingtai/kernel/nudge/kernel_version.py
@@ -233,6 +233,8 @@ def check(agent) -> None:
     # each tick either starts one or consumes a finished one.
     pending = _fetch_slot(agent)
     if pending is None:
+        if not _remote_check_due(kernel_state, info.installed_version, today):
+            return
         _start_fetch(agent)
         return
     if not pending.done.is_set():
@@ -437,8 +439,18 @@ def _module_from_source_checkout(module_file: str) -> bool:
 
 
 def _remote_check_due(kernel_state: dict[str, Any], installed_version: str, today: str) -> bool:
-    """Bounded probe gate; repeat/dismiss semantics are global, never daily."""
-    return True
+    """Return whether this installed version has not been checked on this UTC day.
+
+    State is deliberately fail-open for malformed or missing values: a new
+    process must still get one observation. A completed probe (including a
+    failure) records both fields, so retries are suppressed until either the
+    UTC day or installed version changes. Nudge dismissal/repeat remains a
+    separate global policy concern.
+    """
+    return not (
+        kernel_state.get("last_remote_check_date") == today
+        and kernel_state.get("checked_installed_version") == installed_version
+    )
 
 
 def _fetch_latest_version() -> _ReleaseObservation:

--- a/tests/test_kernel_version_nudge.py
+++ b/tests/test_kernel_version_nudge.py
@@ -298,7 +298,7 @@ def test_match_after_refresh_keeps_independent_remote_finding_during_outage(tmp_
     assert _entries(tmp_path)[0]["source"] == kv._GITHUB_SOURCE
 
 
-def test_remote_update_check_uses_bounded_probe_not_daily_product_cadence(tmp_path, monkeypatch):
+def test_remote_update_check_is_gated_by_installed_version_and_utc_day(tmp_path, monkeypatch):
     agent = _Agent(tmp_path)
     calls = {"n": 0}
     monkeypatch.setattr(
@@ -337,14 +337,35 @@ def test_remote_update_check_uses_bounded_probe_not_daily_product_cadence(tmp_pa
     assert state["kernel_version"]["checked_installed_version"] == "0.14.1"
     assert state["kernel_version"]["latest_seen"] == "0.14.2"
 
-    # A later probe starts a fresh fetch (the single-flight slot was consumed).
+    # A later same-day probe for the same installed version is suppressed.
+    _reset_fast_gate(agent)
+    kv.check(agent)
+    assert kv._fetch_slot(agent) is None
+    assert calls["n"] == 1
+
+    # An in-day installed-version change re-arms the remote observation.
+    monkeypatch.setattr(
+        kv,
+        "_runtime_info",
+        lambda: kv._RuntimeInfo("0.14.2", "0.14.2", None),
+    )
     _reset_fast_gate(agent)
     kv.check(agent)
     pending = kv._fetch_slot(agent)
     assert pending is not None
     pending.thread.join()
+    _reset_fast_gate(agent)
+    kv.check(agent)  # consume the completed version-change observation
     assert calls["n"] == 2
-    assert _entries(tmp_path)[0]["latest"] == "0.14.2"
+
+    # A UTC-day transition also re-arms the check for the same version.
+    monkeypatch.setattr(kv, "_today_utc", lambda: "2026-06-25")
+    _reset_fast_gate(agent)
+    kv.check(agent)
+    pending = kv._fetch_slot(agent)
+    assert pending is not None
+    pending.thread.join()
+    assert calls["n"] == 3
 
 
 @pytest.mark.parametrize("candidate", ["999-not-a-release", "release-999", "not-a-version"])


### PR DESCRIPTION
## Summary

- Check persisted `last_remote_check_date` and `checked_installed_version` before starting a kernel-version remote fetch.
- Suppress a repeat fetch only for the same installed version on the same UTC day.
- Fail open for missing or malformed state, and re-arm on a version change or the next UTC day.

Closes #1577.

## Validation

- `python -m pytest -q tests/test_kernel_version_nudge.py` — **35 passed** on the final worktree.
- Coverage includes success/error/timeout persistence, UTC-day and version transitions, call counts, and existing single-flight behavior.
- `git diff --check` — PASS.

## Scope

This does not change global Nudge repeat/dismiss policy, state concurrency, or unrelated Nudge behavior.

Base reviewed: `38222152313823e2fa03dab75bf9f2db9f865592`.
