### PR TITLE
fix(nudge): emit externalization events once per digest

### DIFF
--- a/src/lingtai/kernel/nudge/__init__.py
+++ b/src/lingtai/kernel/nudge/__init__.py
@@ -72,6 +72,11 @@ _ENTRY_CHANNEL_BY_KIND = {
 # replaced on the wire by a compact summary (see `_cap_inline_payload`).
 INLINE_MAX_CHARS = 10_000
 
+# Serialize same-process sidecar claims. The content-addressed filename and
+# O_EXCL temp file remain the cross-process safety boundary; this lock keeps
+# same-process heartbeat threads from contending on one PID-derived temp name.
+_SIDECAR_WRITE_LOCK = threading.Lock()
+
 # Bounded shape a `kind` must satisfy before it can participate in
 # externalization filename construction. Current built-in kinds
 # ("kernel_version", "source_drift", "init_config_shape", …) are short
@@ -496,23 +501,35 @@ def _write_sidecar_atomic(target: Path, text: str) -> None:
     opened — via ``os.open`` with an explicit ``mode``, not ``open()`` at the
     process umask followed by a later ``chmod`` — so the oversized finding
     body is never briefly readable at a broader mode. Content is written as
-    exact UTF-8 bytes and flushed/fsynced before the atomic ``os.replace``,
-    so a crash between write and replace cannot leave a target that looks
-    complete but is actually truncated.
+    exact UTF-8 bytes and flushed/fsynced before an atomic no-overwrite
+    ``os.link`` claim. A concurrent process that prepared the same digest gets
+    ``FileExistsError`` instead of replacing a complete target; the caller can
+    then reuse that target and suppress a duplicate event.
 
-    On any failure the caller is responsible for translating the raised
-    ``OSError`` into a bounded ``NudgeExternalizationError``; this helper
-    itself never logs or otherwise persists ``text``. No temp-file cleanup is
-    performed here — a failed write's partial temp file, already owner-only,
-    is left on disk as forensic evidence rather than being deleted.
+    The private temp link is unlinked on every return path, including a losing
+    concurrent claim, so ordinary failures do not leave plaintext temp files.
+    The caller translates raised ``OSError`` into a bounded
+    ``NudgeExternalizationError``; this helper itself never logs or otherwise
+    persists ``text`` beyond the content-addressed target.
     """
     tmp = target.with_name(f".{target.name}.{os.getpid()}.tmp")
     fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
-    with os.fdopen(fd, "w", encoding="utf-8") as f:
-        f.write(text)
-        f.flush()
-        os.fsync(f.fileno())
-    os.replace(str(tmp), str(target))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(text)
+            f.flush()
+            os.fsync(f.fileno())
+        # Hard-linking is an atomic no-overwrite claim: unlike os.replace,
+        # competing processes cannot overwrite the winner's complete target.
+        os.link(str(tmp), str(target))
+    finally:
+        # A losing process (FileExistsError) and every ordinary failure must
+        # not strand a plaintext temp artifact. The target hard link, if any,
+        # retains the inode after this private name is removed.
+        try:
+            os.unlink(str(tmp))
+        except FileNotFoundError:
+            pass
 
 
 def _cap_inline_payload(agent, kind: str, entry: dict, *, fingerprint: str) -> dict:
@@ -568,20 +585,44 @@ def _cap_inline_payload(agent, kind: str, entry: dict, *, fingerprint: str) -> d
         )
 
     target = findings_dir / f"{kind}-{digest}.json"
-    if not target.is_file():
-        try:
-            findings_dir.mkdir(parents=True, exist_ok=True)
-            # Always enforce owner-only, even when the directory pre-existed
-            # with looser permissions (e.g. created before this cap existed,
-            # or by an external process) — a sidecar containing the full
-            # oversized finding must never be group/world-readable.
-            os.chmod(findings_dir, 0o700)
-            _write_sidecar_atomic(target, text)
-        except OSError as exc:
-            raise NudgeExternalizationError(
-                f"failed to durably write nudge finding sidecar file: "
-                f"{type(exc).__name__}"
-            ) from exc
+    with _SIDECAR_WRITE_LOCK:
+        if not target.is_file():
+            wrote_sidecar = False
+            try:
+                findings_dir.mkdir(parents=True, exist_ok=True)
+                # Always enforce owner-only, even when the directory pre-existed
+                # with looser permissions (e.g. created before this cap existed,
+                # or by an external process) — a sidecar containing the full
+                # oversized finding must never be group/world-readable.
+                os.chmod(findings_dir, 0o700)
+                _write_sidecar_atomic(target, text)
+                wrote_sidecar = True
+            except FileExistsError:
+                # Another concurrent process won the content-addressed O_EXCL
+                # create. Its complete, fsynced bytes are the same digest; reuse
+                # them without treating the benign race as a write failure or
+                # duplicating the journal event.
+                if not target.is_file():
+                    raise NudgeExternalizationError(
+                        "nudge finding sidecar creation raced without a durable target"
+                    )
+            except OSError as exc:
+                raise NudgeExternalizationError(
+                    f"failed to durably write nudge finding sidecar file: "
+                    f"{type(exc).__name__}"
+                ) from exc
+            # Content-addressing makes this the one durable transition for a
+            # digest. Keep the journal event coupled to that transition so a
+            # persisting finding is not logged once per heartbeat.
+            if wrote_sidecar:
+                _safe_log(
+                    agent,
+                    "nudge_finding_externalized",
+                    kind=kind,
+                    original_char_count=char_count,
+                    cap_chars=INLINE_MAX_CHARS,
+                    sha256=digest,
+                )
 
     # Bound every field sourced from producer-controlled text (title, source)
     # so a pathological producer value cannot itself blow the compact entry
@@ -635,15 +676,6 @@ def _cap_inline_payload(agent, kind: str, entry: dict, *, fingerprint: str) -> d
             compact["title"] = compact["title"][:50] + "…"
         else:
             break
-
-    _safe_log(
-        agent,
-        "nudge_finding_externalized",
-        kind=kind,
-        original_char_count=char_count,
-        cap_chars=INLINE_MAX_CHARS,
-        sha256=digest,
-    )
     return compact
 
 

--- a/tests/test_nudge_inline_cap.py
+++ b/tests/test_nudge_inline_cap.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import hashlib
 import json
 import stat
+import threading
 import time
 from pathlib import Path
 
@@ -200,6 +201,133 @@ def test_content_addressed_reuse_and_distinct_files(tmp_path):
     assert len(list(findings_dir.iterdir())) == 2
 
 
+def test_repeated_externalization_logs_once_per_digest(tmp_path):
+    agent = _Agent(tmp_path)
+    body = {"title": "Repeated finding", "detail": "w" * 20_000, "source": "producer"}
+
+    upsert(agent, "repeated", dict(body))
+    upsert(agent, "repeated", dict(body))
+    events = [event for event, _fields in agent.logs if event == "nudge_finding_externalized"]
+    assert len(events) == 1
+
+    upsert(agent, "repeated", {**body, "detail": "x" * 20_000})
+    events = [event for event, _fields in agent.logs if event == "nudge_finding_externalized"]
+    assert len(events) == 2
+
+
+def test_concurrent_same_digest_externalization_logs_once(tmp_path):
+    agents = [_Agent(tmp_path), _Agent(tmp_path)]
+    body = {"title": "Concurrent finding", "detail": "c" * 20_000, "source": "producer"}
+    errors = []
+
+    def _run(agent):
+        try:
+            upsert(agent, "concurrent", dict(body))
+        except BaseException as exc:  # pragma: no cover - assertion reports any race
+            errors.append(exc)
+
+    threads = [threading.Thread(target=_run, args=(agent,)) for agent in agents]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert not any(thread.is_alive() for thread in threads)
+    assert errors == []
+    events = [
+        event
+        for agent in agents
+        for event, _fields in agent.logs
+        if event == "nudge_finding_externalized"
+    ]
+    assert len(events) == 1
+    assert len(list(_findings_dir(tmp_path).glob("concurrent-*.json"))) == 1
+
+
+def test_cross_process_same_digest_has_one_sidecar_winner_and_event(tmp_path):
+    """The content-addressed target is once-only across independent PIDs."""
+    import os
+    import subprocess
+    import sys
+
+    repo_root = Path(__file__).parents[1]
+    workdir = tmp_path / "cross-process"
+    workdir.mkdir()
+    start = workdir / "start"
+    child_result = r'''
+import json
+import sys
+import time
+from pathlib import Path
+
+from lingtai.kernel.nudge import upsert
+from tests._notification_store_helpers import notification_store_for
+
+workdir = Path(sys.argv[1])
+start = Path(sys.argv[2])
+result = Path(sys.argv[3])
+class Agent:
+    def __init__(self):
+        self._working_dir = workdir
+        self._notification_store = notification_store_for(workdir)
+        self._notification_fp = ()
+        self.logs = []
+    def _log(self, event, **fields):
+        self.logs.append((event, fields))
+
+agent = Agent()
+print("READY", flush=True)
+deadline = time.monotonic() + 5
+while not start.exists() and time.monotonic() < deadline:
+    time.sleep(0.005)
+if not start.exists():
+    raise SystemExit("barrier was not released")
+upsert(agent, "cross-process", {"title": "same", "detail": "c" * 20_000, "source": "producer"})
+result.write_text(json.dumps({"externalized_events": sum(
+    event == "nudge_finding_externalized" for event, _fields in agent.logs
+)}))
+print("DONE", flush=True)
+'''
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(repo_root / "src"), str(repo_root), env.get("PYTHONPATH", "")]
+    )
+    processes = []
+    try:
+        for index in range(2):
+            result = workdir / f"child-{index}.json"
+            process = subprocess.Popen(
+                [sys.executable, "-c", child_result, str(workdir), str(start), str(result)],
+                cwd=repo_root,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            processes.append((process, result))
+        for process, _result in processes:
+            assert process.stdout.readline().strip() == "READY"
+        start.touch()
+        for process, result in processes:
+            stdout, stderr = process.communicate(timeout=10)
+            assert process.returncode == 0, (stdout, stderr)
+            assert result.is_file()
+    finally:
+        for process, _result in processes:
+            if process.poll() is None:
+                process.kill()
+                process.communicate(timeout=5)
+
+    event_counts = [
+        json.loads(result.read_text())["externalized_events"]
+        for _process, result in processes
+    ]
+    assert sum(event_counts) == 1
+    findings_dir = _findings_dir(workdir)
+    assert len(list(findings_dir.glob("cross-process-*.json"))) == 1
+    assert list(findings_dir.glob(".*.tmp")) == []
+
+
 def test_sidecar_and_dir_permissions_owner_only_including_preexisting_loose_dir(tmp_path):
     findings_dir = _findings_dir(tmp_path)
 
@@ -300,6 +428,13 @@ def test_ordinary_small_nudge_behavior_is_unchanged(tmp_path):
 
 def test_dismissal_round_trip_for_capped_finding(tmp_path, monkeypatch):
     agent = _Agent(tmp_path)
+    from types import SimpleNamespace
+    from lingtai.kernel import nudge as nudge_module
+
+    # Use a deterministic clock so the tiny repeat interval cannot make this
+    # persistence round-trip flaky on a busy CI host.
+    now = [100.0]
+    monkeypatch.setattr(nudge_module, "time", SimpleNamespace(time=lambda: now[0]))
     monkeypatch.setenv("LINGTAI_NUDGE_REPEAT_INTERVAL", "0.001s")
     body = {"title": "Capped finding", "detail": "r" * 30_000, "source": "s"}
 
@@ -319,7 +454,7 @@ def test_dismissal_round_trip_for_capped_finding(tmp_path, monkeypatch):
     entries = snapshot_notifications(tmp_path).get("nudge", {}).get("data", {}).get("nudges", [])
     assert entries == []
 
-    time.sleep(0.01)
+    now[0] += 0.01
     upsert(agent, "capped-dismiss", dict(body))
     entries = snapshot_notifications(tmp_path).get("nudge", {}).get("data", {}).get("nudges", [])
     assert len(entries) == 1


### PR DESCRIPTION
## Summary

- Emit `nudge_finding_externalized` only when the content-addressed sidecar is first published, not whenever an existing sidecar is reused.
- Serialize same-process creation and use an `os.link` no-overwrite claim across processes.
- Remove temporary files on winner and loser paths; write failures still produce no success event or state mutation.

Closes #1578.

## Validation

- `python -m pytest -q tests/test_nudge_inline_cap.py` — **15 passed** on the final worktree.
- Coverage includes new/existing digests, write failure, same-process concurrency, cross-process claim behavior, one-event publication, and temporary-file cleanup.
- `git diff --check` — PASS.

## Scope

This does not redesign the sidecar format or path, repair the shared-state issue in #1553, or change the fsync contract tracked in #1547.

Base reviewed: `38222152313823e2fa03dab75bf9f2db9f865592`.
