### PR TITLE
fix(task-card,nudge): preserve count carries and fractional-day durations

### DIFF
--- a/src/lingtai/kernel/nudge/__init__.py
+++ b/src/lingtai/kernel/nudge/__init__.py
@@ -173,9 +173,14 @@ def _parse_duration(value: str) -> float | None:
 
 
 def _format_duration(seconds: float) -> str:
-    # Preserve the product default's documented spelling (`24h`) while using
-    # day units for intervals longer than one day.
-    if seconds % 3600 == 0 and seconds > 86400:
+    # Zero is a degenerate interval, but it is still rendered in the smallest
+    # unit rather than looking like a one-hour policy value. Preserve the
+    # product default's documented spelling (`24h`) for positive values. Use
+    # day units only for an exact whole-day interval; 25h/36h/47h must not lose
+    # their remaining hours through floor-to-days truncation.
+    if seconds == 0:
+        return "0s"
+    if seconds % 86400 == 0 and seconds > 86400:
         return f"{int(seconds // 86400)}d"
     if seconds % 3600 == 0:
         return f"{int(seconds // 3600)}h"

--- a/src/lingtai/mcp_servers/task_card/event_projection.py
+++ b/src/lingtai/mcp_servers/task_card/event_projection.py
@@ -744,17 +744,24 @@ class TaskCardEventProjection:
     def format_count(value: object) -> str | None:
         if type(value) is not int or value < 0:
             return None
-        for threshold, suffix in (
+        tiers = (
             (1_000_000_000_000, "T"),
             (1_000_000_000, "B"),
             (1_000_000, "M"),
             (1_000, "k"),
-        ):
-            if value >= threshold:
+        )
+        for index, (threshold, suffix) in enumerate(tiers):
+            if value < threshold:
+                continue
+            tenths = (value * 10 + threshold // 2) // threshold
+            # Half-up rounding can carry 999.95 of a tier to 1000.0. Select
+            # the next tier rather than emitting a value outside X.Y<suffix>.
+            if tenths >= 10_000 and index > 0:
+                threshold, suffix = tiers[index - 1]
                 tenths = (value * 10 + threshold // 2) // threshold
-                if suffix == "T":
-                    tenths = min(tenths, 9_999)
-                return f"{tenths // 10}.{tenths % 10}{suffix}"
+            if suffix == "T":
+                tenths = min(tenths, 9_999)
+            return f"{tenths // 10}.{tenths % 10}{suffix}"
         return str(value)
 
     @classmethod

--- a/tests/test_count_duration_formatting_pr1579.py
+++ b/tests/test_count_duration_formatting_pr1579.py
@@ -1,0 +1,61 @@
+"""Focused regressions for issue #1579 display-boundary formatting."""
+import pytest
+
+from lingtai.kernel.nudge import _format_duration
+from lingtai.mcp_servers.task_card.event_projection import TaskCardEventProjection
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (999, "999"),
+        (1_000, "1.0k"),
+        (999_949, "999.9k"),
+        (999_950, "1.0M"),
+        (1_000_000, "1.0M"),
+        (999_949_999, "999.9M"),
+        (999_950_000, "1.0B"),
+        (1_000_000_000, "1.0B"),
+        (999_949_999_999, "999.9B"),
+        (999_950_000_000, "1.0T"),
+        (1_000_000_000_000, "1.0T"),
+        (999_999_999_999_999, "999.9T"),
+        (10**100, "999.9T"),
+    ],
+)
+def test_count_rounding_carries_at_each_tier_and_clamps_t(value, expected):
+    assert TaskCardEventProjection.format_count(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [-1, -10**100, 1.5, 1_000.0, True, False, "1000"],
+)
+def test_count_formatter_rejects_negative_non_integer_inputs(value):
+    assert TaskCardEventProjection.format_count(value) is None
+
+
+@pytest.mark.parametrize(
+    "seconds, expected",
+    [
+        (0, "0s"),
+        (0.5, "0.5s"),
+        (59.9, "59.9s"),
+        (60, "1m"),
+        (60.5, "60.5s"),
+        (3599, "3599s"),
+        (3600, "1h"),
+        (3600.5, "3600.5s"),
+        (86399, "86399s"),
+        (86400, "24h"),
+        (86400.5, "86400.5s"),
+        (24 * 3600, "24h"),
+        (25 * 3600, "25h"),
+        (36 * 3600, "36h"),
+        (47 * 3600, "47h"),
+        (48 * 3600, "2d"),
+        (73 * 3600, "73h"),
+    ],
+)
+def test_duration_boundaries_preserve_fractional_hours_and_exact_days(seconds, expected):
+    assert _format_duration(seconds) == expected


### PR DESCRIPTION
## Summary

- Carry half-up count rounding into the next `k`/`M`/`B` tier instead of rendering values such as `1000.0k`, while preserving the existing top-tier clamp.
- Keep `24h` as hours and use day units only for exact whole-day values longer than 24 hours; fractional-day values such as 25h, 36h, 47h, and 73h remain hours.
- Include `tests/test_count_duration_formatting_pr1579.py` with the complete boundary matrix.

Closes #1579.

## Validation

- `python -m pytest -q tests/test_count_duration_formatting_pr1579.py` — **37 passed** on the final worktree.
- The combined candidate run recorded **64 passed / 1 failed**. The single task-card golden-surface failure reproduces on the untouched frozen base, so it is inherited and is not attributed to this change.
- `git diff --check` — PASS.

## Scope

This does not introduce a new formatting framework, rewrite task-card rendering, change the `24h` spelling, or alter the top-tier policy. The inherited golden mismatch remains a separate pre-existing issue and this PR does not claim a fully green adjacent suite.

Base reviewed: `38222152313823e2fa03dab75bf9f2db9f865592`.
