### PR TITLE
fix(bash): report only actually denied commands

### DIFF
--- a/src/lingtai/tools/bash/__init__.py
+++ b/src/lingtai/tools/bash/__init__.py
@@ -740,8 +740,11 @@ class ShellManager:
                     )
                 ),
             }
-        if not all(self._policy._check_single(cmd, case_insensitive=case_insensitive) for cmd in commands):
-            denied = commands
+        denied = list(dict.fromkeys(
+            cmd for cmd in commands
+            if not self._policy._check_single(cmd, case_insensitive=case_insensitive)
+        ))
+        if denied:
             return {
                 "status": "error",
                 "message": f"Command not allowed by policy. "

--- a/tests/test_bash_shell_dialect.py
+++ b/tests/test_bash_shell_dialect.py
@@ -125,6 +125,17 @@ def test_script_process_args_omits_unset_executable():
     )
 
 
+def test_policy_refusal_names_only_actual_denials_in_order(tmp_path):
+    policy = BashPolicy(deny=["rm"])
+    mgr = manager(tmp_path, policy=policy)
+
+    result = mgr.handle({"command": "echo before; rm -f file; echo after; rm -f other"})
+
+    assert result["status"] == "error"
+    assert result["message"].endswith("Denied command(s): rm")
+    assert "echo" not in result["message"]
+
+
 def test_selected_dialect_drives_policy_and_sync_execution(tmp_path):
     dialect = MarkerDialect()
     policy = BashPolicy(deny=["blocked"])


### PR DESCRIPTION
## Summary

- Build the refusal message from commands that actually fail policy checks rather than from the full extracted command list.
- Preserve first-seen display order and avoid repeated identical denied entries.
- Leave the underlying policy decision, shell parsing, dialect flags, and marker semantics unchanged.

Closes #1580.

## Validation

- `python -m pytest -q tests/test_bash_shell_dialect.py tests/test_layers_bash.py` — **86 passed** on the final worktree.
- Coverage includes mixed allowed/denied commands plus existing dialect and layer boundaries.
- `git diff --check` — PASS.

## Scope

This changes refusal diagnostics only. It does not alter which commands are allowed or denied, and it does not include the separate parser-policy work from #1573.

Base reviewed: `38222152313823e2fa03dab75bf9f2db9f865592`.
