### PR TITLE
fix(bash): enforce policy across POSIX compound syntax

### DIFF
--- a/src/lingtai/tools/bash/__init__.py
+++ b/src/lingtai/tools/bash/__init__.py
@@ -27,6 +27,7 @@ from ._shell_dialect import (
     ShellDialect,
     ShellInvocation,
     ShellKind,
+    _POSIX_UNSUPPORTED,
     extract_posix_commands,
 )
 
@@ -557,6 +558,11 @@ class ShellPolicy:
         if self._allow is None and self._deny is None:
             return True
         commands = self._extract_commands(command)
+        # The extractor emits this sentinel when static policy cannot prove
+        # command safety. A configured allow/deny policy must reject it rather
+        # than treating the sentinel as an ordinary, non-denied command.
+        if _POSIX_UNSUPPORTED in commands:
+            return False
         return all(self._check_single(cmd) for cmd in commands)
 
     def _check_single(self, cmd: str, *, case_insensitive: bool = False) -> bool:
@@ -713,6 +719,7 @@ class ShellManager:
         case_insensitive = state_key in {"powershell", "cmd"}
         powershell = state_key == "powershell"
         cmd = state_key == "cmd"
+        posix = state_key == "posix"
         # PowerShell and cmd.exe both fail closed on syntax the static
         # extractor cannot prove (dynamic invocation, ``%`` expansion): the
         # refusal marker is only enforced when a policy is actually
@@ -720,6 +727,7 @@ class ShellManager:
         unsupported = (
             (powershell and "__powershell_unsupported__" in commands)
             or (cmd and "__cmd_unsupported__" in commands)
+            or (posix and "__posix_unsupported__" in commands)
         )
         if unsupported and (
             self._policy._allow is not None or self._policy._deny is not None
@@ -731,12 +739,19 @@ class ShellManager:
                     "refusing to run it"
                     if cmd
                     else (
-                        "PowerShell policy validation does not support this syntax; refusing "
-                        "to run it. The parser could not statically extract all commands "
-                        "(likely variable-based invocation, here-strings, or complex "
-                        "expressions). Options: (1) simplify the script to use only literal "
-                        "command names, (2) run with yolo=true to bypass policy, or "
-                        "(3) split into multiple simpler commands."
+                        "POSIX policy validation does not support this syntax; refusing "
+                        "to run it. The parser could not statically extract all commands; "
+                        "simplify the command or use yolo=true only when bypassing policy "
+                        "is intentional."
+                        if posix
+                        else (
+                            "PowerShell policy validation does not support this syntax; refusing "
+                            "to run it. The parser could not statically extract all commands "
+                            "(likely variable-based invocation, here-strings, or complex "
+                            "expressions). Options: (1) simplify the script to use only literal "
+                            "command names, (2) run with yolo=true to bypass policy, or "
+                            "(3) split into multiple simpler commands."
+                        )
                     )
                 ),
             }

--- a/src/lingtai/tools/bash/_shell_dialect.py
+++ b/src/lingtai/tools/bash/_shell_dialect.py
@@ -278,19 +278,401 @@ def make_invocation_for_kind(
     )
 
 
-def extract_posix_commands(command: str) -> tuple[str, ...]:
-    """Extract command names using the existing POSIX Bash policy rules."""
-    flat = re.sub(r"\$\([^)]*\)", lambda m: "; " + m.group()[2:-1] + " ;", command)
-    flat = re.sub(r"`[^`]*`", lambda m: "; " + m.group()[1:-1] + " ;", flat)
-    parts = re.split(r"\|{1,2}|&&|;|\n", flat)
+_POSIX_UNSUPPORTED = "__posix_unsupported__"
+_POSIX_RESERVED = {
+    "!", "case", "coproc", "do", "done", "elif", "else", "esac", "fi",
+    "for", "function", "if", "in", "select", "then", "time", "until",
+    "while",
+}
+_POSIX_CONTROL = {";", "|", "||", "&", "&&", "(", ")", "{", "}", "\n"}
+_POSIX_REDIRECTION_RE = re.compile(
+    r"^(?:[0-9]{1,3})?(?P<operator>&>>|&>|>>|<<-|<<<|<<|<>|>&|<&|>|<)(?P<target>.*)$"
+)
+_POSIX_LITERAL_COMMAND_RE = re.compile(r"^[A-Za-z0-9_./:+@=-]+$")
+
+
+def _posix_redirection(token: str) -> tuple[bool, bool, bool]:
+    """Return ``(is_redirection, needs_target, is_heredoc)`` for a token."""
+    match = _POSIX_REDIRECTION_RE.fullmatch(token)
+    if match is None:
+        return False, False, False
+    operator = match.group("operator")
+    return True, not bool(match.group("target")), operator.startswith("<<")
+
+
+def _posix_literal_command(token: str) -> bool:
+    """Whether *token* is a static executable name, not shell expansion text."""
+    return bool(_POSIX_LITERAL_COMMAND_RE.fullmatch(token))
+
+
+def _posix_command_name(token: str) -> str:
+    """Normalize a literal command path to its executable basename for policy."""
+    return token.rsplit("/", 1)[-1]
+
+
+def _balanced_parenthesis(text: str, opening: int) -> int | None:
+    """Return the close index for a shell parenthesis, honoring quotes/escapes."""
+    depth = 0
+    quote: str | None = None
+    escaped = False
+    for index in range(opening, len(text)):
+        char = text[index]
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\" and quote != "'":
+            escaped = True
+            continue
+        if quote:
+            if char == quote:
+                quote = None
+            continue
+        if char in "'\\\"":
+            quote = char
+        elif char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+            if depth == 0:
+                return index
+    return None
+
+
+def _peel_posix_expansions(command: str) -> tuple[str, list[str], bool]:
+    """Remove executable command substitutions while recursively extracting them."""
+    flat: list[str] = []
+    nested: list[str] = []
+    unsupported = False
+    quote: str | None = None
+    escaped = False
+    index = 0
+    while index < len(command):
+        char = command[index]
+        if escaped:
+            flat.append(char)
+            escaped = False
+            index += 1
+            continue
+        if char == "\\" and quote != "'":
+            flat.append(char)
+            escaped = True
+            index += 1
+            continue
+        if quote == "'":
+            flat.append(char)
+            if char == "'":
+                quote = None
+            index += 1
+            continue
+        if quote == '"':
+            if char == '"':
+                quote = None
+                flat.append(char)
+                index += 1
+                continue
+            # Parameter expansion remains a normal argument; command and
+            # arithmetic substitutions are still active inside double quotes.
+        elif char in "'\"":
+            quote = char
+            flat.append(char)
+            index += 1
+            continue
+
+        if char in "<>" and index + 1 < len(command) and command[index + 1] == "(":
+            # Process substitutions execute an opaque command asynchronously;
+            # policy cannot prove its command set from this extractor.
+            unsupported = True
+            flat.extend((char, " "))
+            index += 2
+            continue
+        if (
+            char == "$"
+            and index + 2 < len(command)
+            and command[index + 1:index + 3] == "(("
+        ):
+            # Arithmetic expansion is evaluated data, not a command body.
+            closing = _balanced_parenthesis(command, index + 1)
+            if closing is None:
+                return "", nested, True
+            flat.append(" ")
+            index = closing + 1
+            continue
+        if char == "$" and index + 1 < len(command) and command[index + 1] == "(":
+            opening = index + 1
+            closing = _balanced_parenthesis(command, opening)
+            if closing is None:
+                return "", nested, True
+            inner_commands, inner_unsupported = _extract_posix(command[index + 2:closing])
+            nested.extend(inner_commands)
+            unsupported = unsupported or inner_unsupported
+            flat.append(" ")
+            index = closing + 1
+            continue
+        if char == "`":
+            closing = index + 1
+            while closing < len(command):
+                if command[closing] == "`" and command[closing - 1] != "\\":
+                    break
+                closing += 1
+            if closing >= len(command):
+                return "", nested, True
+            inner_commands, inner_unsupported = _extract_posix(command[index + 1:closing])
+            nested.extend(inner_commands)
+            unsupported = unsupported or inner_unsupported
+            flat.append(" ")
+            index = closing + 1
+            continue
+        flat.append(char)
+        index += 1
+    return "".join(flat), nested, unsupported
+
+
+def _posix_tokens(command: str) -> list[str]:
+    """Tokenize enough POSIX shell syntax to identify command positions."""
+    tokens: list[str] = []
+    word: list[str] = []
+    quote: str | None = None
+    escaped = False
+
+    def flush() -> None:
+        if word:
+            tokens.append("".join(word))
+            word.clear()
+
+    index = 0
+    while index < len(command):
+        char = command[index]
+        if escaped:
+            # POSIX backslash-newline is a line continuation, not a command
+            # separator and not part of the resulting argument.
+            if char != "\n":
+                word.append(char)
+            escaped = False
+            index += 1
+            continue
+        if char == "\\" and quote != "'":
+            escaped = True
+            index += 1
+            continue
+        if quote:
+            if char == quote:
+                quote = None
+            else:
+                word.append(char)
+            index += 1
+            continue
+        if char in "'\"":
+            quote = char
+            index += 1
+            continue
+        if char == "#" and not word:
+            # A comment begins only at the start of a shell word. Keep the
+            # terminating newline so a following command remains visible.
+            while index < len(command) and command[index] != "\n":
+                index += 1
+            continue
+        if char == "\n":
+            flush()
+            tokens.append("\n")
+            index += 1
+            continue
+        if char.isspace():
+            flush()
+            index += 1
+            continue
+        # Braces inside a word are parameter/brace expansion text, not a
+        # group delimiter (e.g. ``${HOME}`` and ``{a,b}``). A standalone
+        # no-whitespace brace expansion is also one argument; a group opener
+        # such as ``{ rm`` remains punctuation.
+        if char == "{" and not word:
+            closing = command.find("}", index + 1)
+            if closing >= index + 1 and not any(c.isspace() for c in command[index + 1:closing]):
+                word.append(command[index:closing + 1])
+                index = closing + 1
+                continue
+        if char in "{}" and word:
+            word.append(char)
+            index += 1
+            continue
+        # Keep ``>&``/``<&`` and the Bash ``&>`` redirections together rather
+        # than treating their ampersand as a command-control operator.
+        if char == "&" and word and word[-1] in "<>":
+            word.append(char)
+            index += 1
+            continue
+        if char == "&" and not word and index + 1 < len(command) and command[index + 1] == ">":
+            word.append("&>")
+            index += 2
+            continue
+        if char in "|&;(){}":
+            flush()
+            if index + 1 < len(command) and command[index:index + 2] in {"&&", "||", ";;"}:
+                tokens.append(command[index:index + 2])
+                index += 2
+            else:
+                tokens.append(char)
+                index += 1
+            continue
+        word.append(char)
+        index += 1
+    if escaped:
+        word.append("\\")
+    flush()
+    return tokens
+
+
+def _extract_posix(command: str) -> tuple[list[str], bool]:
+    flat, nested, unsupported = _peel_posix_expansions(command)
+    tokens = _posix_tokens(flat)
     commands: list[str] = []
-    for part in parts:
-        tokens = part.strip().split()
-        while tokens and re.fullmatch(r"[A-Za-z_]\w*=\S*", tokens[0]):
-            tokens = tokens[1:]
-        if tokens:
-            commands.append(tokens[0])
-    return tuple(commands)
+    at_command_start = True
+    find_command = False
+    expect_find_exec_command = False
+    find_exec_active = False
+    case_pattern = False
+    case_active = False
+    for_header = False
+    redirection_target = False
+    saw_redirection = False
+
+    for token in tokens:
+        if redirection_target:
+            # A control token cannot be a redirection operand. Let it go
+            # through the normal control-state transition after recording the
+            # malformed redirection; an ordinary next word is just the target.
+            if token not in _POSIX_CONTROL and token != ";;":
+                redirection_target = False
+                continue
+            unsupported = True
+            redirection_target = False
+
+        if for_header:
+            # The loop variable, ``in`` list, separators, and ``do`` are
+            # grammar, not executable command positions.
+            if token == "do":
+                for_header = False
+                at_command_start = True
+            continue
+
+        if case_pattern:
+            # Case alternatives (including ``a|b``) are patterns, never
+            # executable names. A closing ``)`` opens the arm command body.
+            if token == ")":
+                case_pattern = False
+                case_active = True
+                at_command_start = True
+            elif token == "esac":
+                case_pattern = False
+                case_active = False
+                at_command_start = False
+            continue
+
+        if token == ";;":
+            if case_active:
+                case_pattern = True
+            at_command_start = True
+            find_command = False
+            expect_find_exec_command = False
+            find_exec_active = False
+            continue
+
+        if token in _POSIX_CONTROL:
+            # ``find -exec ... \\;`` uses a shell-looking semicolon as the
+            # find expression terminator, not as the outer command separator.
+            # Keep scanning options belonging to the same find invocation.
+            if expect_find_exec_command:
+                unsupported = True
+                expect_find_exec_command = False
+            if token == ";" and find_command and find_exec_active:
+                find_exec_active = False
+                continue
+            at_command_start = True
+            find_command = False
+            expect_find_exec_command = False
+            find_exec_active = False
+            continue
+
+        if token == "+" and find_command and find_exec_active:
+            if expect_find_exec_command:
+                unsupported = True
+            find_exec_active = False
+            expect_find_exec_command = False
+            continue
+
+        if find_command and token in {"-exec", "-execdir"}:
+            expect_find_exec_command = True
+            find_exec_active = True
+            continue
+
+        if expect_find_exec_command:
+            # ``{}``, variables, substitutions, and other non-literal words
+            # cannot be proven safe as the utility executed by find.
+            if not _posix_literal_command(token) or token == "{}":
+                unsupported = True
+            else:
+                commands.append(_posix_command_name(token))
+            expect_find_exec_command = False
+            continue
+
+        if at_command_start:
+            is_redirection, needs_target, is_heredoc = _posix_redirection(token)
+            if is_redirection:
+                saw_redirection = True
+                unsupported = unsupported or is_heredoc
+                redirection_target = needs_target
+                continue
+            if token in _POSIX_RESERVED or re.fullmatch(r"[A-Za-z_]\w*=.*", token):
+                if token == "case":
+                    case_pattern = True
+                    case_active = True
+                elif token in {"for", "select"}:
+                    for_header = True
+                elif token == "esac":
+                    case_active = False
+                continue
+            if not _posix_literal_command(token):
+                unsupported = True
+                at_command_start = False
+                continue
+            command_name = _posix_command_name(token)
+            commands.append(command_name)
+            at_command_start = False
+            find_command = command_name == "find"
+            expect_find_exec_command = False
+            continue
+
+        is_redirection, needs_target, is_heredoc = _posix_redirection(token)
+        if is_redirection:
+            saw_redirection = True
+            unsupported = unsupported or is_heredoc
+            redirection_target = needs_target
+
+    if redirection_target or expect_find_exec_command:
+        unsupported = True
+    # A redirection without an executable is not a command that policy can
+    # safely authorize. Comments and grammar-only input, however, remain a
+    # harmless empty extraction rather than a synthetic command name.
+    if saw_redirection and not commands:
+        unsupported = True
+
+    # Preserve ordinary command order; substitutions are appended after the
+    # outer command scan while still ensuring every nested command is checked.
+    commands.extend(nested)
+    return commands, unsupported
+
+
+def extract_posix_commands(command: str) -> tuple[str, ...]:
+    """Extract all provable command names from POSIX compound forms.
+
+    Unknown process substitutions, malformed command substitutions, dynamic
+    command-position expansions, and non-empty input with no provable command
+    produce a fail-closed sentinel. Parameter/arithmetic expansion and normal
+    quoting remain benign arguments.
+    """
+    commands, unsupported = _extract_posix(command)
+    if unsupported:
+        commands.append(_POSIX_UNSUPPORTED)
+    return tuple(dict.fromkeys(commands))
 
 
 def _key_subsets(optional: set[str]) -> list[frozenset[str]]:

--- a/tests/test_bash_shell_dialect.py
+++ b/tests/test_bash_shell_dialect.py
@@ -33,6 +33,135 @@ def manager(tmp_path, dialect=None, policy=None):
     )
 
 
+# PR1 fail-first boundary tests.  These assert the security/correctness
+# contract exposed by the manager, not merely tokenizer implementation details.
+@pytest.mark.parametrize(
+    "command, expected",
+    [
+        ("echo ok" + "\n" + "rm -f victim", ("echo", "rm")),
+        ("echo ok" + chr(92) + "\n" + "rm -f victim", ("echo",)),
+        (">out echo ok", ("echo",)),
+        ("> out echo ok", ("echo",)),
+        ("2>/dev/null echo ok", ("echo",)),
+        ("2> /dev/null echo ok", ("echo",)),
+        ("2>&1 echo ok", ("echo",)),
+        (">out", ("__posix_unsupported__",)),
+        ("echo ok >out" + "\n" + "rm -f victim", ("echo", "rm")),
+        (r"find . -exec $CMD {} \;", ("find", "__posix_unsupported__")),
+        (r"find . -exec {} \;", ("find", "__posix_unsupported__")),
+        (r"find . -execdir ${CMD} {} \;", ("find", "__posix_unsupported__")),
+        (r"find . -exec echo$CMD {} \;", ("find", "__posix_unsupported__")),
+        (r"find . -exec \"$CMD\" {} \;", ("find", "__posix_unsupported__")),
+        (r"find . -exec \;", ("find", "__posix_unsupported__")),
+        ("for item in one two; do echo ok; done", ("echo",)),
+        (
+            "case x in a|b) echo ok;; c|d) printf ok;; esac",
+            ("echo", "printf"),
+        ),
+        ("# rm -f victim" + "\n" + "echo ok; # also-not-a-command", ("echo",)),
+        ("echo ok; # rm -f victim" + "\n" + "printf ok", ("echo", "printf")),
+    ],
+)
+def test_pr1_posix_extraction_handles_control_grammar_and_dynamic_targets(
+    command, expected
+):
+    assert select_bash_shell_dialect().extract_commands(command) == expected
+
+
+def test_pr1_manager_policy_enforces_extracted_boundaries(tmp_path):
+    dialect = select_bash_shell_dialect()
+    allow_echo = manager(tmp_path, dialect=dialect, policy=BashPolicy(allow=["echo"]))
+    assert allow_echo.handle({"command": ">out echo ok"})["status"] == "ok"
+    assert allow_echo.handle({"command": "echo ok" + "\n" + "rm -f victim"})["status"] == "error"
+    assert allow_echo.handle({"command": r"find . -exec $CMD {} \;"})["status"] == "error"
+    assert allow_echo.handle({"command": "for item in one; do echo ok; done"})["status"] == "ok"
+    assert allow_echo.handle({"command": "case x in a|b) echo ok;; c|d) echo ok;; esac"})["status"] == "ok"
+    assert allow_echo.handle({"command": "# rm -f victim" + "\n" + "echo ok"})["status"] == "ok"
+
+    deny_rm = manager(tmp_path, dialect=dialect, policy=BashPolicy(deny=["rm"]))
+    assert deny_rm.handle({"command": "echo ok" + "\n" + "printf ok"})["status"] == "ok"
+    assert deny_rm.handle({"command": "echo ok" + "\n" + "rm -f victim"})["status"] == "error"
+    assert deny_rm.handle({"command": r"find . -exec {} \;"})["status"] == "error"
+    assert deny_rm.handle({"command": r"find . -exec /bin/rm {} \;"})["status"] == "error"
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "rm -f x & echo ok",
+        "{ rm -f x; }",
+        "(rm -f x)",
+        "if true; then rm -f x; fi",
+        "while false; do rm -f x; done",
+        "for x in one; do rm -f x; done",
+        "case x in x) rm -f x;; esac",
+        "find . -exec rm -f {} \\;",
+        "echo $(printf x; rm -f y)",
+    ],
+)
+def test_posix_compound_extraction_finds_nested_denial(command):
+    dialect = select_bash_shell_dialect()
+    assert "rm" in dialect.extract_commands(command)
+
+
+def test_posix_benign_expansions_do_not_trigger_unsupported_marker():
+    dialect = select_bash_shell_dialect()
+    assert dialect.extract_commands("echo $((1 + 2)) ${HOME} {a,b}") == ("echo",)
+
+
+def test_posix_unsupported_marker_fails_closed_only_with_policy(tmp_path):
+    dialect = select_bash_shell_dialect()
+    assert "__posix_unsupported__" in dialect.extract_commands("cat <(echo x)")
+    guarded = manager(tmp_path, dialect=dialect, policy=BashPolicy(allow=["cat", "echo"]))
+    assert guarded.handle({"command": "cat <(echo x)"})["status"] == "error"
+    assert not guarded._policy.is_allowed("cat <(echo x)")
+    yolo = manager(tmp_path, dialect=dialect, policy=BashPolicy.yolo())
+    assert yolo._validate_command("cat <(echo x)") is None
+
+
+@pytest.mark.parametrize(
+    "command, allowed",
+    [
+        ("echo 'rm; x' \"echo && rm\"", True),
+        (r"echo rm\;x; printf ok", True),
+        ("echo $((1 + (2 * 3))) ${HOME} {a,b}", True),
+        ("FOO='a b' rm -f x", False),
+        ("if true; then rm -f x; fi", False),
+        ("while false; do rm -f x; done", False),
+        ("for x in one; do rm -f x; done", False),
+        ("case x in x) rm -f x;; esac", False),
+        (r"find . -exec echo {} \; -exec rm {} +", False),
+        ("echo `printf x; rm x`", False),
+        ("echo $(printf x; echo $(rm x))", False),
+        ("$CMD x", False),
+    ],
+)
+def test_posix_policy_table_keeps_benign_forms_and_denies_compound_forms(
+    tmp_path, command, allowed
+):
+    mgr = manager(tmp_path, dialect=select_bash_shell_dialect(), policy=BashPolicy(deny=["rm"]))
+    assert (mgr._validate_command(command) is None) is allowed
+
+
+def test_posix_quoted_and_escaped_separators_are_arguments_not_commands():
+    dialect = select_bash_shell_dialect()
+    assert dialect.extract_commands("echo 'rm; x' \"echo && rm\"") == ("echo",)
+    assert dialect.extract_commands(r"echo rm\;x; printf ok") == ("echo", "printf")
+
+
+def test_posix_find_exec_collects_each_literal_target_and_ignores_terminators():
+    dialect = select_bash_shell_dialect()
+    assert dialect.extract_commands(r"find . -exec echo {} \; -exec rm {} +") == (
+        "find", "echo", "rm",
+    )
+
+
+def test_posix_malformed_or_dynamic_command_positions_are_unsupported():
+    dialect = select_bash_shell_dialect()
+    assert "__posix_unsupported__" in dialect.extract_commands("echo $(printf x")
+    assert "__posix_unsupported__" in dialect.extract_commands("$CMD x")
+
+
 def test_posix_policy_extraction_and_invocation_are_compatible():
     dialect = select_bash_shell_dialect()
     assert dialect.state_key() == "posix"


### PR DESCRIPTION
## Summary

- parse POSIX command text without flattening compound shell syntax into one token stream
- preserve real command boundaries and conservatively reject malformed or dynamic `find -exec` targets
- propagate unsupported parse results through both shell-policy and manager gates so compound syntax cannot bypass deny-list checks

## Validation

- frozen-base fail-first: 12 failed, 1 passed, 61 deselected
- parser and shell-layer suites: 131 passed
- touched-file Python compilation and `git diff --check`: passed

## Notes

The output-capping suite retains one unrelated failure that reproduces unchanged on the frozen base.

Fixes #1573
