### PR TITLE
fix(tool-family): allow overlapping no-settings input schemas

### DIFF
--- a/src/lingtai/tools/tool_family/CONTRACT.md
+++ b/src/lingtai/tools/tool_family/CONTRACT.md
@@ -90,12 +90,15 @@ both built from the same deep-copied canonical child schemas:
    `allOf`/`if`/`then` schema without error on the current route (see
    `_scrub_responses_schema` in `../../llm/openai/adapter.py` for the
    corresponding wire-level change and its own scope note).
-2. **Typed `input.oneOf` disclosure:** `input` explicitly declares the common
+2. **Typed `input.anyOf` disclosure:** `input` explicitly declares the common
    `type: object` constraint required of every action, then embeds the same
    per-child `input_schema`s verbatim under a `title` for model discoverability
-   of every action's exact shape in one place. The direct type is redundant for
-   a complete JSON Schema validator, but keeps the object contract unambiguous
-   for model/provider schema consumers that inspect only the immediate node.
+   of every action's exact shape in one place. `anyOf` is intentional: titles
+   and descriptions are annotations, not validation discriminators, so two
+   actions may have validation-equivalent input schemas. The direct type is
+   redundant for a complete JSON Schema validator, but keeps the object
+   contract unambiguous for model/provider schema consumers that inspect only
+   the immediate node.
 
 Both layers expose the envelope root `action`, `input`, required
 `reasoning`, and optional `summarize` — exactly the four public fields;
@@ -471,8 +474,10 @@ Guarded by: [T006](BEHAVIORS.md#behavior-t006) and
 - `build_schema()` MUST declare the aggregate `input` property as direct
   `type: object`, then embed each child's own object `input_schema` verbatim
   (no copy-and-reshape) under a branch pairing it with that child's `title`.
-  The branch keyword is `oneOf` for opted-out families and `anyOf` for an
-  opted-in settings family, avoiding duplicate strict-empty branch invalidity.
+  The branch keyword is always `anyOf`, including opted-out families. Input
+  branch annotations are not validation discriminators, so this avoids
+  rejecting a valid call when two actions have overlapping constraints (while
+  the root `allOf` correlation and fail-closed dispatch retain action safety).
   It MUST declare a root `reasoning` string property and include
   `reasoning` in the root `required` list — `reasoning` is Host
   InvocationContext/audit metadata, not left to Agent schema composition's
@@ -558,8 +563,8 @@ schema/dispatch non-regression evidence.
 
 `tests/test_tool_family_generic.py` proves the infrastructure is generic using
 a fake `widget` family unrelated to `web`: deterministic registration order,
-duplicate-name and reserved-`manual`-collision failures, `oneOf` schema
-composition with root `reasoning` REQUIRED and no unconstrained generic
+duplicate-name and reserved-`manual`-collision failures, overlap-tolerant
+`anyOf` schema composition with root `reasoning` REQUIRED and no unconstrained generic
 `input` object, dispatch selecting the correct child and passing only its
 `input`, unknown-action/non-boolean-summarize/unknown-root-field/cross-branch-
 key rejection, no double result wrapping, and two dedicated proofs that
@@ -567,10 +572,10 @@ key rejection, no double result wrapping, and two dedicated proofs that
 child's own canonical `input_schema`. It also proves the root `allOf`
 correlation directly: every condition's `action` const matches the child
 registry name, `then.input` exactly matches that child's own canonical
-schema, a minimal local `if`/`then` structural evaluator (no JSON Schema
-dependency added) shows the schema itself rejects a mismatched
+schema, a standards validator when available (with a faithful local
+fallback and no added dependency) shows the schema itself rejects a mismatched
 `action`/`input` pairing, `handle()` remains authoritative and fail-closed
-regardless, and both the `allOf` conditions and the `oneOf` branches are
+regardless, and both the `allOf` conditions and the `anyOf` branches are
 mutation-isolated from each other and from a child's own canonical schema.
 It also proves the "Diagnostics sidecar" contract using an opted-in fake
 `widget` child: the exact owner-declared `DiagnosticDescriptor` and

--- a/src/lingtai/tools/tool_family/__init__.py
+++ b/src/lingtai/tools/tool_family/__init__.py
@@ -259,7 +259,10 @@ class ToolFamily:
            showed this root construct is accepted, not rejected, by the
            current backend route.
         2. **Typed ``input`` disclosure:** the same per-action branches retained
-           for discoverability (``oneOf`` normally, ``anyOf`` with settings).
+           for discoverability under an overlap-tolerant ``anyOf`` union. Branch
+           annotations such as titles and descriptions are not validation
+           discriminators, so semantically equivalent action schemas are valid
+           members of the same family.
 
         The root carries ``action``, ``input``, required ``reasoning``, and
         optional ``summarize`` — exactly the four LTP v2 envelope fields
@@ -305,9 +308,14 @@ class ToolFamily:
                     },
                 }
             )
-        input_branches_keyword = (
-            "anyOf" if RESERVED_SETTINGS_NAME in self._children else "oneOf"
-        )
+        # Input branches are a discovery union, not an action discriminator:
+        # annotations do not affect JSON-Schema validation, so distinct actions
+        # may legitimately have overlapping constraints (for example, poll and
+        # cancel can both require only a string job_id).  Root allOf/if/then
+        # conditions already correlate action with its exact input schema, and
+        # dispatch remains the fail-closed authority for providers that do not
+        # enforce those conditions.
+        input_branches_keyword = "anyOf"
         return {
             "type": "object",
             "properties": {

--- a/tests/test_tool_family_context_migration.py
+++ b/tests/test_tool_family_context_migration.py
@@ -160,7 +160,7 @@ def test_schema_and_dispatch_come_from_one_registry():
     """A child cannot be schema-advertised but dispatch-rejected."""
     schema = get_schema("en")
     advertised = list(schema["properties"]["action"]["enum"])
-    branch_titles = [b["title"] for b in schema["properties"]["input"]["oneOf"]]
+    branch_titles = [b["title"] for b in schema["properties"]["input"]["anyOf"]]
     correlated = [
         c["if"]["properties"]["action"]["const"] for c in schema["allOf"]
     ]
@@ -729,7 +729,7 @@ def test_one_context_root_survives_both_wires_with_action_input_correlation(tmp_
 
         chat = _build_tools(context_schemas)[0]["function"]["parameters"]
         responses = _build_responses_tools(context_schemas)[0]["parameters"]
-        for wire, combinator in ((chat, "oneOf"), (responses, "anyOf")):
+        for wire, combinator in ((chat, "anyOf"), (responses, "anyOf")):
             assert set(wire["properties"]) == {
                 "action", "input", "reasoning", "summarize",
             }
@@ -839,7 +839,7 @@ def test_rebuild_items_stays_optional_on_both_provider_wires(tmp_path):
         schemas = [s for s in _build_tool_schemas(live) if s.name == "context"]
         chat = _build_tools(schemas)[0]["function"]["parameters"]
         responses = _build_responses_tools(schemas)[0]["parameters"]
-        for wire, combinator in ((chat, "oneOf"), (responses, "anyOf")):
+        for wire, combinator in ((chat, "anyOf"), (responses, "anyOf")):
             branches = {
                 b["title"]: b for b in wire["properties"]["input"][combinator]
             }

--- a/tests/test_tool_family_generic.py
+++ b/tests/test_tool_family_generic.py
@@ -102,7 +102,7 @@ def test_schema_composes_action_input_reasoning_summarize_root():
     assert schema["properties"]["input"]["type"] == "object"
     assert schema["properties"]["reasoning"]["type"] == "string"
     assert schema["properties"]["summarize"]["type"] == "boolean"
-    branches = schema["properties"]["input"]["oneOf"]
+    branches = schema["properties"]["input"]["anyOf"]
     assert [b["title"] for b in branches] == ["spin input", "manual input"]
     spin_branch, manual_branch = branches
     assert spin_branch["required"] == ["speed"]
@@ -118,7 +118,7 @@ def test_schema_composes_action_input_reasoning_summarize_root():
 def test_schema_never_uses_generic_unconstrained_input_object():
     fam = _widget_family()
     schema = fam.build_schema()
-    for branch in schema["properties"]["input"]["oneOf"]:
+    for branch in schema["properties"]["input"]["anyOf"]:
         assert branch.get("type") == "object"
         assert "properties" in branch
 
@@ -396,6 +396,155 @@ def test_handle_remains_authoritative_fail_closed_even_though_schema_now_correla
     assert result["error_code"] == "INVALID_ARGUMENT"
 
 
+def _minimal_json_schema_valid(instance, schema):
+    """Faithful subset evaluator for generated ToolFamily schemas.
+
+    The test uses ``jsonschema`` when that already-available validator can be
+    imported; this fallback covers only the JSON-Schema keywords emitted by
+    ``ToolFamily.build_schema`` so the regression stays dependency-free in
+    environments without that optional test dependency.  In particular,
+    ``oneOf`` counts successful branches and ignores annotation keywords such as
+    ``title`` and ``description``, as the standard requires.
+    """
+    if "const" in schema and instance != schema["const"]:
+        return False
+    if "enum" in schema and instance not in schema["enum"]:
+        return False
+    schema_type = schema.get("type")
+    if schema_type == "object" and not isinstance(instance, dict):
+        return False
+    if schema_type == "string" and not isinstance(instance, str):
+        return False
+    if schema_type == "boolean" and not isinstance(instance, bool):
+        return False
+    if isinstance(instance, dict):
+        required = set(schema.get("required", ()))
+        if not required.issubset(instance):
+            return False
+        properties = schema.get("properties", {})
+        if schema.get("additionalProperties") is False and set(instance) - set(properties):
+            return False
+        if any(
+            key in instance and not _minimal_json_schema_valid(instance[key], subschema)
+            for key, subschema in properties.items()
+        ):
+            return False
+    if "allOf" in schema and not all(
+        _minimal_json_schema_valid(instance, branch) for branch in schema["allOf"]
+    ):
+        return False
+    if "anyOf" in schema and not any(
+        _minimal_json_schema_valid(instance, branch) for branch in schema["anyOf"]
+    ):
+        return False
+    if "oneOf" in schema and sum(
+        _minimal_json_schema_valid(instance, branch) for branch in schema["oneOf"]
+    ) != 1:
+        return False
+    if "if" in schema:
+        if_matches = _minimal_json_schema_valid(instance, schema["if"])
+        if if_matches and "then" in schema and not _minimal_json_schema_valid(instance, schema["then"]):
+            return False
+    return True
+
+
+def _json_schema_valid(instance, schema):
+    """Use an installed standards validator, with the faithful local fallback."""
+    try:
+        from jsonschema import Draft202012Validator
+    except ImportError:
+        return _minimal_json_schema_valid(instance, schema)
+    return not list(Draft202012Validator(schema).iter_errors(instance))
+
+
+def _overlapping_poll_cancel_family() -> ToolFamily:
+    """No-settings fake whose poll/cancel branches overlap semantically."""
+    def _schema(description: str) -> dict:
+        return {
+            "type": "object",
+            "description": description,
+            "properties": {
+                "job_id": {
+                    "type": "string",
+                    "description": f"{description} job identifier",
+                },
+            },
+            "required": ["job_id"],
+            "additionalProperties": False,
+        }
+
+    def _handler(input_):
+        return {"status": "ok", "job_id": input_["job_id"]}
+
+    return ToolFamily(
+        "jobs",
+        [
+            ChildTool("poll", _schema("poll operation"), _handler, title="Poll a job"),
+            ChildTool("cancel", _schema("cancel operation"), _handler, title="Cancel a job"),
+            _manual_child(),
+        ],
+    )
+
+
+def test_no_settings_overlapping_input_branches_validate_with_root_correlation():
+    """A valid action/input call remains valid when input branches overlap.
+
+    ``poll`` and ``cancel`` have identical validation constraints but distinct
+    annotations.  A valid poll call validates against both input branches;
+    JSON Schema ``oneOf`` rejects it, even though the matching root
+    ``allOf``/``if``/``then`` condition validates the selected poll input.
+    The production fix must therefore use a union that permits overlap.
+    """
+    family = _overlapping_poll_cancel_family()
+    schema = family.build_schema()
+    payload = {"action": "poll", "input": {"job_id": "job-1"}, "reasoning": "inspect"}
+    input_schema = schema["properties"]["input"]
+    assert "oneOf" not in input_schema
+    branches = input_schema["anyOf"]
+
+    assert branches[0]["title"] != branches[1]["title"]
+    assert branches[0]["description"] != branches[1]["description"]
+    assert branches[0]["properties"]["job_id"]["description"] != branches[1]["properties"]["job_id"]["description"]
+    assert sum(_json_schema_valid(payload["input"], branch) for branch in branches) == 2
+
+    conditions = {
+        condition["if"]["properties"]["action"]["const"]: condition
+        for condition in schema["allOf"]
+    }
+    poll_input_schema = conditions["poll"]["then"]["properties"]["input"]
+    assert _json_schema_valid(payload["input"], poll_input_schema)
+    assert _json_schema_valid(payload, schema)
+
+
+def test_no_settings_non_overlapping_strict_branches_still_reject_mismatches():
+    """The overlap fix does not weaken strict branch/action correlation."""
+    schema = _widget_family().build_schema()
+    valid_spin = {"action": "spin", "input": {"speed": 1}, "reasoning": "run"}
+    missing_spin_input = {"action": "spin", "input": {}, "reasoning": "run"}
+    spin_input_for_manual = {
+        "action": "manual", "input": {"speed": 1}, "reasoning": "read"
+    }
+    assert _json_schema_valid(valid_spin, schema)
+    assert not _json_schema_valid(missing_spin_input, schema)
+    assert not _json_schema_valid(spin_input_for_manual, schema)
+
+
+def test_settings_enabled_family_keeps_anyof_and_validates_settings_action():
+    """The explicit settings opt-in remains an anyOf family and dispatches."""
+    family = ToolFamily(
+        "widget",
+        [_spin_child([]), _manual_child()],
+        settings_provider=lambda: (),
+    )
+    schema = family.build_schema()
+    input_schema = schema["properties"]["input"]
+    assert "oneOf" not in input_schema
+    assert len(input_schema["anyOf"]) == 3
+    payload = {"action": "settings", "input": {}, "reasoning": "inspect"}
+    assert _json_schema_valid(payload, schema)
+    assert family.handle(payload) == {"settings": []}
+
+
 def test_build_schema_does_not_leak_shared_mutable_child_schema_by_reference():
     """Regression test: ``build_schema()`` must not embed a child's own
     ``input_schema`` (or its nested containers) by reference into the
@@ -407,7 +556,7 @@ def test_build_schema_does_not_leak_shared_mutable_child_schema_by_reference():
     fam = _widget_family(calls)
     first = fam.build_schema()
     first_spin_branch = next(
-        b for b in first["properties"]["input"]["oneOf"] if b["title"] == "spin input"
+        b for b in first["properties"]["input"]["anyOf"] if b["title"] == "spin input"
     )
     # Mutate the nested ``properties`` container reachable from the first
     # returned schema.
@@ -415,16 +564,16 @@ def test_build_schema_does_not_leak_shared_mutable_child_schema_by_reference():
 
     second = fam.build_schema()
     second_spin_branch = next(
-        b for b in second["properties"]["input"]["oneOf"] if b["title"] == "spin input"
+        b for b in second["properties"]["input"]["anyOf"] if b["title"] == "spin input"
     )
     assert second_spin_branch["properties"]["speed"]["type"] == "integer"
 
 
 def test_build_schema_all_of_conditions_are_mutation_isolated():
-    """Companion to the ``oneOf``-branch mutation-isolation regression test,
+    """Companion to the ``anyOf``-branch mutation-isolation regression test,
     for the new ``allOf`` conditions: mutating one call's
     ``then.properties.input`` must not corrupt a later, independent call, the
-    child's own canonical ``input_schema``, or the sibling ``oneOf`` branch —
+    child's own canonical ``input_schema``, or the sibling ``anyOf`` branch —
     each surface is built from its own deep copy."""
     calls: list[dict] = []
     fam = _widget_family(calls)
@@ -442,9 +591,9 @@ def test_build_schema_all_of_conditions_are_mutation_isolated():
     assert fam._children["spin"].input_schema["properties"]["speed"]["type"] == "integer"
     assert dict(fam._children["spin"].input_schema) == original_spin_schema
 
-    # The sibling ``oneOf`` branch from the SAME first call is untouched —
-    # allOf.then.input and the oneOf branch do not share a container either.
-    first_spin_branch = next(b for b in first["properties"]["input"]["oneOf"] if b["title"] == "spin input")
+    # The sibling ``anyOf`` branch from the SAME first call is untouched —
+    # allOf.then.input and the anyOf branch do not share a container either.
+    first_spin_branch = next(b for b in first["properties"]["input"]["anyOf"] if b["title"] == "spin input")
     assert first_spin_branch["properties"]["speed"]["type"] == "integer"
 
 

--- a/tests/test_tool_family_knowledge_migration_parity.py
+++ b/tests/test_tool_family_knowledge_migration_parity.py
@@ -223,7 +223,7 @@ def test_no_authoring_search_or_edit_capability_survives():
     assert actions.isdisjoint(forbidden)
     # And no child accepts an input field at all, so no authoring payload can
     # be smuggled through one.
-    for branch in schema["properties"]["input"]["oneOf"]:
+    for branch in schema["properties"]["input"]["anyOf"]:
         assert branch["properties"] == {}
 
 

--- a/tests/test_tool_family_wire_parity.py
+++ b/tests/test_tool_family_wire_parity.py
@@ -1,6 +1,6 @@
 """Chat Completions / Responses wire parity for the generic ToolFamily schema.
 
-Proves the composed ``oneOf``-over-``input`` schema survives both
+Proves the composed overlap-tolerant ``anyOf``-over-``input`` schema survives both
 provider wire shapes at the smallest existing adapter seam
 (``lingtai.llm.openai.adapter._build_tools`` /
 ``_build_responses_tools``) without any adapter code change — a fake
@@ -58,7 +58,7 @@ def test_generic_family_schema_survives_chat_and_responses_wires():
     chat = _build_tools([schema])[0]["function"]["parameters"]
     responses = _build_responses_tools([schema])[0]["parameters"]
 
-    for wire, combinator in ((chat, "oneOf"), (responses, "anyOf")):
+    for wire, combinator in ((chat, "anyOf"), (responses, "anyOf")):
         assert wire["type"] == "object"
         # ``reasoning`` is REQUIRED Host InvocationContext/audit metadata,
         # declared by the family schema itself (see ToolFamily.build_schema).


### PR DESCRIPTION
## Summary

- use overlap-tolerant `anyOf` for ToolFamily child-input discovery
- preserve action-keyed root `allOf` correlation, closed root fields, settings behavior, and selected-handler routing
- add standards-faithful regression coverage for no-settings families whose child schemas have identical validation constraints

## Validation

- frozen-base fail-first reproduced a valid overlapping call rejected by `oneOf`
- focused ToolFamily suites: 91 passed
- settings-contract subset: 13 passed, 1 deselected
- architecture-document tests: 4 passed
- touched-file Python compilation and `git diff --check`: passed

Fixes #1574
