### PR TITLE
fix(presets): scrub API keys before persistence

### DIFF
--- a/src/lingtai/agent.py
+++ b/src/lingtai/agent.py
@@ -2051,7 +2051,6 @@ class Agent(BaseAgent):
             OSError: the on-disk write failed (init.json untouched)
         """
         import json
-        import os
 
         init_path = self._working_dir / "init.json"
         data = json.loads(init_path.read_text(encoding="utf-8"))
@@ -2064,8 +2063,10 @@ class Agent(BaseAgent):
 
         preset_llm = dict(preset_manifest.get("llm") or manifest.get("llm") or {})
         # Context limits are System-owned runtime policy, never init.json
-        # configuration.  Keep a preset's provider/model selection but do not
-        # hand its context value into the activated init document.
+        # configuration. Keep a preset's provider/model selection but do not
+        # hand its context value into the activated init document. The selected
+        # preset's API key is runtime material: the active preset is
+        # re-materialized on every read rather than persisted here.
         preset_llm.pop("context_limit", None)
         manifest["llm"] = preset_llm
         manifest["capabilities"] = preset_manifest.get(
@@ -2093,11 +2094,22 @@ class Agent(BaseAgent):
 
         self._strip_hidden_runtime_manifest_settings(data)
 
-        # Atomic write
-        tmp = init_path.with_suffix(".json.tmp")
-        tmp.write_text(json.dumps(data, indent=2, ensure_ascii=False),
-                       encoding="utf-8")
-        os.replace(str(tmp), str(init_path))
+        # Sanitize the complete persistent document, including nested
+        # capability kwargs that may carry provider api_key fields. This
+        # targeted copy removes only the supported plaintext API-key field,
+        # retaining provider/model/base_url/api_key_env and all other authored
+        # configuration.
+        from .kernel._fsutil import atomic_write_text
+        from .kernel.workdir import _redact_persisted_api_keys
+        persistent = _redact_persisted_api_keys(data)
+
+        # Atomic write. The shared writer uses a unique same-directory temp and
+        # removes it on every failed write/replace, so no credential-bearing
+        # or stale temporary document can remain.
+        atomic_write_text(
+            init_path,
+            json.dumps(persistent, indent=2, ensure_ascii=False),
+        )
 
     def _activate_default_preset(self) -> None:
         """Read manifest.preset.default and activate it. Used by AED auto-fallback."""

--- a/src/lingtai/kernel/workdir.py
+++ b/src/lingtai/kernel/workdir.py
@@ -130,11 +130,11 @@ def workdir_layout(path: Path | str) -> WorkdirLayout:
     root = Path(path) if isinstance(path, str) else path
     return WorkdirLayout(root)
 
-# Key names that carry (or point at) secret material — dropped recursively
-# before the resolved manifest is published. `*_env` names are included to
-# stay consistent with the `.agent.json` `_SENSITIVE_KEYS` hygiene. The token
-# alternative is anchored on `_`/edges so plural "tokens" fields
-# (e.g. `max_tokens`) survive.
+# Key names that carry secret material — dropped recursively before the
+# resolved manifest is published. `api_key_env` is deliberately retained: an
+# environment-variable name is non-secret configuration metadata, unlike the
+# value resolved from it. The token alternative is anchored on `_`/edges so
+# plural "tokens" fields (e.g. `max_tokens`) survive.
 _SECRET_KEY_RE = re.compile(
     r"(^|_)(api_?key|secret|secrets|password|passwd|credential|credentials"
     r"|private_key|access_key|token)(_|$)",
@@ -152,6 +152,11 @@ def _is_secret_key(key: Any) -> bool:
     """
     raw = str(key)
     normalized = re.sub(r"[^a-z0-9]+", "_", raw.lower()).strip("_")
+    # The variable name is safe to publish so consumers can explain how the
+    # runtime credential is resolved; only the resolved api_key value is
+    # secret-bearing.
+    if normalized == "api_key_env":
+        return False
     if _SECRET_KEY_RE.search(normalized):
         return True
     compact = re.sub(r"[^a-z0-9]+", "", raw.lower())
@@ -164,8 +169,9 @@ def _redact_secrets(value: Any) -> Any:
     """Return a deep copy of *value* with secret-bearing keys removed.
 
     Recurses through dicts and lists; any dict key matching
-    ``_SECRET_KEY_RE`` is dropped entirely (value and all). Non-container
-    leaves are returned as-is.
+    ``_SECRET_KEY_RE`` is dropped entirely (value and all), except the safe
+    ``api_key_env`` variable-name metadata. Non-container leaves are returned
+    as-is.
     """
     if isinstance(value, dict):
         return {
@@ -175,6 +181,30 @@ def _redact_secrets(value: Any) -> Any:
         }
     if isinstance(value, list):
         return [_redact_secrets(v) for v in value]
+    return value
+
+
+def _redact_persisted_api_keys(value: Any) -> Any:
+    """Return a JSON-shaped copy with plaintext API-key fields removed.
+
+    This is intentionally narrower than :func:`_redact_secrets`.  The latter
+    publishes a deliberately secret-free *derived* manifest and therefore
+    removes token/password/credential-like keys too.  ``init.json`` is
+    user-owned configuration: preset activation/default persistence must only
+    remove the supported credential field, ``api_key`` (including its common
+    punctuation/case spellings), while preserving every other authored field,
+    including the non-secret ``api_key_env`` variable name.
+    """
+    if isinstance(value, dict):
+        result: dict[Any, Any] = {}
+        for key, item in value.items():
+            compact = re.sub(r"[^a-z0-9]+", "", str(key).lower())
+            if compact == "apikey":
+                continue
+            result[key] = _redact_persisted_api_keys(item)
+        return result
+    if isinstance(value, list):
+        return [_redact_persisted_api_keys(item) for item in value]
     return value
 
 

--- a/src/lingtai/tools/system/preset.py
+++ b/src/lingtai/tools/system/preset.py
@@ -15,14 +15,25 @@ def _update_default_preset(agent, preset_name: str) -> None:
     """
     import json as _json
     try:
+        from lingtai.kernel._fsutil import atomic_write_text
+        from lingtai.kernel.workdir import _redact_persisted_api_keys
+
         init_path = agent._working_dir / "init.json"
         data = _json.loads(init_path.read_text(encoding="utf-8"))
         preset_block = data.setdefault("manifest", {}).setdefault("preset", {})
         if preset_block.get("default") != preset_name:
             preset_block["default"] = preset_name
-            init_path.write_text(
-                _json.dumps(data, indent=2, ensure_ascii=False) + "\n",
-                encoding="utf-8",
+            # This writer runs after activation and must not reintroduce any
+            # plaintext credentials that were present in the old init snapshot.
+            # Use the shared unique-sibling-temp writer so failed writes clean up
+            # and concurrent writers cannot collide on one fixed temp name.
+            atomic_write_text(
+                init_path,
+                _json.dumps(
+                    _redact_persisted_api_keys(data),
+                    indent=2,
+                    ensure_ascii=False,
+                ) + "\n",
             )
             agent._log("preset_default_persisted", preset=preset_name)
     except Exception as exc:

--- a/tests/test_preset_swap_e2e.py
+++ b/tests/test_preset_swap_e2e.py
@@ -129,6 +129,152 @@ def test_e2e_boot_with_alpha_then_swap_to_beta(tmp_path, monkeypatch):
     assert data2["manifest"]["preset"]["default"] == alpha_path  # original default preserved
 
 
+def test_activation_does_not_persist_preset_plaintext_key_but_reread_materializes(tmp_path, monkeypatch):
+    plib = tmp_path / "presets"
+    _build_lib(plib)
+    alpha = plib / "alpha.json"
+    preset = json.loads(alpha.read_text())
+    preset_secret = "sk-preset-placeholder"
+    old_secret = "sk-old-placeholder"
+    capability_secret = "sk-capability-placeholder"
+    preset["manifest"]["llm"].update({
+        "api_key": preset_secret,
+        "base_url": "https://provider.placeholder/v1",
+    })
+    preset["manifest"]["capabilities"]["file"].update({
+        "api_key": capability_secret,
+        "api_key_env": "FILE_KEY",
+        "base_url": "https://files.placeholder/v1",
+    })
+    alpha.write_text(json.dumps(preset))
+    original_preset = alpha.read_bytes()
+
+    wd = tmp_path / "agent"
+    _build_workdir(wd, plib, str(alpha))
+    init = json.loads((wd / "init.json").read_text())
+    init["manifest"]["llm"]["api_key"] = old_secret
+    (wd / "init.json").write_text(json.dumps(init))
+    agent = _make_probe(wd)
+
+    agent._activate_preset(str(alpha))
+    written_text = (wd / "init.json").read_text()
+    written = json.loads(written_text)
+    assert preset_secret not in written_text
+    assert old_secret not in written_text
+    assert capability_secret not in written_text
+    assert written["manifest"]["llm"] == {
+        "provider": "p1",
+        "model": "m1",
+        "base_url": "https://provider.placeholder/v1",
+        "api_key_env": "P1KEY",
+    }
+    assert written["manifest"]["capabilities"]["file"] == {
+        "api_key_env": "FILE_KEY",
+        "base_url": "https://files.placeholder/v1",
+    }
+    assert alpha.read_bytes() == original_preset
+    assert not (wd / "init.json.tmp").exists()
+    assert not list(wd.glob("*.bak"))
+
+    monkeypatch.setenv("P1KEY", "sk-runtime-placeholder")
+    effective = agent._read_init()
+    assert effective["manifest"]["llm"]["api_key"] == preset_secret
+    artifact_text = (wd / "system" / "manifest.resolved.json").read_text()
+    assert preset_secret not in artifact_text
+    assert capability_secret not in artifact_text
+    assert "api_key" not in json.loads(artifact_text)["manifest"]["llm"]
+    assert json.loads(artifact_text)["manifest"]["llm"]["api_key_env"] == "P1KEY"
+    assert json.loads(artifact_text)["manifest"]["capabilities"]["file"]["api_key_env"] == "FILE_KEY"
+    assert not list((wd / "system").glob("*.tmp"))
+    assert not list((wd / "system").glob(".*.tmp"))
+    assert preset_secret not in json.dumps(agent._log_events)
+    assert capability_secret not in json.dumps(agent._log_events)
+
+
+def test_update_default_preset_redacts_existing_credentials_atomically(tmp_path):
+    """The post-activation default writer must not copy old secrets back."""
+    plib = tmp_path / "presets"
+    _build_lib(plib)
+    alpha_path = plib / "alpha.json"
+    wd = tmp_path / "agent"
+    _build_workdir(wd, plib, str(alpha_path))
+
+    init_path = wd / "init.json"
+    init = json.loads(init_path.read_text())
+    init["manifest"]["llm"].update({
+        "provider": "provider-placeholder",
+        "model": "model-placeholder",
+        "base_url": "https://provider.placeholder/v1",
+        "api_key": "sk-direct-writer-placeholder",
+        "api_key_env": "PLACEHOLDER_LLM_KEY",
+    })
+    init["manifest"]["capabilities"] = {
+        "file": {
+            "api_key": "sk-direct-capability-placeholder",
+            "api_key_env": "PLACEHOLDER_FILE_KEY",
+            "base_url": "https://files.placeholder/v1",
+        },
+    }
+    init_path.write_text(json.dumps(init))
+
+    agent = _make_probe(wd)
+    from lingtai.tools.system.preset import _update_default_preset
+
+    _update_default_preset(agent, str(plib / "beta.json"))
+
+    written_text = init_path.read_text()
+    written = json.loads(written_text)
+    assert "sk-direct-writer-placeholder" not in written_text
+    assert "sk-direct-capability-placeholder" not in written_text
+    assert written["manifest"]["preset"]["default"] == str(plib / "beta.json")
+    assert written["manifest"]["llm"] == {
+        "provider": "provider-placeholder",
+        "model": "model-placeholder",
+        "base_url": "https://provider.placeholder/v1",
+        "api_key_env": "PLACEHOLDER_LLM_KEY",
+    }
+    assert written["manifest"]["capabilities"]["file"] == {
+        "api_key_env": "PLACEHOLDER_FILE_KEY",
+        "base_url": "https://files.placeholder/v1",
+    }
+    assert not (wd / "init.json.tmp").exists()
+    assert not list(wd.glob("*.bak"))
+    assert not list(wd.glob("*.tmp"))
+    assert not list(wd.glob(".*.tmp"))
+    assert "sk-direct-writer-placeholder" not in json.dumps(agent._log_events)
+
+
+def test_activation_replace_failure_cleans_temp_and_keeps_secret_out_of_artifacts(tmp_path, monkeypatch):
+    plib = tmp_path / "presets"
+    _build_lib(plib)
+    alpha = plib / "alpha.json"
+    preset = json.loads(alpha.read_text())
+    preset["manifest"]["llm"]["api_key"] = "sk-failed-write-placeholder"
+    alpha.write_text(json.dumps(preset))
+    wd = tmp_path / "agent"
+    _build_workdir(wd, plib, str(alpha))
+    original_init = (wd / "init.json").read_text()
+    agent = _make_probe(wd)
+
+    import os
+    real_replace = os.replace
+    def fail_replace(source, target):
+        if str(target) == str(wd / "init.json"):
+            raise OSError("simulated replace failure")
+        return real_replace(source, target)
+    monkeypatch.setattr(os, "replace", fail_replace)
+
+    with pytest.raises(OSError):
+        agent._activate_preset(str(alpha))
+    assert (wd / "init.json").read_text() == original_init
+    assert not (wd / "init.json.tmp").exists()
+    assert not list(wd.glob("*.tmp"))
+    assert not list(wd.glob(".*.tmp"))
+    assert "sk-failed-write-placeholder" not in " ".join(
+        event for event, _fields in agent._log_events
+    )
+
+
 def test_e2e_swap_to_unknown_preserves_init(tmp_path, monkeypatch):
     """Swap to nonexistent preset raises KeyError; init.json on disk untouched."""
     plib = tmp_path / "presets"
@@ -205,3 +351,118 @@ def test_e2e_inherit_resolves_after_swap(tmp_path, monkeypatch):
     # model is NOT inherited
     assert "model" not in caps["web"]
     assert "model" not in caps["vision"]
+
+
+def test_persistent_api_key_scrub_is_narrow_and_preserves_auth_metadata():
+    """Durable init cleanup removes only API-key values, not authored config."""
+    from lingtai.kernel.workdir import _redact_persisted_api_keys
+
+    source = {
+        "manifest": {
+            "llm": {
+                "provider": "placeholder-provider",
+                "model": "placeholder-model",
+                "base_url": "https://provider.placeholder/v1",
+                "api_key": "sk-persistent-placeholder",
+                "api_key_env": "PR9_LLM_PLACEHOLDER_ENV",
+                "service_tier": "default",
+                "wire_api": "auto",
+            },
+            "capabilities": {
+                "file": {
+                    "provider": "placeholder-provider",
+                    "base_url": "https://files.placeholder/v1",
+                    "api_key": "sk-capability-placeholder",
+                    "api_key_env": "PR9_CAP_PLACEHOLDER_ENV",
+                },
+            },
+        },
+    }
+
+    cleaned = _redact_persisted_api_keys(source)
+    assert cleaned["manifest"]["llm"] == {
+        "provider": "placeholder-provider",
+        "model": "placeholder-model",
+        "base_url": "https://provider.placeholder/v1",
+        "api_key_env": "PR9_LLM_PLACEHOLDER_ENV",
+        "service_tier": "default",
+        "wire_api": "auto",
+    }
+    assert cleaned["manifest"]["capabilities"]["file"] == {
+        "provider": "placeholder-provider",
+        "base_url": "https://files.placeholder/v1",
+        "api_key_env": "PR9_CAP_PLACEHOLDER_ENV",
+    }
+    assert source["manifest"]["llm"]["api_key"] == "sk-persistent-placeholder"
+    assert source["manifest"]["capabilities"]["file"]["api_key"] == "sk-capability-placeholder"
+
+
+def test_activation_reread_from_fresh_agent_materializes_selected_key(tmp_path, monkeypatch):
+    """A fresh probe (restart simulation) gets the selected key only in memory."""
+    plib = tmp_path / "presets"
+    _build_lib(plib)
+    alpha = plib / "alpha.json"
+    preset = json.loads(alpha.read_text())
+    selected_secret = "sk-restart-selected-placeholder"
+    preset["manifest"]["llm"].update({
+        "api_key": selected_secret,
+        "base_url": "https://provider.placeholder/v1",
+    })
+    alpha.write_text(json.dumps(preset))
+    authored_preset = alpha.read_bytes()
+    wd = tmp_path / "agent"
+    _build_workdir(wd, plib, str(alpha))
+
+    first = _make_probe(wd)
+    first._activate_preset(str(alpha))
+    safe_init_text = (wd / "init.json").read_text(encoding="utf-8")
+    assert selected_secret not in safe_init_text
+
+    # Rebuild the probe after activation: no in-process state is reused.
+    monkeypatch.setenv("P1KEY", "sk-runtime-restart-placeholder")
+    restarted = _make_probe(wd)
+    effective = restarted._read_init()
+    assert effective is not None
+    assert effective["manifest"]["llm"]["provider"] == "p1"
+    assert effective["manifest"]["llm"]["base_url"] == "https://provider.placeholder/v1"
+    assert effective["manifest"]["llm"]["api_key"] == selected_secret
+    artifact_text = (wd / "system" / "manifest.resolved.json").read_text()
+    assert selected_secret not in artifact_text
+    assert restarted._log_events
+    assert selected_secret not in json.dumps(restarted._log_events)
+    assert alpha.read_bytes() == authored_preset
+
+
+def test_default_writer_replace_failure_keeps_existing_safe_init_and_cleans(tmp_path, monkeypatch):
+    """A failed default update leaves the already-safe init bytes untouched."""
+    plib = tmp_path / "presets"
+    _build_lib(plib)
+    alpha = plib / "alpha.json"
+    preset = json.loads(alpha.read_text())
+    preset["manifest"]["llm"]["api_key"] = "sk-default-failure-placeholder"
+    alpha.write_text(json.dumps(preset))
+    wd = tmp_path / "agent"
+    _build_workdir(wd, plib, str(alpha))
+    agent = _make_probe(wd)
+    agent._activate_preset(str(alpha))
+    init_path = wd / "init.json"
+    before = init_path.read_bytes()
+    assert b"sk-default-failure-placeholder" not in before
+
+    import os
+    real_replace = os.replace
+
+    def fail_replace(source, target):
+        if str(target) == str(init_path):
+            raise OSError("simulated default replace failure")
+        return real_replace(source, target)
+
+    monkeypatch.setattr(os, "replace", fail_replace)
+    from lingtai.tools.system.preset import _update_default_preset
+    _update_default_preset(agent, str(plib / "beta.json"))
+
+    assert init_path.read_bytes() == before
+    assert not list(wd.glob("*.tmp"))
+    assert not list(wd.glob(".*.tmp"))
+    assert not list(wd.glob("*.bak"))
+    assert "sk-default-failure-placeholder" not in json.dumps(agent._log_events)

--- a/tests/test_resolved_manifest_artifact.py
+++ b/tests/test_resolved_manifest_artifact.py
@@ -108,7 +108,7 @@ def test_redact_secrets_drops_secret_keys_keeps_public():
     assert llm["api_compat"] == "openai"
     assert llm["context_limit"] == 128000
     assert "api_key" not in llm
-    assert "api_key_env" not in llm  # consistent with .agent.json hygiene
+    assert llm["api_key_env"] == "DEEPSEEK_API_KEY"
     caps = out["capabilities"]
     assert "api_key" not in caps["web_search"]
     assert caps["telegram"] == {"chat_id": 123}
@@ -210,17 +210,16 @@ def test_artifact_redacts_api_key_like_secrets(tmp_path, monkeypatch):
     wd = _make_workdir(
         tmp_path,
         llm={"provider": "deepseek", "model": "deepseek-v4-flash",
-             "api_key": secret},
+             "api_key": secret, "api_key_env": "DEEPSEEK_API_KEY"},
         manifest_extra={"capabilities": {
-            "file": {},
-            "web_search": {"provider": "inherit"},
+            "file": {"provider": "inherit"},
         }},
     )
     a = _make_probe_agent(wd)
     data = a._read_init()
     assert data is not None
     # inherit expansion really copied the secret into capability kwargs
-    assert data["manifest"]["capabilities"]["web_search"]["api_key"] == secret
+    assert data["manifest"]["capabilities"]["file"]["api_key"] == secret
 
     artifact_text = (wd / "system" / "manifest.resolved.json").read_text()
     assert secret not in artifact_text
@@ -229,7 +228,8 @@ def test_artifact_redacts_api_key_like_secrets(tmp_path, monkeypatch):
     assert "api_key" not in llm
     assert llm["provider"] == "deepseek"
     assert llm["model"] == "deepseek-v4-flash"
-    assert "api_key" not in artifact["manifest"]["capabilities"]["web_search"]
+    assert llm["api_key_env"] == "DEEPSEEK_API_KEY"
+    assert "api_key" not in artifact["manifest"]["capabilities"]["file"]
     # no half-written temp file left behind by the atomic write
     assert not (wd / "system" / "manifest.resolved.json.tmp").exists()
 


### PR DESCRIPTION
## Summary

- recursively remove direct and nested API-key fields before writing user-owned `init.json`
- preserve non-secret preset configuration such as provider, model, base URL, and `api_key_env`, while keeping credential materialization in memory
- reuse a unique sibling-temporary-file atomic writer and retain the broader secret scrub only for the derived resolved-manifest artifact

## Validation

- frozen-base fail-first persisted both selected and nested fake key placeholders; the candidate removes them while preserving non-secret configuration
- focused preset and artifact suites: 69 passed
- adjacent filesystem, reader, CLI, runtime, and system suites: 338 passed
- comparison guard: candidate and frozen base both reached 285 passed with the same inherited isolation failure
- touched-file Python compilation and `git diff --check`: passed

## Notes

The remaining isolation failure is inherited from the frozen base and unrelated to preset persistence.

Fixes #1581
