### PR TITLE
feat(puffo): discover initialized runtime candidates

### DIFF
--- a/src/lingtai/adapters/acp/ANATOMY.md
+++ b/src/lingtai/adapters/acp/ANATOMY.md
@@ -78,6 +78,8 @@ co-located [`CONTRACT.md`](CONTRACT.md), and its operator/developer procedure is
   and workspace, verifies an entry digest plus provision-time filesystem
   identity, serializes provision/revoke read-modify-write operations with a
   POSIX lock, records terminal revocations in an append-only tombstone log, and
+  performs read-only discovery of initialized identities below one caller-selected
+  root without following directory symlinks or creating registry artifacts. It
   refuses missing, malformed, tampered, retargeted, or revoked entries before
   Agent construction. Its `entry_digest` authenticates registry data rather
   than claiming to authenticate the effective manifest, tool/action, or full
@@ -100,9 +102,9 @@ co-located [`CONTRACT.md`](CONTRACT.md), and its operator/developer procedure is
   Shared poisoned-worker exit logging is lease-aware: retained ownership may log,
   while a successful `STOPPED` release skips every later workdir append and still
   reaches the unconditional process exit.
-- `../../cli_puffo_v0.py` — local-only control plane that provisions an existing
-  persistent identity or revokes it for future `puffo-v0` launches; it is not an
-  ACP data-plane surface.
+- `../../cli_puffo_v0.py` — local-only control plane that discovers initialized
+  identities below an explicit root, provisions an existing persistent identity,
+  or revokes it for future `puffo-v0` launches; it is not an ACP data-plane surface.
 - `../../kernel/process_match.py` — exact duplicate-host grammar for module,
   console, legacy, and quoted Windows `.exe` ACP launch forms.
 - `../../kernel/turns.py`, `../../kernel/execution_workspace.py`, `../../kernel/turn_events.py`, `../../kernel/turn_permissions.py`, `../../kernel/provider_admission.py`, and `../../kernel/tool_executor.py` — inward Core boundary consumed by the Adapter:

--- a/src/lingtai/adapters/acp/BEHAVIORS.md
+++ b/src/lingtai/adapters/acp/BEHAVIORS.md
@@ -104,10 +104,74 @@ the evidence trail in the task report.
 ### Steps
 
 1. Run `python -m pytest -q -x tests/test_puffo_v0_profile.py`.
-2. Inspect the registry cases: only an active, entry-digest-valid opaque id
+2. Inspect the registry and discovery cases: only an active, entry-digest-valid opaque id
   with its original directory identity resolves; tampered, retargeted, or
   revoked entries, including a missing required revocation log, fail before
-  composition. An active identity and workspace cannot be bound twice.
+  composition, each with a distinct message keyed to the caller's recovery, and
+  integrity is decided before policy version so a tampered entry is never read as
+  a benign drift. An active identity and workspace cannot be bound twice; a
+  policy-drifted occupant still blocks provisioning but names its own id and the
+  revoke recovery. The one-to-one binding guard compares the stored device/inode
+  identity, not the path string, so a directory renamed away and reached through
+  a symlink at its old path cannot be bound twice; it reads each entry through the
+  classifier (a corrupted status cannot hide an occupant) and fails closed on an
+  unreadable binding rather than skipping it. A discovery query stays below its
+  explicit root, skips symlink
+  escapes and unreadable descendants, classifies each directory by caller action
+  (`available`/`bound`/`revoked`/`policy_version_mismatch`/`stale_binding`/
+  `integrity_failed`/`shape_mismatch`) with no two distinct-action states sharing
+  a `(status, runtime_id, workspace)` representation, surfaces the `runtime_id` of
+  a revoked, drifted, or stale binding so it can be revoked, reports no fabricated
+  workspace for an unbound directory, and leaves registry bytes and modes
+  unchanged. Discovery attributes each entry to a walked directory by its
+  provisioned device/inode identity, not the stored path, so `bound` is a live
+  promise verified against that identity — the same check resolve enforces; an
+  entry whose runtime-id syntax is invalid (rejected by resolve, unreachable by
+  revoke) classifies `shape_mismatch`, never `bound`. A
+  same-path replacement therefore reports the recreated directory `available` (a
+  new, unbound identity that really provisions) and the moved original
+  `stale_binding`; that recreated `available` directory additionally carries an
+  advisory `formerly_bound_runtime_id` naming the entry that recorded the path but
+  no longer holds it (sourced from any non-revoked entry's stored path, so a
+  policy-drifted or shape-mismatched replacement is flagged too), which changes no
+  `status` and is not part of the distinctness invariant. Discovery reads the same
+  two binding fields the guard does (`agent_dir` and `workspace`): a revocation log
+  present without its registry, or any non-revoked entry whose stored `agent_dir`
+  or `workspace` binding cannot be read, makes discovery fail closed for the whole
+  listing rather than report any directory `available` — the guard parses both
+  bindings before any comparison and refuses every provision while such an entry
+  stands, so discovery must match. Confirm the classifier ordering: digest PRESENCE
+  AND digest MATCH are both decided BEFORE the structural key-set, so `integrity_failed`
+  means exactly "binding not authenticated by its digest" and `shape_mismatch` always
+  implies "digest verified"; an un-resigned edit (bumped inode, extra key, changed
+  status) is `integrity_failed` no matter what else it changes, never a milder state
+  whose binding gets consulted. Confirm an unauthenticated (`integrity_failed`) entry
+  decides NO occupancy: it blocks every provision unconditionally (its stored
+  device/inode may point away from the directory it truly holds, so the guard never
+  consults it) and aborts the whole discovery listing (never emitted as an
+  `integrity_failed` row) — so a directory it holds can never read `available`. Sweep
+  the wrong-value × stale-digest cross-product on BOTH bindings (structurally valid new
+  inode + old digest), asserting discover fails closed, provision refused, and
+  registry/tombstone bytes unchanged. Then value-shape — profile fields, runtime-id
+  syntax, a `status` that is exactly `active`/`revoked`, and well-formed binding
+  payloads — is decided (on an authenticated entry) BEFORE the revoked gate, so an
+  unknown signed `status` (e.g. `disabled`) is blocking, never released, and no value
+  defect is laundered into `revoked` by editing `status`.
+  Confirm `revoke_runtime` admits only a `bound`/policy-drift/stale entry and
+  refuses tampered, malformed, unknown-status, or already-revoked ones BEFORE any
+  write — critically before the tombstone append, since a tombstone alone releases
+  the directory and the log is append-only — so a refused revoke leaves registry
+  bytes and the tombstone's bytes/line-count unchanged and the entry still blocking;
+  `integrity_failed`/`shape_mismatch` thus have no self-service clear as behavior,
+  not wording. Confirm the guard aggregates conflicts and selects by the discover
+  precedence, so its named occupant and recovery are independent of registry
+  insertion order. Confirm a policy-drifted entry reports a workspace only when that
+  workspace's binding is still live (a deleted or same-path-replaced workspace
+  reports `null`). Confirm the mechanized invariants over the damaged-entry roster:
+  every discover `bound` output resolves and every `available` output provisions
+  (with a healthy control exercising both branches), and every blocking subtype
+  stays blocked and byte-unchanged across `revoke` — swept per subtype, not by a
+  single sample, and across registry insertion orders.
 3. Inspect the profile session and turn-origin cases: `puffo-v0` rejects every
    non-empty `mcpServers` input. `puffo-v1` accepts exactly one `puffo` service
    with `-m puffo_agent.mcp.puffo_core_server`, a deployment-local absolute
@@ -135,7 +199,11 @@ the evidence trail in the task report.
 - [ ] Root provider calls and derived-launch requests use the consumed Driver
   endpoint, or both return `driver_authority_unavailable`; the environment
   locator is absent before Agent construction and cannot reach descendants.
-- [ ] The host-boundary non-guarantee remains documented.
+- [ ] The host-boundary non-guarantee remains documented, including that
+  `entry_digest` is an UNKEYED checksum: the fail-closed occupancy rules stop an
+  UNAUTHENTICATED (un-resigned/corrupt) entry from deciding occupancy, but a principal
+  who can write the registry AND recompute the checksum is not defended against —
+  a keyed signature is a separate threat-model decision.
 
 ### Pass / Fail
 

--- a/src/lingtai/adapters/acp/CONTRACT.md
+++ b/src/lingtai/adapters/acp/CONTRACT.md
@@ -1,6 +1,6 @@
 ---
 name: acp-local-stdio
-contract_version: 3
+contract_version: 4
 root_contract: CONTRACT.md
 related_files:
   - src/lingtai/adapters/acp/ANATOMY.md
@@ -310,7 +310,15 @@ argv, environment, or MCP command from the remote caller.
     `entry_digest` protects the exact registry entry only; it is not a digest
     of `init.json`, effective tool/action policy, executable/argv/environment,
     or addon/plugin policy. The driver-owned full launch-plan digest remains a
-    separate cross-process contract. A profile session accepts
+    separate cross-process contract. `entry_digest` is an UNKEYED content checksum,
+    not a keyed signature: it detects an entry edited without recomputing it —
+    corruption or an un-resigned tamper — and the fail-closed occupancy rules above
+    stop such an UNAUTHENTICATED entry from deciding occupancy. It does NOT make the
+    registry tamper-resistant against a principal who can both write the registry
+    file and recompute the checksum; such an entry classifies as though authentic.
+    That principal is the same-OS registry-writer already inside the host trust
+    boundary; upgrading `entry_digest` to a keyed signature is a separate
+    threat-model decision, not part of this occupancy contract. A profile session accepts
     only that workspace and
     `mcpServers: []`; it never starts a client-supplied process. This is an
     identity/workspace-bound **full-tool** profile: operator-managed LingTai
@@ -332,8 +340,139 @@ argv, environment, or MCP command from the remote caller.
     no background descendants, or network containment. “Authenticated Adapter”
     is a typed handoff from the Puffo driver that owns the local ACP process;
     LingTai's stdio server does not independently authenticate a remote Puffo
-    user. Registry provision/revoke
-    mutations are process-serialized; revocation additionally writes an
+    user. Registry provision/revoke mutations are process-serialized.
+    `lingtai-agent puffo-v0 discover --root <directory> --json` is a separate
+    read-only control-plane query: it lists only initialized directories below
+    the caller-selected canonical root, never follows directory symlinks, skips
+    unreadable descendants, and creates or rewrites no registry, lock, or
+    tombstone artifact. Each item returns canonical `agent_dir`, a directory-name
+    display label, a `runtime_id` when the directory is attributed to a registry
+    entry, a `workspace` only when a live binding exists (`null` otherwise, never
+    a fabricated path), a `status` classifying the directory by the action it
+    demands of the caller, and an advisory `formerly_bound_runtime_id` (`null`
+    except on an `available` directory whose path a prior entry recorded — see
+    below). `status` is emitted directly from that classification,
+    never re-derived from whether a `runtime_id` is present, so the states below
+    are distinguishable: `available` (no entry — may provision), `bound` (usable
+    now — resolvable), `revoked` (re-provision under a new id),
+    `policy_version_mismatch` (authentic but provisioned under an older policy
+    version — revoke and re-provision the same directory), `stale_binding`
+    (authentic and active, but the on-disk directory it names no longer presents
+    the provisioned device/inode/owner/group identity — revoke and re-provision
+    after verifying the directory), and
+    `shape_mismatch` (authentic but not this profile — escalate). An entry whose
+    digest is missing or mismatched (`integrity_failed`) is NOT a discovery status:
+    such an entry is not authenticated, so its stored binding cannot be trusted to
+    attribute it to any directory, and discovery fails closed for the whole listing
+    rather than emit a row it cannot place — stop and escalate; never auto-revoked.
+    Discovery
+    attributes each entry to a walked directory by that provisioned device/inode
+    identity, never by the stored path string, so an entry whose recorded path has
+    since become non-canonical (a parent turned into a symlink, or the directory
+    was renamed with a symlink left at the old path) is still attributed to the
+    physical directory it actually holds. `bound` is a
+    live promise, not a registry-content claim: discovery verifies the recorded
+    agent_dir and workspace still resolve to their provisioned identity — the
+    exact check `resolve_runtime` enforces — before reporting
+    `bound`, and reports `stale_binding` (with the `runtime_id` and no workspace)
+    otherwise, so `bound = usable now` cannot be a lie a subsequent resolve
+    exposes. The classifier also validates runtime-id syntax: an entry whose id is
+    syntactically invalid — which `resolve_runtime` rejects outright and `revoke`
+    cannot reach — classifies as `shape_mismatch`, never `bound`, closing the gap
+    where a valid digest over an illegal id was reported `bound` yet not resolvable. Because attribution is by identity, a same-path replacement — the
+    recorded directory renamed away and a fresh directory recreated at the same
+    path — reports the fresh directory `available` (its identity is genuinely
+    unbound and provisioning it succeeds), while the moved original, if still
+    under the root, reports `stale_binding` under the runtime_id that owns that
+    identity. So the caller is not left to mistake a reused path for a never-bound
+    one, that `available` directory also carries `formerly_bound_runtime_id`: the
+    id of the entry that recorded this exact path but whose identity is no longer
+    here. It is sourced from the stored path of any non-revoked entry (a revoked
+    entry released its path on purpose), so a policy-drifted or shape-mismatched
+    entry whose directory was replaced is flagged too, not only the active-then-
+    moved case; when several entries name one path the most-constraining supplies
+    the id. It is advisory: it never changes `status` (the directory stays
+    provisionable) and is deliberately NOT part of the distinctness invariant —
+    two `available` directories, one signed and one not, demand the same action.
+    The governing invariant: two states that require a different caller
+    response never share a `(status, runtime_id, workspace)` representation.
+    Classifier ordering is load-bearing. Integrity — the digest check — is decided
+    first among the content checks, so the enum carries the trust fact: digest
+    PRESENCE (a missing or non-string `entry_digest`) AND the digest MATCH are both
+    decided BEFORE the structural key-set comparison, so `integrity_failed` means
+    exactly "this entry's stored binding is not authenticated by its digest" and
+    `shape_mismatch` always implies "digest verified, values wrong". This matters
+    beyond version ordering: if the key-set check ran first, an un-signed entry with
+    an extra or missing key would be read as a merely malformed `shape_mismatch`
+    while its binding was just as unauthenticated as a digest-mismatch entry's, and
+    the occupancy checks would consume that binding. Ordering the digest match ahead
+    of the key-set closes that. Integrity is also decided before policy version and
+    independently, so a tampered entry is never read as a benign version drift and
+    auto-revoked. Every value-shape check — the profile fields, a syntactically valid
+    runtime id, a `status` that is exactly `active` or `revoked`, and well-formed
+    binding payloads — is decided (on an authenticated entry) BEFORE the revoked gate,
+    and only an explicit revocation (`status == "revoked"` or a revocation-log
+    tombstone) releases a directory. An unknown but validly signed `status` is
+    therefore blocking (`shape_mismatch`), never silently released, and no value
+    defect can be laundered into a released state by editing `status`. When one
+    directory is named by several entries, the most constraining state governs
+    (`integrity_failed` > `shape_mismatch` > `policy_version_mismatch` >
+    `stale_binding` > `bound` > `revoked`); the provision guard selects among
+    conflicting entries by this SAME precedence — an unauthenticated occupant outranks
+    every readable one — so which occupant it names is independent of registry
+    insertion order, and discovery realizes the top of that order by failing closed
+    (an unauthenticated entry present anywhere aborts the listing) rather than by
+    emitting an `integrity_failed` row. Two active entries on one directory remain
+    hard corruption. The same classification
+    governs `resolve_runtime`, which rejects every non-active state with a
+    distinct message, and `provision_runtime`, whose one-to-one binding guard
+    compares that same provisioned device/inode identity — never the path string,
+    so a renamed directory reached through a symlink cannot be bound twice — and
+    reads each entry's status through the classifier, so a corrupted status field
+    cannot make an occupant vanish from the guard. The guard fails closed on an
+    entry whose binding it cannot read rather than skipping it (a skip is the
+    allow direction). It also fails closed, UNCONDITIONALLY, on an entry whose binding
+    it cannot TRUST: an unauthenticated (`integrity_failed`) entry blocks EVERY
+    provision, not only one whose target happens to equal its stored device/inode,
+    because the digest failure means that stored device/inode may have been edited to
+    point away from the directory the entry actually holds — so the guard cannot rule
+    out that the entry still holds the target and must not consult the tampered value
+    at all. Discovery matches: an unauthenticated entry present anywhere aborts the
+    listing (it cannot be attributed to any directory), so a directory such an entry
+    truly holds can never read `available` while it stands. Every rejection it raises names the runtime_id that holds the
+    directory, the path that entry recorded, and the operation that actually clears
+    it — never a generic "another active runtime" the caller cannot act on, and
+    never an operation that does not work. For an active or policy-drifted occupant
+    that is revoke. For a tampered (`integrity_failed`) or malformed
+    (`shape_mismatch`) entry there is no safe self-service clear, and that is a
+    BEHAVIOR, not merely a message: `revoke_runtime` admits only an entry the
+    classifier rules ACTIVE or `policy_version_mismatch` (a stale binding is included
+    — the classifier rules it ACTIVE and discovery downgrades it only for display)
+    and refuses every other entry — tampered, malformed, unknown-status, or already
+    revoked — before it writes anything. The admission check runs BEFORE the first
+    persistence deliberately: revocation appends a tombstone before it touches the
+    entry, and a tombstone alone releases the directory (the classifier honours the
+    revocation log), so a check placed after the append would release identity even
+    on a refused call — irreversibly, because the log is append-only. Refusing up
+    front also means revoke never re-signs a tampered entry (which would erase the
+    integrity signal) and never re-adds a dropped `entry_digest`/`status` to launder
+    a broken entry into a released state. Each rejection message names this admission
+    rule rather than a per-subtype capability claim (so no message can be falsified
+    by a shape subtype it did not enumerate), and `resolve_runtime` reports the same
+    escalation for the same states. The guard parses both stored bindings —
+    `agent_dir` and `workspace` — before any identity comparison, so an entry with
+    either binding unreadable makes the guard refuse every provision; discovery reads
+    the same two fields and fails closed for the whole listing to match. A revocation
+    log present without its registry, and any non-revoked entry whose stored
+    `agent_dir` or `workspace` binding cannot be read, are broken control-plane states
+    — provisioning refuses to re-initialize over an orphaned log and cannot rule out a
+    conflict on a binding it cannot read — so discovery fails closed rather than
+    reporting any directory `available`. A legitimately revoked entry, by contrast,
+    has released its directory, which is reported `available` — matching provision,
+    which lets a new-id binding through; such an entry always has well-formed
+    bindings, because a malformed binding payload classifies `shape_mismatch` ahead of
+    the revoked gate, so a "revoked entry with an unreadable binding" cannot arise. Revocation
+    additionally writes an
     append-only tombstone before the mutable registry, so a stale full-registry
     snapshot cannot reactivate an id. The versioned registry declares this log
     mandatory: a missing, unreadable, malformed, or mismatched log rejects

--- a/src/lingtai/adapters/acp/MANUAL.md
+++ b/src/lingtai/adapters/acp/MANUAL.md
@@ -107,13 +107,173 @@ Revocation does not terminate an already-running ACP host or invalidate its
 in-progress turn; stop that host separately when incident response must stop
 existing work.
 
+To show importable identities, scan only a directory explicitly selected by the
+operator:
+
+```bash
+lingtai-agent puffo-v0 discover --root /operator/selected/root --json
+```
+
+The command is read-only: it lists only descendant directories containing
+`init.json`, skips unreadable descendants and directory symlinks, and never
+creates or rewrites the registry, lock, or tombstone log. Each result includes
+canonical `agent_dir`, a directory-name `display_name`, a `runtime_id` when the
+directory is attributed to an entry, a `workspace` only when a live binding
+exists (`null` otherwise), a `status` classifying the directory by the
+caller's next action, and an advisory `formerly_bound_runtime_id` (`null` unless
+this is an `available` path a prior entry recorded): `available` (may provision), `bound` (usable now —
+resolvable), `revoked` (re-provision under a new id), `policy_version_mismatch`
+(revoke and re-provision the same directory), `stale_binding` (the recorded
+directory no longer presents the provisioned device/inode/owner/group identity —
+revoke and re-provision after verifying the directory), or `shape_mismatch`
+(escalate). An entry whose digest is missing or mismatched (`integrity_failed`) is
+NOT a discovery status: it is not authenticated, so its stored binding cannot be
+trusted to say which directory it holds, and discovery fails closed for the whole
+listing rather than emit a row it cannot place (stop and escalate). The `status` is
+emitted from the
+classification, not inferred from the presence of a `runtime_id`, so a drifted or
+tampered directory is never reported as simply `available` or `bound`. Discovery
+attributes each entry to a walked directory by its provisioned device/inode
+identity, not by the stored path string, so an entry whose recorded path has
+since become non-canonical (a parent symlink, or a rename with a symlink left
+behind) is still attributed to the physical directory it holds. `bound`
+verifies the recorded agent_dir and workspace still resolve to their provisioned
+identity — the same check `resolve` enforces — so it is never reported for a
+directory `resolve` would reject. The classifier also validates the entry's
+runtime-id syntax: a syntactically invalid id (which `resolve` rejects outright,
+and which `revoke` cannot even reach) classifies as `shape_mismatch`, never
+`bound`, so `bound` continues to imply "`resolve` succeeds here". One consequence of identity attribution: a
+same-path replacement (rename the recorded directory away, recreate a fresh one
+at the same path) reports the fresh directory `available` — its identity is
+genuinely unbound and provisioning it succeeds — while the moved original, if
+still under the root, reports `stale_binding`. So a reused path is not mistaken
+for a never-bound one, that `available` directory also carries an advisory
+`formerly_bound_runtime_id` naming the entry that recorded this path but no longer
+holds it. It is sourced from the stored path of any non-revoked entry (so a
+policy-drifted or shape-mismatched entry whose directory was replaced is flagged
+too), and is advisory only: `status` stays `available` and the field is not part
+of the distinctness invariant. The hint is matched by comparing the entry's stored
+canonical path against the walked directory's resolved path as strings; if those
+canonical forms ever diverge the sign is silently omitted (the door still opens,
+just without the sign), so treat its presence as best-effort, not a guarantee.
+A revocation log present without
+its registry, or a non-revoked entry whose stored `agent_dir` **or** `workspace`
+binding cannot be read, makes discovery fail closed rather than report any
+directory `available`, because provision refuses to re-initialize over an
+orphaned log and cannot rule out a conflict it cannot read. Discovery checks the
+same two binding fields the provision guard does: the guard parses both stored
+bindings before any identity comparison and rejects on either, so a single
+unreadable binding makes the guard refuse *every* provision — the whole registry
+is unprovisionable until that entry is repaired. Discovery therefore fails closed
+for the whole listing, not just for the one directory that entry names; reporting
+any other directory `available` while that entry stands would promise a provision
+that cannot succeed. The same fail-closed posture covers an entry whose binding it
+cannot *trust*, not only one it cannot *read*: an unauthenticated (`integrity_failed`)
+entry — one whose digest is missing or does not match, so its stored device/inode may
+have been edited to point away from the directory it actually holds — blocks EVERY
+provision unconditionally (never consulting the tampered value) and aborts the whole
+discovery listing, so a directory it truly holds can never read `available`. Because
+the digest match is decided before the structural key-set, this holds no matter what
+else is wrong with the entry: any un-resigned edit (a bumped inode, an extra key, a
+changed status) is `integrity_failed`, not a milder `shape_mismatch` whose binding
+would be consulted. A legitimately revoked entry has released its directory, so
+its directory reads `available`, matching provision's new-id allowance; such an
+entry always has well-formed bindings, because a malformed binding payload
+classifies `shape_mismatch` ahead of the revoked gate — a "revoked entry with an
+unreadable binding" cannot arise.
+
 Provision stores each directory's canonical path and POSIX device/inode/owner/
 group identity. An active agent directory or workspace may be bound to only one
-runtime. At launch the profile rejects symlink retargeting, a changed canonical
-path, or a replacement directory at the same path, then rechecks the binding
-immediately before Agent construction. This detects normal configuration drift;
-it is not host isolation against a same-OS principal that changes the filesystem
-after that final check.
+runtime: the guard compares that stored device/inode identity, never the path
+string, so a directory renamed away and reached through a symlink at its old
+path cannot be bound a second time. The guard reads each entry through the
+classifier rather than its raw `status`, so a corrupted status field cannot hide
+an occupant, and it fails closed on an entry whose binding it cannot read instead
+of skipping it. It also blocks unconditionally on an entry whose binding it cannot
+*trust* — an unauthenticated (`integrity_failed`) entry refuses EVERY provision, not
+only one whose target equals its stored device/inode, because the digest failure
+means that stored value may point away from the directory the entry actually holds,
+so the guard must not consult it to clear a target. When several entries conflict on
+one target directory the guard aggregates them and reports the most-constraining by
+the SAME precedence discovery uses (an unauthenticated or unreadable binding outranks
+every readable occupant), so which occupant it names — and thus which recovery it
+prescribes — is independent of registry insertion order and never contradicts
+discovery for that directory. At launch the
+profile rejects symlink retargeting, a changed canonical path, or a replacement
+directory at the same path, then rechecks the binding immediately before Agent
+construction. This detects normal configuration drift; it is not host isolation
+against a same-OS principal that changes the filesystem after that final check.
+
+`revoke_runtime` is a state change, not a repair. It admits only an entry the
+classifier rules `bound` or `policy_version_mismatch` (a stale binding is admitted
+too — the classifier rules it `bound`, discovery downgrades it only for display) and
+refuses every other entry — tampered, malformed, unknown-status, or already revoked.
+The admission check runs BEFORE the first write: revocation appends its tombstone
+before it touches the entry, and a tombstone alone releases the directory, so a
+check placed after the append would release identity even on a refused call, and the
+append-only log makes that release irreversible. Refusing up front is also what
+keeps the integrity signal intact (revoke never re-signs a tampered entry) and stops
+a dropped `entry_digest`/`status` from being re-added to launder a broken entry into
+a released state. So `integrity_failed` and `shape_mismatch` have no self-service
+clear as a matter of behavior, not just wording; every rejection names that
+admission rule rather than a per-subtype "cannot" claim.
+
+The four operations that read an entry — `discover`, the provision guard,
+`resolve`, and `revoke` — must agree on every input that decides an entry's
+usability, or one promises an outcome another rejects. Each such input must be read
+on all four sides (or, where a side legitimately does not act on it, deliberately
+not). "classifier" means the input is consumed through `_classify_registry_entry`,
+the single source of truth all four route through:
+
+| Entry input | discover | provision guard | resolve | revoke |
+| --- | --- | --- | --- | --- |
+| structural shape (key set) | classifier | classifier | classifier | classifier (admission) |
+| `entry_digest` present + matches | classifier | classifier | classifier | classifier (admission) |
+| revocation-log presence/validity | fail-closed read | fail-closed read | fail-closed read | fail-closed read |
+| raw `status` value (incl. unknown) | classifier | classifier | classifier | classifier (admission) |
+| profile fields | classifier | classifier | classifier | classifier (admission) |
+| `runtime_policy_version` | classifier | classifier | classifier | classifier (admitted) |
+| key ↔ `entry.runtime_id` | classifier | classifier | classifier | classifier (admission) |
+| runtime-id syntax | classifier | classifier | `_valid_runtime_id` | `_valid_runtime_id` + classifier |
+| `agent_dir_binding` well-formed | classifier + fail-closed | classifier + fail-closed | classifier + `_bound_directory` | classifier (admission) |
+| `workspace_binding` well-formed | classifier + fail-closed | classifier + fail-closed | classifier + `_bound_directory` | classifier (admission) |
+| live on-disk identity | `bound`→`stale_binding`; workspace liveness on drift | n/a (compares target) | `_bound_directory` | n/a |
+| `init.json` present | lister only | n/a | n/a | n/a |
+
+An empty cell is a candidate defect of the "one side promises, another does not
+deliver" kind — every gap found so far was one. The table alone is not enough;
+three axes cut across it and must be swept explicitly, because a per-state row can
+hide a defect that lives inside a state or across entries:
+
+- **Raw `status` value → state, including unknown values.** Only an explicit
+  `revoked` (or a revocation-log tombstone) releases a directory; any other signed
+  `status` (e.g. `disabled`) is blocking (`shape_mismatch`), never silently released.
+- **Subtypes within one state.** `shape_mismatch` and `integrity_failed` each have
+  many subtypes (a foreign profile, a dropped key, an invalid binding payload, a
+  missing vs. mismatched digest, …). A message or test that asserts a universal about
+  a state ("revoke cannot clear it") must range over its subtypes, not one sample —
+  the single-sample confirmation of a universal is what let an earlier review pass a
+  false claim. Recovery must be uniform across a state's subtypes.
+- **Registry iteration order.** When several entries conflict on one directory, the
+  chosen conflict and its prescribed recovery must not depend on insertion order; the
+  guard selects by the discover precedence.
+- **Digest authentication is orthogonal to every other defect (the cross-product
+  axis).** Whether the digest matches is decided BEFORE any other field, so an
+  un-resigned edit is `integrity_failed` no matter what else it changes — a bumped
+  inode, an extra key, a foreign profile, a drifted version. A test must not pair
+  "wrong value" only with "digest re-signed" and "wrong digest" only with "value
+  unchanged": the dangerous cell is a STRUCTURALLY VALID new binding value carried by
+  a STALE digest, which is unauthenticated yet was once mis-read as a milder state
+  whose binding got consulted for occupancy. Sweep the wrong-value × stale-digest
+  cross-product on both bindings, and assert the entry decides no occupancy at all
+  (discover fails closed, provision refused, registry/tombstone bytes unchanged).
+
+`test_discover_promises_hold_across_a_damaged_entry_matrix` and the parametrized
+`test_damaged_entry_never_breaks_a_discover_promise` / `test_revoke_refuses_and_preserves_a_blocking_entry`
+sweep a damaged-entry roster and pin the end-to-end invariants this table protects —
+every `bound` output resolves, every `available` output provisions, and a blocking
+entry stays blocked (and unchanged) across `revoke` — so a newly emptied cell
+reddens without relying on the table being kept in sync by hand.
 
 `entry_digest` protects the exact registry record, not the complete effective
 launch/security configuration. In particular, it does not freeze or hash

--- a/src/lingtai/adapters/acp/puffo_v0.py
+++ b/src/lingtai/adapters/acp/puffo_v0.py
@@ -9,6 +9,7 @@ import re
 import stat
 import tempfile
 from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
 from typing import Any, Iterator
 
@@ -126,6 +127,82 @@ class PuffoV0Runtime:
     policy_version: str
 
 
+class PuffoV0RuntimeState(Enum):
+    """Classification of one agent_dir's registry status, keyed by caller action.
+
+    The ``value`` is the stable external status string the discover CLI emits.
+    The governing invariant: any two states that require a *different* caller
+    response must have different values here, so a consumer never sees the same
+    representation for "you may provision" and "stop, this looks tampered".
+
+    Member *declaration* order here carries no meaning and is safe to change.
+    The multi-entry precedence for one agent_dir is defined explicitly and
+    independently by ``_DISCOVERY_STATE_PRECEDENCE`` (and pinned by tests),
+    precisely so that it cannot be altered by a cosmetic reordering here.
+    """
+
+    INTEGRITY_FAILED = "integrity_failed"
+    SHAPE_MISMATCH = "shape_mismatch"
+    POLICY_VERSION_MISMATCH = "policy_version_mismatch"
+    STALE_BINDING = "stale_binding"
+    ACTIVE = "bound"
+    REVOKED = "revoked"
+    PROVISIONABLE = "available"
+
+
+# Precedence for reporting one agent_dir that appears in several registry
+# entries: report the state that most constrains the caller.  Lower index wins.
+#
+# This ordering is SAFETY-LOAD-BEARING and is therefore written out explicitly
+# here, NOT derived from the enum's member declaration order.  The reason:
+# INTEGRITY_FAILED must outrank REVOKED (and every recoverable state) so that a
+# directory holding both a tampered entry and a revoked one is reported as the
+# integrity failure ("stop, escalate, never auto-revoke") rather than the
+# revoked one ("re-provision under a new id").  If precedence merely mirrored
+# the enum's source order, a purely cosmetic edit -- reordering members,
+# alphabetising, or appending a new member "where it reads nicely" -- would
+# silently reopen the auto-revoke-a-tampered-entry hole with nothing to catch
+# it.  ``test_discovery_state_precedence_*`` pin both the exact order and that
+# every rankable state appears exactly once; reordering this tuple reds them.
+# PROVISIONABLE is excluded: it describes a directory with no entry at all, so
+# it never competes with an entry-derived state for the same directory.
+# Most-constraining state first.  ``_state_rank`` reads this to break ties among
+# READABLE, digest-authenticated occupants (SHAPE_MISMATCH..REVOKED).  INTEGRITY_FAILED
+# heads the tuple to document that an unauthenticated entry is the most constraining of
+# all, but its position is NOT realized through ``_state_rank`` at runtime: discovery
+# fails closed (raises) on such an entry before any ranking, and the provision guard
+# gives it ``_UNREADABLE_CONFLICT_RANK`` (-1, below index 0) so it outranks every
+# readable occupant there.  So ``_state_rank(INTEGRITY_FAILED)`` has no runtime caller;
+# it is kept in the tuple for completeness and pinned by the precedence unit test that
+# documents the intended ordering.
+_DISCOVERY_STATE_PRECEDENCE: tuple[PuffoV0RuntimeState, ...] = (
+    PuffoV0RuntimeState.INTEGRITY_FAILED,
+    PuffoV0RuntimeState.SHAPE_MISMATCH,
+    PuffoV0RuntimeState.POLICY_VERSION_MISMATCH,
+    PuffoV0RuntimeState.STALE_BINDING,
+    PuffoV0RuntimeState.ACTIVE,
+    PuffoV0RuntimeState.REVOKED,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class PuffoV0DiscoveryCandidate:
+    """One initialized identity found under an operator-selected directory."""
+
+    agent_dir: Path
+    workspace: Path | None
+    display_name: str
+    runtime_id: str | None
+    state: PuffoV0RuntimeState
+    # Advisory only, and set ONLY on an `available` (PROVISIONABLE) candidate: the
+    # runtime_id a registry entry recorded at this exact path, whose provisioned
+    # identity is no longer the directory now sitting there (it moved elsewhere or
+    # is gone). It does NOT change the action -- the directory is genuinely unbound
+    # and provisioning it succeeds -- it hangs a sign that this path was reused, so
+    # a same-path replacement is not silently mistaken for a never-bound directory.
+    formerly_bound_runtime_id: str | None = None
+
+
 def default_registry_path() -> Path:
     """Return the one operator-managed registry location for this profile."""
 
@@ -141,7 +218,12 @@ def _valid_runtime_id(runtime_id: object) -> str:
 def _canonical_directory(path: Path, *, field: str) -> Path:
     try:
         resolved = path.expanduser().resolve(strict=True)
-    except (OSError, RuntimeError) as exc:
+    except (OSError, RuntimeError, ValueError) as exc:
+        # ValueError covers an embedded NUL in a stored path ("embedded null
+        # character"), which resolve() raises as a plain ValueError -- neither OSError
+        # nor RuntimeError. Wrapping it here converts it to the bounded registry error
+        # at the one chokepoint every path read (discover, guard, resolve) passes
+        # through, so a digest-valid NUL path can never leak a raw ValueError.
         raise PuffoV0RegistryError(f"{field} must be an existing directory") from exc
     if not resolved.is_dir():
         raise PuffoV0RegistryError(f"{field} must be an existing directory")
@@ -187,6 +269,24 @@ def _parse_binding(value: object) -> DirectoryBinding:
     )
 
 
+def _is_valid_binding_payload(value: object) -> bool:
+    """Whether ``value`` is a well-formed stored directory binding, without I/O.
+
+    A malformed binding payload is a shape defect of the entry itself, decided by
+    the pure classifier so all four operations agree on it (discover, guard,
+    resolve, revoke), rather than only surfacing later when a binding read fails.
+    This validates the payload's *structure*; it does not read the filesystem, so
+    a well-formed payload that no longer matches the live directory is a separate,
+    liveness concern (STALE_BINDING), not a shape one.
+    """
+
+    try:
+        _parse_binding(value)
+    except PuffoV0RegistryError:
+        return False
+    return True
+
+
 def _canonical_entry(
     runtime_id: str,
     agent_dir: Path,
@@ -212,6 +312,94 @@ def _canonical_entry(
 def _digest(entry: dict[str, Any]) -> str:
     canonical = json.dumps(entry, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+_RUNTIME_ENTRY_KEYS = frozenset({
+    "agent_dir", "agent_dir_binding", "entry_digest", "mcp_servers",
+    "profile", "runtime_id", "runtime_policy_version", "status", "tool_surface",
+    "turn_origins", "workspace", "workspace_binding",
+})
+
+
+def _classify_registry_entry(
+    runtime_id: str, entry: object, *, revoked_runtime_ids: frozenset[str]
+) -> PuffoV0RuntimeState:
+    """Classify one registry entry by the action its state demands of the caller.
+
+    Ordering is load-bearing: integrity (the ``entry_digest`` match) is decided
+    before the policy-version comparison and independently of it.  A tampered or
+    corrupt entry must never be read as a benign version drift, because the
+    caller's recovery for a drift is an automatic revoke + re-provision -- running
+    that on a forged entry would let an attacker drive the revocation.  Every
+    field examined after the digest check is one the digest signed, so its value
+    can be trusted; nothing before it can.
+
+    This is the single source of truth for entry status.  It absorbs the former
+    ``_has_runtime_entry_shape`` / ``_is_active_discovery_entry`` pair: discover,
+    resolve, and provision all read the entry through this classifier so no two
+    of them can disagree about what one entry means.
+    """
+
+    if not isinstance(entry, dict):
+        return PuffoV0RuntimeState.SHAPE_MISMATCH
+    # Integrity is decided first among the content checks, and digest *presence* is
+    # part of integrity: a missing or non-string ``entry_digest`` is an integrity
+    # failure, not a shape mismatch.  This is tested before the structural key-set
+    # comparison on purpose -- a record we cannot authenticate must never read as a
+    # merely malformed one, and (critically) revoke re-adds ``entry_digest`` and
+    # re-signs, so a dropped digest classified as shape could be laundered into a
+    # released state.  Keeping "no/invalid digest => integrity" holds that closed.
+    digest = entry.get("entry_digest")
+    if not isinstance(digest, str):
+        return PuffoV0RuntimeState.INTEGRITY_FAILED
+    # The digest *match* is decided before the structural key-set comparison, not
+    # after it.  This is load-bearing beyond bug #4's presence check: the enum has
+    # to carry the trust fact, so that a single predicate -- ``INTEGRITY_FAILED``
+    # -- means "this entry's stored binding is not authenticated by its digest".
+    # If the key-set check ran first, an un-resigned entry with an extra or missing
+    # key would return SHAPE_MISMATCH *before* its digest was ever compared, and its
+    # binding would be exactly as unauthenticated as a digest-mismatch entry's --
+    # yet discover and the guard would consume that binding to decide occupancy
+    # (the same "a record proven untrustworthy still decides allow" defect, one
+    # state over).  Ordering match ahead of key-set makes SHAPE always imply
+    # "digest verified, values wrong" and INTEGRITY_FAILED the exact untrusted-
+    # binding predicate the fail-closed occupancy checks below key off.
+    canonical = {key: value for key, value in entry.items() if key != "entry_digest"}
+    if _digest(canonical) != digest:
+        return PuffoV0RuntimeState.INTEGRITY_FAILED
+    if set(entry) != _RUNTIME_ENTRY_KEYS:
+        return PuffoV0RuntimeState.SHAPE_MISMATCH
+    # Authentic from here: every field below is one the digest signed, so its value
+    # can be trusted.  The value-shape checks -- including an unknown ``status`` and
+    # a syntactically invalid runtime id -- are decided BEFORE the revoked gate, and
+    # the gate recognizes only an *explicit* revocation.  This is load-bearing: if a
+    # value defect were decided after the gate, editing ``status`` to any non-active
+    # value would route the entry to REVOKED (released) instead of the blocking
+    # state it is -- exactly the laundering that let a foreign-profile or unknown-
+    # status entry free its directory.  A malformed binding payload is a shape
+    # defect of the entry too (decided here so discover, the guard, resolve, and
+    # revoke all agree), distinct from a well-formed binding that no longer matches
+    # the live directory (STALE_BINDING, a liveness check the pure classifier does
+    # not run).
+    if (
+        entry.get("runtime_id") != runtime_id
+        or _RUNTIME_ID.fullmatch(runtime_id) is None
+        or entry.get("profile") != PROFILE_NAME
+        or entry.get("mcp_servers") != []
+        or entry.get("tool_surface") != RUNTIME_POLICY.tool_surface
+        or entry.get("turn_origins") != [TurnOrigin.AUTHENTICATED_ADAPTER.value]
+        or not isinstance(entry.get("agent_dir"), str)
+        or not isinstance(entry.get("workspace"), str)
+        or entry.get("status") not in ("active", "revoked")
+        or not _is_valid_binding_payload(entry.get("agent_dir_binding"))
+        or not _is_valid_binding_payload(entry.get("workspace_binding"))
+    ):
+        return PuffoV0RuntimeState.SHAPE_MISMATCH
+    if runtime_id in revoked_runtime_ids or entry.get("status") == "revoked":
+        return PuffoV0RuntimeState.REVOKED
+    if entry.get("runtime_policy_version") != RUNTIME_POLICY.policy_version:
+        return PuffoV0RuntimeState.POLICY_VERSION_MISMATCH
+    return PuffoV0RuntimeState.ACTIVE
 
 
 def _require_posix_registry_security() -> None:
@@ -297,6 +485,12 @@ def _read_revoked_runtime_ids(path: Path) -> frozenset[str]:
     tombstones = _revocation_log_path(path)
     if not _secure_registry_file(tombstones):
         raise PuffoV0RegistryError("puffo-v0 revocation log is unavailable or invalid")
+    return _parse_revocation_log(tombstones)
+
+
+def _parse_revocation_log(tombstones: Path) -> frozenset[str]:
+    """Parse a tombstone file without changing its permissions or contents."""
+
     try:
         lines = tombstones.read_text(encoding="utf-8").splitlines()
     except (OSError, UnicodeError) as exc:
@@ -311,6 +505,21 @@ def _read_revoked_runtime_ids(path: Path) -> frozenset[str]:
             raise PuffoV0RegistryError("puffo-v0 revocation log is unavailable or invalid")
         revoked.add(_valid_runtime_id(entry["runtime_id"]))
     return frozenset(revoked)
+
+
+def _read_revoked_runtime_ids_read_only(path: Path) -> frozenset[str]:
+    """Read tombstones for discovery without creating or hardening artifacts."""
+
+    tombstones = _revocation_log_path(path)
+    try:
+        mode = tombstones.lstat().st_mode
+    except FileNotFoundError as exc:
+        raise PuffoV0RegistryError("puffo-v0 revocation log is unavailable or invalid") from exc
+    except OSError as exc:
+        raise PuffoV0RegistryError("puffo-v0 revocation log is unavailable or invalid") from exc
+    if not stat.S_ISREG(mode):
+        raise PuffoV0RegistryError("puffo-v0 revocation log is unavailable or invalid")
+    return _parse_revocation_log(tombstones)
 
 
 def _append_revocation_tombstone(path: Path, runtime_id: str) -> None:
@@ -389,6 +598,33 @@ def _read_registry(path: Path) -> dict[str, Any]:
     return data
 
 
+def _read_registry_read_only(path: Path) -> dict[str, Any]:
+    """Read a registry for discovery without mutating its security metadata."""
+
+    try:
+        mode = path.lstat().st_mode
+    except FileNotFoundError as exc:
+        raise PuffoV0RegistryError("puffo-v0 runtime registry is unavailable or invalid") from exc
+    except OSError as exc:
+        raise PuffoV0RegistryError("puffo-v0 runtime registry is unavailable or invalid") from exc
+    if not stat.S_ISREG(mode):
+        raise PuffoV0RegistryError("puffo-v0 runtime registry has an invalid file type")
+    try:
+        raw = path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise PuffoV0RegistryError("puffo-v0 runtime registry is unavailable or invalid") from exc
+    if not isinstance(data, dict) or set(data) != {"revocation_log", "runtimes", "version"}:
+        raise PuffoV0RegistryError("puffo-v0 runtime registry has an invalid shape")
+    if (
+        data["version"] != REGISTRY_VERSION
+        or data["revocation_log"] != REVOCATION_LOG_REQUIRED
+        or not isinstance(data["runtimes"], dict)
+    ):
+        raise PuffoV0RegistryError("puffo-v0 runtime registry has an unsupported version")
+    return data
+
+
 def _write_registry(path: Path, data: dict[str, Any]) -> None:
     _secure_registry_directory(path.parent)
     temporary: Path | None = None
@@ -434,23 +670,213 @@ def _bound_directory(
     return resolved, expected
 
 
+def _binding_matches(entry: dict[str, Any]) -> bool:
+    """Return whether an authentic entry's on-disk identity still resolves.
+
+    Discovery calls this ONLY for an entry the classifier already ruled ACTIVE,
+    to decide whether ``bound`` is truthful.  It runs the exact same check
+    ``resolve_runtime`` enforces -- ``_bound_directory`` for both the agent_dir
+    and the workspace -- so ``bound`` from discovery means precisely "resolve
+    would succeed here".  Any mismatch (a replaced directory with a new
+    device/inode, a path that became a symlink, or a directory that no longer
+    exists) makes this false; discovery then downgrades to STALE_BINDING rather
+    than promising a runtime that ``resolve_runtime`` will immediately reject.
+
+    Read-only: ``_bound_directory`` only resolves paths and lstats them.  A
+    malformed path or binding payload would also make this false, but on an entry
+    the classifier already ruled ACTIVE those were signed by the digest and built
+    well-formed by ``_canonical_entry``, so the only reachable falsity here is a
+    genuine on-disk identity change -- STALE_BINDING never masks a corrupt entry
+    (that is INTEGRITY_FAILED/SHAPE_MISMATCH, decided earlier and ranked above).
+    """
+
+    try:
+        for field in ("agent_dir", "workspace"):
+            _bound_directory(entry.get(field), entry.get(f"{field}_binding"), field=field)
+    except PuffoV0RegistryError:
+        return False
+    return True
+
+
+def _state_releases_directory(state: PuffoV0RuntimeState) -> bool:
+    """Whether an entry in this state has released the directory it recorded.
+
+    The single roster both occupancy checks consult, so the set of states that
+    "no longer hold their directory" cannot diverge between them: the provision
+    guard skips such an entry (it never blocks a new binding) and discovery skips
+    it when its binding is unreadable (its directory is genuinely reusable, so
+    reporting `available` is truthful). Only a REVOKED entry releases -- every
+    other state still holds its directory and must block / fail closed. Route
+    both ``_active_binding_conflicts`` and ``_discovery_records`` through this so a
+    state added later cannot be released on one side but not the other.
+    """
+
+    return state is PuffoV0RuntimeState.REVOKED
+
+
+def _binding_conflict_message(
+    field: str, runtime_id: str, state: PuffoV0RuntimeState, stored_path: object
+) -> str:
+    """Explain a provisioning conflict by the recovery its state actually needs.
+
+    Reached only for a readable, digest-authenticated occupant of the target
+    directory (SHAPE_MISMATCH, POLICY_VERSION_MISMATCH, or an active binding); an
+    unauthenticated entry (INTEGRITY_FAILED) never reaches here -- it blocks
+    unconditionally through ``_unauthenticated_binding_conflict_message`` because
+    its stored device/inode cannot be trusted to equal the target.  Every message
+    names (a) the runtime_id that causes the rejection, (b) the path the conflicting
+    entry recorded, and (c) the operation that actually helps.  The truth of the
+    malformed case reduces to one rule -- ``revoke_runtime`` refuses an entry that
+    does not classify as a live or policy-drifted runtime -- so no message makes a
+    per-subtype capability claim ("cannot be cleared by revoke") that a later
+    subtype could falsify.  It names the escalation instead.
+    """
+
+    location = f" (recorded at {stored_path!r})" if isinstance(stored_path, str) else ""
+    if state is PuffoV0RuntimeState.POLICY_VERSION_MISMATCH:
+        return (
+            f"{field} is bound to runtime {runtime_id!r}{location} provisioned under "
+            "a different policy version; revoke it before re-provisioning"
+        )
+    if state is PuffoV0RuntimeState.SHAPE_MISMATCH:
+        return (
+            f"{field} is bound to runtime {runtime_id!r}{location} whose registry entry "
+            "does not match the puffo-v0 profile; revoke is refused for it -- escalate "
+            "for review and repair it out of band"
+        )
+    return (
+        f"{field} is already bound to active runtime {runtime_id!r}{location}; "
+        "revoke it before re-provisioning"
+    )
+
+
+def _unreadable_binding_conflict_message(
+    field: str, runtime_id: str, state: PuffoV0RuntimeState
+) -> str:
+    """Explain a fail-closed provisioning block on an entry whose binding is unreadable."""
+
+    return (
+        f"cannot rule out a {field} conflict: runtime {runtime_id!r} has an unreadable "
+        f"binding ({state.value}); escalate for review and repair it out of band"
+    )
+
+
+def _unauthenticated_binding_conflict_message(runtime_id: str) -> str:
+    """Explain the unconditional block an unauthenticated entry imposes.
+
+    An entry whose stored binding is not authenticated by its digest
+    (``INTEGRITY_FAILED``) cannot be pinned to a directory, so the guard cannot
+    rule out that it holds the very directory being provisioned.  It therefore
+    blocks EVERY provision, not only one whose target happens to equal the
+    (untrusted) stored device/inode -- the field-keyed comparison is skipped for
+    it precisely because that comparison would trust the tampered value.  Revoke
+    is refused for it (revoking would re-sign the tampered entry and erase the
+    signal), so the only recovery is out-of-band repair.
+    """
+
+    return (
+        f"cannot rule out a conflict: runtime {runtime_id!r} failed its integrity check "
+        "(its registry entry is not authenticated by its digest, so its stored binding "
+        "cannot be trusted to place it); revoke is refused for it (revoking would "
+        "re-sign the tampered entry and erase the integrity signal) -- escalate for "
+        "review and repair it out of band"
+    )
+
+
+# A conflict on an entry whose stored binding cannot even be parsed outranks every
+# readable occupant: "cannot rule out that it holds the target" is stricter than any
+# known state.  It sorts below _state_rank's smallest index (0), so it always wins.
+_UNREADABLE_CONFLICT_RANK = -1
+
+
+@dataclass(frozen=True, slots=True)
+class _BindingConflict:
+    """One reason a provision is blocked, ranked so selection is order-independent."""
+
+    sort_key: tuple[int, int, str]
+    message: str
+
+
 def _active_binding_conflicts(
     runtimes: dict[str, Any],
     *,
-    agent_dir: Path,
-    workspace: Path,
+    agent_dir_binding: DirectoryBinding,
+    workspace_binding: DirectoryBinding,
+    revoked_runtime_ids: frozenset[str],
 ) -> None:
-    """Require the Phase A active binding to remain one-to-one."""
+    """Require the Phase A active binding to remain one-to-one.
 
+    The accept/reject set is by physical identity: any non-released entry occupying
+    the target ``agent_dir`` or ``workspace`` device/inode blocks provisioning, as
+    does any non-released entry whose binding cannot be parsed (fail closed -- a
+    skip would be the allow direction).  The criterion is device/inode, never the
+    path string, so a directory renamed away behind a symlink cannot be bound twice.
+
+    Conflicts are AGGREGATED and then the most-constraining one is chosen by the
+    SAME precedence discovery uses, rather than raising on the first entry the
+    iteration happens to reach.  Registry insertion order therefore cannot decide
+    which of several occupants of one directory is named: a directory held by both
+    an integrity-failed and an active entry always reports the integrity failure
+    (whose recovery is "escalate"), never the active one (whose recovery is
+    "revoke") -- so the guard and discover never hand the caller contradictory
+    guidance for the same directory.  Only a revoked entry (which released its
+    directory) is skipped, shared with discovery via ``_state_releases_directory``.
+    """
+
+    targets = (
+        ("agent_dir", agent_dir_binding, 0),
+        ("workspace", workspace_binding, 1),
+    )
+    conflicts: list[_BindingConflict] = []
     for existing_runtime_id, entry in runtimes.items():
         if not isinstance(existing_runtime_id, str) or not isinstance(entry, dict):
             raise PuffoV0RegistryError("runtime registry entry has an invalid shape")
-        if entry.get("status") != "active":
+        state = _classify_registry_entry(
+            existing_runtime_id, entry, revoked_runtime_ids=revoked_runtime_ids
+        )
+        if _state_releases_directory(state):
             continue
-        if entry.get("agent_dir") == str(agent_dir):
-            raise PuffoV0RegistryError("agent_dir is already bound to an active runtime")
-        if entry.get("workspace") == str(workspace):
-            raise PuffoV0RegistryError("workspace is already bound to an active runtime")
+        if state is PuffoV0RuntimeState.INTEGRITY_FAILED:
+            # Untrusted binding: it may point away from the directory this entry
+            # actually holds, so a field-keyed comparison against the (tampered)
+            # stored device/inode could clear the target while the entry still holds
+            # it.  Block unconditionally instead -- any unauthenticated entry refuses
+            # every provision until it is repaired out of band.  It outranks readable
+            # occupants (same rank as an unparseable binding: "cannot rule out that it
+            # holds the target" beats any known state), so a directory contested by an
+            # unauthenticated and a readable entry always reports the integrity
+            # failure, matching discover's precedence.
+            conflicts.append(
+                _BindingConflict(
+                    sort_key=(_UNREADABLE_CONFLICT_RANK, 0, existing_runtime_id),
+                    message=_unauthenticated_binding_conflict_message(existing_runtime_id),
+                )
+            )
+            continue
+        for field, target, field_priority in targets:
+            try:
+                stored = _parse_binding(entry.get(f"{field}_binding"))
+            except PuffoV0RegistryError:
+                conflicts.append(
+                    _BindingConflict(
+                        sort_key=(_UNREADABLE_CONFLICT_RANK, field_priority, existing_runtime_id),
+                        message=_unreadable_binding_conflict_message(
+                            field, existing_runtime_id, state
+                        ),
+                    )
+                )
+                continue
+            if (stored.device, stored.inode) == (target.device, target.inode):
+                conflicts.append(
+                    _BindingConflict(
+                        sort_key=(_state_rank(state), field_priority, existing_runtime_id),
+                        message=_binding_conflict_message(
+                            field, existing_runtime_id, state, entry.get(field)
+                        ),
+                    )
+                )
+    if conflicts:
+        raise PuffoV0RegistryError(min(conflicts, key=lambda conflict: conflict.sort_key).message)
 
 
 def provision_runtime(
@@ -491,7 +917,12 @@ def provision_runtime(
         runtimes = registry["runtimes"]
         if runtime_id in runtimes:
             raise PuffoV0RegistryError("runtime_id is already provisioned")
-        _active_binding_conflicts(runtimes, agent_dir=agent_dir, workspace=workspace)
+        _active_binding_conflicts(
+            runtimes,
+            agent_dir_binding=agent_dir_binding,
+            workspace_binding=workspace_binding,
+            revoked_runtime_ids=revoked_runtime_ids,
+        )
         entry = _canonical_entry(
             runtime_id,
             agent_dir,
@@ -513,6 +944,36 @@ def provision_runtime(
     )
 
 
+def _revoke_refusal_message(runtime_id: str, state: PuffoV0RuntimeState) -> str:
+    """Explain why revoke refuses an entry, naming an action that actually helps.
+
+    revoke is a state change, not a repair.  For a tampered or malformed entry the
+    only honest guidance is out-of-band repair -- naming revoke as the recovery
+    would be a dead end (and re-signing would destroy the very signal that must be
+    preserved).  The truth of each message reduces to this one admission rule, so
+    no message makes a per-subtype claim that a later subtype could falsify.
+    """
+
+    if state is PuffoV0RuntimeState.INTEGRITY_FAILED:
+        return (
+            f"runtime {runtime_id!r} failed its integrity check; revoke is refused "
+            "so the tampered record is not re-signed (which would erase the "
+            "integrity signal) -- escalate for review and repair it out of band"
+        )
+    if state is PuffoV0RuntimeState.SHAPE_MISMATCH:
+        return (
+            f"runtime {runtime_id!r} does not match the puffo-v0 profile; revoke is "
+            "refused for a malformed entry -- escalate for review and repair it out "
+            "of band"
+        )
+    if state is PuffoV0RuntimeState.REVOKED:
+        return f"runtime {runtime_id!r} is already revoked"
+    return (
+        f"runtime {runtime_id!r} is not in a revocable state ({state.value}); "
+        "escalate for review"
+    )
+
+
 def revoke_runtime(runtime_id: str, *, registry_path: Path | None = None) -> None:
     """Mark a provisioned profile identity unavailable for future ACP spawns."""
 
@@ -523,12 +984,399 @@ def revoke_runtime(runtime_id: str, *, registry_path: Path | None = None) -> Non
         entry = registry["runtimes"].get(runtime_id)
         if not isinstance(entry, dict):
             raise PuffoV0RegistryError("runtime_id is not provisioned")
-        if runtime_id not in _read_revoked_runtime_ids(path):
+        revoked_runtime_ids = _read_revoked_runtime_ids(path)
+        # Admission BEFORE the first persistence.  revoke may only act on an entry
+        # that already classifies as a live or policy-drifted runtime.  Two reasons
+        # it must refuse everything else here, before writing anything:
+        #   * revoke re-signs the entry (and re-adds a dropped ``entry_digest`` or
+        #     ``status``), so on a tampered/malformed entry it would erase the
+        #     tamper signal or launder a shape defect into a released state.
+        #   * the tombstone is appended first and a tombstone ALONE releases the
+        #     directory (the classifier honours the revocation record), so any check
+        #     placed after the append would release identity even on a "failed"
+        #     call -- irreversibly, because the log is append-only.
+        state = _classify_registry_entry(
+            runtime_id, entry, revoked_runtime_ids=revoked_runtime_ids
+        )
+        if state not in (
+            PuffoV0RuntimeState.ACTIVE,
+            PuffoV0RuntimeState.POLICY_VERSION_MISMATCH,
+        ):
+            raise PuffoV0RegistryError(_revoke_refusal_message(runtime_id, state))
+        if runtime_id not in revoked_runtime_ids:
             _append_revocation_tombstone(path, runtime_id)
         entry["status"] = "revoked"
         canonical = {key: value for key, value in entry.items() if key != "entry_digest"}
         entry["entry_digest"] = _digest(canonical)
         _write_registry(path, registry)
+
+
+@dataclass(frozen=True, slots=True)
+class _DiscoveryRecord:
+    """One registry entry's classification as attributed to its agent_dir."""
+
+    state: PuffoV0RuntimeState
+    runtime_id: str | None
+    workspace: Path | None
+
+
+@dataclass(frozen=True, slots=True)
+class _DiscoveryIndex:
+    """The two lookups discovery needs, both built read-only from the registry.
+
+    ``by_identity`` attributes an entry to the physical directory it holds, keyed
+    by device/inode -- the authoritative classification for a walked directory.
+    ``formerly_bound`` maps a stored canonical agent_dir path to the runtime_id
+    that recorded it, for the option-C advisory hint: it is consulted ONLY for a
+    directory that came back unbound, where the fact that identity attribution
+    missed already proves the recorded entry no longer holds this path.
+    """
+
+    by_identity: dict[tuple[int, int], _DiscoveryRecord]
+    formerly_bound: dict[str, str]
+
+
+def _state_rank(state: PuffoV0RuntimeState) -> int:
+    return _DISCOVERY_STATE_PRECEDENCE.index(state)
+
+
+def _authentic_workspace(entry: object, state: PuffoV0RuntimeState) -> Path | None:
+    """Return the entry's workspace only when it names a LIVE, signed binding.
+
+    A workspace is meaningful only for a directory that is currently held.  The
+    two states that report one differ in how liveness was established:
+
+    * ACTIVE reached this point only after the ``_binding_matches`` check in
+      discovery already proved both the agent_dir and the workspace still resolve
+      to their provisioned identity (otherwise it would have been downgraded to
+      STALE_BINDING), so its workspace is known live.
+    * POLICY_VERSION_MISMATCH runs no such downgrade, so its workspace liveness is
+      unverified here.  Verify it directly and return ``None`` if the workspace no
+      longer resolves to its provisioned identity -- otherwise discovery would
+      report a drifted entry's workspace path that no longer exists, which breaks
+      the promise that a reported workspace names a live binding.
+
+    For every other (revoked, tampered, foreign) state there is no binding to
+    report.
+    """
+
+    if not isinstance(entry, dict):
+        return None
+    if state is PuffoV0RuntimeState.ACTIVE:
+        workspace_value = entry.get("workspace")
+        if isinstance(workspace_value, str):
+            return Path(workspace_value)
+        return None
+    if state is PuffoV0RuntimeState.POLICY_VERSION_MISMATCH:
+        try:
+            resolved, _binding = _bound_directory(
+                entry.get("workspace"), entry.get("workspace_binding"), field="workspace"
+            )
+        except PuffoV0RegistryError:
+            return None
+        return resolved
+    return None
+
+
+def _entry_identity_key(entry: object) -> tuple[int, int]:
+    """Return the stored ``(device, inode)`` an entry names, for attribution.
+
+    Discovery keys records by this and looks them up by the walked directory's
+    live device/inode (not by path string).  That closes two holes a path key
+    cannot: a stored path whose parent became a symlink, and a directory renamed
+    away with a symlink left behind -- both keep the physical device/inode, so
+    identity still attributes the entry to the directory that actually holds it.
+
+    On an authentic entry the device/inode come from the digest-signed
+    ``agent_dir_binding``.  On a corrupt one the binding may be missing or
+    malformed; this raises then, and the caller must fail closed rather than drop
+    the entry, because a dropped entry's directory would be reported ``available``
+    -- the dangerous direction.
+    """
+
+    if not isinstance(entry, dict):
+        raise PuffoV0RegistryError("runtime registry entry has an invalid shape")
+    binding = _parse_binding(entry.get("agent_dir_binding"))
+    return (binding.device, binding.inode)
+
+
+def _record_formerly_bound(
+    formerly: dict[str, tuple[PuffoV0RuntimeState, str]],
+    entry: object,
+    *,
+    state: PuffoV0RuntimeState,
+    runtime_id: str,
+) -> None:
+    """Note that ``runtime_id`` recorded ``entry``'s stored path, for the hint.
+
+    Sourced from the PATH, not the state: any non-revoked entry with a readable
+    stored agent_dir is a candidate to have its path reused.  We do NOT pre-filter
+    to only the STALE downgrade -- a POLICY_VERSION_MISMATCH or SHAPE_MISMATCH
+    entry whose directory was replaced at the same path never gets that downgrade,
+    yet its path reuse is exactly what the hint must flag.  The "is it still here"
+    test is deferred to discovery: the hint is read only for a directory that came
+    back unbound, where identity attribution having missed already proves this
+    entry no longer holds the path.  A revoked entry released its directory on
+    purpose, so reusing its path is expected and needs no sign.  When two entries
+    name one path, the most-constraining state supplies the hint (same rule as the
+    identity-keyed collision), decided here rather than by dict order.
+    """
+
+    if _state_releases_directory(state) or not isinstance(entry, dict):
+        return
+    stored_path = entry.get("agent_dir")
+    if not isinstance(stored_path, str):
+        return
+    existing = formerly.get(stored_path)
+    if existing is None or _state_rank(state) < _state_rank(existing[0]):
+        formerly[stored_path] = (state, runtime_id)
+
+
+def _discovery_records(path: Path) -> _DiscoveryIndex:
+    """Classify every registry entry, keyed by the device/inode it binds.
+
+    Reads only -- never creates a lock, initializes a registry, or rewrites
+    permissions.  When several entries name the same directory, the most
+    constraining state wins (``_DISCOVERY_STATE_PRECEDENCE``) so discovery never
+    reports a directory as usable while a corrupt or drifted entry for it is
+    outstanding.  The historical guard -- two *active* runtimes may not share a
+    directory -- is preserved as hard corruption.  Also returns the
+    ``formerly_bound`` path->runtime_id map for the advisory reuse hint.
+    """
+
+    try:
+        path.lstat()
+    except FileNotFoundError:
+        # A registry that is absent yet still has its mandatory revocation log is a
+        # broken control-plane state: provision refuses to re-initialize over an
+        # orphaned tombstone (O_EXCL), so a directory here is NOT provisionable.
+        # Discovery must not report it as `available`; fail closed with a distinct
+        # message keyed to that recovery (restore the registry or remove the log).
+        try:
+            _revocation_log_path(path).lstat()
+        except FileNotFoundError:
+            return _DiscoveryIndex(by_identity={}, formerly_bound={})
+        except OSError as exc:
+            raise PuffoV0RegistryError(
+                "puffo-v0 runtime registry is unavailable or invalid"
+            ) from exc
+        raise PuffoV0RegistryError(
+            "puffo-v0 revocation log exists without its runtime registry"
+        )
+    except OSError as exc:
+        raise PuffoV0RegistryError("puffo-v0 runtime registry is unavailable or invalid") from exc
+
+    revoked_runtime_ids = _read_revoked_runtime_ids_read_only(path)
+    registry = _read_registry_read_only(path)
+    records: dict[tuple[int, int], _DiscoveryRecord] = {}
+    formerly: dict[str, tuple[PuffoV0RuntimeState, str]] = {}
+    for runtime_id, entry in registry["runtimes"].items():
+        if not isinstance(runtime_id, str):
+            # JSON object keys are strings, so this is structurally unreachable
+            # from a parsed registry; fail closed rather than silently drop it,
+            # because a dropped entry's directory reads as `available`.
+            raise PuffoV0RegistryError("puffo-v0 runtime registry has a non-string runtime id")
+        state = _classify_registry_entry(
+            runtime_id, entry, revoked_runtime_ids=revoked_runtime_ids
+        )
+        if state is PuffoV0RuntimeState.INTEGRITY_FAILED:
+            # An entry whose stored binding is not authenticated by its digest cannot
+            # be attributed to any walked directory: the device/inode it names may
+            # have been edited to point away from the directory it actually holds, so
+            # keying discovery by that binding would leave the real directory
+            # unattributed and reported `available` -- the dangerous direction (a
+            # second runtime could then seize a directory that is still held).  There
+            # is no independently trustworthy binding copy to fall back on (the digest
+            # is what authenticates the binding), so discovery fails closed for the
+            # WHOLE registry rather than reporting a subset it cannot vouch for --
+            # exactly as it already does for an unreadable binding below.  Revoke is
+            # refused for such an entry too, so the only recovery is out-of-band
+            # repair; the message names that.
+            raise PuffoV0RegistryError(
+                f"puffo-v0 runtime registry entry {runtime_id!r} is not authenticated "
+                "by its digest; its stored binding cannot be trusted to attribute it, "
+                "so discovery fails closed -- escalate for review and repair it out of band"
+            )
+        if (
+            state is PuffoV0RuntimeState.ACTIVE
+            and isinstance(entry, dict)
+            and not _binding_matches(entry)
+        ):
+            # Authentic and active in the registry, but the on-disk directory it
+            # names has been replaced/moved (different device/inode, now a symlink,
+            # or gone). resolve_runtime would reject it, so `bound` would be a lie.
+            state = PuffoV0RuntimeState.STALE_BINDING
+        # Note this entry's stored path for the reuse hint; whether it surfaces is
+        # decided at lookup time (only for a directory that comes back unbound). The
+        # helper skips revoked and path-less entries.
+        _record_formerly_bound(formerly, entry, state=state, runtime_id=runtime_id)
+        try:
+            identity = _entry_identity_key(entry)
+            # Parity with the provision guard's field set. The guard parses BOTH
+            # stored bindings (agent_dir AND workspace) before any identity
+            # comparison and fails closed on either, so a single unreadable
+            # workspace_binding makes it reject EVERY provision -- the parse
+            # precedes the target comparison. Reading only agent_dir here would
+            # report other directories `available` while that entry silently blocks
+            # all provisioning, so discover must fail closed on the same both-field
+            # set. ``_entry_identity_key`` covers agent_dir; this covers workspace.
+            _parse_binding(entry.get("workspace_binding"))
+        except PuffoV0RegistryError as exc:
+            # A non-revoked entry with no readable device/inode cannot be attributed
+            # to a walked directory, and dropping it would let a directory it holds
+            # read `available`, so fail closed. A REVOKED entry cannot reach here: a
+            # malformed binding payload classifies SHAPE_MISMATCH ahead of the revoked
+            # gate (see ``_classify_registry_entry``), so a REVOKED verdict implies
+            # both bindings parse -- discover's fail-closed set therefore still equals
+            # the guard's block set without a released-state special case here. The
+            # message names the action that actually helps: an unreadable binding is
+            # repaired out of band, not by resolve (which rejects it) or revoke (which
+            # is refused for it).
+            raise PuffoV0RegistryError(
+                f"puffo-v0 runtime registry entry {runtime_id!r} has an unreadable "
+                "directory binding; escalate for review and repair it out of band"
+            ) from exc
+        record = _DiscoveryRecord(
+            state=state,
+            runtime_id=runtime_id,
+            workspace=_authentic_workspace(entry, state),
+        )
+        existing = records.get(identity)
+        if existing is None:
+            records[identity] = record
+            continue
+        if existing.state is PuffoV0RuntimeState.ACTIVE and state is PuffoV0RuntimeState.ACTIVE:
+            raise PuffoV0RegistryError("multiple active runtimes bind the same agent_dir")
+        if _state_rank(state) < _state_rank(existing.state):
+            records[identity] = record
+    return _DiscoveryIndex(
+        by_identity=records,
+        formerly_bound={stored: rid for stored, (_state, rid) in formerly.items()},
+    )
+
+
+def _is_within_root(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def discover_runtimes(
+    root: Path,
+    *,
+    registry_path: Path | None = None,
+) -> list[PuffoV0DiscoveryCandidate]:
+    """List initialized agents below one user-selected root without side effects.
+
+    Directory symlinks are never followed.  The registry is read directly rather
+    than through its mutation/security-hardening helpers so discovery cannot
+    create a lock, initialize a registry, or rewrite permissions.
+    """
+
+    _require_posix_registry_security()
+    canonical_root = _canonical_directory(root, field="root")
+    index = _discovery_records(registry_path or default_registry_path())
+    candidates: list[PuffoV0DiscoveryCandidate] = []
+
+    def _ignore_walk_error(_error: OSError) -> None:
+        return None
+
+    for raw_current, directory_names, _file_names in os.walk(
+        canonical_root,
+        topdown=True,
+        followlinks=False,
+        onerror=_ignore_walk_error,
+    ):
+        current = Path(raw_current)
+        directory_names[:] = [
+            name
+            for name in directory_names
+            if not name.startswith(".") and not (current / name).is_symlink()
+        ]
+        try:
+            agent_dir = current.resolve(strict=True)
+        except (OSError, RuntimeError):
+            continue
+        if not _is_within_root(agent_dir, canonical_root):
+            continue
+        try:
+            initialized = (agent_dir / "init.json").is_file()
+        except OSError:
+            continue
+        if not initialized:
+            continue
+        try:
+            live_binding = _directory_binding(agent_dir, field="agent_dir")
+        except PuffoV0RegistryError:
+            # Cannot read this directory's identity to look it up; skip listing it
+            # rather than report an identity we could not verify. This is the safe
+            # direction (it never claims an occupied directory is `available`).
+            continue
+        record = index.by_identity.get((live_binding.device, live_binding.inode))
+        if record is None:
+            # Unbound now. If a registry entry recorded this exact path, its
+            # identity is no longer here (or attribution would have hit above), so
+            # hang the option-C reuse sign -- the directory stays `available` and
+            # provisionable, but the caller learns the path was previously bound.
+            candidates.append(
+                PuffoV0DiscoveryCandidate(
+                    agent_dir=agent_dir,
+                    workspace=None,
+                    display_name=agent_dir.name,
+                    runtime_id=None,
+                    state=PuffoV0RuntimeState.PROVISIONABLE,
+                    formerly_bound_runtime_id=index.formerly_bound.get(str(agent_dir)),
+                )
+            )
+        else:
+            candidates.append(
+                PuffoV0DiscoveryCandidate(
+                    agent_dir=agent_dir,
+                    workspace=record.workspace,
+                    display_name=agent_dir.name,
+                    runtime_id=record.runtime_id,
+                    state=record.state,
+                )
+            )
+    return sorted(candidates, key=lambda candidate: str(candidate.agent_dir))
+
+
+# Resolution rejection messages, one per non-active state.  Distinct strings are
+# required, not cosmetic: the caller's recovery differs per state (see the
+# discover status table), and the invariant forbids two different recoveries
+# sharing one representation.
+#
+# STALE_BINDING is discover-only: ``_classify_registry_entry`` never returns it
+# (it is synthesized in ``_discovery_records`` from a live filesystem check that
+# the pure classifier deliberately does not run), so ``resolve_runtime`` cannot
+# reach this entry -- resolve enforces the same binding directly via
+# ``_bound_directory`` and raises its richer per-field message.  The entry is
+# kept here defensively and to satisfy the completeness guard, not because
+# resolve emits it.
+_RESOLVE_STATE_MESSAGES: dict[PuffoV0RuntimeState, str] = {
+    PuffoV0RuntimeState.REVOKED: (
+        "runtime id has been revoked; provision a new runtime id"
+    ),
+    PuffoV0RuntimeState.POLICY_VERSION_MISMATCH: (
+        "runtime was provisioned under a different policy version; "
+        "revoke it and re-provision the same directory under a new id"
+    ),
+    PuffoV0RuntimeState.STALE_BINDING: (
+        "runtime's provisioned directory identity changed on disk; revoke it and "
+        "re-provision after verifying the directory"
+    ),
+    PuffoV0RuntimeState.INTEGRITY_FAILED: (
+        "runtime registry entry failed its integrity check; do not reuse it, and do "
+        "not revoke it (revoke is refused for a tampered entry so its integrity "
+        "signal is preserved) -- escalate for review and repair it out of band"
+    ),
+    PuffoV0RuntimeState.SHAPE_MISMATCH: (
+        "runtime registry entry does not match the puffo-v0 profile; revoke is "
+        "refused for it -- escalate for review and repair it out of band"
+    ),
+}
 
 
 def resolve_runtime(
@@ -539,32 +1387,16 @@ def resolve_runtime(
     runtime_id = _valid_runtime_id(runtime_id)
     path = registry_path or default_registry_path()
     _secure_registry_directory(path.parent)
-    if runtime_id in _read_revoked_runtime_ids(path):
-        raise PuffoV0RegistryError("runtime registry entry is inactive or does not match puffo-v0")
+    revoked_runtime_ids = _read_revoked_runtime_ids(path)
     registry = _read_registry(path)
     entry = registry["runtimes"].get(runtime_id)
     if not isinstance(entry, dict):
         raise PuffoV0RegistryError("runtime_id is not provisioned")
-    expected_keys = {
-        "agent_dir", "agent_dir_binding", "entry_digest", "mcp_servers",
-        "profile", "runtime_id", "runtime_policy_version", "status", "tool_surface",
-        "turn_origins", "workspace", "workspace_binding",
-    }
-    if set(entry) != expected_keys:
-        raise PuffoV0RegistryError("runtime registry entry has an invalid shape")
-    canonical = {key: value for key, value in entry.items() if key != "entry_digest"}
-    if (
-        entry.get("profile") != PROFILE_NAME
-        or entry.get("runtime_id") != runtime_id
-        or entry.get("status") != "active"
-        or entry.get("mcp_servers") != []
-        or entry.get("tool_surface") != RUNTIME_POLICY.tool_surface
-        or entry.get("turn_origins") != [TurnOrigin.AUTHENTICATED_ADAPTER.value]
-        or entry.get("runtime_policy_version") != RUNTIME_POLICY.policy_version
-        or not isinstance(entry.get("entry_digest"), str)
-        or entry["entry_digest"] != _digest(canonical)
-    ):
-        raise PuffoV0RegistryError("runtime registry entry is inactive or does not match puffo-v0")
+    state = _classify_registry_entry(
+        runtime_id, entry, revoked_runtime_ids=revoked_runtime_ids
+    )
+    if state is not PuffoV0RuntimeState.ACTIVE:
+        raise PuffoV0RegistryError(_RESOLVE_STATE_MESSAGES[state])
     agent_dir, agent_dir_binding = _bound_directory(
         entry.get("agent_dir"), entry.get("agent_dir_binding"), field="agent_dir"
     )
@@ -587,11 +1419,14 @@ def resolve_runtime(
 __all__ = [
     "DirectoryBinding",
     "PROFILE_NAME",
+    "PuffoV0DiscoveryCandidate",
     "PuffoV0RegistryError",
     "PuffoV0Runtime",
     "PuffoV0RuntimePolicy",
+    "PuffoV0RuntimeState",
     "RUNTIME_POLICY",
     "default_registry_path",
+    "discover_runtimes",
     "provision_runtime",
     "resolve_runtime",
     "revoke_runtime",

--- a/src/lingtai/cli_puffo_v0.py
+++ b/src/lingtai/cli_puffo_v0.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from lingtai.adapters.acp.puffo_v0 import (
     PuffoV0RegistryError,
+    discover_runtimes,
     provision_runtime,
     revoke_runtime,
 )
@@ -35,6 +36,12 @@ def add_puffo_v0_parser(
     )
     revoke.add_argument("--runtime-id", required=True)
     revoke.add_argument("--json", action="store_true", dest="as_json")
+    discover = commands.add_parser(
+        "discover",
+        help="List initialized agents below one user-selected directory",
+    )
+    discover.add_argument("--root", type=Path, required=True)
+    discover.add_argument("--json", action="store_true", dest="as_json")
 
 
 def handle_puffo_v0_command(args: argparse.Namespace) -> None:
@@ -51,6 +58,31 @@ def handle_puffo_v0_command(args: argparse.Namespace) -> None:
         elif args.puffo_v0_command == "revoke":
             revoke_runtime(args.runtime_id)
             payload = {"status": "revoked", "runtime_id": args.runtime_id}
+        elif args.puffo_v0_command == "discover":
+            candidates = discover_runtimes(args.root)
+            payload = {
+                "runtimes": [
+                    {
+                        "agent_dir": str(candidate.agent_dir),
+                        "display_name": candidate.display_name,
+                        "runtime_id": candidate.runtime_id,
+                        # Status comes straight from the classifier so a third
+                        # state (drifted / integrity-failed / ...) can never be
+                        # flattened into the bound/available pair a caller acts on.
+                        "status": candidate.state.value,
+                        "workspace": (
+                            str(candidate.workspace)
+                            if candidate.workspace is not None
+                            else None
+                        ),
+                        # Advisory reuse sign (option C): present on an `available`
+                        # directory whose exact path a prior runtime recorded but no
+                        # longer holds. null otherwise. Does not change `status`.
+                        "formerly_bound_runtime_id": candidate.formerly_bound_runtime_id,
+                    }
+                    for candidate in candidates
+                ]
+            }
         else:
             raise SystemExit(2)
     except PuffoV0RegistryError as exc:
@@ -58,6 +90,17 @@ def handle_puffo_v0_command(args: argparse.Namespace) -> None:
         raise SystemExit(1) from None
     if args.as_json:
         print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+    elif args.puffo_v0_command == "discover":
+        for candidate in payload["runtimes"]:
+            runtime_id = candidate["runtime_id"]
+            suffix = f" {runtime_id}" if runtime_id else ""
+            formerly = candidate["formerly_bound_runtime_id"]
+            note = (
+                f" [path previously bound {formerly}; its identity has moved or is gone]"
+                if formerly
+                else ""
+            )
+            print(f"{candidate['agent_dir']} ({candidate['status']}{suffix}){note}")
     else:
         print(f"puffo-v0 runtime {payload['runtime_id']} {payload['status']}.")
 

--- a/tests/test_puffo_v0_profile.py
+++ b/tests/test_puffo_v0_profile.py
@@ -6,6 +6,7 @@ import io
 import json
 import multiprocessing
 import os
+import shutil
 import stat
 import threading
 import time
@@ -17,7 +18,10 @@ import pytest
 
 from lingtai.adapters.acp.puffo_v0 import (
     PuffoV0RegistryError,
+    PuffoV0RuntimeState,
     RUNTIME_POLICY,
+    _digest,
+    discover_runtimes,
     provision_runtime,
     resolve_runtime,
     revoke_runtime,
@@ -137,6 +141,1874 @@ def test_provisioned_runtime_resolves_only_the_canonical_local_paths(tmp_path):
     assert entry["runtime_policy_version"] == RUNTIME_POLICY.policy_version
 
 
+def test_discover_lists_only_initialized_agents_and_preserves_registry_bytes(tmp_path):
+    root = tmp_path / "selected-root"
+    root.mkdir()
+    agent_dir = root / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    ordinary_directory = root / "ordinary"
+    ordinary_directory.mkdir()
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    registry = tmp_path / "registry.json"
+    provision_runtime("runtime-a", agent_dir, workspace, registry_path=registry)
+    # Discovery is read-only: it must not opportunistically harden a legacy
+    # registry mode while scanning candidates.
+    registry.chmod(0o644)
+    registry_before = registry.read_bytes()
+    registry_mode_before = stat.S_IMODE(registry.stat().st_mode)
+    tombstone = registry.with_name(f".{registry.name}.revocations.jsonl")
+    tombstone.chmod(0o644)
+    tombstone_mode_before = stat.S_IMODE(tombstone.stat().st_mode)
+
+    candidates = discover_runtimes(root, registry_path=registry)
+
+    assert len(candidates) == 1
+    candidate = candidates[0]
+    assert candidate.agent_dir == agent_dir.resolve()
+    assert candidate.workspace == workspace.resolve()
+    assert candidate.display_name == "identity"
+    assert candidate.runtime_id == "runtime-a"
+    assert registry.read_bytes() == registry_before
+    assert stat.S_IMODE(registry.stat().st_mode) == registry_mode_before
+    assert stat.S_IMODE(tombstone.stat().st_mode) == tombstone_mode_before
+
+
+def test_discover_skips_symlink_escape_and_reports_revoked_binding(tmp_path):
+    # Behavior change (was ..._revoked_bindings_are_available): a revoked binding
+    # is no longer collapsed into an unbound "available" candidate. It surfaces
+    # state=REVOKED and its runtime_id, because the caller's correct action --
+    # re-provision under a NEW id -- differs from "you may provision here".
+    root = tmp_path / "selected-root"
+    root.mkdir()
+    agent_dir = root / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "init.json").write_text("{}", encoding="utf-8")
+    (root / "outside-link").symlink_to(outside, target_is_directory=True)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    registry = tmp_path / "registry.json"
+    provision_runtime("runtime-a", agent_dir, workspace, registry_path=registry)
+    revoke_runtime("runtime-a", registry_path=registry)
+
+    candidates = discover_runtimes(root, registry_path=registry)
+
+    assert [candidate.agent_dir for candidate in candidates] == [agent_dir.resolve()]
+    assert candidates[0].state is PuffoV0RuntimeState.REVOKED
+    assert candidates[0].runtime_id == "runtime-a"
+    assert candidates[0].workspace is None
+
+
+def test_discover_skips_unreadable_descendant_errors(tmp_path, monkeypatch):
+    import lingtai.adapters.acp.puffo_v0 as puffo_v0
+
+    root = tmp_path / "selected-root"
+    root.mkdir()
+    agent_dir = root / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+
+    def unreadable_walk(path, *, topdown, followlinks, onerror):
+        assert path == root.resolve()
+        assert topdown is True
+        assert followlinks is False
+        yield str(path), ["blocked", "identity"], []
+        onerror(PermissionError("blocked"))
+        yield str(agent_dir), [], ["init.json"]
+
+    monkeypatch.setattr(puffo_v0.os, "walk", unreadable_walk)
+
+    candidates = discover_runtimes(root, registry_path=tmp_path / "missing-registry.json")
+
+    assert [candidate.agent_dir for candidate in candidates] == [agent_dir.resolve()]
+
+
+def test_discover_cli_emits_stable_json(tmp_path, monkeypatch, capsys):
+    import lingtai.adapters.acp.puffo_v0 as puffo_v0
+    import lingtai.cli_puffo_v0 as cli_puffo_v0
+
+    root = tmp_path / "selected-root"
+    root.mkdir()
+    agent_dir = root / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    registry = tmp_path / "registry.json"
+    monkeypatch.setattr(puffo_v0, "default_registry_path", lambda: registry)
+    parser = argparse.ArgumentParser()
+    commands = parser.add_subparsers(dest="command", required=True)
+    cli_puffo_v0.add_puffo_v0_parser(commands)
+    args = parser.parse_args(["puffo-v0", "discover", "--root", str(root), "--json"])
+
+    cli_puffo_v0.handle_puffo_v0_command(args)
+
+    assert json.loads(capsys.readouterr().out) == {
+        "runtimes": [{
+            "agent_dir": str(agent_dir.resolve()),
+            "display_name": "identity",
+            "formerly_bound_runtime_id": None,
+            "runtime_id": None,
+            "status": "available",
+            "workspace": None,
+        }]
+    }
+
+
+def test_discover_cli_human_output_hangs_the_reuse_sign(tmp_path, monkeypatch, capsys):
+    # Option C's sign must reach the human-readable (non-JSON) output too, not only
+    # --json: a same-path replacement prints `available` AND the inline note naming
+    # the runtime whose path was reused.
+    import lingtai.adapters.acp.puffo_v0 as puffo_v0
+    import lingtai.cli_puffo_v0 as cli_puffo_v0
+
+    root = tmp_path / "selected-root"
+    root.mkdir()
+    agent_dir = root / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    registry = tmp_path / "registry.json"
+    monkeypatch.setattr(puffo_v0, "default_registry_path", lambda: registry)
+    provision_runtime("runtime-a", agent_dir, workspace, registry_path=registry)
+    # Same-path replacement: move the recorded identity out of the root, recreate
+    # a fresh directory at the same path -> `available` with the reuse sign.
+    agent_dir.rename(tmp_path / "identity-moved")
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+
+    parser = argparse.ArgumentParser()
+    commands = parser.add_subparsers(dest="command", required=True)
+    cli_puffo_v0.add_puffo_v0_parser(commands)
+    args = parser.parse_args(["puffo-v0", "discover", "--root", str(root)])  # no --json
+    cli_puffo_v0.handle_puffo_v0_command(args)
+
+    out = capsys.readouterr().out
+    assert "(available)" in out
+    assert "path previously bound runtime-a" in out
+
+
+def test_discover_fails_closed_when_posix_registry_security_is_unavailable(tmp_path, monkeypatch):
+    import lingtai.adapters.acp.puffo_v0 as puffo_v0
+
+    root = tmp_path / "selected-root"
+    root.mkdir()
+    monkeypatch.setattr(puffo_v0.os, "name", "nt")
+
+    with pytest.raises(PuffoV0RegistryError, match="requires POSIX"):
+        discover_runtimes(root, registry_path=tmp_path / "missing-registry.json")
+
+
+def _mutate_registry_entry(registry, runtime_id, *, resign, **overrides):
+    """Overwrite fields of one registry entry, optionally re-signing its digest.
+
+    ``resign=True`` recomputes ``entry_digest`` so the entry stays authentic
+    (used to build a *legitimately* drifted/foreign entry); ``resign=False``
+    leaves the digest untouched so the override alone decides integrity.
+    """
+    data = json.loads(registry.read_text(encoding="utf-8"))
+    entry = data["runtimes"][runtime_id]
+    entry.update(overrides)
+    if resign:
+        canonical = {k: v for k, v in entry.items() if k != "entry_digest"}
+        entry["entry_digest"] = _digest(canonical)
+    registry.write_text(json.dumps(data), encoding="utf-8")
+
+
+def _discover_one(root, registry):
+    candidates = discover_runtimes(root, registry_path=registry)
+    assert len(candidates) == 1
+    return candidates[0]
+
+
+def _make_agent_dir_binding_owner_stale(registry, runtime_id="runtime-a"):
+    """Make the live agent_dir identity mismatch WITHOUT moving the directory.
+
+    Re-sign the entry with a wrong ``owner`` in ``agent_dir_binding``, keeping the
+    same device/inode.  The classifier still rules it ACTIVE (the entry is
+    authentic), and it is still keyed by the unchanged device/inode, so it attaches
+    to the same walked directory -- but ``_bound_directory`` compares the full
+    identity, so the mismatched owner makes ``_binding_matches`` false and discovery
+    downgrades it to STALE_BINDING.  Leaves exactly one directory under the root,
+    which the ``--json`` CLI pairwise test needs (it asserts a single row).
+    """
+    data = json.loads(registry.read_text(encoding="utf-8"))
+    binding = dict(data["runtimes"][runtime_id]["agent_dir_binding"])
+    binding["owner"] = binding["owner"] + 1
+    _mutate_registry_entry(
+        registry, runtime_id, resign=True, agent_dir_binding=binding
+    )
+
+
+def test_same_path_agent_dir_replacement_reports_available_and_moved_original_stale(
+    tmp_path,
+):
+    # Tianzhe's report (agent_dir half), resolved by identity keying. A same-path
+    # replacement no longer reports the recreated directory as `bound`: its
+    # device/inode are genuinely new and unbound, so discover reports it
+    # `available` -- and provisioning it under a new id really succeeds, so
+    # `available = may provision` holds. The moved original keeps the provisioned
+    # identity, so while it stays under the root it is reported `stale_binding`
+    # with the runtime_id (the revoke path), and resolve_runtime still rejects the
+    # entry on the binding. Assert BOTH rows and both follow-on operations.
+    root = tmp_path / "root"
+    root.mkdir()
+    agent_dir = root / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    registry = tmp_path / "registry.json"
+    provision_runtime("runtime-a", agent_dir, workspace, registry_path=registry)
+    # Move the real directory (device/inode preserved) to a new path UNDER the
+    # root, then recreate a fresh directory (new device/inode) at the old path.
+    moved = root / "identity-moved"
+    agent_dir.rename(moved)
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+
+    candidates = {c.agent_dir: c for c in discover_runtimes(root, registry_path=registry)}
+    recreated = candidates[agent_dir]
+    assert recreated.state is PuffoV0RuntimeState.PROVISIONABLE   # fresh identity, unbound
+    assert recreated.runtime_id is None
+    assert recreated.workspace is None
+    # Option C: the recreated path carries the advisory reuse sign -- the caller
+    # sees this path formerly bound runtime-a even though it is now provisionable.
+    assert recreated.formerly_bound_runtime_id == "runtime-a"
+    moved_candidate = candidates[moved]
+    assert moved_candidate.state is PuffoV0RuntimeState.STALE_BINDING
+    assert moved_candidate.state is not PuffoV0RuntimeState.ACTIVE
+    assert moved_candidate.runtime_id == "runtime-a"   # surfaced so it can be revoked
+    assert moved_candidate.workspace is None
+    # resolve still rejects the entry (its stored path now holds a new identity):
+    with pytest.raises(PuffoV0RegistryError, match="binding no longer matches"):
+        resolve_runtime("runtime-a", registry_path=registry)
+    # And `available` is truthful: provisioning the recreated directory succeeds.
+    workspace2 = tmp_path / "workspace2"
+    workspace2.mkdir()
+    provision_runtime("runtime-c", agent_dir, workspace2, registry_path=registry)
+
+
+def test_bound_requires_live_workspace_binding_not_just_agent_dir(tmp_path):
+    # Tianzhe's report (workspace half): the agent_dir is untouched but the
+    # WORKSPACE is replaced. The workspace lives outside the discovery root and is
+    # never walked, so discovery must lstat it directly. A test that only renamed
+    # the agent_dir would leave this half unpinned.
+    root = tmp_path / "root"
+    root.mkdir()
+    agent_dir = root / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    registry = tmp_path / "registry.json"
+    provision_runtime("runtime-a", agent_dir, workspace, registry_path=registry)
+    # Replace the workspace at the same path with a fresh directory (new inode).
+    workspace.rename(tmp_path / "workspace-moved")
+    workspace.mkdir()
+
+    candidate = _discover_one(root, registry)
+    assert candidate.state is PuffoV0RuntimeState.STALE_BINDING
+    assert candidate.runtime_id == "runtime-a"
+    assert candidate.workspace is None
+    with pytest.raises(PuffoV0RegistryError, match="binding no longer matches"):
+        resolve_runtime("runtime-a", registry_path=registry)
+
+
+def test_orphaned_revocation_log_is_not_reported_available(tmp_path):
+    # Tianzhe's report (orphaned tombstone): a revocation log with no registry is a
+    # broken control-plane state. discover previously reported the directory as
+    # `available` (may provision), but provision refuses to re-initialize over the
+    # orphaned log. discover must fail closed instead. Assert the PAIR -- discover
+    # raises AND provision raises.
+    root = tmp_path / "root"
+    root.mkdir()
+    agent_dir = root / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    registry = tmp_path / "registry.json"
+    # Provision then revoke to create both the registry and its revocation log,
+    # then delete only the registry to orphan the tombstone.
+    provision_runtime("runtime-a", agent_dir, workspace, registry_path=registry)
+    revoke_runtime("runtime-a", registry_path=registry)
+    tombstone = registry.with_name(f".{registry.name}.revocations.jsonl")
+    assert tombstone.exists()
+    registry.unlink()
+
+    with pytest.raises(PuffoV0RegistryError, match="revocation log exists without"):
+        discover_runtimes(root, registry_path=registry)
+    # And the operation discover is supposed to predict really does fail:
+    other = tmp_path / "identity-2"
+    other.mkdir()
+    (other / "init.json").write_text("{}", encoding="utf-8")
+    with pytest.raises(PuffoV0RegistryError, match="unexpected revocation log"):
+        provision_runtime("runtime-b", other, workspace, registry_path=registry)
+
+
+def test_provision_rejects_double_binding_through_a_renamed_directory_symlink(tmp_path):
+    # Peter's bug 3 at the EXECUTION point. Provision a runtime, then move the real
+    # agent_dir to a new path and leave a symlink at the old path. The physical
+    # directory keeps its device/inode, so a second provision at the NEW path binds
+    # the SAME physical directory twice unless the guard compares identity: a
+    # path-string comparison sees two different strings and waves it through.
+    # Assert the PAIR -- discover reports the new path stale_binding (not
+    # available), and the second provision is refused as a conflict on the same
+    # identity. The provision match string is specific ("already bound to an active
+    # runtime") so reverting the guard to a path-string comparison reddens here.
+    root = tmp_path / "root"
+    root.mkdir()
+    agent_dir = root / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    registry = tmp_path / "registry.json"
+    provision_runtime("runtime-a", agent_dir, workspace, registry_path=registry)
+    # Move the real directory (device/inode preserved) and leave a symlink behind.
+    new_path = root / "identity-new"
+    agent_dir.rename(new_path)
+    agent_dir.symlink_to(new_path)
+
+    candidates = {c.agent_dir: c for c in discover_runtimes(root, registry_path=registry)}
+    assert new_path in candidates                      # the symlink itself is not followed
+    assert candidates[new_path].state is PuffoV0RuntimeState.STALE_BINDING
+    assert candidates[new_path].state is not PuffoV0RuntimeState.PROVISIONABLE
+    assert candidates[new_path].runtime_id == "runtime-a"
+    # provision at the new path must be refused: same physical identity.
+    workspace2 = tmp_path / "workspace2"
+    workspace2.mkdir()
+    with pytest.raises(PuffoV0RegistryError, match="already bound to active runtime") as exc_info:
+        provision_runtime("runtime-b", new_path, workspace2, registry_path=registry)
+    # Boris condition 二: the rejection must name (a) the offending runtime_id and
+    # (b) the operation that clears it, plus the path the conflicting entry recorded.
+    message = str(exc_info.value)
+    assert "runtime-a" in message                         # (a) who holds it
+    assert "revoke it before re-provisioning" in message  # (b) how to release it
+    assert str(agent_dir) in message                      # the conflicting recorded path
+
+
+def test_provision_conflict_criterion_excludes_owner_group_so_chown_cannot_reopen_it(
+    tmp_path,
+):
+    # Boris's chown trap. "Same physical directory" is (device, inode); "still the
+    # binding I provisioned" is the full (device, inode, owner, group) + canonical
+    # path. The double-bind conflict criterion must use ONLY device/inode -- if it
+    # ever widened to the full tuple, a chown between provisions (dev/inode
+    # unchanged, owner changed) would make the two compare unequal and the second
+    # provision of the SAME physical directory would be waved through, reviving
+    # bug 3 while every test stayed green. A real chown needs root, so simulate the
+    # post-provision owner change by re-signing the stored binding with a different
+    # owner (authentic, so still ACTIVE): the live directory now has a different
+    # owner than the entry records, exactly the change the widened criterion would
+    # mishandle. It must still be refused, with the directory-occupied reason
+    # (provision never emits stale_binding). Widening the criterion to the full
+    # tuple reddens here.
+    root = tmp_path / "root"
+    root.mkdir()
+    agent_dir = root / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    registry = tmp_path / "registry.json"
+    provision_runtime("runtime-a", agent_dir, workspace, registry_path=registry)
+    # Simulate `chown agent_dir` after provision: stored owner now differs from the
+    # live owner, but device/inode are unchanged. Re-signed, so still authentic.
+    binding = dict(json.loads(registry.read_text())["runtimes"]["runtime-a"]["agent_dir_binding"])
+    binding["owner"] = binding["owner"] + 1
+    _mutate_registry_entry(registry, "runtime-a", resign=True, agent_dir_binding=binding)
+    workspace2 = tmp_path / "workspace2"
+    workspace2.mkdir()
+    with pytest.raises(PuffoV0RegistryError, match="already bound to active runtime"):
+        provision_runtime("runtime-b", agent_dir, workspace2, registry_path=registry)
+
+
+def test_provision_conflict_survives_a_corrupted_status_field(tmp_path):
+    # Boris's second execution-point hole: the guard must read status THROUGH the
+    # classifier (after the integrity check), never the raw signed field before it.
+    # Corrupt an active entry's status WITHOUT re-signing: the digest now fails, so
+    # the classifier rules it INTEGRITY_FAILED. It still occupies its directory, so
+    # a second provision on the SAME identity must be refused -- with the integrity
+    # message, distinct from the plain directory-occupied one -- NOT waved through
+    # because the raw status no longer reads "active". Moving the status check back
+    # above the classifier reddens here (the corrupt entry would vanish from the
+    # guard and the second provision would succeed).
+    root = tmp_path / "root"
+    root.mkdir()
+    agent_dir = root / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    registry = tmp_path / "registry.json"
+    provision_runtime("runtime-a", agent_dir, workspace, registry_path=registry)
+    # Corrupt status without re-signing -> digest mismatch -> INTEGRITY_FAILED, but
+    # the agent_dir_binding stays intact and still names the live identity.
+    _mutate_registry_entry(registry, "runtime-a", resign=False, status="disabled")
+    workspace2 = tmp_path / "workspace2"
+    workspace2.mkdir()
+    with pytest.raises(PuffoV0RegistryError, match="failed its integrity check") as exc_info:
+        provision_runtime("runtime-b", agent_dir, workspace2, registry_path=registry)
+    # The message names the escalation, not a dead-end recovery, and its truth
+    # reduces to one behavior: revoke is REFUSED for a tampered entry.
+    msg = str(exc_info.value)
+    assert "escalate for review" in msg
+    assert "revoke is refused" in msg
+    assert "resolve it before provisioning" not in msg
+    # Executable proof the message is honest: revoke actually refuses the tampered
+    # entry (so it cannot re-sign it and erase the integrity signal), and the block
+    # therefore persists rather than being cleared by a "successful" revoke.
+    with pytest.raises(PuffoV0RegistryError, match="revoke is refused"):
+        revoke_runtime("runtime-a", registry_path=registry)
+    with pytest.raises(PuffoV0RegistryError, match="failed its integrity check"):
+        provision_runtime("runtime-b", agent_dir, workspace2, registry_path=registry)
+
+
+def test_shape_mismatch_conflict_names_escalation_and_revoke_refuses_it(tmp_path):
+    # A shape-broken entry occupying a directory blocks provisioning, and the
+    # rejection must name the action that actually helps -- escalate + repair out of
+    # band -- not revoke. Its truth reduces to one behavior: revoke_runtime REFUSES a
+    # malformed entry (rather than "succeeding" while leaving the block in place, the
+    # earlier dead end). This uses an extra-key subtype, RE-SIGNED so it is a genuine
+    # SHAPE_MISMATCH: an extra key WITHOUT re-signing is INTEGRITY_FAILED now (the
+    # digest match is decided before the key-set), which blocks unconditionally
+    # through a different message -- the un-signed cross-product is pinned by
+    # test_unauthenticated_extra_key_binding_tamper_fails_closed. The per-subtype
+    # matrix (test_revoke_refuses_and_preserves_a_blocking_entry) proves the SAME
+    # refusal holds for every shape/integrity subtype, so the message's universal
+    # claim is backed by the admission rule rather than a single sample.
+    root = tmp_path / "root"
+    root.mkdir()
+    agent_dir = root / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    registry = tmp_path / "registry.json"
+    provision_runtime("runtime-a", agent_dir, workspace, registry_path=registry)
+    _mutate_registry_entry(registry, "runtime-a", resign=True, unexpected=True)
+    ws2 = tmp_path / "ws2"
+    ws2.mkdir()
+    with pytest.raises(
+        PuffoV0RegistryError, match="does not match the puffo-v0 profile"
+    ) as exc_info:
+        provision_runtime("runtime-b", agent_dir, ws2, registry_path=registry)
+    msg = str(exc_info.value)
+    assert "escalate for review" in msg
+    assert "revoke is refused" in msg
+    assert "resolve it before provisioning" not in msg
+    # revoke really refuses (not "succeeds yet leaves the block"), so the block
+    # persists and no self-service clear exists.
+    with pytest.raises(PuffoV0RegistryError, match="revoke is refused"):
+        revoke_runtime("runtime-a", registry_path=registry)
+    with pytest.raises(PuffoV0RegistryError, match="does not match the puffo-v0 profile"):
+        provision_runtime("runtime-c", agent_dir, ws2, registry_path=registry)
+
+
+def test_provision_fails_closed_on_an_unreadable_conflict_binding(tmp_path):
+    # The no-silent-skip invariant AT the guard. An existing entry whose stored
+    # binding cannot even be parsed cannot be proven NOT to occupy the target, so
+    # it must not pass as "no conflict" (the old `continue`'s allow direction). It
+    # fails closed with a distinct "unreadable binding" message -- even when the
+    # target is an unrelated directory -- so a corrupt entry blocks provisioning
+    # until it is resolved rather than being silently skipped.
+    root = tmp_path / "root"
+    root.mkdir()
+    agent_dir = root / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    registry = tmp_path / "registry.json"
+    provision_runtime("runtime-a", agent_dir, workspace, registry_path=registry)
+    # Corrupt the binding into an unparseable-but-SIGNED shape: re-signing makes the
+    # digest match, so the entry is SHAPE_MISMATCH (a well-formed digest over a
+    # malformed binding payload), and _parse_binding raises when the guard reads its
+    # identity -> the unreadable-binding fail-closed path. An UN-signed malformed
+    # binding is INTEGRITY_FAILED now (digest checked first) and is pinned separately
+    # by test_unauthenticated_agent_binding_tamper_fails_closed.
+    _mutate_registry_entry(registry, "runtime-a", resign=True, agent_dir_binding={"device": 1})
+    other = tmp_path / "other"
+    other.mkdir()
+    (other / "init.json").write_text("{}", encoding="utf-8")
+    workspace2 = tmp_path / "workspace2"
+    workspace2.mkdir()
+    with pytest.raises(PuffoV0RegistryError, match="unreadable binding"):
+        provision_runtime("runtime-b", other, workspace2, registry_path=registry)
+
+
+def test_discover_fails_closed_on_an_unreadable_entry_binding(tmp_path):
+    # The no-silent-drop invariant AT discover. An entry whose stored binding cannot
+    # be parsed has no device/inode to key on, so it cannot be attributed to any
+    # walked directory. Dropping it would let a directory it actually holds be
+    # reported `available` (the dangerous direction), so discover fails closed with
+    # a distinct message rather than omit the entry.
+    root = tmp_path / "root"
+    root.mkdir()
+    agent_dir = root / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    registry = tmp_path / "registry.json"
+    provision_runtime("runtime-a", agent_dir, workspace, registry_path=registry)
+    # SIGNED unparseable binding -> SHAPE_MISMATCH, so _entry_identity_key's
+    # _parse_binding raises and discover fails closed on the unreadable-binding path.
+    # (An un-signed malformed binding is INTEGRITY_FAILED and fails closed earlier;
+    # pinned by test_unauthenticated_agent_binding_tamper_fails_closed.)
+    _mutate_registry_entry(registry, "runtime-a", resign=True, agent_dir_binding={"device": 1})
+    with pytest.raises(PuffoV0RegistryError, match="unreadable directory binding"):
+        discover_runtimes(root, registry_path=registry)
+
+
+def test_reuse_hint_does_not_change_the_decision_only_the_advisory_field(tmp_path):
+    # Boris condition 一: the sign is JUST a sign, enforced not asserted. Two
+    # `available` directories -- one whose path was reused (carries the hint), one
+    # that never had an entry -- must be byte-identical in (status, runtime_id,
+    # workspace) and BOTH must actually provision. The stored path reaches only the
+    # advisory field, never a decision branch; if it ever leaked into
+    # status/accept-reject, the two would diverge and this reds.
+    root = tmp_path / "root"
+    root.mkdir()
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    registry = tmp_path / "registry.json"
+    # Hinted directory: provision, then same-path replace so its path was reused
+    # (move the recorded identity OUT of the root so only the recreated dir walks).
+    hinted = root / "hinted"
+    hinted.mkdir()
+    (hinted / "init.json").write_text("{}", encoding="utf-8")
+    provision_runtime("runtime-a", hinted, workspace, registry_path=registry)
+    hinted.rename(tmp_path / "hinted-moved")
+    hinted.mkdir()
+    (hinted / "init.json").write_text("{}", encoding="utf-8")
+    # Plain directory: never bound.
+    plain = root / "plain"
+    plain.mkdir()
+    (plain / "init.json").write_text("{}", encoding="utf-8")
+
+    cands = {c.agent_dir: c for c in discover_runtimes(root, registry_path=registry)}
+    h, p = cands[hinted], cands[plain]
+    # The decision is identical; ONLY the advisory field differs.
+    assert (h.state, h.runtime_id, h.workspace) == (p.state, p.runtime_id, p.workspace)
+    assert h.state is PuffoV0RuntimeState.PROVISIONABLE
+    assert h.formerly_bound_runtime_id == "runtime-a"
+    assert p.formerly_bound_runtime_id is None
+    # accept/reject is identical too: both directories really provision.
+    ws2 = tmp_path / "ws2"
+    ws2.mkdir()
+    ws3 = tmp_path / "ws3"
+    ws3.mkdir()
+    provision_runtime("runtime-h", hinted, ws2, registry_path=registry)
+    provision_runtime("runtime-p", plain, ws3, registry_path=registry)
+
+
+def test_released_directory_roster_is_revoked_only_and_shared():
+    # Boris condition 三: "discover fail-closed set == guard block set" is a
+    # set-equality claim, not a single member. Both occupancy checks route through
+    # the one predicate _state_releases_directory, so the sets cannot diverge by
+    # construction; this pins the roster itself -- only REVOKED releases -- over the
+    # whole enum, so a state added later without deciding its membership reds here
+    # rather than silently landing in `available`/no-conflict on one side only.
+    from lingtai.adapters.acp.puffo_v0 import _state_releases_directory
+
+    released = {state for state in PuffoV0RuntimeState if _state_releases_directory(state)}
+    assert released == {PuffoV0RuntimeState.REVOKED}
+    # The two sides that must agree (guard vs discover) both call the predicate.
+    # Two fail-closed behaviors sit on either side of the digest boundary and are
+    # pinned separately: a SIGNED-but-unparseable binding (SHAPE_MISMATCH) blocks
+    # through the unreadable-binding path -- test_provision_fails_closed_on_an_
+    # unreadable_conflict_binding / test_discover_fails_closed_on_an_unreadable_entry_
+    # binding; an UN-signed binding (INTEGRITY_FAILED) blocks wholesale through the
+    # unauthenticated-entry path -- test_unauthenticated_agent_binding_tamper_fails_
+    # closed and its workspace/extra-key siblings. A REVOKED entry can no longer have an
+    # unreadable binding at all: a malformed binding payload classifies SHAPE_MISMATCH
+    # ahead of the revoked gate, pinned by
+    # test_a_malformed_binding_never_classifies_revoked_even_with_a_signed_revoked_status,
+    # so the earlier "revoked + unreadable binding" asymmetry is unreachable, not
+    # merely handled.
+
+
+def test_reuse_hint_is_sourced_from_path_so_policy_drifted_replacement_is_flagged(
+    tmp_path,
+):
+    # Option C's discriminating case, and why the hint must be sourced from the
+    # stored PATH not from the STALE downgrade. The STALE downgrade only runs on an
+    # ACTIVE entry; a POLICY_VERSION_MISMATCH entry whose directory is replaced at
+    # the same path never becomes STALE, so a hint sourced from STALE entries would
+    # leave the recreated directory bare `available` with no sign. Sourcing from
+    # the path (any non-revoked entry) fires the sign here, while the identity
+    # attribution still (correctly) reports the fresh directory PROVISIONABLE.
+    root = tmp_path / "root"
+    root.mkdir()
+    agent_dir = root / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    registry = tmp_path / "registry.json"
+    provision_runtime("runtime-a", agent_dir, workspace, registry_path=registry)
+    # Drift the policy version (re-signed, so authentic -> POLICY_VERSION_MISMATCH,
+    # NOT stale), then replace the directory at the same path with a fresh inode.
+    _mutate_registry_entry(
+        registry, "runtime-a", resign=True, runtime_policy_version="puffo-v0.OLD"
+    )
+    agent_dir.rename(tmp_path / "identity-moved")   # move the drifted identity out of root
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+
+    candidate = _discover_one(root, registry)
+    assert candidate.state is PuffoV0RuntimeState.PROVISIONABLE   # fresh identity, provisionable
+    assert candidate.formerly_bound_runtime_id == "runtime-a"     # but the sign is hung
+    # And the sign is truthful: provisioning the recreated directory succeeds.
+    workspace2 = tmp_path / "workspace2"
+    workspace2.mkdir()
+    provision_runtime("runtime-b", agent_dir, workspace2, registry_path=registry)
+
+
+def test_a_malformed_binding_never_classifies_revoked_even_with_a_signed_revoked_status(
+    tmp_path,
+):
+    # A REVOKED entry always has a well-formed binding payload: the binding-payload
+    # shape check precedes the revoked gate, so a malformed binding classifies as a
+    # blocking SHAPE_MISMATCH even when its ``status`` is a validly-signed "revoked".
+    # This closes the old asymmetry (a REVOKED entry whose binding was unreadable)
+    # at the source -- it can no longer arise -- and keeps discover's fail-closed set
+    # equal to the guard's block set: both treat it as blocking, neither releases it.
+    from lingtai.adapters.acp.puffo_v0 import _classify_registry_entry
+
+    root = tmp_path / "root"
+    root.mkdir()
+    agent_dir = root / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    registry = tmp_path / "registry.json"
+    provision_runtime("runtime-a", agent_dir, workspace, registry_path=registry)
+    # A signed entry with status="revoked" AND a malformed binding: the malformed
+    # binding must win (SHAPE_MISMATCH), never REVOKED.
+    _mutate_registry_entry(
+        registry, "runtime-a", resign=True, status="revoked", agent_dir_binding={"device": 1}
+    )
+    data = json.loads(registry.read_text(encoding="utf-8"))
+    state = _classify_registry_entry("runtime-a", data["runtimes"]["runtime-a"], revoked_runtime_ids=frozenset())
+    assert state is PuffoV0RuntimeState.SHAPE_MISMATCH
+    assert state is not PuffoV0RuntimeState.REVOKED
+    # Both sides treat it as blocking: discover fails closed (cannot key the entry),
+    # and the guard fails closed (cannot read the binding) rather than releasing it.
+    with pytest.raises(PuffoV0RegistryError, match="unreadable directory binding"):
+        discover_runtimes(root, registry_path=registry)
+    other = tmp_path / "other"
+    other.mkdir()
+    (other / "init.json").write_text("{}", encoding="utf-8")
+    ws2 = tmp_path / "ws2"
+    ws2.mkdir()
+    with pytest.raises(PuffoV0RegistryError, match="unreadable binding"):
+        provision_runtime("runtime-b", other, ws2, registry_path=registry)
+
+
+def test_policy_version_drift_is_a_recoverable_state_not_integrity_failure(tmp_path):
+    # The one auto-recoverable class: an authentic entry (digest re-signed) whose
+    # only divergence is runtime_policy_version. It must NOT be read as tampering,
+    # or the caller's revoke+re-provision recovery would run against a forged entry.
+    root = tmp_path / "root"
+    root.mkdir()
+    agent_dir = root / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    registry = tmp_path / "registry.json"
+    provision_runtime("runtime-a", agent_dir, workspace, registry_path=registry)
+    _mutate_registry_entry(
+        registry, "runtime-a", resign=True, runtime_policy_version="puffo-v0.OLD"
+    )
+
+    candidate = _discover_one(root, registry)
+    assert candidate.state is PuffoV0RuntimeState.POLICY_VERSION_MISMATCH
+    assert candidate.state is not PuffoV0RuntimeState.INTEGRITY_FAILED
+    # The runtime_id is surfaced: it is the escape from the dead-end (you must
+    # know it to revoke), and the workspace is still an authentic binding.
+    assert candidate.runtime_id == "runtime-a"
+    assert candidate.workspace == workspace.resolve()
+    with pytest.raises(PuffoV0RegistryError, match="different policy version"):
+        resolve_runtime("runtime-a", registry_path=registry)
+
+
+def test_policy_drift_dead_end_is_sealed_at_both_discover_and_provision(tmp_path):
+    # Boris's reproducible dead-end, now escapable. Before the fix: discover said
+    # the dir was unbound while provision said "already bound to an active
+    # runtime", and you could not revoke because discover hid the id.
+    root = tmp_path / "root"
+    root.mkdir()
+    agent_dir = root / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    registry = tmp_path / "registry.json"
+    provision_runtime("runtime-a", agent_dir, workspace, registry_path=registry)
+    _mutate_registry_entry(
+        registry, "runtime-a", resign=True, runtime_policy_version="puffo-v0.OLD"
+    )
+
+    # Discover half: the dir is surfaced as drifted, carrying the id to revoke.
+    candidate = _discover_one(root, registry)
+    assert candidate.state is PuffoV0RuntimeState.POLICY_VERSION_MISMATCH
+    assert candidate.runtime_id == "runtime-a"
+
+    # Provision half: still rejected (accept/reject set unchanged), but the reason
+    # points at the revoke recovery instead of the misleading "another runtime".
+    with pytest.raises(PuffoV0RegistryError) as exc_info:
+        provision_runtime("runtime-b", agent_dir, workspace, registry_path=registry)
+    message = str(exc_info.value)
+    assert "revoke it before re-provisioning" in message
+    assert "already bound to active runtime" not in message
+
+    # And the escape actually works end to end: revoke the surfaced id, re-provision.
+    revoke_runtime(candidate.runtime_id, registry_path=registry)
+    runtime = provision_runtime("runtime-b", agent_dir, workspace, registry_path=registry)
+    assert runtime.runtime_id == "runtime-b"
+
+
+def test_integrity_failure_is_decided_by_digest_alone(tmp_path):
+    # Boris's finding (1): break ONLY the digest, nothing that also trips the path
+    # binding check, so the INTEGRITY_FAILED verdict cannot come from another gate.
+    root = tmp_path / "root"
+    root.mkdir()
+    agent_dir = root / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    registry = tmp_path / "registry.json"
+    provision_runtime("runtime-a", agent_dir, workspace, registry_path=registry)
+    _mutate_registry_entry(registry, "runtime-a", resign=False, entry_digest="0" * 64)
+
+    # An unauthenticated entry is no longer a discover-reportable state: its stored
+    # binding cannot be trusted to attribute it, so discover fails closed for the
+    # whole registry rather than report an integrity_failed row it cannot place.
+    # resolve still classifies it INTEGRITY_FAILED by the digest alone and rejects it.
+    with pytest.raises(PuffoV0RegistryError, match="not authenticated by its digest"):
+        discover_runtimes(root, registry_path=registry)
+    with pytest.raises(PuffoV0RegistryError, match="integrity check"):
+        resolve_runtime("runtime-a", registry_path=registry)
+
+
+def test_tampered_entry_that_also_drifts_version_is_integrity_failure(tmp_path):
+    # The security-critical ordering: integrity is decided before version. Changing
+    # runtime_policy_version WITHOUT re-signing both drifts the version AND breaks
+    # the digest. If version were judged first this would look like the one
+    # auto-recoverable state and the caller's automatic revoke would run against a
+    # forged entry. It must be INTEGRITY_FAILED, never POLICY_VERSION_MISMATCH.
+    root = tmp_path / "root"
+    root.mkdir()
+    agent_dir = root / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    registry = tmp_path / "registry.json"
+    provision_runtime("runtime-a", agent_dir, workspace, registry_path=registry)
+    _mutate_registry_entry(
+        registry, "runtime-a", resign=False, runtime_policy_version="puffo-v0.OLD"
+    )
+
+    # If version were judged first, resolve would emit the recoverable drift message
+    # and the caller's auto-revoke would run against a forged entry. Integrity is
+    # decided first, so resolve rejects it as an integrity failure -- never the drift.
+    # discover, seeing an unauthenticated entry, fails closed for the whole registry.
+    with pytest.raises(PuffoV0RegistryError, match="not authenticated by its digest"):
+        discover_runtimes(root, registry_path=registry)
+    with pytest.raises(PuffoV0RegistryError, match="integrity check"):
+        resolve_runtime("runtime-a", registry_path=registry)
+    with pytest.raises(PuffoV0RegistryError) as exc_info:
+        resolve_runtime("runtime-a", registry_path=registry)
+    assert "different policy version" not in str(exc_info.value)
+
+
+def test_authentic_but_foreign_profile_is_shape_mismatch(tmp_path):
+    # Digest re-signed over a changed tool_surface: authentic yet not our profile.
+    # Distinct from integrity failure (the entry is validly signed) and from drift.
+    root = tmp_path / "root"
+    root.mkdir()
+    agent_dir = root / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    registry = tmp_path / "registry.json"
+    provision_runtime("runtime-a", agent_dir, workspace, registry_path=registry)
+    _mutate_registry_entry(
+        registry, "runtime-a", resign=True, tool_surface="operator_managed_partial"
+    )
+
+    candidate = _discover_one(root, registry)
+    assert candidate.state is PuffoV0RuntimeState.SHAPE_MISMATCH
+    with pytest.raises(PuffoV0RegistryError, match="does not match the puffo-v0 profile"):
+        resolve_runtime("runtime-a", registry_path=registry)
+
+
+def _bump_binding_inode_without_resigning(registry, runtime_id, field):
+    """Point one stored binding at a different LEGAL inode, leaving the digest stale.
+
+    The cross-product the 21-case matrix missed: a structurally VALID new binding
+    value whose ``entry_digest`` was NOT recomputed.  The entry classifies
+    INTEGRITY_FAILED (the digest no longer covers the edited value), and the edited
+    inode no longer names the directory the entry actually holds -- so any occupancy
+    decision that trusts it is exactly the "a record proven untrustworthy still
+    decides allow" defect.
+    """
+    data = json.loads(registry.read_text(encoding="utf-8"))
+    binding = dict(data["runtimes"][runtime_id][f"{field}_binding"])
+    binding["inode"] = binding["inode"] + 1
+    _mutate_registry_entry(
+        registry, runtime_id, resign=False, **{f"{field}_binding": binding}
+    )
+
+
+def _assert_control_plane_bytes_unchanged(registry):
+    """Return a callable asserting the registry AND tombstone are byte-identical.
+
+    Both files must be untouched by a refused operation: the registry so no entry is
+    added, the tombstone (bytes AND line count, separately) because a tombstone alone
+    releases a directory and the log is append-only, so a single spurious line would
+    release identity irreversibly.
+    """
+    tombstone = registry.with_name(f".{registry.name}.revocations.jsonl")
+    registry_before = registry.read_bytes()
+    tombstone_before = tombstone.read_bytes()
+
+    def _check():
+        assert registry.read_bytes() == registry_before
+        assert tombstone.read_bytes() == tombstone_before
+        assert tombstone_before.count(b"\n") == tombstone.read_bytes().count(b"\n")
+
+    return _check
+
+
+def test_unauthenticated_agent_binding_tamper_fails_closed(tmp_path):
+    # Tianzhe's blocker, agent half: edit agent_dir_binding.inode to another legal
+    # integer WITHOUT re-signing. The old code keyed discovery by -- and compared the
+    # guard against -- that unauthenticated inode, so the REAL agent_dir (whose live
+    # inode no longer equals the tampered stored one) read `available` and a second
+    # runtime could seize a directory that is still held. A record proven
+    # untrustworthy must not decide occupancy: discover fails closed and the second
+    # provision is refused, both leaving the control plane byte-identical.
+    root = tmp_path / "root"
+    root.mkdir()
+    agent_dir = root / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    registry = tmp_path / "registry.json"
+    provision_runtime("runtime-a", agent_dir, workspace, registry_path=registry)
+
+    _bump_binding_inode_without_resigning(registry, "runtime-a", "agent_dir")
+    unchanged = _assert_control_plane_bytes_unchanged(registry)
+
+    with pytest.raises(PuffoV0RegistryError, match="not authenticated by its digest"):
+        discover_runtimes(root, registry_path=registry)
+    workspace2 = tmp_path / "workspace2"
+    workspace2.mkdir()
+    with pytest.raises(PuffoV0RegistryError, match="failed its integrity check"):
+        provision_runtime("runtime-b", agent_dir, workspace2, registry_path=registry)
+    unchanged()
+
+
+def test_unauthenticated_workspace_binding_tamper_fails_closed(tmp_path):
+    # Tianzhe's blocker, workspace half: edit workspace_binding.inode WITHOUT
+    # re-signing. discover already flagged the entry, yet the ORIGINAL workspace could
+    # still be handed to a second runtime, because the guard compared the target
+    # against the entry's tampered -- unauthenticated -- stored workspace inode. The
+    # guard cannot rule out that the entry still holds the target, so it refuses every
+    # provision while the entry stands; discover fails closed too.
+    root = tmp_path / "root"
+    root.mkdir()
+    agent_dir = root / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    registry = tmp_path / "registry.json"
+    provision_runtime("runtime-a", agent_dir, workspace, registry_path=registry)
+
+    _bump_binding_inode_without_resigning(registry, "runtime-a", "workspace")
+    unchanged = _assert_control_plane_bytes_unchanged(registry)
+
+    with pytest.raises(PuffoV0RegistryError, match="not authenticated by its digest"):
+        discover_runtimes(root, registry_path=registry)
+    # A second runtime tries to seize the ORIGINAL workspace under a fresh agent_dir.
+    agent_dir2 = root / "identity-2"
+    agent_dir2.mkdir()
+    (agent_dir2 / "init.json").write_text("{}", encoding="utf-8")
+    with pytest.raises(PuffoV0RegistryError, match="failed its integrity check"):
+        provision_runtime("runtime-b", agent_dir2, workspace, registry_path=registry)
+    unchanged()
+
+
+def test_unauthenticated_extra_key_binding_tamper_fails_closed(tmp_path):
+    # The advisor's adjacent finding: the SAME defect one state over. An extra key
+    # plus an inode bump, un-signed, once classified SHAPE_MISMATCH -- because the
+    # key-set check ran before the digest match -- and SHAPE consulted the binding
+    # for occupancy, so the real agent_dir read `available` and was seizable. With the
+    # digest match decided first, an un-signed entry is INTEGRITY_FAILED regardless of
+    # what else is wrong with it, so this cross-product fails closed exactly like the
+    # inode-only case. Reddens if the key-set check is moved back above digest match.
+    root = tmp_path / "root"
+    root.mkdir()
+    agent_dir = root / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    registry = tmp_path / "registry.json"
+    provision_runtime("runtime-a", agent_dir, workspace, registry_path=registry)
+
+    data = json.loads(registry.read_text(encoding="utf-8"))
+    entry = data["runtimes"]["runtime-a"]
+    binding = dict(entry["agent_dir_binding"])
+    binding["inode"] = binding["inode"] + 1
+    entry["agent_dir_binding"] = binding
+    entry["unexpected_extra_key"] = "x"          # extra key AND stale digest, un-signed
+    registry.write_text(json.dumps(data), encoding="utf-8")
+    unchanged = _assert_control_plane_bytes_unchanged(registry)
+
+    with pytest.raises(PuffoV0RegistryError, match="not authenticated by its digest"):
+        discover_runtimes(root, registry_path=registry)
+    workspace2 = tmp_path / "workspace2"
+    workspace2.mkdir()
+    with pytest.raises(PuffoV0RegistryError, match="failed its integrity check"):
+        provision_runtime("runtime-b", agent_dir, workspace2, registry_path=registry)
+    unchanged()
+
+
+def test_discover_cli_representations_are_pairwise_distinct_across_states(
+    tmp_path, monkeypatch, capsys
+):
+    # The invariant, checked at the boundary Puffo actually parses: run every
+    # discover-REPORTABLE state through the real --json CLI path and assert no two
+    # share a (status, runtime_id, workspace) triple. REVOKED / SHAPE_MISMATCH /
+    # STALE_BINDING all carry (runtime_id="runtime-a", workspace=None), so if
+    # cli_puffo_v0 ever re-derives status from `runtime_id is not None` (finding
+    # (2)) they collapse to one triple and this fails -- which is the point.
+    # INTEGRITY_FAILED is NOT reportable: an unauthenticated entry fails discover
+    # closed for the whole registry, so it is exercised as a CLI error below, not as
+    # a row, and is excluded from the coverage set.
+    import lingtai.adapters.acp.puffo_v0 as puffo_v0
+    import lingtai.cli_puffo_v0 as cli_puffo_v0
+
+    def _run_cli(base, registry):
+        monkeypatch.setattr(
+            puffo_v0, "default_registry_path", lambda registry=registry: registry
+        )
+        parser = argparse.ArgumentParser()
+        commands = parser.add_subparsers(dest="command", required=True)
+        cli_puffo_v0.add_puffo_v0_parser(commands)
+        args = parser.parse_args(["puffo-v0", "discover", "--root", str(base), "--json"])
+        cli_puffo_v0.handle_puffo_v0_command(args)
+
+    def _setup(name, mutate):
+        base = tmp_path / name
+        base.mkdir()
+        agent_dir = base / "identity"
+        agent_dir.mkdir()
+        (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+        workspace = base / "workspace"
+        workspace.mkdir()
+        registry = base / "registry.json"
+        if mutate is not None:
+            provision_runtime("runtime-a", agent_dir, workspace, registry_path=registry)
+            mutate(registry)
+        return base, registry
+
+    def _triple_for(name, mutate):
+        base, registry = _setup(name, mutate)
+        _run_cli(base, registry)
+        rows = json.loads(capsys.readouterr().out)["runtimes"]
+        assert len(rows) == 1
+        row = rows[0]
+        return (row["status"], row["runtime_id"], row["workspace"])
+
+    triples = [
+        _triple_for("provisionable", None),
+        _triple_for("active", lambda registry: None),
+        _triple_for(
+            "revoked",
+            lambda registry: revoke_runtime("runtime-a", registry_path=registry),
+        ),
+        _triple_for(
+            "drift",
+            lambda registry: _mutate_registry_entry(
+                registry, "runtime-a", resign=True, runtime_policy_version="puffo-v0.OLD"
+            ),
+        ),
+        _triple_for(
+            "shape",
+            lambda registry: _mutate_registry_entry(
+                registry, "runtime-a", resign=True, tool_surface="operator_managed_partial"
+            ),
+        ),
+        _triple_for("stale", _make_agent_dir_binding_owner_stale),
+    ]
+    assert len(set(triples)) == len(triples), triples
+    # Coverage, not just distinctness: the cases must exercise every discover-
+    # reportable enum member, so a state added later without a case is caught here
+    # rather than silently escaping the invariant. INTEGRITY_FAILED is the one member
+    # discovery never reports (it fails closed instead), so it is excluded here and
+    # pinned by the CLI-error case below.
+    observed_statuses = {status for status, _runtime_id, _workspace in triples}
+    reportable = {state.value for state in PuffoV0RuntimeState} - {
+        PuffoV0RuntimeState.INTEGRITY_FAILED.value
+    }
+    assert observed_statuses == reportable
+    # The excluded member IS exercised: an unauthenticated entry makes the --json CLI
+    # exit non-zero with a fail-closed error rather than emit any row.
+    base, registry = _setup(
+        "integrity",
+        lambda registry: _mutate_registry_entry(
+            registry, "runtime-a", resign=False, entry_digest="0" * 64
+        ),
+    )
+    with pytest.raises(SystemExit) as exit_info:
+        _run_cli(base, registry)
+    assert exit_info.value.code == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""                                    # no row emitted
+    assert "not authenticated by its digest" in captured.err
+
+
+def test_resolve_state_messages_cover_every_rejectable_state():
+    # resolve_runtime looks a non-active state up in _RESOLVE_STATE_MESSAGES; a
+    # member the classifier can return but the map omits would raise a bare
+    # KeyError on the execution path instead of PuffoV0RegistryError. PROVISIONABLE
+    # is discover-only (never returned for an existing entry); ACTIVE resolves.
+    from lingtai.adapters.acp.puffo_v0 import _RESOLVE_STATE_MESSAGES
+
+    rejectable = set(PuffoV0RuntimeState) - {
+        PuffoV0RuntimeState.ACTIVE,
+        PuffoV0RuntimeState.PROVISIONABLE,
+    }
+    assert set(_RESOLVE_STATE_MESSAGES) == rejectable
+
+
+def test_discovery_state_precedence_ranks_every_rankable_state_exactly_once():
+    # Completeness of the multi-entry precedence: every state that can be
+    # attributed to a directory must be rankable, or _state_rank raises a bare
+    # ValueError from inside discovery for the unranked one. PROVISIONABLE is the
+    # no-entry state and never competes for a directory, so it is excluded.
+    # Adding a member to the enum without placing it in _DISCOVERY_STATE_PRECEDENCE
+    # reddens this.
+    from lingtai.adapters.acp.puffo_v0 import _DISCOVERY_STATE_PRECEDENCE
+
+    rankable = set(PuffoV0RuntimeState) - {PuffoV0RuntimeState.PROVISIONABLE}
+    assert set(_DISCOVERY_STATE_PRECEDENCE) == rankable
+    # No duplicates: a repeated member would make _state_rank order-dependent on
+    # which index .index() happens to return.
+    assert len(_DISCOVERY_STATE_PRECEDENCE) == len(rankable)
+
+
+def test_discovery_state_precedence_orders_integrity_above_every_recoverable_state():
+    # The safety order is pinned here, not left to the enum's declaration order:
+    # a directory holding both a tampered (INTEGRITY_FAILED) entry and a revoked
+    # or drifted one must be reported as the integrity failure ("stop, escalate,
+    # never auto-revoke"), never as the recoverable state ("re-provision"). A
+    # cosmetic reorder of _DISCOVERY_STATE_PRECEDENCE -- exactly the edit that
+    # would silently reopen the auto-revoke-a-tampered-entry hole -- reddens this.
+    from lingtai.adapters.acp.puffo_v0 import _DISCOVERY_STATE_PRECEDENCE, _state_rank
+
+    # Full sequence, most-constraining first.
+    assert _DISCOVERY_STATE_PRECEDENCE == (
+        PuffoV0RuntimeState.INTEGRITY_FAILED,
+        PuffoV0RuntimeState.SHAPE_MISMATCH,
+        PuffoV0RuntimeState.POLICY_VERSION_MISMATCH,
+        PuffoV0RuntimeState.STALE_BINDING,
+        PuffoV0RuntimeState.ACTIVE,
+        PuffoV0RuntimeState.REVOKED,
+    )
+    # The load-bearing inequalities, stated independently of the tuple literal so
+    # the security intent survives even if the sequence above is ever revised:
+    # integrity outranks (is more constraining than) every state whose recovery
+    # would mutate the registry.
+    for recoverable in (
+        PuffoV0RuntimeState.SHAPE_MISMATCH,
+        PuffoV0RuntimeState.POLICY_VERSION_MISMATCH,
+        PuffoV0RuntimeState.STALE_BINDING,
+        PuffoV0RuntimeState.ACTIVE,
+        PuffoV0RuntimeState.REVOKED,
+    ):
+        assert _state_rank(PuffoV0RuntimeState.INTEGRITY_FAILED) < _state_rank(recoverable)
+    # A stale binding is authentic-but-unusable: it must outrank ACTIVE so a
+    # directory that also has a usable entry is never reported usable while the
+    # stale one stands, and stay below the tamper/shape/drift states.
+    assert _state_rank(PuffoV0RuntimeState.STALE_BINDING) < _state_rank(
+        PuffoV0RuntimeState.ACTIVE
+    )
+    assert _state_rank(PuffoV0RuntimeState.POLICY_VERSION_MISMATCH) < _state_rank(
+        PuffoV0RuntimeState.STALE_BINDING
+    )
+    # And a drifted (auto-revoke-recoverable) occupant must never outrank a
+    # revoked one in a way that hides the drift's recovery id.
+    assert _state_rank(PuffoV0RuntimeState.POLICY_VERSION_MISMATCH) < _state_rank(
+        PuffoV0RuntimeState.REVOKED
+    )
+
+
+def test_discovery_reports_most_constraining_state_when_one_dir_has_several_entries(
+    tmp_path,
+):
+    # Pins the CONSUMER of the safety posture, not just the table: when one agent_dir
+    # is named by both a REVOKED and an unauthenticated (INTEGRITY_FAILED) entry,
+    # discovery must NEVER report the revoked one ("re-provision under a new id") --
+    # that would invite a caller to reuse a directory an untrustworthy entry may still
+    # hold. Reporting integrity_failed used to be the answer; now, because an
+    # unauthenticated entry's binding cannot be trusted to attribute it at all,
+    # discovery fails closed for the whole registry -- strictly more conservative than
+    # the old per-directory integrity row, and it still prevents the concrete harm
+    # (never surface the released/re-provisionable state while a tampered entry stands).
+    root = tmp_path / "root"
+    root.mkdir()
+    agent_dir = root / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace_a = tmp_path / "workspace-a"
+    workspace_a.mkdir()
+    workspace_b = tmp_path / "workspace-b"
+    workspace_b.mkdir()
+    registry = tmp_path / "registry.json"
+    # First occupant: provisioned then revoked -> a REVOKED entry for agent_dir.
+    provision_runtime("runtime-a", agent_dir, workspace_a, registry_path=registry)
+    revoke_runtime("runtime-a", registry_path=registry)
+    # Second occupant on the SAME agent_dir: the revoked one no longer blocks it.
+    provision_runtime("runtime-b", agent_dir, workspace_b, registry_path=registry)
+    # Tamper the live one so agent_dir now carries REVOKED + INTEGRITY_FAILED.
+    _mutate_registry_entry(registry, "runtime-b", resign=False, entry_digest="0" * 64)
+
+    # The revoked, re-provisionable reading is never surfaced: discover fails closed.
+    with pytest.raises(PuffoV0RegistryError, match="not authenticated by its digest") as exc_info:
+        discover_runtimes(root, registry_path=registry)
+    assert "runtime-b" in str(exc_info.value)   # the unauthenticated entry, named
+    assert "revoked" not in str(exc_info.value)
+
+
+def test_discovery_prefers_stale_binding_over_active_on_the_same_directory(tmp_path):
+    # Pins the NEW rank edge STALE_BINDING < ACTIVE at the consumer, not just the
+    # table: one agent_dir named by both a stale-binding entry and a genuinely
+    # usable one must report `stale_binding` -- reporting `bound` would send the
+    # caller to a runtime whose sibling entry is broken. Under identity keying both
+    # entries must share the SAME stored device/inode to compete for the directory,
+    # so the stale one is forged with the same device/inode but a wrong owner:
+    # authentic (re-signed, not INTEGRITY_FAILED), keyed to the same directory, yet
+    # its full identity no longer matches the live lstat -> STALE_BINDING. runtime-b
+    # is provisioned normally (ACTIVE, full binding matches live).
+    # Reddens under `_state_rank(...) < ...` -> `>`.
+    root = tmp_path / "root"
+    root.mkdir()
+    agent_dir = root / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    registry = tmp_path / "registry.json"
+    provision_runtime("runtime-b", agent_dir, workspace, registry_path=registry)
+
+    data = json.loads(registry.read_text(encoding="utf-8"))
+    clone = dict(data["runtimes"]["runtime-b"])
+    clone["runtime_id"] = "runtime-a"
+    wrong = dict(clone["agent_dir_binding"])
+    wrong["owner"] = wrong["owner"] + 1          # same device/inode, wrong owner -> stale
+    clone["agent_dir_binding"] = wrong
+    canonical = {k: v for k, v in clone.items() if k != "entry_digest"}
+    clone["entry_digest"] = _digest(canonical)   # authentic, so not INTEGRITY_FAILED
+    # runtime-b first so discovery sees ACTIVE, then the stale entry must win.
+    data["runtimes"] = {"runtime-b": data["runtimes"]["runtime-b"], "runtime-a": clone}
+    registry.write_text(json.dumps(data), encoding="utf-8")
+
+    candidate = _discover_one(root, registry)
+    assert candidate.state is PuffoV0RuntimeState.STALE_BINDING
+    assert candidate.state is not PuffoV0RuntimeState.ACTIVE
+    # Both entries share the directory's device/inode; the stale forgery wins the
+    # rank, and its own id is surfaced so the broken binding can be revoked.
+    assert candidate.runtime_id == "runtime-a"
+    assert candidate.workspace is None
+
+
+def test_discovery_rejects_two_active_runtimes_on_one_directory(tmp_path):
+    # The historical hard-corruption guard: two *active* entries cannot bind one
+    # agent_dir. provision refuses to create the second, so this is only reachable
+    # by a directly forged registry -- built here by re-signing a copy under a new
+    # id -- and discovery must raise rather than silently pick one.
+    root = tmp_path / "root"
+    root.mkdir()
+    agent_dir = root / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    registry = tmp_path / "registry.json"
+    provision_runtime("runtime-a", agent_dir, workspace, registry_path=registry)
+
+    data = json.loads(registry.read_text(encoding="utf-8"))
+    clone = dict(data["runtimes"]["runtime-a"])
+    clone["runtime_id"] = "runtime-b"
+    canonical = {k: v for k, v in clone.items() if k != "entry_digest"}
+    clone["entry_digest"] = _digest(canonical)
+    data["runtimes"]["runtime-b"] = clone
+    registry.write_text(json.dumps(data), encoding="utf-8")
+
+    with pytest.raises(PuffoV0RegistryError, match="multiple active runtimes"):
+        discover_runtimes(root, registry_path=registry)
+
+
+def test_discover_fails_closed_on_an_unreadable_workspace_binding_like_the_guard(tmp_path):
+    # Peter/Boris bug 1: the guard parses BOTH stored bindings (agent_dir AND
+    # workspace) before any identity comparison and fails closed on either, so a
+    # single unreadable workspace_binding makes it reject EVERY provision -- the
+    # whole registry is unprovisionable while that entry stands. discover only read
+    # agent_dir, so it kept reporting OTHER directories `available` that could not
+    # in fact be provisioned. discover must fail closed on the same both-field set.
+    # Assert the PAIR the way Boris framed it: not "b provisions" but "no `available`
+    # holds while the bad entry stands" -- a brand-new directory + workspace is
+    # refused too. Reddens if the workspace_binding parse is dropped from discovery.
+    root = tmp_path / "root"
+    root.mkdir()
+    agent_dir = root / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    # A second, genuinely unbound initialized directory: pre-fix discovery reported
+    # THIS one `available` even though provisioning it was impossible.
+    other = root / "other"
+    other.mkdir()
+    (other / "init.json").write_text("{}", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    registry = tmp_path / "registry.json"
+    provision_runtime("runtime-a", agent_dir, workspace, registry_path=registry)
+    # Corrupt ONLY the workspace binding (agent_dir stays keyable), RE-SIGNED so the
+    # entry is SHAPE_MISMATCH (valid digest over a malformed workspace_binding). The
+    # agent_dir_binding parses, so _entry_identity_key succeeds and the both-field
+    # parity parse of workspace_binding raises -> the unreadable-binding fail-closed
+    # path. (An un-signed workspace tamper is INTEGRITY_FAILED and fails discover
+    # closed earlier; pinned by test_unauthenticated_workspace_binding_tamper_fails_closed.)
+    _mutate_registry_entry(
+        registry, "runtime-a", resign=True, workspace_binding={"device": 1}
+    )
+    with pytest.raises(PuffoV0RegistryError, match="unreadable directory binding"):
+        discover_runtimes(root, registry_path=registry)
+    # The operation discover is supposed to predict: a completely fresh directory +
+    # workspace is still refused, so there was no truthful `available` to report.
+    fresh_dir = tmp_path / "fresh"
+    fresh_dir.mkdir()
+    (fresh_dir / "init.json").write_text("{}", encoding="utf-8")
+    fresh_ws = tmp_path / "fresh-ws"
+    fresh_ws.mkdir()
+    with pytest.raises(PuffoV0RegistryError, match="unreadable binding"):
+        provision_runtime("runtime-b", fresh_dir, fresh_ws, registry_path=registry)
+
+
+def test_invalid_runtime_id_is_shape_mismatch_not_bound_because_resolve_rejects_it(
+    tmp_path,
+):
+    # Peter/Boris bug 2: a valid digest over a syntactically illegal runtime id (key
+    # and entry.runtime_id agree) classified as ACTIVE, so discover reported `bound`
+    # -- but resolve_runtime rejects the id outright (`_valid_runtime_id`), so `bound`
+    # promised a resolve that always fails. The classifier now validates runtime-id
+    # syntax, so discover reports SHAPE_MISMATCH instead. Assert the PAIR (discover
+    # state AND resolve), then prove the SHAPE_MISMATCH guard message is HONEST on
+    # this new code path by EXECUTION -- the 190618 trap was string-asserting a cell
+    # that was never run.
+    root = tmp_path / "root"
+    root.mkdir()
+    agent_dir = root / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    registry = tmp_path / "registry.json"
+    provision_runtime("valid-id", agent_dir, workspace, registry_path=registry)
+    # Rekey the (otherwise authentic) entry to an illegal id and RE-SIGN it, so the
+    # digest is valid and only the id syntax is wrong -- exactly Peter's fixture.
+    data = json.loads(registry.read_text(encoding="utf-8"))
+    entry = data["runtimes"].pop("valid-id")
+    entry["runtime_id"] = "invalid/runtime"
+    canonical = {k: v for k, v in entry.items() if k != "entry_digest"}
+    entry["entry_digest"] = _digest(canonical)
+    data["runtimes"]["invalid/runtime"] = entry
+    registry.write_text(json.dumps(data), encoding="utf-8")
+
+    candidate = _discover_one(root, registry)
+    assert candidate.state is PuffoV0RuntimeState.SHAPE_MISMATCH
+    assert candidate.state is not PuffoV0RuntimeState.ACTIVE     # never `bound`
+    with pytest.raises(PuffoV0RegistryError, match="opaque local identifier"):
+        resolve_runtime("invalid/runtime", registry_path=registry)
+
+    # The SHAPE_MISMATCH conflict message names escalation and states that revoke is
+    # refused. Prove that is TRUE here, not merely asserted: provisioning the SAME
+    # directory hits the shape conflict, revoke cannot even reach the entry (the id
+    # is rejected first), and a repeat provision still blocks. The invalid-id term
+    # now sits BEFORE the revoked gate (with the rest of value-shape), so a signed
+    # ``status="revoked"`` can no longer launder it into a released state.
+    ws2 = tmp_path / "ws2"
+    ws2.mkdir()
+    with pytest.raises(
+        PuffoV0RegistryError, match="does not match the puffo-v0 profile"
+    ) as exc_info:
+        provision_runtime("runtime-b", agent_dir, ws2, registry_path=registry)
+    assert "revoke is refused" in str(exc_info.value)
+    with pytest.raises(PuffoV0RegistryError, match="opaque local identifier"):
+        revoke_runtime("invalid/runtime", registry_path=registry)     # revoke is a dead end
+    with pytest.raises(PuffoV0RegistryError, match="does not match the puffo-v0 profile"):
+        provision_runtime("runtime-c", agent_dir, ws2, registry_path=registry)
+
+
+def _matrix_healthy(base):
+    """One bound runtime + one initialized-but-unbound directory (the control)."""
+    root = base / "root"
+    root.mkdir()
+    bound_dir = root / "bound"
+    bound_dir.mkdir()
+    (bound_dir / "init.json").write_text("{}", encoding="utf-8")
+    unbound_dir = root / "unbound"
+    unbound_dir.mkdir()
+    (unbound_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace = base / "workspace"
+    workspace.mkdir()
+    registry = base / "registry.json"
+    provision_runtime("runtime-a", bound_dir, workspace, registry_path=registry)
+    return root, registry
+
+
+def _matrix_corrupt_workspace_binding(base):
+    """Bug 1: unreadable workspace_binding + a second unbound directory."""
+    root = base / "root"
+    root.mkdir()
+    agent_dir = root / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    other = root / "other"
+    other.mkdir()
+    (other / "init.json").write_text("{}", encoding="utf-8")
+    workspace = base / "workspace"
+    workspace.mkdir()
+    registry = base / "registry.json"
+    provision_runtime("runtime-a", agent_dir, workspace, registry_path=registry)
+    _mutate_registry_entry(
+        registry, "runtime-a", resign=False, workspace_binding={"device": 1}
+    )
+    return root, registry
+
+
+def _matrix_corrupt_agent_dir_binding(base):
+    """Unreadable agent_dir_binding (discover already fails closed here)."""
+    root = base / "root"
+    root.mkdir()
+    agent_dir = root / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace = base / "workspace"
+    workspace.mkdir()
+    registry = base / "registry.json"
+    provision_runtime("runtime-a", agent_dir, workspace, registry_path=registry)
+    _mutate_registry_entry(
+        registry, "runtime-a", resign=False, agent_dir_binding={"device": 1}
+    )
+    return root, registry
+
+
+def _matrix_invalid_runtime_id(base):
+    """Bug 2: valid digest, illegal runtime-id syntax (key == entry.runtime_id)."""
+    root = base / "root"
+    root.mkdir()
+    agent_dir = root / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace = base / "workspace"
+    workspace.mkdir()
+    registry = base / "registry.json"
+    provision_runtime("valid-id", agent_dir, workspace, registry_path=registry)
+    data = json.loads(registry.read_text(encoding="utf-8"))
+    entry = data["runtimes"].pop("valid-id")
+    entry["runtime_id"] = "invalid/runtime"
+    canonical = {k: v for k, v in entry.items() if k != "entry_digest"}
+    entry["entry_digest"] = _digest(canonical)
+    data["runtimes"]["invalid/runtime"] = entry
+    registry.write_text(json.dumps(data), encoding="utf-8")
+    return root, registry
+
+
+def _matrix_same_path_replacement(base):
+    """A reused agent_dir path: recreated dir is `available`, moved one is stale."""
+    root = base / "root"
+    root.mkdir()
+    agent_dir = root / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace = base / "workspace"
+    workspace.mkdir()
+    registry = base / "registry.json"
+    provision_runtime("runtime-a", agent_dir, workspace, registry_path=registry)
+    agent_dir.rename(root / "identity-moved")
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    return root, registry
+
+
+def _matrix_stale_workspace(base):
+    """A moved workspace: discover reports stale_binding (neither bound nor available)."""
+    root = base / "root"
+    root.mkdir()
+    agent_dir = root / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace = base / "workspace"
+    workspace.mkdir()
+    registry = base / "registry.json"
+    provision_runtime("runtime-a", agent_dir, workspace, registry_path=registry)
+    workspace.rename(base / "workspace-moved")
+    workspace.mkdir()
+    return root, registry
+
+
+def test_discover_promises_hold_across_a_damaged_entry_matrix(tmp_path):
+    # Boris's crown recommendation, mechanized: for EVERY discover output, `bound`
+    # must resolve and `available` must provision -- the #1622 invariant itself.
+    # The two bugs Peter found lived on axes a per-state scenario table cannot reach
+    # (which binding FIELD, which validity PREDICATE each side reads), so instead of
+    # enumerating that table this pins the end-to-end promise over a matrix of
+    # damaged entries. On the PRE-FIX code the damaged fixtures made discover emit
+    # `available`/`bound` that then failed the follow-on op (RED); post-fix each
+    # either fails closed (promised nothing) or reports a non-usable state.
+    #
+    # Fail-closed is an acceptable outcome, so a broken fixture passing silently is a
+    # risk -- the `healthy` and `same_path_replacement` controls defeat it by
+    # exercising BOTH promise branches positively, asserted at the end, so the matrix
+    # cannot pass by discover raising on everything.
+    fixtures = [
+        ("healthy", _matrix_healthy, True),
+        ("corrupt_workspace_binding", _matrix_corrupt_workspace_binding, False),
+        ("corrupt_agent_dir_binding", _matrix_corrupt_agent_dir_binding, False),
+        ("invalid_runtime_id", _matrix_invalid_runtime_id, False),
+        ("same_path_replacement", _matrix_same_path_replacement, True),
+        ("stale_workspace", _matrix_stale_workspace, False),
+    ]
+    saw_bound = 0
+    saw_available = 0
+    for name, build, must_report in fixtures:
+        base = tmp_path / name
+        base.mkdir()
+        root, registry = build(base)
+        try:
+            candidates = discover_runtimes(root, registry_path=registry)
+        except PuffoV0RegistryError:
+            # Fail-closed: discover promised nothing, so no promise can be broken.
+            assert not must_report, f"{name}: a healthy fixture must not fail closed"
+            continue
+        tombstone = registry.with_name(f".{registry.name}.revocations.jsonl")
+        for candidate in candidates:
+            if candidate.state is PuffoV0RuntimeState.ACTIVE:
+                saw_bound += 1
+                resolve_runtime(candidate.runtime_id, registry_path=registry)  # `bound` => resolvable
+            elif candidate.state is PuffoV0RuntimeState.PROVISIONABLE:
+                saw_available += 1
+                # `available` => provisionable. Provision mutates the registry, so
+                # snapshot + restore around each attempt, with a fresh id and a fresh
+                # workspace outside every recorded one (advisor: else a legitimate
+                # workspace conflict would red the test for the wrong reason).
+                registry_snapshot = registry.read_bytes()
+                tombstone_snapshot = (
+                    tombstone.read_bytes() if tombstone.exists() else None
+                )
+                probe_ws = base / f"probe-ws-{saw_available}"
+                probe_ws.mkdir()
+                provision_runtime(
+                    f"probe-{saw_available}",
+                    candidate.agent_dir,
+                    probe_ws,
+                    registry_path=registry,
+                )
+                registry.write_bytes(registry_snapshot)
+                if tombstone_snapshot is None:
+                    tombstone.unlink(missing_ok=True)
+                else:
+                    tombstone.write_bytes(tombstone_snapshot)
+    # Non-degeneracy: both promise branches were actually exercised by the controls.
+    assert saw_bound >= 1, "the matrix never checked a `bound => resolve` promise"
+    assert saw_available >= 1, "the matrix never checked an `available => provision` promise"
+
+
+# Boris's damaged-entry roster (msg_63a298f5), adapted to parametrized fixtures. The
+# list itself is the "roster": adding a classifier/shape check means adding a row
+# here, so a future check can never be tested against only the one subtype someone
+# reproduced by hand -- the failure that cost round 190632. resign=True reflects the
+# threat model in force everywhere in this suite: _digest is keyless, so anyone with
+# write access can produce a "signed" edit; no secret is needed.
+def _matrix_rekey(entry, data, new_id):
+    entry["runtime_id"] = new_id
+    data["runtimes"].pop("runtime-a")
+    data["runtimes"][new_id] = entry
+
+
+_DAMAGED_ENTRY_CASES = [
+    ("status=disabled",             lambda e, d: e.update(status="disabled"),                 True),
+    ("status=empty",                lambda e, d: e.update(status=""),                         True),
+    ("status missing",              lambda e, d: e.pop("status", None),                       True),
+    ("status non-str",              lambda e, d: e.update(status=123),                        True),
+    ("runtime_id invalid syntax",   lambda e, d: _matrix_rekey(e, d, "invalid/runtime"),      True),
+    ("runtime_id key mismatch",     lambda e, d: e.update(runtime_id="other"),                True),
+    ("profile foreign",             lambda e, d: e.update(profile="not-puffo-v0"),            True),
+    ("mcp_servers non-empty",       lambda e, d: e.update(mcp_servers=["x"]),                 True),
+    ("tool_surface wrong",          lambda e, d: e.update(tool_surface=["nope"]),             True),
+    ("turn_origins wrong",          lambda e, d: e.update(turn_origins=["nope"]),             True),
+    ("agent_dir non-str",           lambda e, d: e.update(agent_dir=5),                       True),
+    ("workspace non-str",           lambda e, d: e.update(workspace=5),                       True),
+    ("agent_dir_binding broken",    lambda e, d: e.update(agent_dir_binding={"device": 1}),   True),
+    ("workspace_binding broken",    lambda e, d: e.update(workspace_binding={"device": 1}),   True),
+    ("agent_dir_binding wrong ino", lambda e, d: e["agent_dir_binding"].update(inode=999999), True),
+    ("workspace_binding wrong ino", lambda e, d: e["workspace_binding"].update(inode=999999), True),
+    ("entry_digest missing",        lambda e, d: e.pop("entry_digest", None),                 False),
+    ("entry_digest wrong",          lambda e, d: e.update(entry_digest="0" * 64),             False),
+    ("entry_digest non-str",        lambda e, d: e.update(entry_digest=None),                 False),
+    ("extra key",                   lambda e, d: e.update(unexpected=True),                   True),
+    ("policy drift",                lambda e, d: e.update(runtime_policy_version="OLD"),      True),
+]
+_MATRIX_IDS = [case[0] for case in _DAMAGED_ENTRY_CASES]
+
+# The only cases that leave a legitimately revocable classification (ACTIVE or
+# POLICY_VERSION_MISMATCH). A wrong-inode binding keeps a WELL-FORMED payload -- a
+# liveness mismatch, not a shape defect -- so the pure classifier rules it ACTIVE.
+# Every other case is a blocking state whose revoke must be refused with zero writes.
+_MATRIX_REVOCABLE = {
+    "agent_dir_binding wrong ino",
+    "workspace_binding wrong ino",
+    "policy drift",
+}
+
+
+def _seed_matrix_registry(base):
+    base.mkdir()
+    registry = base / "registry.json"
+    root = base / "root"
+    root.mkdir()
+    bound_dir = root / "bound"
+    bound_dir.mkdir()
+    (bound_dir / "init.json").write_text("{}", encoding="utf-8")
+    free_dir = root / "free"
+    free_dir.mkdir()
+    (free_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace = base / "ws"
+    workspace.mkdir()
+    provision_runtime("runtime-a", bound_dir, workspace, registry_path=registry)
+    return registry, root, bound_dir
+
+
+def _apply_matrix_case(registry, mutate, resign):
+    data = json.loads(registry.read_text(encoding="utf-8"))
+    entry = data["runtimes"]["runtime-a"]
+    mutate(entry, data)
+    if resign:  # keyless _digest: a "signed" edit is available to anyone with write access
+        canonical = {k: v for k, v in entry.items() if k != "entry_digest"}
+        entry["entry_digest"] = _digest(canonical)
+    registry.write_text(json.dumps(data), encoding="utf-8")
+
+
+@pytest.mark.parametrize("label,mutate,resign", _DAMAGED_ENTRY_CASES, ids=_MATRIX_IDS)
+def test_damaged_entry_never_breaks_a_discover_promise(tmp_path, label, mutate, resign):
+    # Boris's crown invariant, swept over the full roster: for EVERY discover output,
+    # `bound` must resolve and `available` must provision, and a non-bound state must
+    # never expose a workspace path that no longer exists (#7). Discover raising is an
+    # acceptable outcome -- it promised nothing, so neither implication can break --
+    # but the raise is not left UNCHECKED: it must be CONSISTENT with the guard, so we
+    # assert the damaged entry's own directory is not provisionable while discover
+    # refuses to list it (the discover/guard fail-closed sets agree). This keeps every
+    # case non-vacuous: a raising case checks the guard refusal, a returning case
+    # checks the bound/available promises.
+    registry, root, _bound_dir = _seed_matrix_registry(tmp_path / "case")
+    _apply_matrix_case(registry, mutate, resign)
+    try:
+        candidates = discover_runtimes(root, registry_path=registry)
+    except PuffoV0RegistryError:
+        intruder_ws = tmp_path / "intruder-ws"
+        intruder_ws.mkdir()
+        with pytest.raises(PuffoV0RegistryError):
+            provision_runtime("intruder", _bound_dir, intruder_ws, registry_path=registry)
+        return
+    for probe_n, candidate in enumerate(candidates):
+        if candidate.state is PuffoV0RuntimeState.ACTIVE:
+            resolve_runtime(candidate.runtime_id, registry_path=registry)  # bound => resolvable
+        elif candidate.state is PuffoV0RuntimeState.PROVISIONABLE:
+            snapshot = registry.read_bytes()
+            probe_ws = tmp_path / f"probe-ws-{probe_n}"
+            probe_ws.mkdir()
+            provision_runtime(  # available => provisionable
+                f"probe-{probe_n}", candidate.agent_dir, probe_ws, registry_path=registry
+            )
+            registry.write_bytes(snapshot)
+        if candidate.state is not PuffoV0RuntimeState.ACTIVE and candidate.workspace is not None:
+            assert candidate.workspace.exists(), (
+                f"{label}: {candidate.state.value} exposed a workspace that does not "
+                f"exist: {candidate.workspace}"
+            )
+
+
+@pytest.mark.parametrize("label,mutate,resign", _DAMAGED_ENTRY_CASES, ids=_MATRIX_IDS)
+def test_revoke_refuses_and_preserves_a_blocking_entry(tmp_path, label, mutate, resign):
+    # Peter's full-row invariant over the roster (190664) plus Boris's tombstone-
+    # ordering trap (190662): revoke either legitimately succeeds (only for a
+    # classification that is ACTIVE or policy-drift) or is REFUSED with ZERO
+    # persistence. The refusal path is the dangerous one: a tombstone is appended
+    # before the entry is touched, and a tombstone ALONE releases the directory, so a
+    # check placed after it would report an error while irreversibly releasing
+    # identity. Registry bytes AND the tombstone's bytes/line-count are therefore
+    # asserted SEPARATELY, and the classification + occupancy must be unchanged.
+    from lingtai.adapters.acp.puffo_v0 import _classify_registry_entry
+
+    registry, _root, bound_dir = _seed_matrix_registry(tmp_path / "case")
+    _apply_matrix_case(registry, mutate, resign)
+    tombstone = registry.with_name(f".{registry.name}.revocations.jsonl")
+
+    def _classify():
+        data = json.loads(registry.read_text(encoding="utf-8"))
+        rid = next(iter(data["runtimes"]))
+        return rid, _classify_registry_entry(
+            rid, data["runtimes"][rid], revoked_runtime_ids=frozenset()
+        )
+
+    rid, before = _classify()
+    if label in _MATRIX_REVOCABLE:
+        assert before in (
+            PuffoV0RuntimeState.ACTIVE,
+            PuffoV0RuntimeState.POLICY_VERSION_MISMATCH,
+        )
+        revoke_runtime(rid, registry_path=registry)  # a live/drifted runtime is revocable
+        _rid, after = _classify()
+        assert after is PuffoV0RuntimeState.REVOKED
+        return
+    # A blocking entry: revoke must refuse and change nothing.
+    assert before in (
+        PuffoV0RuntimeState.INTEGRITY_FAILED,
+        PuffoV0RuntimeState.SHAPE_MISMATCH,
+    )
+    registry_before = registry.read_bytes()
+    tombstone_before = tombstone.read_bytes()
+    with pytest.raises(PuffoV0RegistryError):
+        revoke_runtime(rid, registry_path=registry)
+    assert registry.read_bytes() == registry_before                    # registry byte-identical
+    assert tombstone.read_bytes() == tombstone_before                  # tombstone byte-identical
+    assert tombstone_before.count(b"\n") == tombstone.read_bytes().count(b"\n")  # no appended line
+    _rid, after = _classify()
+    assert after is before                                             # still the same blocking state
+    ws2 = tmp_path / "still-blocked-ws"
+    ws2.mkdir()
+    with pytest.raises(PuffoV0RegistryError):  # identity still occupied, not released
+        provision_runtime("probe-after", bound_dir, ws2, registry_path=registry)
+
+
+def test_provision_conflict_selection_is_independent_of_registry_order(tmp_path):
+    # #5: a directory named by both an active and an integrity-failed entry must
+    # report the integrity failure (recovery: escalate), never the active one
+    # (recovery: revoke), regardless of registry insertion order -- discover already
+    # picks by precedence, and the guard must too, or the two hand the caller
+    # contradictory recoveries for the same directory. Build the two-entry registry in
+    # BOTH orders and assert the guard raises the identical message.
+    agent_dir = tmp_path / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    def _guard_message(registry, *, integrity_first):
+        provision_runtime("runtime-a", agent_dir, workspace, registry_path=registry)
+        data = json.loads(registry.read_text(encoding="utf-8"))
+        active = data["runtimes"]["runtime-a"]
+        integrity = dict(active)
+        integrity["runtime_id"] = "runtime-b"
+        integrity["entry_digest"] = "0" * 64  # break digest -> INTEGRITY_FAILED, same agent_dir_binding
+        ordered = (
+            {"runtime-b": integrity, "runtime-a": active}
+            if integrity_first
+            else {"runtime-a": active, "runtime-b": integrity}
+        )
+        data["runtimes"] = ordered
+        registry.write_text(json.dumps(data), encoding="utf-8")
+        ws2 = registry.with_name("ws2")
+        ws2.mkdir()
+        with pytest.raises(PuffoV0RegistryError) as exc_info:
+            provision_runtime("runtime-c", agent_dir, ws2, registry_path=registry)
+        return str(exc_info.value)
+
+    # provision_runtime creates the registry's parent directory, so the two runs live
+    # in separate subdirectories and cannot see each other's registry.
+    integrity_first = _guard_message(tmp_path / "a" / "registry.json", integrity_first=True)
+    active_first = _guard_message(tmp_path / "b" / "registry.json", integrity_first=False)
+    assert integrity_first == active_first                  # order-independent selection
+    assert "failed its integrity check" in integrity_first  # the integrity entry, not the active one
+    assert "runtime-b" in integrity_first
+
+
+def test_policy_drift_with_a_deleted_workspace_reports_no_workspace(tmp_path):
+    # #7: a policy-drifted entry whose workspace was deleted must not report the dead
+    # workspace path -- a reported workspace names a LIVE binding. The agent_dir is
+    # intact so discover still classifies policy_version_mismatch, but workspace=None.
+    root = tmp_path / "root"
+    root.mkdir()
+    agent_dir = root / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    registry = tmp_path / "registry.json"
+    provision_runtime("runtime-a", agent_dir, workspace, registry_path=registry)
+    _mutate_registry_entry(
+        registry, "runtime-a", resign=True, runtime_policy_version="puffo-v0.OLD"
+    )
+    shutil.rmtree(workspace)
+
+    candidate = _discover_one(root, registry)
+    assert candidate.state is PuffoV0RuntimeState.POLICY_VERSION_MISMATCH
+    assert candidate.runtime_id == "runtime-a"
+    assert candidate.workspace is None
+
+
+def test_unknown_signed_status_is_blocking_not_released(tmp_path):
+    # #3: a validly-signed but unknown `status` (e.g. "disabled") must NOT be read as
+    # REVOKED / released -- that is the allow direction. It classifies as a blocking
+    # shape_mismatch, discover never reports it revoked, the directory stays occupied,
+    # and revoke refuses it.
+    from lingtai.adapters.acp.puffo_v0 import _classify_registry_entry
+
+    root = tmp_path / "root"
+    root.mkdir()
+    agent_dir = root / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    registry = tmp_path / "registry.json"
+    provision_runtime("runtime-a", agent_dir, workspace, registry_path=registry)
+    _mutate_registry_entry(registry, "runtime-a", resign=True, status="disabled")
+
+    data = json.loads(registry.read_text(encoding="utf-8"))
+    state = _classify_registry_entry(
+        "runtime-a", data["runtimes"]["runtime-a"], revoked_runtime_ids=frozenset()
+    )
+    assert state is PuffoV0RuntimeState.SHAPE_MISMATCH
+    assert state is not PuffoV0RuntimeState.REVOKED
+    candidate = _discover_one(root, registry)
+    assert candidate.state is PuffoV0RuntimeState.SHAPE_MISMATCH
+    ws2 = tmp_path / "ws2"
+    ws2.mkdir()
+    with pytest.raises(PuffoV0RegistryError, match="does not match the puffo-v0 profile"):
+        provision_runtime("runtime-b", agent_dir, ws2, registry_path=registry)
+    with pytest.raises(PuffoV0RegistryError, match="revoke is refused"):
+        revoke_runtime("runtime-a", registry_path=registry)
+
+
+def test_missing_entry_digest_is_integrity_not_shape(tmp_path):
+    # #4 (contract alignment): a missing entry_digest is an integrity failure, not a
+    # shape mismatch. Decided before the structural key-set check on purpose -- an
+    # unauthenticated record must read as integrity, and with the write-side admission
+    # revoke cannot re-add the digest to launder it into a released state.
+    from lingtai.adapters.acp.puffo_v0 import _classify_registry_entry
+
+    agent_dir = tmp_path / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    registry = tmp_path / "registry.json"
+    provision_runtime("runtime-a", agent_dir, workspace, registry_path=registry)
+    data = json.loads(registry.read_text(encoding="utf-8"))
+    data["runtimes"]["runtime-a"].pop("entry_digest")
+    registry.write_text(json.dumps(data), encoding="utf-8")
+
+    reloaded = json.loads(registry.read_text(encoding="utf-8"))["runtimes"]["runtime-a"]
+    state = _classify_registry_entry("runtime-a", reloaded, revoked_runtime_ids=frozenset())
+    assert state is PuffoV0RuntimeState.INTEGRITY_FAILED
+    assert state is not PuffoV0RuntimeState.SHAPE_MISMATCH
+    with pytest.raises(PuffoV0RegistryError, match="failed its integrity check"):
+        resolve_runtime("runtime-a", registry_path=registry)
+    with pytest.raises(PuffoV0RegistryError, match="revoke is refused"):
+        revoke_runtime("runtime-a", registry_path=registry)
+
+
+def test_digest_valid_nul_path_surfaces_a_registry_error_not_a_raw_valueerror(tmp_path):
+    # Hardening: a digest-valid entry whose stored path contains an embedded NUL must
+    # surface a bounded PuffoV0RegistryError, not a raw ValueError from resolve()/lstat
+    # (which is neither OSError nor RuntimeError, so it used to propagate). pytest.raises
+    # (PuffoV0RegistryError) does NOT match a plain ValueError, so this reddens if the
+    # wrap is removed.
+    agent_dir = tmp_path / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    registry = tmp_path / "registry.json"
+    provision_runtime("runtime-a", agent_dir, workspace, registry_path=registry)
+    _mutate_registry_entry(
+        registry, "runtime-a", resign=True, agent_dir=str(agent_dir) + "\x00evil"
+    )
+    with pytest.raises(PuffoV0RegistryError):
+        resolve_runtime("runtime-a", registry_path=registry)
+
+
+def test_matrix_revocable_set_matches_classification(tmp_path):
+    # Guards _MATRIX_REVOCABLE against silent drift. The revocable set the
+    # parametrized revoke test branches on must EQUAL the roster labels that actually
+    # classify ACTIVE or POLICY_VERSION_MISMATCH -- otherwise a future edit that made,
+    # say, `policy drift` classify SHAPE would leave that test green (it would just
+    # take the other branch) and hide a real behavior change.
+    from lingtai.adapters.acp.puffo_v0 import _classify_registry_entry
+
+    revocable = set()
+    for index, (label, mutate, resign) in enumerate(_DAMAGED_ENTRY_CASES):
+        registry, _root, _bound = _seed_matrix_registry(tmp_path / f"case-{index}")
+        _apply_matrix_case(registry, mutate, resign)
+        data = json.loads(registry.read_text(encoding="utf-8"))
+        rid = next(iter(data["runtimes"]))
+        state = _classify_registry_entry(
+            rid, data["runtimes"][rid], revoked_runtime_ids=frozenset()
+        )
+        if state in (
+            PuffoV0RuntimeState.ACTIVE,
+            PuffoV0RuntimeState.POLICY_VERSION_MISMATCH,
+        ):
+            revocable.add(label)
+    assert revocable == _MATRIX_REVOCABLE
+
+
+def test_policy_drift_with_a_replaced_workspace_reports_no_workspace(tmp_path):
+    # #7, tightened past mere existence: a reported workspace names a LIVE binding.
+    # Replace the drifted entry's workspace with a FRESH directory at the same path
+    # (new inode) -- the path exists but no longer holds the provisioned identity, so
+    # discover must report workspace=None. Proves the check is a binding match, not an
+    # os.path.exists.
+    root = tmp_path / "root"
+    root.mkdir()
+    agent_dir = root / "identity"
+    agent_dir.mkdir()
+    (agent_dir / "init.json").write_text("{}", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    registry = tmp_path / "registry.json"
+    provision_runtime("runtime-a", agent_dir, workspace, registry_path=registry)
+    _mutate_registry_entry(
+        registry, "runtime-a", resign=True, runtime_policy_version="puffo-v0.OLD"
+    )
+    workspace.rename(tmp_path / "workspace-moved")
+    workspace.mkdir()  # fresh directory, same path, new inode -> exists but wrong identity
+
+    candidate = _discover_one(root, registry)
+    assert candidate.state is PuffoV0RuntimeState.POLICY_VERSION_MISMATCH
+    assert candidate.workspace is None
+
+
 def test_registry_rejects_tampering_and_revoked_runtime(tmp_path):
     agent_dir = tmp_path / "identity"
     agent_dir.mkdir()
@@ -149,7 +2021,21 @@ def test_registry_rejects_tampering_and_revoked_runtime(tmp_path):
     data = json.loads(registry.read_text(encoding="utf-8"))
     data["runtimes"]["opaque-id"]["workspace"] = str(tmp_path)
     registry.write_text(json.dumps(data), encoding="utf-8")
-    with pytest.raises(PuffoV0RegistryError, match="does not match"):
+    # Editing a signed field without re-signing breaks the digest; integrity is
+    # decided before any path-binding check, so the rejection names the digest.
+    with pytest.raises(PuffoV0RegistryError, match="integrity check"):
+        resolve_runtime("opaque-id", registry_path=registry)
+
+    data = json.loads(registry.read_text(encoding="utf-8"))
+    entry = data["runtimes"]["opaque-id"]
+    entry["unexpected"] = True
+    # An extra key is a shape mismatch -- but ONLY once the entry is authenticated:
+    # the digest match is decided before the key-set, so an UN-signed extra key is an
+    # integrity failure (pinned elsewhere). Re-sign over the extra-key structure so
+    # this exercises the shape path: a validly signed entry that is not our profile.
+    entry["entry_digest"] = _digest({k: v for k, v in entry.items() if k != "entry_digest"})
+    registry.write_text(json.dumps(data), encoding="utf-8")
+    with pytest.raises(PuffoV0RegistryError, match="does not match the puffo-v0 profile"):
         resolve_runtime("opaque-id", registry_path=registry)
 
     other_agent_dir = tmp_path / "other-identity"
@@ -159,7 +2045,7 @@ def test_registry_rejects_tampering_and_revoked_runtime(tmp_path):
     other_workspace.mkdir()
     provision_runtime("active-id", other_agent_dir, other_workspace, registry_path=registry)
     revoke_runtime("active-id", registry_path=registry)
-    with pytest.raises(PuffoV0RegistryError, match="inactive"):
+    with pytest.raises(PuffoV0RegistryError, match="has been revoked"):
         resolve_runtime("active-id", registry_path=registry)
 
 
@@ -309,7 +2195,10 @@ def test_revocation_tombstone_denies_a_stale_active_registry_snapshot(tmp_path):
     revoke_runtime("runtime-a", registry_path=registry)
     registry.write_text(stale_active_snapshot, encoding="utf-8")
 
-    with pytest.raises(PuffoV0RegistryError, match="inactive"):
+    # The stale snapshot is self-consistent (its digest still matches), so
+    # integrity passes and the tombstone -- which the snapshot restore cannot
+    # erase -- is what denies it: a revoked id, never a reusable one.
+    with pytest.raises(PuffoV0RegistryError, match="has been revoked"):
         resolve_runtime("runtime-a", registry_path=registry)
 
 


### PR DESCRIPTION
## Summary
- add read-only `lingtai-agent puffo-v0 discover --root <directory> [--json]`
- return canonical agent/workspace metadata and an active runtime ID only when valid
- keep revoked identities available; do not follow directory symlinks or mutate registry artifacts

## Validation
- `.venv/bin/python -m pytest -q -x tests/test_puffo_v0_profile.py`
- `.venv/bin/python -m pytest -q -x tests/test_architecture_documents.py`
- `.venv/bin/python scripts/check_docs_governance.py --check`
- `git diff --check`

Boris: please review this as the consuming Puffo-side owner.