### PR TITLE
refactor(avatar)!: remove rules action and automatic distribution

### DIFF
--- a/src/lingtai/adapters/tool_plugin_host.py
+++ b/src/lingtai/adapters/tool_plugin_host.py
@@ -489,16 +489,15 @@ class AgentContextRuntimeAdapter:
 class AgentAvatarParentAdapter:
     """Avatar's narrow parent-context port over the live Agent.
 
-    The adapter exposes only the three current-Agent facts Avatar already uses:
-    parent identity for the first prompt, an optional venv inheritance value,
-    and the existing any-admin-value rule gate.  It owns no Agent object; each
-    value is read through its one narrow closure when Avatar asks for it.
+    The adapter exposes only the two current-Agent facts Avatar already uses:
+    parent identity for the first prompt and an optional venv inheritance
+    value.  It owns no Agent object; each value is read through its one
+    narrow closure when Avatar asks for it.
     """
 
     __slots__ = (
         "_parent_name",
         "_venv_path",
-        "_has_rule_privilege",
         "_authorize_derived_launch",
     )
 
@@ -506,12 +505,10 @@ class AgentAvatarParentAdapter:
         self,
         parent_name: Callable[[], str],
         venv_path: Callable[[], str | None],
-        has_rule_privilege: Callable[[], bool],
         authorize_derived_launch: Callable[[Any], Any],
     ) -> None:
         self._parent_name = parent_name
         self._venv_path = venv_path
-        self._has_rule_privilege = has_rule_privilege
         self._authorize_derived_launch = authorize_derived_launch
 
     @property
@@ -521,9 +518,6 @@ class AgentAvatarParentAdapter:
     @property
     def venv_path(self) -> str | None:
         return self._venv_path()
-
-    def has_rule_privilege(self) -> bool:
-        return self._has_rule_privilege()
 
     def authorize_derived_launch(self, capability: Any) -> Any:
         return self._authorize_derived_launch(capability)
@@ -1642,7 +1636,6 @@ def agent_host_ports(
         ports["avatar_parent"] = AgentAvatarParentAdapter(
             lambda: agent.agent_name or agent.working_dir.name,
             lambda: getattr(agent, "_venv_path", None),
-            lambda: any((getattr(agent, "_admin", {}) or {}).values()),
             _authorize_derived_launch,
         )
     elif plugin_name == "plugin":

--- a/src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: psyche-manual
-last_changed_at: 2026-08-29T00:00:00Z
+last_changed_at: 2026-09-04T00:00:00Z
 description: >
   Routing table for the `psyche` tool — the one public root for your four
   durable domains: pad + lingtai + knowledge + skills = psyche. Read this to
-  learn which action loads which manual, inspect Psyche-owned prompt settings, and
-  follow the one mutation/rebuild model all four domains share.
+  learn which action loads which manual, inspect Psyche-owned prompt settings,
+  follow the one mutation/rebuild model all four domains share, and
+  distinguish that model from the separate `.rules` heartbeat-signal protocol
+  (also documented here, though not a psyche action).
 related_files:
 - src/lingtai/tools/psyche/CONTRACT.md
 - src/lingtai/tools/psyche/ANATOMY.md
@@ -16,7 +18,11 @@ related_files:
 - src/lingtai/tools/knowledge/manual/SKILL.md
 - src/lingtai/tools/skills/manual/SKILL.md
 - src/lingtai/tools/context/manual/SKILL.md
+- src/lingtai/kernel/base_agent/lifecycle.py
+- src/lingtai/kernel/base_agent/__init__.py
+- src/lingtai/tools/avatar/manual/SKILL.md
 - tests/test_psyche_family.py
+- tests/test_avatar_rules.py
 maintenance: |
   This is the psyche family's own manual, loaded by
   `psyche(action='manual', input={}, reasoning='...')`.
@@ -24,7 +30,10 @@ maintenance: |
   domain manuals it points to. Update it together with
   src/lingtai/tools/psyche/{CONTRACT,ANATOMY}.md whenever the public action
   inventory, owned settings, a domain's durable source, or the rebuild model
-  changes.
+  changes. The `.rules` network-rules protocol section is a signpost target
+  from `avatar-manual` §9 (Avatar owns no rules action or mechanism); keep it
+  in sync with `src/lingtai/kernel/base_agent/lifecycle.py`'s
+  `_check_rules_file` if that consumer's semantics change.
 ---
 
 # Psyche
@@ -203,3 +212,90 @@ owner value removes the section on the applied reconstruction.
 
 Optional pointer; default `null`, configurable `true`. A readable file wins
 over `comment`; it is fully redacted and has no mirror behavior.
+
+## Network rules protocol (`.rules`)
+
+`.rules` is a real mechanism, but it is **not** owned by `psyche`, `avatar`, or
+any other action tool — there is no `psyche(action='rules')` and no generic
+instruction API for it. It is a plain signal file consumed by an agent's own
+heartbeat loop (`_check_rules_file` in
+`src/lingtai/kernel/base_agent/lifecycle.py`), documented here because it is
+easy to confuse with the ordinary Psyche edit-then-`context.rebuild` model
+above — the two are deliberately different mechanisms:
+
+- **Ordinary Psyche edit:** write a durable source file (`system/pad.md`,
+  `system/lingtai.md`, a `KNOWLEDGE.md`/`SKILL.md`, or the Psyche owner
+  document), then call `context(action="rebuild", ...)` (or wait for
+  refresh/molt) to recompose **all** enabled sections at once.
+- **`.rules`:** use Shell to write a `.rules` file to the explicitly authorized
+  target agent's working-directory root. Its next runnable heartbeat reads and
+  unlinks the signal before deciding whether to apply it; no explicit rebuild
+  or refresh is needed. A read or unlink failure leaves the signal unconsumed
+  and stops processing, so file disappearance alone is not proof of success.
+
+### Write through Shell
+
+First prepare the complete approved UTF-8 rule body and confirm the exact target
+path. For example, in a POSIX shell (use the active shell's equivalent elsewhere):
+
+```sh
+target='/absolute/path/to/authorized-agent'
+body='/absolute/path/to/approved-rules.txt'
+tmp=$(mktemp "$target/.rules.XXXXXX") &&
+  cat "$body" > "$tmp" &&
+  mv "$tmp" "$target/.rules"
+```
+
+The temporary file is in the target directory so the final rename exposes the
+complete signal, not a partly written body. If a command fails, stop and inspect
+that exact temporary file; do not announce success or blindly replay the batch.
+For multiple agents, confirm an explicit target list and perform/report the write
+for each target. There is no automatic descendant broadcast or post-spawn fan-out.
+Do not write `system/rules.md` as a substitute for this live signal workflow.
+
+Consumption semantics, exactly as implemented:
+
+- **Complete replacement, not a merge.** A non-empty `.rules` body entirely
+  replaces the canonical `system/rules.md` content and the protected `rules`
+  prompt section — it is never appended to or merged with prior rules.
+- **Empty is a no-op.** Whitespace-only or empty `.rules` content is consumed
+  (the signal file is deleted either way) but writes nothing and triggers no
+  prompt refresh.
+- **Identical content is a no-flush no-op.** If the `.rules` body (stripped)
+  equals the existing `system/rules.md` (stripped), the signal is consumed
+  but `system/rules.md` is not rewritten and the system prompt is not
+  reflushed.
+- **Changed content persists and flushes.** A genuinely different body
+  overwrites `system/rules.md`, rewrites the protected `rules` prompt
+  section, and flushes the live system prompt — logged as `rules_loaded`.
+  A write failure while persisting the canonical file is logged as
+  `rules_write_error` and aborts before any prompt mutation.
+- **Boot/rebuild injection.** `system/rules.md` is also re-read directly into
+  the protected `rules` prompt section on ordinary agent construction and on
+  every full reconstruction (`context.rebuild`, refresh, molt) — independent
+  of any pending `.rules` signal. This is what makes existing rules survive a
+  molt, refresh, or resume even without a fresh `.rules` write; an empty or
+  missing `system/rules.md` at reconstruction time removes the section.
+
+**Verification.** The canonical value is `system/rules.md` on disk — read it
+directly. The effective (currently composed) value is what the protected
+`rules` prompt section holds; a `.rules` write is only reflected there after
+that *same agent's own* next heartbeat tick actually processed it (or after
+any subsequent boot/rebuild/refresh/molt, which re-reads the same canonical
+file). A `.rules` file that has not yet ticked is real on disk as a pending
+signal, not yet visible in the prompt — the same "written but not applied"
+distinction as an unbuilt Psyche source edit, but on the heartbeat's cadence
+instead of an explicit `context.rebuild` call.
+
+**Cross-agent writes are scoped by what you can reach, not by a privilege
+check.** `avatar` used to own an admin/karma-gated `rules` action that wrote
+`.rules` to a caller's own directory and to every descendant in its avatar
+tree; that action and its authorization check were both **removed**, not
+replaced by a new guard anywhere else. Today, writing a `.rules` file to
+another agent's directory (e.g. a sibling avatar) is an ordinary filesystem
+write — typically via `shell` naming that agent's explicit path — subject
+only to whatever access the same-OS-user trust model already gives you, not
+to any dedicated authorization mechanism. This paragraph is documentation,
+not enforcement: do not treat it, or any other prose, as proof that a write
+outside your own directory is authorized — only the human's actual scope and
+the target's real accessibility decide that.

--- a/src/lingtai/kernel/tool_plugin/CONTRACT.md
+++ b/src/lingtai/kernel/tool_plugin/CONTRACT.md
@@ -1,6 +1,6 @@
 ---
 name: declared-host-tool-plugin
-contract_version: 3
+contract_version: 4
 root_contract: CONTRACT.md
 related_files:
   - src/lingtai/kernel/tool_plugin/ANATOMY.md
@@ -228,7 +228,7 @@ capability.
 | `WorkdirPort` | `path -> Path` | The agent working directory, read through on every access so a holder never renders a stale directory after a refresh. Grants no read, write, listing, or lease operation. |
 | `PromptSectionPort` | `write_protected_section(body) -> None` | Replace **this plugin's own** protected system-prompt section. There is no section argument and no `protected` flag: the granted port is bound to the declaring plugin's name, so a plugin can neither address another's section nor write an unprotected one. |
 | `FileIOPort` | `read`, `write`, `glob`, `grep`, `last_traversal`, `max_result_chars` | File-only bounded UTF-8 text operations and concrete match/traversal facts. It exposes neither the backing generic service nor the Agent; path rooting remains the separate `WorkdirPort`. |
-| `AvatarParentPort` | `parent_name`, `venv_path`, `has_rule_privilege()` | Avatar-only parent context: the identity placed in a newborn prompt, optional runtime location inherited into its init, and the existing any-admin-value gate for rules. It grants no mutable admin/configuration surface or Agent reference. |
+| `AvatarParentPort` | `parent_name`, `venv_path` | Avatar-only parent context: the identity placed in a newborn prompt and optional runtime location inherited into its init. It grants no mutable admin/configuration surface or Agent reference. Avatar owns no rules-distribution action, so this port no longer carries an authorization-bit method for one (**contract_version 4**, breaking: `has_rule_privilege()` removed). |
 | `ContextRuntimePort` | `molt(args)`, `summarize(args)`, `rebuild(args)` | Context-only lifecycle-operation boundary. It preserves the live molt, record-only summary, and reconstruction/replay engines without granting Context the Agent or unrelated private state. |
 | `DaemonRuntimePort` | named model/tool/preset/notification/log operations | Daemon-only parent-runtime boundary: inherited service and regular tool snapshots, preset sandbox/load, live notification route, time, Task Card, logging, and resolved manager options. It never grants the Agent or a mount operation. |
 | `NotificationStatePort` | `dismiss(channel, *, force, reason, event_id=None, ref_id=None)`, `delay(channel, seconds)`, hook operations, `read_settings() -> tuple[int, int]`, bounded `log` | Notification-only Core delegation. `read_settings` returns the fresh effective payload cap and delay ceiling through canonical resolvers; it grants no configuration object or writer. `AgentNotificationStateAdapter` owns only callbacks bound to the live Agent; it hands the family no Agent, Store, fingerprint, producer state, generic dispatch, or mount seam. Notification Core retains dismissal authorization, stale-delivery comparison, producer guards, acknowledgement, delay/timer, hook-manifest, and logging policy. |

--- a/src/lingtai/kernel/tool_plugin/__init__.py
+++ b/src/lingtai/kernel/tool_plugin/__init__.py
@@ -358,10 +358,9 @@ class AvatarParentPort(Protocol):
     """The parent facts Avatar needs to spawn and control its own subtree.
 
     This is deliberately Avatar-specific rather than a second whole-Agent
-    facade: spawning needs the parent identity and inherited runtime location,
-    while rules control needs only the already-decided authorization bit.  It
-    grants no mutable administration surface, no generic configuration, and no
-    tool mounting capability.
+    facade: spawning needs only the parent identity and inherited runtime
+    location. It grants no mutable administration surface, no generic
+    configuration, and no tool mounting capability.
     """
 
     @property
@@ -371,9 +370,6 @@ class AvatarParentPort(Protocol):
     @property
     def venv_path(self) -> str | None:
         """Optional parent runtime location inherited by a newborn avatar."""
-
-    def has_rule_privilege(self) -> bool:
-        """Whether this parent may distribute rules through its avatar subtree."""
 
     def authorize_derived_launch(self, capability: Any) -> Any:
         """Decide one avatar-derived process launch before side effects."""

--- a/src/lingtai/tools/CONTRACT.md
+++ b/src/lingtai/tools/CONTRACT.md
@@ -733,11 +733,12 @@ public tool name and existing action result shapes including the tool-specific
 body through two granted host ports instead of the whole `Agent` (see
 `src/lingtai/tools/mcp/CONTRACT.md`).
 
-`avatar` (`spawn | rules | manual`) is the second family declared under
-`### Tool-to-MCP Plugin Contract`: its static declaration preserves the public
-tool name, action values, strict action inputs, and result behavior while
-binding `AvatarManager` only to `workdir` and `avatar_parent`, never the whole
-`Agent` (see `src/lingtai/tools/avatar/CONTRACT.md`).
+`avatar` (`spawn | settings | manual`, `rules` removed at contract_version 9) is the
+second family declared under `### Tool-to-MCP Plugin Contract`: its static
+declaration preserves the public tool name, action values, strict action
+inputs, and result behavior while binding `AvatarManager` only to `workdir`
+and `avatar_parent`, never the whole `Agent` (see
+`src/lingtai/tools/avatar/CONTRACT.md`).
 
 `context` (`molt | summarize | rebuild | manual`) is the current in-process lifecycle
 vertical slice. It keeps Context's LTP shape, molt transport seam, and live
@@ -806,15 +807,18 @@ workdir-relative `settings/vision.json` remains the only Vision-owned document
 and configures only the generic `local` provider. SHOW adds no settings file,
 parser, writer, or generic control plane.
 
-`avatar` (`spawn | rules | manual`) is the sixth family migrated, keeping its
-public name and action values unchanged (see
+`avatar` (`spawn | rules | manual` at the time of this migration) is the sixth
+family migrated, keeping its public name unchanged (see
 `src/lingtai/tools/avatar/CONTRACT.md`, contract_version 4). It owns no
-settings file at either level, and its manual says so explicitly. Two
-avatar-specific facts are worth naming here because they are envelope
-consequences, not local details: its `spawn` mission brief is root `reasoning`
-(never an `input` property, per "Envelope"), and its `rules` action is
-karma-gated while `spawn` and `manual` are not — a family must not hide a
-stronger child action behind a weaker family posture.
+settings file at either level, and its manual says so explicitly. One
+avatar-specific fact is worth naming here because it is an envelope
+consequence, not a local detail: its `spawn` mission brief is root
+`reasoning` (never an `input` property, per "Envelope"). At the time, its
+`rules` action was karma-gated while `spawn` and `manual` were not — the
+precedent this established, that a family must not hide a stronger child
+action behind a weaker family posture, outlived the action itself: `rules`
+and its automatic post-spawn fan-out were later removed rather than
+relocated (contract_version 9), so `avatar` today is `spawn | settings | manual`.
 
 `shell` (`run | poll | cancel | settings | manual`) is the eighth: its final model-facing
 root is likewise exactly `action`, `input`, `reasoning`, and `summarize`, its
@@ -1116,10 +1120,11 @@ child inputs, root `allOf` correlation surviving both wires, cross-action and
 unknown-root-field rejection *before* any handler I/O, `summarize` never
 reaching a child handler and `avatar` actually being on the kernel allowlist,
 the preserved unknown-action envelope, spawn's dry-run/mission-guard/identity
-and path validation, the karma gate and distribution for `rules`, and `manual`
-performing no spawn or rules I/O. Every test there builds its own isolated
-temporary network and fakes the launcher Port, so it neither creates a live
-avatar nor writes a live `.rules` signal.
+and path validation, and `manual` performing no spawn I/O. Every test there
+builds its own isolated temporary network and fakes the launcher Port, so it
+neither creates a live avatar nor mutates anything outside its own temporary
+tree; `tests/test_avatar_rules.py` separately covers the retired `rules`
+action's absence and the removed post-spawn fan-out (contract_version 9).
 
 `context`'s evidence (`tests/test_tool_family_context_migration.py`,
 plus the updated `tests/test_context.py`, `tests/test_pad.py`,

--- a/src/lingtai/tools/avatar/ANATOMY.md
+++ b/src/lingtai/tools/avatar/ANATOMY.md
@@ -10,6 +10,8 @@ related_files:
   - src/lingtai/tools/avatar/settings.py
   - src/lingtai/kernel/_fsutil.py
   - src/lingtai/kernel/prompt.py
+  - src/lingtai/kernel/base_agent/lifecycle.py
+  - src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
   - src/lingtai/tools/avatar/CONTRACT.md
   - src/lingtai/kernel/tool_plugin/ANATOMY.md
   - src/lingtai/kernel/tool_plugin/CONTRACT.md
@@ -55,8 +57,8 @@ independent life — its existence does not depend on yours.
 ## Components
 
 - `avatar/__init__.py` — static official `DECLARATION`, settings binding, local
-  manual child, validation, preparation, boot policy, ledger, rules, schemas,
-  and registrar setup. The core class is `AvatarManager`.
+  manual child, validation, preparation, boot policy, ledger, schemas, and
+  registrar setup. The core class is `AvatarManager`.
 - `avatar/_launcher.py` — immutable launch request/receipt, the avatar-local
   opaque-handle Port, current restrictive child-boot marker name, read-only
   legacy-marker compatibility path, and their shared present/absent/unknown
@@ -76,9 +78,15 @@ family (`src/lingtai/tools/CONTRACT.md`) whose actions are canonical children:
 | Action | Own strict `input` | Description |
 |------|------|-------------|
 | `spawn` | `name`, `type`, `comment`, `dry_run`, `confirm` | Spawn a new avatar agent (shallow or deep). `dry_run` previews only; `confirm` acknowledges the mission-quality gate. |
-| `rules` | `rules_content` | Set rules content and distribute via `.rules` signal files to self + all descendants. Karma-gated. |
 | `settings` | `{}` | Return 16 immutable Avatar defaults, validation constraints, and lifecycle policies as exact five-field rows. |
-| `manual` | *(empty)* | Read-only: returns the exact `manual/SKILL.md` body plus its host-local `manual_path`. No spawn or rules I/O. |
+| `manual` | *(empty)* | Read-only: returns the exact `manual/SKILL.md` body plus its host-local `manual_path`. No spawn I/O. |
+
+Avatar no longer owns a `rules` action or an automatic post-spawn rules
+fan-out (removed, not relocated — see `src/lingtai/tools/avatar/CONTRACT.md`
+contract_version 9). The `.rules` heartbeat signal and `system/rules.md`
+persistence remain real, unchanged kernel state owned by
+`src/lingtai/kernel/base_agent/lifecycle.py`; see `psyche-manual` for that
+protocol.
 
 The model-facing root is exactly `action` + `input` + required `reasoning` +
 optional `summarize`, `additionalProperties: false`. Each action owns exactly
@@ -108,7 +116,7 @@ unknown-action error string.
 
 ```
 avatar/__init__.py
-  ├── _SPAWN/_RULES_INPUT_SCHEMA    — canonical strict operational inputs
+  ├── _SPAWN_INPUT_SCHEMA           — canonical strict operational input
   ├── DECLARATION                   — static official identity, actions,
   │                                    settings/manual reservations, and exact
   │                                    `(workdir, avatar_parent)` grant
@@ -120,8 +128,8 @@ avatar/__init__.py
   │                                    delegates to ToolFamily.handle(), then
   │                                    normalizes ACTION_REQUIRED back to
   │                                    avatar's pinned unknown-action error
-  ├── _dispatch_spawn/_rules        — operational child handlers; strip nulls,
-  │                                    thread the mission brief to _spawn
+  ├── _dispatch_spawn               — operational child handler; strips nulls,
+  │                                    threads the mission brief to _spawn
   ├── _strip_nulls()                — nullable-optional → absent
   ├── _manual_payload()             — plugin-owned local `manual/SKILL.md`
   │                                    result; no manager/host mutation
@@ -138,20 +146,21 @@ avatar/__init__.py
   │
   │  Ledger:
   ├── _append_ledger()              — appends spawn event to delegates/ledger.jsonl
-  ├── _read_ledger()                — reads all ledger records
-  │
-  │  Rules distribution:
-  ├── _rules()                      — admin-gated rules update, distributes via .rules signal files
-  ├── _walk_avatar_tree()           — recursively discovers all descendants from ledger files
-  └── _distribute_rules_to_descendants() — writes .rules signal file to every descendant
+  └── _read_ledger()                — reads all ledger records
 ```
+
+`_rules()`, `_walk_avatar_tree()`, and `_distribute_rules_to_descendants()`
+(the admin-gated rules update and its BFS descendant fan-out) plus the
+post-spawn canonical-rules read they fed are removed entirely — not renamed
+or relocated (contract_version 9). Nothing in this package writes `.rules`
+anymore.
 
 ## Key Invariants
 
 - **Declared least privilege:** `AvatarManager` receives a `ToolPluginHost`, not
   an Agent. `workdir` supplies every local path; `avatar_parent` supplies only
-  the current parent identity, optional venv inheritance, and the already-made
-  rules authorization decision. The binder cannot mount itself.
+  the current parent identity and optional venv inheritance. The binder cannot
+  mount itself.
 - **Local manual:** `manual` is the declaration-appended reserved child but
   remains package-local: it returns `manual/SKILL.md` and performs no host or
   manager I/O.
@@ -200,13 +209,12 @@ avatar/__init__.py
   routes `DECLARATION` through `register_agent_tool_plugins`; the kernel checks
   the reserved `avatar` name, grants only `workdir`/`avatar_parent`, binds the
   manager, and mounts the issued transaction. `AvatarManager` internally
-  dispatches `spawn`/`rules`, the generic declaration-bound `settings` child,
+  dispatches `spawn`, the generic declaration-bound `settings` child,
   and the declaration-owned local `manual` child through `ToolFamily`. `avatar`
   is on the kernel's `_LTP_V2_MIGRATED_FAMILIES` allowlist
   (`src/lingtai/kernel/tool_result_summary.py`), so the root `summarize` boolean
   it advertises is actually honored by the single central summarizer. The daemon
-  capability blacklists `avatar` to prevent avatar-in-daemon recursion and rules
-  mutation from emanations.
+  capability blacklists `avatar` to prevent avatar-in-daemon recursion.
 
 Platform process mechanics are in `adapters/avatar_launcher.py` plus the POSIX
 and Windows adapters. A Driver child-endpoint handoff is POSIX-only: the POSIX

--- a/src/lingtai/tools/avatar/BEHAVIORS.md
+++ b/src/lingtai/tools/avatar/BEHAVIORS.md
@@ -1,6 +1,6 @@
 ---
 name: avatar-behavior-tests
-behavior_version: 1
+behavior_version: 2
 labt_version: 2
 contract: CONTRACT.md
 anatomy: ANATOMY.md
@@ -20,14 +20,15 @@ maintenance: |
 # Avatar Capability Behavior Tests
 
 Self-contained agent behavior tasks guarding the observable behavior clauses of
-`src/lingtai/tools/avatar/CONTRACT.md` (spawn mission gate, name grammar, rules
-admin gate, five-field settings SHOW, manual no-I/O). Pinned pytest commands
-must run from the repo root with the project's Python.
+`src/lingtai/tools/avatar/CONTRACT.md` (spawn mission gate, name grammar,
+absence of the retired `rules` action, five-field settings SHOW, manual
+no-I/O). Pinned pytest commands must run from the repo root with the
+project's Python.
 
-## Behavior AV001 — spawn enforces the name grammar and the mission-quality gate, and rules requires admin privilege
+## Behavior AV001 — spawn enforces the name grammar and the mission-quality gate, and `rules` is a retired action
 
 - **id**: AV001
-- **title**: spawn enforces the name grammar and the mission-quality gate, and rules requires admin privilege
+- **title**: spawn enforces the name grammar and the mission-quality gate; `action="rules"` and its automatic post-spawn fan-out are removed, not admin-gated
 - **guards**: `avatar-contract` § Tool surface
 - **runner**: any LingTai agent with `shell` and `file` access to this repository
 - **prerequisites**: a clean checkout of `<repo>`; a scratch parent agent directory `<scratch>`; no live avatar of the probe name
@@ -36,15 +37,15 @@ must run from the repo root with the project's Python.
 ### Steps
 1. From `<repo>`, run `python -m pytest tests/test_avatar_launcher.py tests/test_avatar_rules.py -q` and capture the outcome.
 2. Call `avatar(action="spawn", input={"name": "bad name with spaces"}, reasoning="probe")` and record the result; then call it with `name="good"` and a mission shorter than 20 characters and record the result.
-3. Call `avatar(action="rules", input={"rules_content": "..."}, reasoning="probe")` from a caller without admin karma and record the result; retry with a truthy admin karma.
+3. Call `avatar(action="rules", input={"rules_content": "..."}, reasoning="probe")` from a caller with a truthy admin karma and record the result; confirm no `.rules` file appears in `<scratch>`.
 
 ### Expected evidence
-- [ ] Step 1: the avatar launcher/rules suites pass, pinning dry-run, mission gate, receipts, authorization, and distribution.
+- [ ] Step 1: the avatar launcher/rules suites pass, pinning dry-run, mission gate, receipts, and the removed `rules` action/fan-out.
 - [ ] Step 2: a name violating `^[\w-]+$` or carrying a dot/slash/leading dot is rejected; an empty/very-short/debug-placeholder mission is refused with `confirmation_needed` unless `confirm=true` (dry_run exempt).
-- [ ] Step 3: `rules` without admin privilege is refused before any write; with admin privilege it writes the self `.rules` signal and returns `distributed_to`.
+- [ ] Step 3: `action="rules"` fails with the ordinary unknown-action envelope regardless of admin karma, and writes no `.rules` file — there is no admin gate to check because the action no longer exists.
 
 ### Pass / Fail
-Pass when the suites pass and the gate observations hold. Fail on a malformed name spawning, on a weak mission spawning without confirmation, or on `rules` executing without admin karma; record the evidence trail in the task report.
+Pass when the suites pass and the gate observations hold. Fail on a malformed name spawning, on a weak mission spawning without confirmation, or on `action="rules"` performing any filesystem write; record the evidence trail in the task report.
 
 ## Behavior AV002 — settings shows only immutable Avatar owner policy
 

--- a/src/lingtai/tools/avatar/CONTRACT.md
+++ b/src/lingtai/tools/avatar/CONTRACT.md
@@ -1,7 +1,7 @@
 ---
 name: avatar-contract
 tool: avatar
-contract_version: 8
+contract_version: 9
 related_files:
   - src/lingtai/tools/avatar/BEHAVIORS.md
   - src/lingtai/tools/avatar/__init__.py
@@ -9,8 +9,10 @@ related_files:
   - src/lingtai/tools/avatar/settings.py
   - src/lingtai/kernel/_fsutil.py
   - src/lingtai/kernel/prompt.py
+  - src/lingtai/kernel/base_agent/lifecycle.py
   - src/lingtai/tools/psyche/settings.py
   - src/lingtai/tools/psyche/CONTRACT.md
+  - src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
   - src/lingtai/kernel/tool_plugin/CONTRACT.md
   - src/lingtai/kernel/tool_plugin/ANATOMY.md
   - src/lingtai/adapters/tool_plugin_host.py
@@ -35,12 +37,31 @@ maintenance: |
 
 # Avatar capability contract
 
-`avatar` spawns independent peer agents (分身) as fully detached processes, and
-distributes shared rules across the avatar subtree. It registers **one** public
-tool, `avatar`, dispatched by an `action` enum (`spawn` | `rules` | `settings`
-| `manual`).
+`avatar` spawns independent peer agents (分身) as fully detached processes. It
+registers **one** public tool, `avatar`, dispatched by an `action` enum
+(`spawn` | `settings` | `manual`).
 The implementation lives in `src/lingtai/tools/avatar/`; the code is the source
 of truth.
+
+**contract_version 9** (breaking, Option B): Avatar's dedicated `rules` action
+— and the automatic post-spawn rules fan-out that ran after every successful
+spawn — are both **removed**, not replaced by a new mechanism.
+`action="rules"` now fails with avatar's ordinary unknown-action envelope (see
+§Invalid or missing `action`); its `rules_content` input schema, its karma
+authorization check, and the `_walk_avatar_tree`/`_distribute_rules_to_descendants`
+helpers are gone (the sole `AvatarParentPort.has_rule_privilege()` caller is
+also gone, so that Port method was removed too —
+`src/lingtai/kernel/tool_plugin/CONTRACT.md` contract_version 4). This is
+**not** a relocation: nothing else in the kernel or another tool now performs
+an authorization-gated rules broadcast. The underlying `.rules` heartbeat
+signal, `system/rules.md` persistence, and protected prompt-section injection
+in `src/lingtai/kernel/base_agent/lifecycle.py` are **unchanged** — any agent
+may still write a `.rules` file to an explicitly targeted path itself (e.g.
+via `shell`), and ordinary deep-copy spawn behavior (`_prepare_deep` copying
+the whole `system/` tree, including any `system/rules.md` it contains) is also
+unchanged. See `psyche-manual` for the `.rules` protocol and `avatar-manual`
+§9 for the signpost. Avatar's manual now points to Psyche's manual instead of
+teaching this protocol itself.
 
 **contract_version 2** (breaking): the former two-tool surface (`avatar_spawn`,
 `avatar_rules`) was merged into the single `avatar` tool below. `avatar_spawn`
@@ -63,16 +84,17 @@ per-action `input` object, and the model-facing root is exactly `action`,
 `input`, required `reasoning`, and optional `summarize`, with
 `additionalProperties: false`.
 
-- Public tool name and action values are **unchanged**: `avatar` with
-  `spawn | rules | manual`.
-- `spawn` owns `name`, `type`, `comment`, `dry_run`, `confirm`. `rules` owns
-  `rules_content`. `manual` has strict empty input. A key belonging to another
-  action's branch, an unknown root field, a non-boolean `summarize`, or a
-  missing/non-object `input` is rejected **before any handler I/O** with the
-  generic typed failure (`{"status": "failed", "error_code":
-  "INVALID_ARGUMENT", ...}`), performing no spawn, ledger, `.rules`, or process
-  side effect. Previously an unrecognized extra key (e.g. the retired `dir`)
-  was silently ignored; it now fails loudly.
+- Public tool name and action values were **unchanged** at contract_version 4:
+  `avatar` with `spawn | rules | manual` (`rules` was later removed at
+  contract_version 9 — see above).
+- `spawn` owns `name`, `type`, `comment`, `dry_run`, `confirm`. `manual` has
+  strict empty input. A key belonging to another action's branch, an unknown
+  root field, a non-boolean `summarize`, or a missing/non-object `input` is
+  rejected **before any handler I/O** with the generic typed failure
+  (`{"status": "failed", "error_code": "INVALID_ARGUMENT", ...}`), performing
+  no spawn, ledger, `.rules`, or process side effect. Previously an
+  unrecognized extra key (e.g. the retired `dir`) was silently ignored; it now
+  fails loudly.
 - The spawn mission brief remains root `reasoning` (injected as `_reasoning`),
   **not** an `input` property, and is captured per call — it never leaks from
   one call into the next.
@@ -114,10 +136,13 @@ Guarded by: [AV001](BEHAVIORS.md#behavior-av001),
 
 **Use this when:**
 - You are editing avatar spawning (shallow 初生 / deep 二重身), the spawn ledger,
-  boot verification, or rules distribution.
+  or boot verification.
 - You are reviewing the mission-quality gate, avatar-name validation, the
-  init.json plus narrow Psyche owner-document rewrite for a newborn avatar, or the `.prompt` / `.rules` signal
-  files.
+  init.json plus narrow Psyche owner-document rewrite for a newborn avatar, or
+  the `.prompt` signal file.
+- You are looking for `.rules`/rules distribution: that mechanism is no longer
+  Avatar's — see `src/lingtai/kernel/base_agent/lifecycle.py` and
+  `psyche-manual`.
 
 **Do not use this for:**
 - Ephemeral in-process subagents/emanations: use `daemon` (see
@@ -134,7 +159,7 @@ storage; detached-process launch -> §Cross-platform invariants.
   whose root property set is exactly `action`, `input`, `reasoning`, and
   `summarize`, with `additionalProperties: false` and
   `required: ["action", "input", "reasoning"]`. `action` is the enum
-  (`spawn` | `rules` | `settings` | `manual`) — schema-required, the same convention as
+  (`spawn` | `settings` | `manual`) — schema-required, the same convention as
   `knowledge`, `mcp`, `skills`, `notification`, `system`, `soul`, and `daemon`.
   Each action's own strict, closed `input` schema is exposed to the model
   before invocation two ways, both generated from the one child registry: an
@@ -142,22 +167,22 @@ storage; detached-process launch -> §Cross-platform invariants.
   `manual` both have strict empty input), and one root `allOf`/`if`/`then`
   condition per action correlating that action's `const` with that exact input
   shape. Dispatch re-validates independently and is always authoritative.
-- Action-specific required inputs (`name` for spawn, `rules_content` for rules)
-  are enforced both by the child schema and again in the handler.
+- `name` (required for spawn) is enforced both by the child schema and again
+  in the handler.
 - `action="spawn"` (must be passed explicitly — there is no default action)
   creates a sibling agent directory named after the avatar and launches it via
   the global venv. Shallow copies `init.json` plus only Psyche base/covenant
   owner inputs (no identity/pad/history);
-  deep also copies `system/`, `knowledge/`, `exports/`, and `combo.json`.
-- `action="rules"` writes a `.rules` signal to the caller and every descendant
-  so each agent refreshes its own `system/rules.md`-derived prompt. It carries
-  its own admin gate, independent of `spawn` — spawning never requires admin.
+  deep also copies `system/`, `knowledge/`, `exports/`, and `combo.json`
+  (including any `system/rules.md` that ordinary copy carries along —
+  unaffected by contract_version 9). Spawn never requires admin and performs
+  no rules-distribution side effect of its own.
 - `action="settings"` calls the Avatar-owned provider for immutable defaults,
   constraints, and lifecycle policy. It has no mutation or configuration I/O.
 - `action="manual"` is read-only: it returns the exact packaged
   `src/lingtai/tools/avatar/manual/SKILL.md` body plus its host-local
   `manual_path`, and performs no filesystem mutation (no spawn, no ledger
-  write, no `.rules` write). Avatar's manual ships inside this package rather
+  write). Avatar's manual ships inside this package rather
   than being installed into the agent's `.library` intrinsic catalog, so this
   action owns its own loader instead of the shared
   `load_installed_manual`/`build_manual_child` pair — that builder would
@@ -172,13 +197,15 @@ avatar's ongoing lifecycle after boot (mail/system intrinsics do that).
 Avatar is an official static `ToolPluginDeclaration`, reserved by the kernel and
 mounted only through `register_agent_tool_plugins`. Its binder receives exactly
 `workdir` and `avatar_parent`: the former resolves the current agent's local
-spawn ledger, sibling directories, and rules signals; the latter exposes only
-the existing parent name, optional inherited venv location, and the existing
-any-admin-value authorization decision for `rules`. `AvatarManager` never holds
-or accepts a whole Agent. The registrar still owns reservation, activation, and
-mounting; `setup(agent)` is composition wiring only.
+spawn ledger and sibling directories; the latter exposes only the existing
+parent name and optional inherited venv location (contract_version 9: it no
+longer carries a rules-authorization decision — see
+`src/lingtai/kernel/tool_plugin/CONTRACT.md` contract_version 4).
+`AvatarManager` never holds or accepts a whole Agent. The registrar still owns
+reservation, activation, and mounting; `setup(agent)` is composition wiring
+only.
 
-The declaration owns operational `spawn`/`rules`; generic composition inserts
+The declaration owns operational `spawn`; generic composition inserts
 the opted-in `settings` slot immediately before the reserved `manual` slot.
 Avatar owns the manual child directly so its longstanding local-manual contract
 remains unchanged: `manual` returns the packaged `manual/SKILL.md` body and its
@@ -193,12 +220,12 @@ Every call is `avatar(action=..., input={...}, reasoning="...", summarize?=bool)
 
 | Root field | Required | Meaning |
 |---|---|---|
-| `action` | yes | One of `spawn` \| `rules` \| `settings` \| `manual`. No default. |
+| `action` | yes | One of `spawn` \| `settings` \| `manual`. No default. |
 | `input` | yes | The selected action's own strict, closed object. |
 | `reasoning` | yes | Cross-cutting rationale. For `spawn` this **is** the mission brief and becomes the avatar's first prompt. Never an `input` property. |
 | `summarize` | no | Root-only result post-processing control, absent/false by default. Never action input, never reaches a handler. |
 
-Rejected before any handler I/O, with no spawn/ledger/`.rules`/process side
+Rejected before any handler I/O, with no spawn/ledger/process side
 effect: an unknown `action` (see below), a missing or non-object `input`, an
 unknown root field, a non-boolean `summarize`, and any `input` key belonging to
 another action's branch (`{"status": "failed", "error_code":
@@ -218,20 +245,6 @@ The mission-quality gate refuses empty / very short (<20 chars) / debug-placehol
 missions unless `confirm=true`; `dry_run` is exempt. Avatar names must match
 `^[\w-]+$` (Unicode letters, digits, `_`, `-`), be ≤64 chars, and carry no dot,
 slash, or leading `.` — the name doubles as the working-dir basename.
-
-### `avatar` — `action="rules"`
-
-`input` owns exactly `rules_content`. A `spawn`-branch key (e.g. `name`,
-`dry_run`) in this action's `input` is rejected before the authorization check
-and before any write.
-
-| Input | Optional input | Success output | Error shapes |
-|---|---|---|---|
-| `rules_content` (required) | — | `{status: "ok", message, distributed_to: [...]}` | `{error: ...}` — empty `rules_content`, no admin privilege, or failure writing the self `.rules` signal |
-
-`action="rules"` requires at least one truthy admin privilege (karma) on the
-caller. This gate applies only to `rules`; `spawn` never checks admin. The
-family must not hide this stronger action behind a weaker family posture.
 
 ### `avatar` — `action="settings"`
 
@@ -255,13 +268,13 @@ arguments, and invocation/session state are not settings and MUST NOT be read
 or returned. A non-empty input fails before the provider runs. Provider,
 malformed-row, non-JSON, or response-size failure produces the generic fixed
 bounded no-row failure; no partial inventory or exception detail is exposed.
-SHOW performs no filesystem, process, launcher, ledger, rules, privilege,
+SHOW performs no filesystem, process, launcher, ledger, privilege,
 configuration, or environment mutation.
 
 ### `avatar` — `action="manual"`
 
-Strict empty `input` (`{}`); any field is rejected. Performs no spawn or rules
-I/O of any kind.
+Strict empty `input` (`{}`); any field is rejected. Performs no spawn I/O of
+any kind.
 
 | Input | Optional input | Success output | Error shapes |
 |---|---|---|---|
@@ -272,13 +285,13 @@ nested inside another action's result envelope and never double-wrapped.
 
 ### Invalid or missing `action`
 
-An `action` value outside `spawn`/`rules`/`settings`/`manual` — including an entirely
-omitted `action` key — returns
-`{error: "unknown action: <repr>, only 'spawn', 'rules', 'settings', or 'manual' is supported"}`
+An `action` value outside `spawn`/`settings`/`manual` — including an entirely
+omitted `action` key, and including the retired `rules` value — returns
+`{error: "unknown action: <repr>, only 'spawn', 'settings', or 'manual' is supported"}`
 (for the omitted case, `<repr>` is `''`) without touching the filesystem, the
-ledger, `.rules`, or launching any process. There is no default action: a
-`name`- or `rules_content`-shaped payload with `action` omitted still fails
-this way rather than being inferred as `spawn` or `rules`.
+ledger, or launching any process. There is no default action: a
+`name`-shaped payload with `action` omitted still fails this way rather than
+being inferred as `spawn`.
 
 This exact envelope is a pinned public promise that predates the LTP v2
 migration. The generic dispatcher's own `ACTION_REQUIRED` failure shape is
@@ -293,19 +306,23 @@ the network root (`<parent>/..`):
 
 ```text
 <parent>/delegates/ledger.jsonl   # append-only spawn ledger (one JSON record/line)
-<parent>/system/rules.md          # canonical rules; auto-distributed on spawn
-<parent>/.rules                   # self rules signal (consumed by heartbeat)
 
 <network-root>/<avatar-name>/     # sibling of the parent
   init.json                       # rewritten copy of parent's init.json
   settings/psyche.json            # base/covenant inheritance + spawn comment
   .prompt                         # first-turn brief (parent identity + reasoning), consumed once
-  .rules                          # distributed rules signal
   logs/spawn.stderr               # captured child stderr for boot diagnosis
   logs/agent.log                  # rotating stdlib logging (boot + runtime warnings)
   .lingtai-derived-child.json     # Driver-derived child state only
-  knowledge/ exports/ combo.json  # deep mode only (system/ also has deep state)
+  knowledge/ exports/ combo.json  # deep mode only (system/ also has deep state,
+                                   # including system/rules.md if the parent had one —
+                                   # ordinary deep copy, not an Avatar-owned write)
 ```
+
+`<parent>/system/rules.md` and `<parent>/.rules` / `<avatar>/.rules` are real,
+unchanged kernel state (`src/lingtai/kernel/base_agent/lifecycle.py`) that
+Avatar simply no longer writes to at spawn or through a dedicated action — see
+contract_version 9 and `psyche-manual`.
 
 The avatar's `init.json` is a deep copy of the parent's with: `agent_name` set,
 `lingtai` seed blanked, `admin` cleared, all six inert legacy prompt fields and
@@ -320,9 +337,7 @@ position, not precedence over later sections. The spawn brief is delivered
 out-of-band via the `.prompt` signal file, not the `lingtai` seed.
 
 Each spawn appends a ledger record (`event: "avatar"`, `name`, `working_dir`,
-`mission`, `type`, `pid`, `boot_status`, optional `boot_error`). Rules
-distribution walks the ledger tree (cycle-guarded) and writes `.rules` to each
-live descendant.
+`mission`, `type`, `pid`, `boot_status`, optional `boot_error`).
 
 ## Cross-platform launcher contract
 
@@ -394,28 +409,27 @@ live descendant.
 | The mission-quality gate rejects empty/short/placeholder missions | `src/lingtai/tools/avatar/__init__.py` | `tests/test_layers_avatar.py::test_helper_rejects_empty`, `::test_helper_rejects_short`, `::test_helper_rejects_test_word`, `::test_helper_rejects_test_prefix` |
 | Unsafe / duplicate avatar names are rejected | `src/lingtai/tools/avatar/__init__.py` | `tests/test_layers_avatar.py::test_spawn_rejects_unsafe_name`, `::test_spawn_duplicate_name_error` |
 | Shallow spawn does not copy identity files | `src/lingtai/tools/avatar/__init__.py` | `tests/test_layers_avatar.py::test_spawn_does_not_copy_identity_files` |
-| `action="rules"` requires admin and non-empty content; `spawn` does not inherit that gate | `src/lingtai/tools/avatar/__init__.py` | `tests/test_avatar_rules.py::test_rules_requires_admin`, `::test_rules_requires_content`; `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_spawn_does_not_inherit_rules_permission_gate` |
+| `action="rules"` is a retired action: it now fails with the same unknown-action envelope as any other unrecognized value, for admin and non-admin callers alike, and writes no `.rules` file | `src/lingtai/tools/avatar/__init__.py` | `tests/test_avatar_rules.py::TestAvatarRulesActionRemoved::test_rules_is_an_unknown_action`; `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_rules_action_is_unknown_regardless_of_admin` |
 | `action="settings"` is immediately before `manual`, returns the exact 16 five-field fixed-policy rows, points to owner-manual anchors, excludes private/runtime/auth/handoff state, accepts no writer input or environment peer, and fails as one bounded result | `src/lingtai/tools/avatar/settings.py`, `src/lingtai/tools/avatar/__init__.py` | `tests/test_tool_family_avatar_migration.py::test_avatar_settings_inventory_is_exact_fresh_and_excludes_private_state`, `::test_avatar_settings_is_show_only_and_has_no_environment_peer`, `::test_avatar_settings_provider_failure_is_one_bounded_result`; `tests/test_tool_settings_contract.py` |
-| Rules are distributed recursively to descendants (cycle-safe) | `src/lingtai/tools/avatar/__init__.py` | `tests/test_avatar_rules.py::test_rules_distributes_recursively`, `::test_rules_root_not_duplicated_via_cycle` |
-| Spawning distributes existing rules to the newborn | `src/lingtai/tools/avatar/__init__.py` | `tests/test_avatar_rules.py::test_spawn_distributes_existing_rules`, `::test_spawn_deep_clone_also_gets_rules_signal` |
+| Spawn no longer performs an automatic rules-distribution side effect (shallow or deep); ordinary deep-copy of `system/` — including any `system/rules.md` it carries — is unaffected | `src/lingtai/tools/avatar/__init__.py` | `tests/test_avatar_rules.py::TestSpawnNoAutoRulesDistribution::test_shallow_spawn_no_longer_writes_a_rules_signal`, `::test_deep_spawn_still_copies_rules_md_but_writes_no_signal` |
 | `_prepare_deep` refuses a non-sibling destination | `src/lingtai/tools/avatar/__init__.py` | `tests/test_layers_avatar.py::test_prepare_deep_refuses_non_sibling_dst` |
-| `action="manual"` returns the exact packaged manual body and mutates nothing | `src/lingtai/tools/avatar/__init__.py` | `tests/test_tool_family_avatar_migration.py::test_avatar_manager_uses_only_granted_ports_for_local_manual_and_rules`, `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_manual_returns_exact_body_and_performs_no_mutation` |
+| `action="manual"` returns the exact packaged manual body and mutates nothing | `src/lingtai/tools/avatar/__init__.py` | `tests/test_tool_family_avatar_migration.py::test_avatar_manager_uses_only_granted_ports_for_local_manual`, `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_manual_returns_exact_body_and_performs_no_mutation` |
 | Invalid `action` fails deterministically without touching other actions | `src/lingtai/tools/avatar/__init__.py` | `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_invalid_action_fails_deterministically`, `::test_spawn_missing_name_fails_without_affecting_other_actions` |
-| `action` is schema-required (root `required: ["action", "input", "reasoning"]`) and runtime-required — a missing `action` never defaults to `spawn`, `rules`, `settings`, or `manual`, regardless of which action's fields are present, and mutates nothing | `src/lingtai/tools/avatar/__init__.py` | `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_missing_action_fails_deterministically_regardless_of_payload_shape`; `tests/test_avatar_rules.py::TestAvatarRulesAction::test_explicit_spawn_action_required` |
+| `action` is schema-required (root `required: ["action", "input", "reasoning"]`) and runtime-required — a missing `action` never defaults to `spawn`, `settings`, or `manual`, regardless of which action's fields are present, and mutates nothing | `src/lingtai/tools/avatar/__init__.py` | `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_missing_action_fails_deterministically_regardless_of_payload_shape`; `tests/test_avatar_rules.py::TestAvatarRulesActionRemoved::test_explicit_spawn_action_required` |
 | The daemon blacklists the canonical `avatar` name (not the retired two-tool names) | `src/lingtai/tools/daemon/__init__.py` | `tests/test_daemon.py::test_build_tool_surface_blacklist`, `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_daemon_excludes_avatar_from_child_surface` |
 
 ## Verification matrix
 
 | Invariant | Automated test | Manual check | Risk if broken |
 |---|---|---|---|
-| Exactly one official tool mounts on setup | `tests/test_tool_family_avatar_migration.py::test_agent_mounts_avatar_only_through_the_official_registrar` | Boot with `capabilities={"avatar": {}}` and inspect tools | Rules distribution or spawning silently unavailable |
+| Exactly one official tool mounts on setup | `tests/test_tool_family_avatar_migration.py::test_agent_mounts_avatar_only_through_the_official_registrar` | Boot with `capabilities={"avatar": {}}` and inspect tools | Spawning silently unavailable |
 | Spawn is ledgered with boot status | `tests/test_layers_avatar.py::test_ledger_records_spawn` | Spawn an avatar, inspect `delegates/ledger.jsonl` | No audit trail; duplicate/liveness checks break |
 | Mission gate stops accidental spawns | `tests/test_layers_avatar.py::test_helper_rejects_short` | `avatar(action="spawn", input={"name": "x"}, reasoning="short")` with a 5-char mission, confirm gate | Stray detached processes from batched calls |
 | Name validation / path-scope guard holds | `tests/test_layers_avatar.py::test_spawn_rejects_unsafe_name` | Spawn with `name="../x"`, confirm refusal | Avatar dir escapes the network root |
 | Boot verification catches early child exit | `tests/test_avatar_launcher.py::test_manager_boot_policy_uses_opaque_port_and_preserves_precedence` | Corrupt an avatar `init.json`, spawn, confirm `failed` + stderr | Parent thinks a crashed avatar is alive |
 | Omitted `action` never defaults to spawn | `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_missing_action_fails_deterministically_regardless_of_payload_shape` | Call `avatar(input={"name": "x", "confirm": true}, reasoning="...")` with no `action`, confirm error + no spawned process | A model omitting `action` could accidentally spawn an untracked process |
-| Rules propagate to the whole subtree | `tests/test_avatar_rules.py::test_rules_distributes_recursively` | Set rules on a root, confirm `.rules` on each descendant | Descendants run stale/ungoverned rules |
-| `manual` action is read-only | `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_manual_returns_exact_body_and_performs_no_mutation` | Call `avatar(action="manual", input={}, reasoning="...")`, confirm no new files | A "manual" call could accidentally spawn or mutate rules |
+| `action="rules"` and its automatic post-spawn fan-out are gone; no `.rules` is ever written by Avatar | `tests/test_avatar_rules.py::TestAvatarRulesActionRemoved::test_rules_is_an_unknown_action`, `tests/test_avatar_rules.py::TestSpawnNoAutoRulesDistribution::test_shallow_spawn_no_longer_writes_a_rules_signal` | Spawn a child from a parent with `system/rules.md`, confirm no `.rules` appears | Reintroducing a broadcast without the removed authorization gate would silently widen exposure |
+| `manual` action is read-only | `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_manual_returns_exact_body_and_performs_no_mutation` | Call `avatar(action="manual", input={}, reasoning="...")`, confirm no new files | A "manual" call could accidentally spawn |
 | Settings SHOW is exact, fresh, bounded, read-only, and excludes private state | `tests/test_tool_family_avatar_migration.py` settings tests plus `tests/test_tool_settings_contract.py` | Call settings with `{}` and a set-shaped input; inspect exact fields/order/manual targets and no source mutation | A writer, stale result, partial inventory, or host-state leak could drift from the owner contract |
 
 Run before merging avatar changes:

--- a/src/lingtai/tools/avatar/__init__.py
+++ b/src/lingtai/tools/avatar/__init__.py
@@ -19,9 +19,14 @@ Usage (LTP v2 envelope — one action, one strict child input):
     Agent(capabilities=["avatar"])
     # avatar(action="spawn", input={"name": "researcher"}, reasoning="...")
     # avatar(action="spawn", input={"name": "clone", "type": "deep"}, reasoning="...")
-    # avatar(action="rules", input={"rules_content": "..."}, reasoning="...")
     # avatar(action="settings", input={}, reasoning="...")
     # avatar(action="manual", input={}, reasoning="...")
+
+Avatar no longer owns a rules-distribution action or an automatic post-spawn
+rules fan-out; the shared `.rules` heartbeat signal/consumer described in
+`src/lingtai/kernel/base_agent/lifecycle.py` is unchanged, and any agent may
+still write a `.rules` file to an explicitly targeted path (e.g. via `shell`).
+See `psyche-manual` for that protocol.
 
 The spawn mission brief is root ``reasoning`` (normalized to ``_reasoning`` by
 ToolExecutor), never an ``input`` property — see ``handle()``.
@@ -175,37 +180,18 @@ _SPAWN_INPUT_SCHEMA: dict[str, Any] = {
     "additionalProperties": False,
 }
 
-_RULES_INPUT_SCHEMA: dict[str, Any] = {
-    "type": "object",
-    "properties": {
-        "rules_content": {
-            "type": "string",
-            "description": (
-                "Plain text, one rule per line. Non-negotiable constraints "
-                "distributed to self and all descendants. Requires karma."
-            ),
-        },
-    },
-    "required": ["rules_content"],
-    "additionalProperties": False,
-}
-
 # Avatar's own action registry. The reserved ``manual`` child is appended by
 # this module's official declaration rather than being an operational action.
 _DECLARED_CHILD_SPECS: tuple[tuple[str, dict[str, Any]], ...] = (
     ("spawn", _SPAWN_INPUT_SCHEMA),
-    ("rules", _RULES_INPUT_SCHEMA),
 )
 
 _DESCRIPTION = (
-    "Spawn an independent agent (他我), set network rules for descendants, "
-    "inventory Avatar settings, or read the avatar manual. Requires an "
-    "explicit action — no default. "
+    "Spawn an independent agent (他我), inventory Avatar settings, or read "
+    "the avatar manual. Requires an explicit action — no default. "
     "avatar(action='spawn', input={'name': 'researcher', ...}, "
     "reasoning='<the avatar's mission>'): inherits init.json, boots on "
     "default preset; your reasoning becomes the avatar's first prompt. "
-    "avatar(action='rules', input={'rules_content': '...'}, reasoning='...'): "
-    "distribute rules to self + all descendants (requires karma). "
     "avatar(action='settings', input={}, reasoning='...'): show immutable "
     "defaults, constraints, and lifecycle policy. "
     "avatar(action='manual', input={}, reasoning='...'): return the "
@@ -342,7 +328,6 @@ class AvatarManager:
         self._family = _build_family(
             {
                 "spawn": self._dispatch_spawn,
-                "rules": self._dispatch_rules,
             }
         )
         self._pending_reasoning: str | None = None
@@ -407,9 +392,6 @@ class AvatarManager:
 
     def _dispatch_spawn(self, action_input: Mapping[str, Any]) -> dict:
         return self._spawn(self._strip_nulls(action_input), self._pending_reasoning)
-
-    def _dispatch_rules(self, action_input: Mapping[str, Any]) -> dict:
-        return self._rules(self._strip_nulls(action_input))
 
     # ------------------------------------------------------------------
     # Ledger (append-only JSONL log of avatar spawn events)
@@ -699,16 +681,6 @@ class AvatarManager:
                     "agent_name": peer_name,
                     "pid": pid,
                 }
-
-        # Auto-distribute rules to all descendants (including newborn) — read from canonical system/rules.md
-            parent_rules_md = parent_working_dir / "system" / "rules.md"
-            if parent_rules_md.is_file():
-                try:
-                    rules_content = parent_rules_md.read_text(encoding="utf-8")
-                except OSError:
-                    rules_content = ""
-                if rules_content.strip():
-                    self._distribute_rules_to_descendants(rules_content, parent_working_dir)
 
             result = {
                 "status": "ok",
@@ -1056,113 +1028,6 @@ class AvatarManager:
                 except json.JSONDecodeError:
                     continue
         return records
-
-    # ------------------------------------------------------------------
-    # Rules distribution
-    # ------------------------------------------------------------------
-
-    def _rules(self, args: dict) -> dict:
-        """Set rules and distribute via .rules signal files to self + descendants.
-
-        Self and descendants are handled uniformly: a `.rules` signal file is
-        written to every agent directory in the subtree (including the caller's
-        own). Each agent's heartbeat loop (`_check_rules_file`) then consumes
-        the signal, diffs it against `system/rules.md`, and refreshes its own
-        system prompt if the content changed. The caller's own prompt refresh
-        happens on its next heartbeat tick (within ~1s).
-        """
-        parent_working_dir = self._host.workdir.path
-        content = args.get("rules_content", "").strip()
-        if not content:
-            return {"error": "rules_content is required"}
-
-        # The host decides the existing any-admin-value rule once and exposes
-        # only this action-specific authorization bit to the plugin.
-        if not self._host.avatar_parent.has_rule_privilege():
-            return {"error": "Not authorized — admin privilege required to set rules"}
-
-        # Write .rules signal to self — heartbeat will consume and persist
-        try:
-            (parent_working_dir / ".rules").write_text(content, encoding="utf-8")
-        except OSError as e:
-            return {"error": f"failed to write .rules signal: {e}"}
-
-        # Write .rules signal file to all descendants
-        distributed = self._distribute_rules_to_descendants(content, parent_working_dir)
-
-        # Include self in the reported distribution for transparency
-        return {
-            "status": "ok",
-            "message": f"Rules set; signal written to self and {len(distributed)} descendant(s).",
-            "distributed_to": [parent_working_dir.name] + distributed,
-        }
-
-    @staticmethod
-    def _walk_avatar_tree(root: Path) -> list[Path]:
-        """Recursively collect all descendant working-dir Paths from ledger files.
-
-        Ledger entries store relative names (e.g. 'researcher'); we resolve each
-        against the *parent agent's parent directory* since avatars live as
-        siblings in .lingtai/. Returns absolute Paths of live descendant dirs.
-        """
-        from lingtai.kernel.handshake import resolve_address
-
-        visited: set[str] = {str(Path(root))}
-        queue: list[Path] = [Path(root)]
-        result: list[Path] = []
-
-        while queue:
-            current = queue.pop(0)
-            ledger_path = current / "delegates" / "ledger.jsonl"
-            if not ledger_path.is_file():
-                continue
-            try:
-                lines = ledger_path.read_text(encoding="utf-8").splitlines()
-            except OSError:
-                continue
-            # Siblings of `current` live in current.parent
-            base_dir = current.parent
-            for line in lines:
-                if not line.strip():
-                    continue
-                try:
-                    record = json.loads(line)
-                except json.JSONDecodeError:
-                    continue
-                if record.get("event") != "avatar":
-                    continue
-                wd = record.get("working_dir", "")
-                if not wd:
-                    continue
-                # Resolve relative name to absolute Path
-                child_dir = resolve_address(wd, base_dir)
-                key = str(child_dir)
-                if key in visited:
-                    continue
-                if not child_dir.is_dir():
-                    continue  # dead avatar, directory gone
-                visited.add(key)
-                result.append(child_dir)
-                queue.append(child_dir)
-
-        return result
-
-    def _distribute_rules_to_descendants(self, content: str, root: Path) -> list[str]:
-        """Write `.rules` signal file to every descendant in the avatar tree.
-
-        Returns the list of descendant directory names that were successfully written.
-        Failures are silently swallowed (caller has no visibility), consistent with
-        the best-effort, idempotent design of signal files.
-        """
-        distributed: list[str] = []
-        for child_dir in self._walk_avatar_tree(root):
-            try:
-                (child_dir / ".rules").write_text(content, encoding="utf-8")
-                distributed.append(child_dir.name)
-            except OSError:
-                pass
-        return distributed
-
 
 def setup(agent: "BaseAgent", **_ignored) -> AvatarManager:
     """Register Avatar through the official declared-host-plugin route."""

--- a/src/lingtai/tools/avatar/glossary-wen.md
+++ b/src/lingtai/tools/avatar/glossary-wen.md
@@ -16,7 +16,7 @@ maintenance: |
 **名相对照**
 
 - `avatar`：唯一公开之器，以 `action` 分遣，每遣各有严整自专之 `input`。详见 avatar-manual 技。
-- `action`：必填，无默认。`spawn`（化出独立他我，承 init.json，以默认预设启）｜`rules`（设网法以布一切后嗣，需 karma）｜`settings`（唯读，以五栏列 Avatar 之定默认与策）｜`manual`（只读，还 avatar 手册全文及其 `manual_path`）。
+- `action`：必填，无默认。`spawn`（化出独立他我，承 init.json，以默认预设启）｜`settings`（唯读，以五栏列 Avatar 之定默认与策）｜`manual`（只读，还 avatar 手册全文及其 `manual_path`）。Avatar 已无 `rules` 之遣；网法之协见于 psyche-manual。
 - `input`：必填，乃所遣一动作自专之严封之器。他遣分支之名，未及动手之先即斥。
 - `reasoning`：必填，居根，非动作之入。`action=spawn` 时即任务之书，为他我第一言。
 - `summarize`：可选，居根之布尔，默然为否。惟司果之后治，终不入动作之实。
@@ -25,4 +25,3 @@ maintenance: |
 - `input.comment`：他我提示之恒注（跨蜕/刷/眠不去）。不承自父。无事勿填。
 - `input.dry_run`：预览而不化。用于提交前省察。
 - `input.confirm`：确认已审任务且决意化。任务空/短/似试时必填。
-- `input.rules_content`：action=rules 所需法则之文。纯文每行一则。不可议之约束，布一切后嗣。

--- a/src/lingtai/tools/avatar/glossary-zh.md
+++ b/src/lingtai/tools/avatar/glossary-zh.md
@@ -16,7 +16,7 @@ maintenance: |
 **术语对照**
 
 - `avatar`：唯一公开工具，以 `action` 分派，每个动作各有严格独立的 `input`。详见 avatar-manual 技能。
-- `action`：必填，无默认值。`spawn`（化出独立他我，继承 init.json，用默认预设启动）｜`rules`（设置网络法则并分发给所有后代，需 karma）｜`settings`（只读，以五字段列出 Avatar 的固定默认值与策略）｜`manual`（只读，返回 avatar 手册全文及其 `manual_path`）。
+- `action`：必填，无默认值。`spawn`（化出独立他我，继承 init.json，用默认预设启动）｜`settings`（只读，以五字段列出 Avatar 的固定默认值与策略）｜`manual`（只读，返回 avatar 手册全文及其 `manual_path`）。Avatar 已无 `rules` 动作；网络法则协议详见 psyche-manual。
 - `input`：必填，为所选 `action` 独有之严格封闭对象。属于他动作分支之字段一律在任何写入前拒斥。
 - `reasoning`：必填，根层字段，非动作输入。`action=spawn` 时即为任务书，成为他我第一道提示。
 - `summarize`：可选，根层布尔，默认为否。仅作结果后处理之开关，永不传入动作实现。
@@ -25,4 +25,3 @@ maintenance: |
 - `input.comment`：写入他我系统提示之持久注解（跨凝蜕/刷新/休眠不变）。不承自父。非必要勿填。
 - `input.dry_run`：预览化出而不生进程。用于提交前审查。
 - `input.confirm`：确认已审阅任务并决意化出。任务空白/过短/似试时必填。
-- `input.rules_content`：action=rules 所需之法则内容。纯文，每行一则。不可协商之约束，分发一切后代。

--- a/src/lingtai/tools/avatar/manual/SKILL.md
+++ b/src/lingtai/tools/avatar/manual/SKILL.md
@@ -2,8 +2,8 @@
 name: avatar-manual
 description: |
   Complete operational guide for the avatar tool — spawning, managing, and communicating with 他我 (alter-ego agents). Read this when: you are about to spawn an avatar; an avatar you spawned goes quiet; you need to decide between avatar, daemon, or bash; or you are an avatar and need to know how to escalate to your parent. Covers spawn types, naming rules, discipline, escalation protocol, and the parent_prompt contract.
-version: 1.2.0
-last_changed_at: 2026-08-29T00:00:00Z
+version: 1.3.0
+last_changed_at: 2026-09-04T00:00:00Z
 related_files:
 - src/lingtai/tools/avatar/__init__.py
 - src/lingtai/tools/avatar/settings.py
@@ -11,6 +11,8 @@ related_files:
 - src/lingtai/tools/avatar/CONTRACT.md
 - src/lingtai/tools/CONTRACT.md
 - src/lingtai/kernel/prompt.py
+- src/lingtai/kernel/base_agent/lifecycle.py
+- src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
 maintenance: |
   Tracks the routed source/resources it summarizes; update when the underlying capability or its sub-references change.
 ---
@@ -19,24 +21,24 @@ maintenance: |
 
 ## 0. How to Call `avatar`
 
-One tool, four actions, each with its own strict `input` object:
+One tool, three actions, each with its own strict `input` object:
 
 ```
 avatar(action="spawn",  input={"name": "researcher"},        reasoning="<mission briefing>")
 avatar(action="spawn",  input={"name": "clone", "type": "deep"}, reasoning="<mission briefing>")
-avatar(action="rules",  input={"rules_content": "..."},      reasoning="why these rules")
 avatar(action="settings", input={},                           reasoning="inventory Avatar policy")
 avatar(action="manual", input={},                            reasoning="load avatar guidance")
 ```
 
 - `action` is **required** — there is no default. Omitting it never spawns.
 - `input` is **required** and closed. `spawn` owns `name`, `type`, `comment`,
-  `dry_run`, `confirm`; `rules` owns `rules_content`; `settings` and `manual`
-  each take only `{}`.
+  `dry_run`, `confirm`; `settings` and `manual` each take only `{}`.
   Putting one action's field in another's `input` is rejected before anything
-  happens — no process, no ledger entry, no `.rules` write.
+  happens — no process, no ledger entry.
 - `reasoning` is **required** and lives at the root, never inside `input`. For
   `spawn` it *is* the mission briefing (see §4).
+- Avatar has no `rules` action. Network rules (`.rules`) are a separate,
+  unchanged kernel mechanism — see §9.
 
 **Settings:** `avatar` has no settings file at either the family or action
 level and reads no `LINGTAI_AVATAR_*` environment variable. The read-only
@@ -44,7 +46,7 @@ level and reads no `LINGTAI_AVATAR_*` environment variable. The read-only
 does not make them mutable.
 
 **`summarize` (short-result profile).** Every action here returns a small
-result — a spawn receipt, a distribution list, or a manual body you asked for
+result — a spawn receipt, a settings inventory, or a manual body you asked for
 verbatim. `summarize` is available but normally unnecessary: leave it false.
 Keep it false for `manual` in particular, so exact procedure and constraints
 are not summarized away, and for `spawn`, whose receipt carries the address,
@@ -210,21 +212,20 @@ The `input.comment` field (spawn only) is a persistent system-level note injecte
 
 Leave empty unless you have something the avatar should never forget.
 
-## 9. Network Rules (`avatar(action="rules", input={"rules_content": ...})`)
+## 9. Network Rules — see `psyche-manual`
 
-The `rules` action writes a `.rules` file to your directory and distributes it to **all descendants** in the avatar tree. Properties:
+Avatar does **not** own a rules action or an automatic post-spawn rules
+fan-out. Spawning an avatar (shallow or deep) never distributes rules to it
+or to any other descendant on your behalf.
 
-- Requires **karma** privilege (admin)
-- Rules are injected into the system prompt (after covenant, before tools)
-- Persist across molts
-- Plain text — one rule per line
-- These are **non-negotiable constraints**, not suggestions
-
-Example:
-```
-Always report findings via email.
-Do not spawn more than 3 avatars.
-```
+`.rules` is a real, unchanged mechanism, but it is not an Avatar capability:
+any agent may write a `.rules` file directly (e.g. with `shell`) to its own
+directory, or to another agent's directory it can explicitly reach, and that
+agent's own heartbeat applies it to `system/rules.md` and its protected
+prompt section. Read `psyche-manual` for the complete protocol — the
+replacement/empty/no-op/no-flush semantics, how to verify canonical vs.
+effective rules, and how this differs from an ordinary Psyche source edit
+plus `context.rebuild`.
 
 ## Cleanup / Footprint
 

--- a/src/lingtai/tools/tool_family/ANATOMY.md
+++ b/src/lingtai/tools/tool_family/ANATOMY.md
@@ -190,7 +190,9 @@ pre-migration unknown-action result.
 `avatar/__init__.py` ([`../avatar/ANATOMY.md`](../avatar/ANATOMY.md)) is the
 sixth real consumer, and shows partial adoption is conforming: it reuses
 `ChildTool`/`ToolFamily` and the exported `MANUAL_INPUT_SCHEMA` for
-`spawn`/`rules`/`settings`/`manual` schema composition and dispatch. Its
+`spawn`/`settings`/`manual` schema composition and dispatch (the former
+`rules` child was removed, not relocated — see avatar CONTRACT.md
+contract_version 9). Its
 declaration opts into the generic settings child with the no-I/O provider from
 `avatar/settings.py`, while its operational actions remain one
 `_DECLARED_CHILD_SPECS` source and its public listing derives from the

--- a/src/lingtai/tools/tool_family/BEHAVIORS.md
+++ b/src/lingtai/tools/tool_family/BEHAVIORS.md
@@ -1,6 +1,6 @@
 ---
 name: tool-family-behavior-tests
-behavior_version: 4
+behavior_version: 5
 labt_version: 2
 contract: CONTRACT.md
 anatomy: ANATOMY.md
@@ -40,7 +40,8 @@ LABT v1. These are self-contained agent-executable behavioral tests for the
 families built on the generic `src/lingtai/tools/tool_family/` infrastructure.
 They prove the *observable* promises of the family contracts this package
 serves: the `file` read/write/edit surface and its fail-closed envelope, the
-`avatar` spawn/rules/settings/manual migration envelope, the reserved `manual` child's
+`avatar` spawn/settings/manual envelope (and the absence of the retired
+`rules` action), the reserved `manual` child's
 canonical result contract (no double wrap), the `psyche` five-manual router
 plus redacted Pad settings (pad + lingtai + knowledge + skills = psyche), `mcp` identity
 discovery with secret-safe projection, and `email` abs-mode reply routing with
@@ -241,8 +242,8 @@ tree untouched.
    `avatar(input={"name": "x", "confirm": true}, reasoning="...")` with the
    `action` key omitted entirely.
 6. Call `avatar(action="spawn", input={"name": "x", "rules_content": "no"},
-   reasoning="a genuine mission brief, long enough to pass")` (a key from the
-   `rules` branch smuggled into spawn input) and then
+   reasoning="a genuine mission brief, long enough to pass")` (an unknown key
+   — `rules_content` names no current avatar action's input) and then
    `avatar(action="spawn", input={"name": "x", "confirm": true},
    reasoning="...", summarize="yes")`.
 7. Call `avatar(action="manual", input={}, reasoning="...")`; record
@@ -266,11 +267,11 @@ tree untouched.
       created (names must match `^[\w-]+$`, be ≤64 chars, with no dot, slash,
       or leading `.`).
 - [ ] Step 5 returns exactly `{"error": "unknown action: 'bogus', only
-      'spawn', 'rules', 'settings', or 'manual' is supported"}` and `{"error":
-      "unknown action: '', only 'spawn', 'rules', 'settings', or 'manual' is
+      'spawn', 'settings', or 'manual' is supported"}` and `{"error":
+      "unknown action: '', only 'spawn', 'settings', or 'manual' is
       supported"}` for the
       omitted case — no spawn, no ledger, no process.
-- [ ] Step 6: the cross-action key fails with `{"status": "failed",
+- [ ] Step 6: the unknown key fails with `{"status": "failed",
       "error_code": "INVALID_ARGUMENT", "message": "unsupported avatar input
       field"}` before any I/O, and `summarize: "yes"` fails with
       `INVALID_ARGUMENT` before any spawn.
@@ -286,50 +287,49 @@ name is accepted, `action`-less payload is inferred as `spawn`, or the
 manual result is wrapped. Forbidden side effect: any failed spawn must leave
 no avatar dir, no ledger record, and no live process.
 
-## Behavior T005 — avatar rules gate: authorization and distribution
+## Behavior T005 — avatar has no rules action or automatic rules fan-out
 
 - **id**: T005
-- **title**: `avatar` rules requires admin.karma, writes the `.rules` signal,
-  and distributes to the caller — with cross-action keys rejected before
-  authorization
-- **guards**: `avatar-contract` § Tool surface — rules
+- **title**: `avatar` owns no `rules` action and performs no automatic
+  post-spawn rules broadcast; `.rules` is unaffected as a separate, unchanged
+  heartbeat mechanism
+- **guards**: `avatar-contract` § Tool surface — contract_version 9
   ([CONTRACT.md](../avatar/CONTRACT.md#tool-surface))
-- **supersedes**: `tests/test_tool_family_avatar_migration.py` (rules tests);
-  the no-admin refusal path stays covered by
-  `tests/test_avatar_rules.py::test_rules_requires_admin`
+- **supersedes**: `tests/test_avatar_rules.py::TestAvatarRulesActionRemoved`,
+  `::TestSpawnNoAutoRulesDistribution`;
+  `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_rules_action_is_unknown_regardless_of_admin`
 - **runner**: an agent with the `avatar` capability whose `admin` block
   includes at least one truthy privilege (e.g. `admin: {"karma": true}`)
-- **prerequisites**: `<wd>` writable; no `<wd>/.rules` file before the run
+- **prerequisites**: `<wd>` writable; no `<wd>/.rules` file before the run;
+  `<wd>/system/rules.md` pre-populated with some content
 - **estimate**: 1 min
 
 ### Steps
-1. Call `avatar(action="rules", input={"rules_content": "   "},
-   reasoning="...")` (whitespace-only content) and check whether
-   `<wd>/.rules` exists.
-2. Call `avatar(action="rules", input={"rules_content": "Be concise.",
-   "name": "helper"}, reasoning="...")` (a spawn-branch key smuggled into
-   rules input), then check `<wd>/.rules` again.
-3. Call `avatar(action="rules", input={"rules_content": "Be concise."},
-   reasoning="...")`; read `<wd>/.rules` and the returned `distributed_to`.
-4. Call `avatar(action="manual", input={}, reasoning="...")` once more and
-   list `<wd>` before/after to confirm no spawn or rules side effect.
+1. Call `avatar(action="rules", input={"rules_content": "Be concise."},
+   reasoning="...")` and check whether `<wd>/.rules` exists.
+2. Call `avatar(action="spawn", input={"name": "helper", "confirm": true},
+   reasoning="a genuine mission brief, long enough to pass")`; check the new
+   sibling directory for a `.rules` file.
+3. Call `avatar(action="manual", input={}, reasoning="...")` once more and
+   list `<wd>` before/after to confirm no spawn or filesystem side effect.
 
 ### Expected evidence
-- [ ] Step 1 returns an `error` (empty `rules_content`) and no `.rules` file
-      was written.
-- [ ] Step 2 returns `{"status": "failed", "error_code": "INVALID_ARGUMENT",
-      "message": "unsupported avatar input field"}` and no `.rules` file was
-      written (rejected before the authorization check and before any write).
-- [ ] Step 3 returns `{"status": "ok", "message": ..., "distributed_to":
-      [<your agent name>]}` and `<wd>/.rules` contains exactly `Be concise.`
-- [ ] Step 4: the manual result is the same no-I/O flat shape as T004 step 7
+- [ ] Step 1 returns avatar's ordinary unknown-action error (see T004 step 5's
+      exact string) regardless of the caller's admin karma, and no `<wd>/.rules`
+      file is written.
+- [ ] Step 2: the spawn succeeds, but the newborn sibling directory has no
+      `.rules` file even though `<wd>/system/rules.md` was pre-populated
+      (shallow spawn never copies `system/` at all; deep spawn's ordinary
+      copy of `system/` is a separate, unaffected mechanism — not exercised
+      by this step).
+- [ ] Step 3: the manual result is the same no-I/O flat shape as T004 step 7
       and the file listing is unchanged.
 
 ### Pass / Fail
-Pass when every evidence item holds. Fail if rules are written without
-content, a cross-action key passes dispatch, or the `.rules` self signal is
-missing on success. Forbidden side effect: a rejected rules call must write
-no `.rules` file and no ledger record.
+Pass when every evidence item holds. Fail if `action="rules"` performs any
+write, or if a spawn writes a `.rules` file to the newborn. Forbidden side
+effect: this behavior must not observe any `.rules` file appear anywhere as
+a result of an `avatar` call.
 
 ## Behavior T006 — manual action contract: canonical result, no double wrap
 

--- a/src/lingtai/tools/tool_family/CONTRACT.md
+++ b/src/lingtai/tools/tool_family/CONTRACT.md
@@ -287,9 +287,10 @@ knowledge's exact pre-migration unknown-action result.
 `avatar/__init__.py` is the fourth production Adapter/consumer to touch this
 contract (after `file` and `vision`, which adopt this package per
 `../CONTRACT.md` without a dedicated Adapter paragraph here):
-`AvatarManager.__init__` builds a per-instance `ToolFamily` with
-`spawn`/`rules` handlers bound to that instance, the generic `settings` child
-bound to the static no-I/O `AvatarSettingsProvider`, and Avatar's local
+`AvatarManager.__init__` builds a per-instance `ToolFamily` with a `spawn`
+handler bound to that instance (the former `rules` handler was removed, not
+relocated — avatar CONTRACT.md contract_version 9), the generic `settings`
+child bound to the static no-I/O `AvatarSettingsProvider`, and Avatar's local
 `manual` handler. `settings` is injected immediately before `manual`, and
 `AvatarManager.handle()` calls `self._family.handle(args)`. It is a deliberate
 **partial** adoption, which this package permits: `avatar` reuses `ChildTool`

--- a/tests/test_avatar_rules.py
+++ b/tests/test_avatar_rules.py
@@ -148,35 +148,20 @@ class TestRulesHeartbeatWatch:
 
 
 
-class TestAvatarRulesAction:
-    """Test avatar_rules distribution."""
+class TestAvatarRulesActionRemoved:
+    """Avatar no longer owns a dedicated rules-distribution action.
 
-    def test_rules_requires_admin(self, tmp_path):
-        """Non-admin agent cannot set rules."""
-        from lingtai.agent import Agent
+    Option B (see avatar CONTRACT.md contract_version 9): the admin-gated
+    `action="rules"` child and its fan-out were removed entirely rather than
+    replaced by a new guard. `.rules` remains a real, unchanged heartbeat
+    signal (see ``TestRulesHeartbeatWatch`` above and ``psyche-manual``); any
+    agent may still write one to an explicitly targeted path itself (e.g. via
+    `shell`), but Avatar performs no such write and enforces no privilege
+    check for it.
+    """
 
-        agent = Agent(
-            service=make_mock_service(),
-            agent_name="worker",
-            working_dir=tmp_path / "worker",
-            capabilities=["avatar"],
-            admin={},
-        )
-        mgr = agent.get_capability("avatar")
-        result = mgr.handle({
-            "action": "rules",
-            "input": {"rules_content": "No deleting."},
-        })
-        assert "error" in result
-
-    def test_rules_writes_self_signal_then_heartbeat_persists(self, tmp_path):
-        """Admin should write .rules signal to self; heartbeat persists to system/rules.md.
-
-        After calling _rules(), the caller's own directory has a .rules signal file.
-        The prompt section and system/rules.md are NOT updated synchronously — they're
-        applied by the caller's own heartbeat loop on its next tick. This test simulates
-        one heartbeat tick via _check_rules_file() to verify the end-to-end path.
-        """
+    def test_rules_is_an_unknown_action(self, tmp_path):
+        """action='rules' now fails the same way as any other unknown action."""
         from lingtai.agent import Agent
 
         agent = Agent(
@@ -191,124 +176,13 @@ class TestAvatarRulesAction:
             "action": "rules",
             "input": {"rules_content": "Always log actions."},
         })
-        assert result["status"] == "ok"
-
-        # .rules signal file was written to self (not yet consumed)
-        assert (agent._working_dir / ".rules").read_text() == "Always log actions."
-        # Canonical file and prompt section NOT yet updated — heartbeat hasn't ticked
-        assert not (agent._working_dir / "system" / "rules.md").is_file()
-        assert agent._prompt_manager.read_section("rules") is None
-
-        # Simulate one heartbeat tick
-        agent._check_rules_file()
-
-        # Now canonical file and prompt section are updated
-        assert (agent._working_dir / "system" / "rules.md").read_text() == "Always log actions."
-        assert agent._prompt_manager.read_section("rules") == "Always log actions."
-        # Signal consumed
-        assert not (agent._working_dir / ".rules").is_file()
-
-    def test_rules_distributes_signals_to_descendants(self, tmp_path):
-        """Rules should write .rules signal files to all descendant directories.
-
-        IMPORTANT: As of v0.5.13, the ledger stores relative directory names
-        (e.g. 'child_a'), not absolute paths. Descendants live as siblings of
-        the parent agent in the same `.lingtai/` directory.
-        """
-        from lingtai.agent import Agent
-
-        # All agents are siblings under tmp_path (mimicking .lingtai/ layout)
-        parent_dir = tmp_path / "parent"
-        child_a_dir = tmp_path / "child_a"
-        child_b_dir = tmp_path / "child_b"
-        child_a_dir.mkdir(parents=True)
-        child_b_dir.mkdir(parents=True)
-
-        parent = Agent(
-            service=make_mock_service(),
-            agent_name="parent",
-            working_dir=parent_dir,
-            capabilities=["avatar"],
-            admin={"karma": True},
-        )
-
-        # Write ledger entries with RELATIVE names (current convention)
-        ledger_dir = parent_dir / "delegates"
-        ledger_dir.mkdir(parents=True, exist_ok=True)
-        ledger_path = ledger_dir / "ledger.jsonl"
-        with open(ledger_path, "w") as f:
-            f.write(json.dumps({"event": "avatar", "name": "a", "working_dir": "child_a"}) + "\n")
-            f.write(json.dumps({"event": "avatar", "name": "b", "working_dir": "child_b"}) + "\n")
-
-        mgr = parent.get_capability("avatar")
-        result = mgr.handle({
-            "action": "rules",
-            "input": {"rules_content": "No external API calls."},
-        })
-        assert result["status"] == "ok"
-        # Self + descendants uniformly get .rules signal files
-        assert (parent_dir / ".rules").read_text() == "No external API calls."
-        assert (child_a_dir / ".rules").read_text() == "No external API calls."
-        assert (child_b_dir / ".rules").read_text() == "No external API calls."
-        # distributed_to reports relative names for self + descendants
-        assert set(result["distributed_to"]) == {"parent", "child_a", "child_b"}
-
-    def test_rules_distributes_recursively(self, tmp_path):
-        """Rules should propagate to grandchildren (avatars of avatars).
-
-        All three agents are siblings under tmp_path. The ledger records use
-        relative names; resolution happens against the parent's parent dir.
-        """
-        from lingtai.agent import Agent
-
-        parent_dir = tmp_path / "parent"
-        child_dir = tmp_path / "child"
-        grandchild_dir = tmp_path / "grandchild"
-        for d in (parent_dir, child_dir, grandchild_dir):
-            d.mkdir(parents=True)
-
-        parent = Agent(
-            service=make_mock_service(),
-            agent_name="parent",
-            working_dir=parent_dir,
-            capabilities=["avatar"],
-            admin={"karma": True},
-        )
-
-        # Parent → child ledger (relative name "child")
-        p_ledger = parent_dir / "delegates" / "ledger.jsonl"
-        p_ledger.parent.mkdir(parents=True, exist_ok=True)
-        p_ledger.write_text(json.dumps({"event": "avatar", "name": "child", "working_dir": "child"}) + "\n")
-
-        # Child → grandchild ledger (relative name "grandchild")
-        c_ledger = child_dir / "delegates" / "ledger.jsonl"
-        c_ledger.parent.mkdir(parents=True, exist_ok=True)
-        c_ledger.write_text(json.dumps({"event": "avatar", "name": "gc", "working_dir": "grandchild"}) + "\n")
-
-        mgr = parent.get_capability("avatar")
-        result = mgr.handle({
-            "action": "rules",
-            "input": {"rules_content": "Be concise."},
-        })
-        assert result["status"] == "ok"
-        # All descendants get .rules signal files
-        assert (child_dir / ".rules").read_text() == "Be concise."
-        assert (grandchild_dir / ".rules").read_text() == "Be concise."
-
-    def test_rules_requires_content(self, tmp_path):
-        """avatar_rules without rules_content should error."""
-        from lingtai.agent import Agent
-
-        agent = Agent(
-            service=make_mock_service(),
-            agent_name="admin",
-            working_dir=tmp_path / "admin",
-            capabilities=["avatar"],
-            admin={"karma": True},
-        )
-        mgr = agent.get_capability("avatar")
-        result = mgr.handle({"action": "rules", "input": {}})
-        assert "error" in result
+        assert result == {
+            "error": (
+                "unknown action: 'rules', only 'spawn', 'settings', "
+                "or 'manual' is supported"
+            ),
+        }
+        assert not (agent._working_dir / ".rules").exists()
 
     def test_explicit_spawn_action_required(self, tmp_path):
         """action='spawn' must be explicit; omitting action must NOT spawn.
@@ -345,7 +219,7 @@ class TestAvatarRulesAction:
             omitted = mgr.handle({"name": "child", "confirm": True})
             assert "error" in omitted
             assert omitted["error"] == (
-                "unknown action: '', only 'spawn', 'rules', 'settings', "
+                "unknown action: '', only 'spawn', 'settings', "
                 "or 'manual' is supported"
             )
             launch.assert_not_called()
@@ -357,58 +231,14 @@ class TestAvatarRulesAction:
         assert result["agent_name"] == "child"
         assert result["address"] == "child"  # relative name (current convention)
 
-    def test_rules_root_not_duplicated_via_cycle(self, tmp_path):
-        """Cycles through root should not cause root to appear twice in distributed_to.
+class TestSpawnNoAutoRulesDistribution:
+    """Avatar's post-spawn automatic rules fan-out is removed (Option B).
 
-        The caller's own directory is included once (via the explicit self-write).
-        _walk_avatar_tree seeds its visited set with root so that cycles pointing
-        back to root from any descendant don't produce a duplicate entry.
-        """
-        from lingtai.agent import Agent
-
-        parent_dir = tmp_path / "parent"
-        child_dir = tmp_path / "child"
-        child_dir.mkdir(parents=True)
-
-        parent = Agent(
-            service=make_mock_service(),
-            agent_name="parent",
-            working_dir=parent_dir,
-            capabilities=["avatar"],
-            admin={"karma": True},
-        )
-
-        # parent → child
-        p_ledger = parent_dir / "delegates" / "ledger.jsonl"
-        p_ledger.parent.mkdir(parents=True, exist_ok=True)
-        p_ledger.write_text(json.dumps({"event": "avatar", "name": "child", "working_dir": "child"}) + "\n")
-
-        # child → parent (malicious cycle pointing back to root)
-        c_ledger = child_dir / "delegates" / "ledger.jsonl"
-        c_ledger.parent.mkdir(parents=True, exist_ok=True)
-        c_ledger.write_text(json.dumps({"event": "avatar", "name": "parent", "working_dir": "parent"}) + "\n")
-
-        mgr = parent.get_capability("avatar")
-        result = mgr.handle({
-            "action": "rules",
-            "input": {"rules_content": "Cycle test."},
-        })
-        assert result["status"] == "ok"
-        # Both self and child receive .rules signals
-        assert (parent_dir / ".rules").read_text() == "Cycle test."
-        assert (child_dir / ".rules").read_text() == "Cycle test."
-        # 'parent' appears exactly once in distributed_to (from self-write,
-        # not duplicated by the BFS walk through the cycle)
-        assert result["distributed_to"].count("parent") == 1
-        assert "child" in result["distributed_to"]
-
-
-class TestAutoDistributeAfterSpawn:
-    """After avatar_spawn, parent's rules should be distributed to newborn.
-
-    These tests mock _launch to avoid actually spawning subprocesses, and
-    pre-create the parent's init.json so the spawn code path can proceed
-    to ledger append and rules distribution.
+    Ordinary deep-copy behavior is unchanged: a deep clone still gets
+    `system/rules.md` because `_prepare_deep` copies the whole `system/`
+    tree, exactly as before. What is gone is the dedicated read-canonical-
+    then-write-`.rules`-signal step that used to run after every successful
+    spawn — shallow or deep — regardless of copy mode.
     """
 
     def _setup_spawnable_parent(self, tmp_path, with_rules: bool):
@@ -432,8 +262,8 @@ class TestAutoDistributeAfterSpawn:
             (system_dir / "rules.md").write_text("Always be concise.")
         return parent, parent_dir
 
-    def test_spawn_distributes_existing_rules(self, tmp_path):
-        """If parent has system/rules.md, spawning should write .rules to new avatar."""
+    def test_shallow_spawn_no_longer_writes_a_rules_signal(self, tmp_path):
+        """Even with a canonical system/rules.md, a shallow spawn writes no .rules."""
         parent, parent_dir = self._setup_spawnable_parent(tmp_path, with_rules=True)
 
         mgr = parent.get_capability("avatar")
@@ -441,27 +271,13 @@ class TestAutoDistributeAfterSpawn:
             result = mgr.handle({"action": "spawn", "input": {"name": "child", "confirm": True}})
         assert result["status"] == "ok"
 
-        # Child dir is a sibling of parent_dir (avatar_working_dir = parent.parent / name)
         child_dir = parent_dir.parent / "child"
-        # Child gets .rules signal file (heartbeat will consume and persist it)
-        assert (child_dir / ".rules").read_text() == "Always be concise."
+        assert not (child_dir / ".rules").exists()
+        # Shallow spawn never copies system/ at all — unaffected by this change.
+        assert not (child_dir / "system" / "rules.md").exists()
 
-    def test_spawn_without_rules_no_distribution(self, tmp_path):
-        """If parent has no system/rules.md, spawn should not create .rules in child."""
-        parent, parent_dir = self._setup_spawnable_parent(tmp_path, with_rules=False)
-
-        mgr = parent.get_capability("avatar")
-        with _patch_avatar_launch():
-            result = mgr.handle({"action": "spawn", "input": {"name": "child", "confirm": True}})
-        assert result["status"] == "ok"
-
-        child_dir = parent_dir.parent / "child"
-        assert not (child_dir / ".rules").is_file()
-
-    def test_spawn_deep_clone_also_gets_rules_signal(self, tmp_path):
-        """Deep clone already has system/rules.md from _prepare_deep,
-        but auto-distribute still writes .rules (redundant but harmless —
-        the heartbeat will diff and skip)."""
+    def test_deep_spawn_still_copies_rules_md_but_writes_no_signal(self, tmp_path):
+        """Deep copy of system/ (unchanged) supplies rules.md; no .rules signal is added."""
         parent, parent_dir = self._setup_spawnable_parent(tmp_path, with_rules=True)
 
         mgr = parent.get_capability("avatar")
@@ -470,10 +286,10 @@ class TestAutoDistributeAfterSpawn:
         assert result["status"] == "ok"
 
         clone_dir = parent_dir.parent / "clone"
-        # system/rules.md was copied by _prepare_deep
+        # Ordinary deep copy of system/ is preserved.
         assert (clone_dir / "system" / "rules.md").read_text() == "Always be concise."
-        # .rules signal was also written (redundant but harmless)
-        assert (clone_dir / ".rules").read_text() == "Always be concise."
+        # No dedicated .rules signal is written anymore.
+        assert not (clone_dir / ".rules").exists()
 
 
 class TestSpawnNameValidation:

--- a/tests/test_layers_avatar.py
+++ b/tests/test_layers_avatar.py
@@ -636,9 +636,9 @@ class TestMissionQualityGate:
         """The dry_run/confirm gates stay model-visible after the LTP v2 migration.
 
         Under the action-separated envelope they live inside the ``spawn``
-        branch of ``input.anyOf`` (and ``rules_content`` inside the ``rules``
-        branch) rather than at the root, but they must still be declared with
-        their gate types so the model can actually reach them.
+        branch of ``input.anyOf`` rather than at the root, but they must still
+        be declared with their gate types so the model can actually reach
+        them.
         """
         from lingtai.tools.avatar import get_schema
         sch = get_schema("en")
@@ -648,10 +648,10 @@ class TestMissionQualityGate:
         assert spawn_props["dry_run"]["type"] == ["boolean", "null"]
         assert "confirm" in spawn_props
         assert spawn_props["confirm"]["type"] == ["boolean", "null"]
-        assert "rules_content" in branches["rules input"]["properties"]
+        assert "rules input" not in branches
         assert sch["required"] == ["action", "input", "reasoning"]
         assert sch["properties"]["action"]["enum"] == [
-            "spawn", "rules", "settings", "manual"
+            "spawn", "settings", "manual"
         ]
 
     def test_description_points_to_avatar_manual_after_prompt_compaction(self):
@@ -729,7 +729,9 @@ class TestAddCapability:
 
 
 class TestUnifiedAvatarTool:
-    """Regression coverage for the avatar_spawn + avatar_rules → avatar merge."""
+    """Regression coverage for the avatar_spawn + avatar_rules → avatar merge,
+    and for the later removal of the ``rules`` action and its automatic
+    post-spawn fan-out (Option B)."""
 
     def test_schema_is_ltp_v2_action_separated_envelope(self):
         """The root is exactly the LTP v2 envelope, not the old flat object.
@@ -747,9 +749,9 @@ class TestUnifiedAvatarTool:
         assert sch["additionalProperties"] is False
         assert sch["properties"]["action"]["type"] == "string"
         assert sch["properties"]["action"]["enum"] == [
-            "spawn", "rules", "settings", "manual"
+            "spawn", "settings", "manual"
         ]
-        assert len(sch["properties"]["input"]["anyOf"]) == 4
+        assert len(sch["properties"]["input"]["anyOf"]) == 3
 
     def test_spawn_dispatch_preserves_behavior_and_reasoning(self, tmp_path, fake_avatar_launch):
         """action='spawn' preserves outputs and _reasoning → first-prompt propagation."""
@@ -767,28 +769,31 @@ class TestUnifiedAvatarTool:
         prompt_path = parent._working_dir.parent / "helper" / ".prompt"
         assert "Investigate the heartbeat regression" in prompt_path.read_text(encoding="utf-8")
 
-    def test_rules_dispatch_preserves_admin_gate_and_content_validation(self, tmp_path):
-        """action='rules' keeps admin gate + non-empty content validation."""
+    def test_rules_action_is_unknown_regardless_of_admin(self, tmp_path):
+        """action='rules' no longer exists — it fails for admin and non-admin alike."""
         from lingtai.agent import Agent
         no_admin = Agent(service=make_mock_service(), agent_name="worker",
                           working_dir=tmp_path / "worker", capabilities=["avatar"], admin={})
         mgr = no_admin.get_capability("avatar")
         result = mgr.handle({"action": "rules", "input": {"rules_content": "No deleting."}})
         assert "error" in result
+        assert not (no_admin._working_dir / ".rules").exists()
 
         admin = Agent(service=make_mock_service(), agent_name="admin",
                        working_dir=tmp_path / "admin", capabilities=["avatar"],
                        admin={"karma": True})
         mgr2 = admin.get_capability("avatar")
-        empty_result = mgr2.handle({"action": "rules", "input": {"rules_content": ""}})
-        assert "error" in empty_result
+        admin_result = mgr2.handle({"action": "rules", "input": {"rules_content": "Be concise."}})
+        assert admin_result == {
+            "error": (
+                "unknown action: 'rules', only 'spawn', 'settings', "
+                "or 'manual' is supported"
+            ),
+        }
+        assert not (admin._working_dir / ".rules").exists()
 
-        ok_result = mgr2.handle({"action": "rules", "input": {"rules_content": "Be concise."}})
-        assert ok_result["status"] == "ok"
-        assert (admin._working_dir / ".rules").read_text() == "Be concise."
-
-    def test_spawn_does_not_inherit_rules_permission_gate(self, tmp_path, fake_avatar_launch):
-        """A non-admin agent can still spawn — the rules admin gate must not leak into spawn."""
+    def test_spawn_never_required_admin(self, tmp_path, fake_avatar_launch):
+        """A non-admin agent can spawn — unaffected by the rules action's removal."""
         from lingtai.agent import Agent
         no_admin = Agent(service=make_mock_service(), agent_name="worker",
                           working_dir=tmp_path / "worker", capabilities=["avatar"], admin={})
@@ -819,7 +824,7 @@ class TestUnifiedAvatarTool:
         assert not (parent._working_dir / ".rules").exists()
 
     def test_daemon_excludes_avatar_from_child_surface(self, tmp_path):
-        """The daemon's emanation blacklist covers the new canonical 'avatar' name only."""
+        """The daemon's emanation blacklist covers the canonical 'avatar' name only."""
         from lingtai.tools.daemon import EMANATION_BLACKLIST
         assert "avatar" in EMANATION_BLACKLIST
         assert "avatar_spawn" not in EMANATION_BLACKLIST
@@ -846,11 +851,11 @@ class TestUnifiedAvatarTool:
                         admin={"karma": True})
         mgr = parent.get_capability("avatar")
         expected_error = (
-            "unknown action: '', only 'spawn', 'rules', 'settings', "
+            "unknown action: '', only 'spawn', 'settings', "
             "or 'manual' is supported"
         )
 
-        # Payload shaped like a valid rules call, but action omitted.
+        # Payload shaped like a formerly-valid rules call, but action omitted.
         rules_shaped = mgr.handle({"rules_content": "Be concise."})
         assert rules_shaped["error"] == expected_error
         assert rules_shaped.get("status") != "ok"
@@ -879,9 +884,6 @@ class TestUnifiedAvatarTool:
         spawn_result = mgr.handle({"action": "spawn", "input": {}})
         assert "error" in spawn_result
         assert "name is required" in spawn_result["error"]
-
-        rules_result = mgr.handle({"action": "rules", "input": {"rules_content": "Be concise."}})
-        assert rules_result["status"] == "ok"
 
         manual_result = mgr.handle({"action": "manual", "input": {}})
         assert manual_result["status"] == "ok"

--- a/tests/test_tool_family_avatar_migration.py
+++ b/tests/test_tool_family_avatar_migration.py
@@ -34,14 +34,10 @@ class _Workdir:
 
 class _AvatarParent:
     def __init__(
-        self, *, name: str = "parent", venv_path: str | None = None, rules: bool = False
+        self, *, name: str = "parent", venv_path: str | None = None
     ) -> None:
         self.parent_name = name
         self.venv_path = venv_path
-        self._rules = rules
-
-    def has_rule_privilege(self) -> bool:
-        return self._rules
 
     def authorize_derived_launch(self, _capability):
         from lingtai.kernel.provider_admission import (
@@ -57,12 +53,12 @@ class _Launcher:
         return None
 
 
-def _host(parent_dir: Path, *, rules: bool = False, venv_path: str | None = None):
+def _host(parent_dir: Path, *, venv_path: str | None = None):
     return ToolPluginHost.grant(
         avatar.DECLARATION,
         {
             "workdir": _Workdir(parent_dir),
-            "avatar_parent": _AvatarParent(venv_path=venv_path, rules=rules),
+            "avatar_parent": _AvatarParent(venv_path=venv_path),
         },
     )
 
@@ -81,8 +77,8 @@ def test_avatar_declaration_is_static_and_matches_its_composed_public_surface():
     declaration = avatar.DECLARATION
 
     assert declaration.name == "avatar"
-    assert declaration.actions == ("spawn", "rules")
-    assert declaration.public_actions == ("spawn", "rules", "settings", "manual")
+    assert declaration.actions == ("spawn",)
+    assert declaration.public_actions == ("spawn", "settings", "manual")
     assert declaration.settings is True
     assert declaration.requires == ("workdir", "avatar_parent")
     assert declaration.name in OFFICIAL_TOOL_PLUGIN_NAMES
@@ -105,7 +101,6 @@ def test_avatar_settings_inventory_is_exact_fresh_and_excludes_private_state(
             "avatar_parent": _AvatarParent(
                 name=private_parent,
                 venv_path=private_runtime,
-                rules=True,
             ),
         },
     )
@@ -292,7 +287,7 @@ def test_avatar_settings_provider_failure_is_one_bounded_result():
         raise RuntimeError("private provider detail")
 
     family = avatar._build_family(
-        {"spawn": lambda _input: {}, "rules": lambda _input: {}},
+        {"spawn": lambda _input: {}},
         settings_provider=unavailable,
     )
 
@@ -303,7 +298,7 @@ def test_avatar_settings_provider_failure_is_one_bounded_result():
     }
 
 
-def test_avatar_manager_uses_only_granted_ports_for_local_manual_and_rules(tmp_path):
+def test_avatar_manager_uses_only_granted_ports_for_local_manual(tmp_path):
     parent_dir = _parent_dir(tmp_path)
     host = _host(parent_dir)
     manager = AvatarManager(host, launcher=_Launcher())
@@ -323,13 +318,18 @@ def test_avatar_manager_uses_only_granted_ports_for_local_manual_and_rules(tmp_p
     assert sorted(path.name for path in parent_dir.iterdir()) == before
 
     denied = manager({"action": "rules", "input": {"rules_content": "No deleting."}})
-    assert denied == {"error": "Not authorized — admin privilege required to set rules"}
+    assert denied == {
+        "error": (
+            "unknown action: 'rules', only 'spawn', 'settings', "
+            "or 'manual' is supported"
+        ),
+    }
     assert not (parent_dir / ".rules").exists()
 
 
-def test_avatar_spawn_preserves_workdir_identity_venv_and_rules_control(tmp_path, monkeypatch):
+def test_avatar_spawn_preserves_workdir_identity_and_venv(tmp_path, monkeypatch):
     parent_dir = _parent_dir(tmp_path)
-    host = _host(parent_dir, rules=True, venv_path="/parent/runtime")
+    host = _host(parent_dir, venv_path="/parent/runtime")
     manager = AvatarManager(host, launcher=_Launcher())
     receipt = AvatarLaunchReceipt(pid=4242, handle=object())
     monkeypatch.setattr(manager, "_launch", lambda working_dir, **_kwargs: (receipt, working_dir / "stderr"))
@@ -356,11 +356,8 @@ def test_avatar_spawn_preserves_workdir_identity_venv_and_rules_control(tmp_path
     assert spawned["status"] == "ok"
     assert "parent" in (child_dir / ".prompt").read_text(encoding="utf-8")
     assert json.loads((child_dir / "init.json").read_text(encoding="utf-8"))["venv_path"] == "/parent/runtime"
-
-    rules = manager({"action": "rules", "input": {"rules_content": "Be concise."}})
-    assert rules["distributed_to"] == ["parent", "child"]
-    assert (parent_dir / ".rules").read_text(encoding="utf-8") == "Be concise."
-    assert (child_dir / ".rules").read_text(encoding="utf-8") == "Be concise."
+    # No automatic .rules fan-out after spawn (Option B).
+    assert not (child_dir / ".rules").exists()
 
 
 @pytest.mark.parametrize("avatar_type", ["shallow", "deep"])


### PR DESCRIPTION
## Summary

Thin Avatar's public surface without retiring the `.rules` capability:

- Remove `avatar(action="rules")`, its `rules_content` schema/dispatch, and the now-unused rules-privilege port.
- Remove the rules-specific automatic broadcast after successful spawn and the unused descendant-distribution helpers.
- Preserve the existing `.rules` heartbeat consumer, `system/rules.md` persistence and prompt injection, and ordinary deep-copy behavior. A deep clone can still carry `system/rules.md` through the existing whole-`system/` copy; Avatar no longer writes a separate `.rules` signal.
- Route Avatar's manual to Psyche's manual, which explains explicitly authorized Shell writes, complete-replacement semantics, heartbeat application, and verification. No new Psyche action, settings key, or generic Instruction API.
- Update the affected contracts, manual/glossary references, and narrow regression tests.

**Breaking surface change:** the removed action now returns Avatar's ordinary unknown-action error. Its former admin check is removed with the action, not relocated into a new guard. Shell/file access follows the existing command/filesystem/authorization boundaries; the unchanged signal consumer does not authenticate its writer.

## Validation

Parent validation used an existing Python 3.11 project venv from this isolated worktree, without installing packages or changing the live agent runtime. `PY` below denotes that interpreter and `TASK_TMP` denotes task-local validation scratch.

```sh
"$PY" -m pytest -q --basetemp "$TASK_TMP/pytest" \
  tests/test_avatar_rules.py tests/test_layers_avatar.py \
  tests/test_tool_family_avatar_migration.py tests/test_avatar_launcher.py \
  tests/test_avatar_preset_inheritance.py tests/test_avatar_timezone_inheritance.py \
  tests/test_tool_plugin_declaration.py tests/test_tool_settings_contract.py \
  tests/test_psyche_family.py tests/test_architecture_documents.py \
  tests/test_docs_governance.py
# 303 passed in 28.71s

"$PY" scripts/check_docs_governance.py --check
# OK: 375 documents (+ docs.yaml itself) validated.

"$PY" -c "import sys,runpy; sys.path.insert(0,'src'); sys.argv=['lingtai.tools.glossary_validator','--check']; runpy.run_module('lingtai.tools.glossary_validator',run_name='__main__')"
# OK: 63 glossary resources across 21 packages validated.

git diff --check
# PASS
```

Additional checks:
- The unchanged consumer (`kernel/base_agent/lifecycle.py`), renderer (`kernel/prompt.py`), and `prompts/rules/rules.yaml` match the base commit byte-for-byte.
- `TestRulesHeartbeatWatch` is preserved byte-for-byte and passed in the real pytest run.
- The documented POSIX temporary-file → rename example produced exact UTF-8 content in a task-owned test directory; no live agent's rules were changed.
- The Anatomy drift checker reports **3 existing findings**, with output identical to the clean base `07a429c5`: one `soul/config.py` citation and two nudge citations. This PR does not fix unrelated baseline drift.

The implementation worker initially ran documentation checks and a hand-written harness, not pytest. The results above are the subsequent independent parent runs; the worker harness is not presented as a substitute for pytest.

Not run: the full repository suite, native Windows live validation, release/package build, or live runtime refresh. No merge or deployment is included.

## Independent review

The requested GLM-5.2 review failed before any model response because the provider reported insufficient balance/resource package; it produced no verdict. A separate native Codex/Luna (`gpt-5.6-luna`, high, read-only sandbox, MCP disabled) reviewed the frozen candidate. It requested corrections to two current action inventories that omitted retained `settings`, and noted one stale distribution-list description. The parent corrected those documentation-only findings and reran the affected documentation gates; production and test diffs are unchanged from the reviewed patch. No post-fix model approval is claimed.

## Scope

This implements the selected option B: Avatar exits both the dedicated rules action and post-spawn automatic broadcast. It does **not** delete the rules prompt section or signal consumer, alter ordinary deep cloning, introduce Instruction API refactoring, or clean up existing agent files.

Telegram: @lingtaidev2bot | Nickname: 观一
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
