### PR TITLE
docs(soul): progressively disclose flow and consultation guidance

### DIFF
--- a/src/lingtai/tools/soul/ANATOMY.md
+++ b/src/lingtai/tools/soul/ANATOMY.md
@@ -13,6 +13,9 @@ related_files:
   - src/lingtai/tools/soul/glossary-wen.md
   - src/lingtai/tools/soul/CONTRACT.md
   - src/lingtai/tools/soul/manual/SKILL.md
+  - src/lingtai/tools/soul/manual/reference/flow.md
+  - src/lingtai/tools/soul/manual/reference/configuration.md
+  - src/lingtai/tools/soul/manual/reference/consultation.md
   - src/lingtai/kernel/tool_plugin/ANATOMY.md
   - src/lingtai/kernel/tool_plugin/CONTRACT.md
   - src/lingtai/adapters/tool_plugin_host.py

--- a/src/lingtai/tools/soul/CONTRACT.md
+++ b/src/lingtai/tools/soul/CONTRACT.md
@@ -9,6 +9,9 @@ related_files:
   - src/lingtai/tools/soul/config.py
   - src/lingtai/tools/soul/settings.py
   - src/lingtai/tools/soul/manual/SKILL.md
+  - src/lingtai/tools/soul/manual/reference/flow.md
+  - src/lingtai/tools/soul/manual/reference/configuration.md
+  - src/lingtai/tools/soul/manual/reference/consultation.md
   - src/lingtai/kernel/tool_plugin/CONTRACT.md
   - src/lingtai/adapters/tool_plugin_host.py
   - src/lingtai/agent.py

--- a/src/lingtai/tools/soul/__init__.py
+++ b/src/lingtai/tools/soul/__init__.py
@@ -188,18 +188,12 @@ def _handle_flow(runtime) -> dict:
             "enabled": False,
             "env_var": SOUL_FLOW_ENABLED_ENV,
             "message": (
-                "Soul flow is disabled by default on this agent. It is "
-                "opt-in: set the environment variable "
+                "Soul flow is disabled (expected state; opt-in required). Set "
                 f"{SOUL_FLOW_ENABLED_ENV}=1 (also true/yes/on), then "
-                "refresh/restart, to enable periodic and voluntary "
-                "past-self consultation. delay_seconds is only the "
-                "cadence AFTER this opt-in — it is not an off switch, "
-                "and soul(action='config') does not enable flow. "
-                "inquiry, config, voice, and dismiss remain available "
-                "while flow is disabled. Do not retry flow blindly; the "
-                "operator must set the env var first. See soul-manual "
-                "skill for how to enable/disable, troubleshoot, and the "
-                "privacy/cost rationale."
+                "refresh/restart; config changes cadence only and cannot "
+                "enable flow. Do not retry flow blindly. inquiry, config, "
+                "voice, and dismiss remain available. See soul-manual for "
+                "the gate procedure and cost/privacy guidance."
             ),
         }
 
@@ -301,19 +295,16 @@ _DESCRIPTION = (
     "Soul is the agent's inner voice. Use one closed envelope: "
     "soul(action=..., input={...}, reasoning='why'). Actions are inquiry, flow, "
     "config, voice, dismiss, settings, and manual; each has strict action-local "
-    "input. inquiry is on-demand self-reflection and returns its voice in the "
-    "result. flow is mechanical, asynchronous periodic consultation: it is opt-in "
-    "and disabled by default until an operator sets "
-    "LINGTAI_SOUL_FLOW_ENABLED=1 (then refreshes). Disabled flow returns "
-    "status='disabled' before any work; it is expected state, so do not retry "
-    "until the operator changes the environment. config tunes cadence/count only "
-    "and cannot enable or disable flow; "
-    "voice reads or sets the flow-voice profile; dismiss clears its notification. "
-    "config sends both nullable knobs with at least one non-null; voice sends both "
-    "nullable fields, where null/null reads. settings is read-only and manual "
-    "returns the installed guide without a Soul operation. Flow reads current and "
-    "past-self context and may run 1+K LLM calls, so the opt-in protects cost and "
-    "privacy. Keep root summarize=false; see soul-manual for routed detail."
+    "input. inquiry is on-demand self-reflection; flow is mechanical, "
+    "asynchronous periodic consultation and is opt-in, disabled by default until "
+    "an operator sets LINGTAI_SOUL_FLOW_ENABLED=1 and refreshes. Disabled flow "
+    "returns status='disabled' before work; it is expected state, so do not retry "
+    "until the environment changes. config tunes cadence/count only and cannot "
+    "enable or disable flow; voice reads or sets the flow-voice profile; dismiss "
+    "clears its notification; settings is read-only; manual returns the installed "
+    "guide without Soul work. Flow reads current and past-self context and may "
+    "run 1+K LLM calls, so the opt-in protects cost and privacy. Keep root "
+    "summarize=false; see soul-manual for routed detail."
 )
 
 

--- a/src/lingtai/tools/soul/__init__.py
+++ b/src/lingtai/tools/soul/__init__.py
@@ -71,7 +71,7 @@ _INQUIRY_INPUT_SCHEMA: dict[str, Any] = {
     "properties": {
         "inquiry": {
             "type": "string",
-            "description": "Your self-inquiry — a question to yourself. Required for action='inquiry'. This is you asking yourself a question, not prompting someone else.",
+            "description": "Required non-empty question for on-demand self-reflection; the answer returns in the result, not as periodic flow.",
         },
     },
     "required": ["inquiry"],
@@ -99,13 +99,13 @@ _CONFIG_INPUT_SCHEMA: dict[str, Any] = {
         "delay_seconds": {
             "type": ["number", "null"],
             "minimum": SOUL_DELAY_MIN_SECONDS,
-            "description": "Wall-clock delay between soul flow fires, in seconds. This is ONLY the cadence AFTER soul flow is enabled via env LINGTAI_SOUL_FLOW_ENABLED=1 — it is NOT an off switch, and cannot itself enable/disable flow. If the env var is unset, soul flow is disabled entirely and NO fires occur regardless of this value. Soul flow is your periodic inner reflection — when enabled and the timer fires, past versions of yourself (from molt snapshots) and a stepped-back read of your current work speak to you as voices, surfacing patterns, blind spots, and perspective you might miss while busy. Pass null to leave it unchanged. Minimum 30s; lower for more frequent reflection (e.g. 300 = every 5 minutes; 7200 = every 2 hours). Setting it while flow is enabled cancels the currently-pending fire and restarts the timer on the new schedule. See soul-manual.",
+            "description": "Seconds between enabled flow fires; null leaves it unchanged. Cadence only: it cannot enable or disable flow. Minimum 30 seconds. See soul-manual/reference/configuration.md.",
         },
         "consultation_past_count": {
             "type": ["integer", "null"],
             "minimum": CONSULTATION_PAST_COUNT_MIN,
             "maximum": CONSULTATION_PAST_COUNT_MAX,
-            "description": "K — number of past-self voices sampled per fire. Pass null when not setting it. Each fire runs M=1+K parallel LLM calls (1 stepped-back diary reader + K random past-snapshot voices). Range [0, 5]. 0 = insights-only fires (cheapest, no past-self voices). Higher K is costlier per fire and fills more chat-history with voice content; lower K is faster and quieter. At least one of delay_seconds/consultation_past_count must be non-null.",
+            "description": "Past-self voices per fire (K); null leaves it unchanged. Each fire runs 1+K calls; range 0–5. At least one config value must be non-null. See soul-manual/reference/consultation.md.",
         },
     },
     "required": ["delay_seconds", "consultation_past_count"],
@@ -117,12 +117,12 @@ _VOICE_INPUT_SCHEMA: dict[str, Any] = {
     "properties": {
         "set": {
             "type": ["string", "null"],
-            "description": "Which voice profile to switch to. Built-ins: 'inner' (terse — 'you are the soul, speak as inner voice') or 'observer' (structured stepped-back hook framing). Or 'custom', which requires a 'prompt' field with your own system-prompt text. Pass null to read the current voice and resolved prompt without changing anything.",
+            "description": "Profile to read or set: inner, observer, or custom. Null reads the current resolved voice; custom requires prompt. See soul-manual/reference/configuration.md.",
         },
         "prompt": {
             "type": ["string", "null"],
             "maxLength": SOUL_VOICE_PROMPT_MAX,
-            "description": "Custom system prompt for soul-flow voice. Required when set='custom'; ignored otherwise. Length capped at 4000 characters. Speak to yourself as the soul — describe how you want to be framed when reading your own diary. The same prompt is used for both insights (current self) and past (frozen earlier self) consultations; the per-fire cue text differentiates whose diary you're reading.",
+            "description": "Custom flow-voice prompt; required with set='custom', ignored otherwise, and capped at 4000 characters. Null when not setting. See soul-manual/reference/configuration.md.",
         },
     },
     "required": ["set", "prompt"],
@@ -298,25 +298,22 @@ _DECLARED_INPUT_SCHEMAS: dict[str, dict[str, Any]] = {
 }
 
 _DESCRIPTION = (
-    "Your inner voice. One tool, seven actions, each with its own strict input "
-    "object: soul(action=..., input={...}, reasoning='why'). flow is OPT-IN "
-    "and DISABLED by default: it runs only when the operator sets env "
-    "LINGTAI_SOUL_FLOW_ENABLED=1 (then refreshes). While disabled, "
-    "soul(action='flow', input={}) returns status='disabled' (not an error — do not retry); inquiry/config/voice/dismiss still work. When enabled, "
-    "flow fires periodic past-self consultation every soul_delay seconds while "
-    "IDLE — M=1+K parallel LLM calls (1 stepped-back read of current chat + K "
-    "past-snapshot voices) arrive as an involuntary soul(action='flow') pair. "
-    "delay_seconds is only the cadence after opt-in, NOT an off switch, and no "
-    "action in this family can enable flow. inquiry: ask a deep copy of "
-    "yourself a question; answer returns in the tool result. config: tune flow "
-    "knobs at runtime (delay_seconds, consultation_past_count) — does not enable "
-    "flow. voice: read or choose how your own soul-flow voice sounds. dismiss: "
-    "clear the current flow notification. settings: show Soul's five current "
-    "settings without changing them. manual: return the installed "
-    "soul-manual skill without performing any soul operation. Results are "
-    "small, so leave root summarize false (short-result profile); call manual "
-    "with summarize=false so the exact procedure is not summarized away. See "
-    "soul-manual for details."
+    "Soul is the agent's inner voice. Use one closed envelope: "
+    "soul(action=..., input={...}, reasoning='why'). Actions are inquiry, flow, "
+    "config, voice, dismiss, settings, and manual; each has strict action-local "
+    "input. inquiry is on-demand self-reflection and returns its voice in the "
+    "result. flow is mechanical, asynchronous periodic consultation: it is opt-in "
+    "and disabled by default until an operator sets "
+    "LINGTAI_SOUL_FLOW_ENABLED=1 (then refreshes). Disabled flow returns "
+    "status='disabled' before any work; it is expected state, so do not retry "
+    "until the operator changes the environment. config tunes cadence/count only "
+    "and cannot enable or disable flow; "
+    "voice reads or sets the flow-voice profile; dismiss clears its notification. "
+    "config sends both nullable knobs with at least one non-null; voice sends both "
+    "nullable fields, where null/null reads. settings is read-only and manual "
+    "returns the installed guide without a Soul operation. Flow reads current and "
+    "past-self context and may run 1+K LLM calls, so the opt-in protects cost and "
+    "privacy. Keep root summarize=false; see soul-manual for routed detail."
 )
 
 

--- a/src/lingtai/tools/soul/manual/SKILL.md
+++ b/src/lingtai/tools/soul/manual/SKILL.md
@@ -2,7 +2,7 @@
 name: soul-manual
 description: |
   Read before calling `flow`, changing Soul configuration, or troubleshooting a disabled result; routes the seven-action call shape, settings anchors, and focused flow, configuration, and consultation references.
-version: 1.4.0
+version: 1.5.0
 last_changed_at: "2026-09-06T00:00:00Z"
 related_files:
 - src/lingtai/tools/soul/__init__.py
@@ -22,12 +22,12 @@ maintenance: |
 
 # Soul Manual
 
-`soul` is the agent's inner voice. Read this router before changing flow or
-configuration; `manual` remains directly callable with `input={}` and performs
-no Soul operation. The schema is the first-call summary; the references below
-hold the detailed procedures and rationale.
+`soul` is the agent's inner voice. `manual` is directly callable with
+`input={}` and performs no Soul operation. Use the action table below as the
+first-call router; the linked references own the detailed procedures and
+rationale.
 
-## Call shape
+## Actions and routes
 
 Use one closed envelope with `action`, that action's own `input`, and required
 `reasoning`:
@@ -36,79 +36,50 @@ Use one closed envelope with `action`, that action's own `input`, and required
 {"action":"inquiry","input":{"inquiry":"What am I avoiding?"},"reasoning":"check my blind spot"}
 ```
 
-| Action | First call data and meaning |
+| Action | First call and route |
 |---|---|
-| `inquiry` | `{"inquiry":"<non-empty question>"}`; on-demand reflection, answered in the result |
-| `flow` | `{}`; mechanical asynchronous consultation, not on-demand inquiry |
-| `config` | `{"delay_seconds": <number or null>, "consultation_past_count": <integer or null>}`; send both keys and at least one non-null |
-| `voice` | `{"set": <profile or null>, "prompt": <text or null>}`; send both keys; null/null reads |
-| `dismiss` | `{}`; clear only Soul's notification |
-| `settings` | `{}`; read-only five-row SHOW |
-| `manual` | `{}`; return this installed guide without Soul work |
+| `inquiry` | `{"inquiry":"<non-empty question>"}`; synchronous, on-demand reflection answered in the result. See [consultation mechanics](reference/consultation.md). |
+| `flow` | `{}`; asynchronous periodic consultation. It is operator opt-in; a disabled result is expected state, not a retry signal. See [flow and the opt-in gate](reference/flow.md). |
+| `config` | `{"delay_seconds": <number or null>, "consultation_past_count": <integer or null>}`; send both keys and at least one non-null. It tunes cadence/count only. See [configuration and voices](reference/configuration.md). |
+| `voice` | `{"set": <profile or null>, "prompt": <text or null>}`; send both keys; null/null reads. See [configuration and voices](reference/configuration.md). |
+| `dismiss` | `{}`; clear only Soul's notification. |
+| `settings` | `{}`; fresh, read-only five-row owner inventory. The stable comment anchors are below. See [configuration and voices](reference/configuration.md). |
+| `manual` | `{}`; return this installed guide without Soul work. |
 
-`input` is strict and action-local; fields from another action are rejected
-before handler I/O. `summarize` is a root-level boolean, not an input field.
-Soul results are small, so leave it `false`, especially for `manual` so exact
-instructions remain available.
-
-## Choose a path
-
-- **Need a deliberate answer now?** Use `inquiry`; it runs a synchronous mirror
-  session. It is independent of the periodic flow gate.
-- **Need mechanical periodic reflection?** Use `flow` only after an operator
-  opts in. Its disabled result is expected state, not an error: do not retry it
-  until the operator changes the environment and refreshes. Read
-  [flow and the opt-in gate](reference/flow.md).
-- **Need cadence or fan-out changes?** Use `config`; it persists knobs but can
-  never enable or disable flow. See [configuration and voices](reference/configuration.md).
-- **Need a flow voice profile?** Use `voice`; it reads or atomically sets
-  `inner`, `observer`, or `custom` (with a prompt). See the configuration
-  reference.
-- **Need to clear Soul's panel notice?** Use `dismiss`; it only clears the
-  `soul` channel.
-- **Need current owner truth?** Use `settings`; it never writes state and
-  returns exactly the five rows described below.
-
-Flow reads current chat and past-self snapshots and may run `1 + K` LLM calls,
-so it is opt-in for both cost and privacy. For its notification, history, and
-consultation-pair details, read [consultation mechanics](reference/consultation.md).
+`input` is strict and action-local; a field from another action is rejected
+before handler I/O. `summarize` is a root-level boolean, not child input; Soul
+results are small, so leave it `false`, especially for `manual`. Flow may read
+current and past-self context and run `1 + K` LLM calls, so its opt-in protects
+cost and privacy. For notification, history, and consultation-pair details,
+use [consultation mechanics](reference/consultation.md).
 
 ## Settings inventory anchors
 
 Each heading is the stable target of the corresponding `settings` row comment.
-For accepted values, source precedence, persistence, and change procedures,
-follow [configuration and voices](reference/configuration.md).
+The configuration reference owns accepted values, bounds, persistence, source
+owners, and change procedures.
 
 ### Flow enabled
 
-`flow_enabled` is false unless the operator sets
-`LINGTAI_SOUL_FLOW_ENABLED` to `1`, `true`, `yes`, or `on` (case-insensitive),
-then refreshes or restarts. The `settings` action cannot enable it.
+Live process gate; change it only in the launch environment, then refresh or
+restart. `settings` cannot enable it. See [flow and the opt-in gate](reference/flow.md).
 
 ### Delay seconds
 
-`delay_seconds` is the enabled-flow cadence in seconds, with a minimum of 30;
-`null` leaves it unchanged. It is not an off switch and has no effect while the
-environment gate is off.
+Enabled-flow cadence owned by `config`; it is not the gate. See [configuration
+and voices](reference/configuration.md).
 
 ### Consultation past count
 
-`consultation_past_count` is `K`, the number of past-self voices per fire, from
-0 through 5; `null` leaves it unchanged. Each fire fans out to `1 + K` calls.
+`K`, the past-self fan-out count, owned by `config`. See [configuration and
+voices](reference/configuration.md) and [consultation mechanics](reference/consultation.md).
 
 ### Voice
 
-`voice` selects `inner`, `observer`, or `custom`; null reads the current
-profile and resolved prompt. A built-in selection clears a stored custom prompt.
+Flow-voice profile state owned by the `voice` action. See [configuration and
+voices](reference/configuration.md).
 
 ### Voice prompt
 
-`voice_prompt` is the custom flow-voice system prompt, capped at 4000
-characters and shown redacted by `settings`. It is required for `custom` and is
-sensitive; use the authorized `voice` read mode for its actual resolved text.
-
-## Reference map
-
-- [Flow and opt-in gate](reference/flow.md) — accepted gate values, disabled/no-retry behavior, operator procedure, cadence, and cost/privacy rationale.
-- [Configuration and voices](reference/configuration.md) — nullable input rules, bounds, persistence, profiles, prompt sensitivity, and the five-row SHOW owner.
-- [Consultation mechanics](reference/consultation.md) — inquiry versus flow, fan-out, IDLE timing, snapshots, notifications, history pairs, and append-only records.
+Sensitive custom flow-voice text; `settings` redacts it. See [configuration and
+voices](reference/configuration.md).

--- a/src/lingtai/tools/soul/manual/SKILL.md
+++ b/src/lingtai/tools/soul/manual/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: soul-manual
 description: |
-  Read before calling `flow`, changing Soul configuration, or troubleshooting a `status: disabled` result; explains the seven-action call shape, opt-in gate, cadence, and consultation roles.
-version: 1.3.1
-last_changed_at: "2026-09-04T00:00:00Z"
+  Read before calling `flow`, changing Soul configuration, or troubleshooting a disabled result; routes the seven-action call shape, settings anchors, and focused flow, configuration, and consultation references.
+version: 1.4.0
+last_changed_at: "2026-09-06T00:00:00Z"
 related_files:
 - src/lingtai/tools/soul/__init__.py
 - src/lingtai/tools/soul/CONTRACT.md
@@ -12,236 +12,103 @@ related_files:
 - src/lingtai/tools/soul/config.py
 - src/lingtai/tools/soul/settings.py
 - src/lingtai/tools/soul/consultation.py
+- src/lingtai/tools/soul/manual/reference/flow.md
+- src/lingtai/tools/soul/manual/reference/configuration.md
+- src/lingtai/tools/soul/manual/reference/consultation.md
 - tests/test_soul_settings.py
 maintenance: |
-  Tracks the tool/capability behavior it teaches; update when that tool's behavior changes.
+  Tracks the tool/capability behavior it teaches; keep this short router and its focused references aligned with Soul's call, gate, settings, and consultation behavior.
 ---
 
 # Soul Manual
 
-`soul` is your inner voice. `inquiry`, `config`, `voice`, `dismiss`, `settings`,
-and `manual` are **always available**. `flow` is **opt-in and disabled by
-default**.
+`soul` is the agent's inner voice. Read this router before changing flow or
+configuration; `manual` remains directly callable with `input={}` and performs
+no Soul operation. The schema is the first-call summary; the references below
+hold the detailed procedures and rationale.
 
-## 0. How to call it
+## Call shape
 
-One tool, seven actions. Every call is `action` + that action's own strict `input`
-object + `reasoning`; another action's field is rejected before anything runs:
+Use one closed envelope with `action`, that action's own `input`, and required
+`reasoning`:
 
 ```json
-{"action": "inquiry", "input": {"inquiry": "What am I avoiding?"}, "reasoning": "check my own blind spot"}
+{"action":"inquiry","input":{"inquiry":"What am I avoiding?"},"reasoning":"check my blind spot"}
 ```
 
-| Action | `input` |
+| Action | First call data and meaning |
 |---|---|
-| `inquiry` | `{"inquiry": "<your question>"}` — required, non-empty |
-| `flow` | `{}` |
-| `config` | `{"delay_seconds": <num or null>, "consultation_past_count": <int or null>}` — both keys are sent; at least one value must be non-null |
-| `voice` | `{"set": <profile or null>, "prompt": <text or null>}` — both null = read |
-| `dismiss` | `{}` |
-| `settings` | `{}` — read-only; returns the five-field inventory below |
-| `manual` | `{}` |
+| `inquiry` | `{"inquiry":"<non-empty question>"}`; on-demand reflection, answered in the result |
+| `flow` | `{}`; mechanical asynchronous consultation, not on-demand inquiry |
+| `config` | `{"delay_seconds": <number or null>, "consultation_past_count": <integer or null>}`; send both keys and at least one non-null |
+| `voice` | `{"set": <profile or null>, "prompt": <text or null>}`; send both keys; null/null reads |
+| `dismiss` | `{}`; clear only Soul's notification |
+| `settings` | `{}`; read-only five-row SHOW |
+| `manual` | `{}`; return this installed guide without Soul work |
 
-Optional fields are declared nullable rather than omittable, so pass `null` for
-the ones you are not setting.
+`input` is strict and action-local; fields from another action are rejected
+before handler I/O. `summarize` is a root-level boolean, not an input field.
+Soul results are small, so leave it `false`, especially for `manual` so exact
+instructions remain available.
 
-**`summarize`** is a root-level boolean (never inside `input`). Soul's results
-are all small, and summarizing risks losing a voice's exact wording — leave it
-false, especially for `manual`.
+## Choose a path
 
-## Settings inventory
+- **Need a deliberate answer now?** Use `inquiry`; it runs a synchronous mirror
+  session. It is independent of the periodic flow gate.
+- **Need mechanical periodic reflection?** Use `flow` only after an operator
+  opts in. Its disabled result is expected state, not an error: do not retry it
+  until the operator changes the environment and refreshes. Read
+  [flow and the opt-in gate](reference/flow.md).
+- **Need cadence or fan-out changes?** Use `config`; it persists knobs but can
+  never enable or disable flow. See [configuration and voices](reference/configuration.md).
+- **Need a flow voice profile?** Use `voice`; it reads or atomically sets
+  `inner`, `observer`, or `custom` (with a prompt). See the configuration
+  reference.
+- **Need to clear Soul's panel notice?** Use `dismiss`; it only clears the
+  `soul` channel.
+- **Need current owner truth?** Use `settings`; it never writes state and
+  returns exactly the five rows described below.
 
-Call `soul(action="settings", input={}, reasoning="inspect Soul settings")` to
-read the current values. The action has no set/reset API and never writes the
-process environment or `init.json`. Every row has exactly `key`, `current`,
-`default`, `configurable`, and `comment`; each comment links back to one exact
-section below.
+Flow reads current chat and past-self snapshots and may run `1 + K` LLM calls,
+so it is opt-in for both cost and privacy. For its notification, history, and
+consultation-pair details, read [consultation mechanics](reference/consultation.md).
+
+## Settings inventory anchors
+
+Each heading is the stable target of the corresponding `settings` row comment.
+For accepted values, source precedence, persistence, and change procedures,
+follow [configuration and voices](reference/configuration.md).
 
 ### Flow enabled
 
-`flow_enabled` says whether periodic and voluntary Soul flow is currently
-enabled. The process gate accepts `1`, `true`, `yes`, or `on`
-(case-insensitive, surrounding whitespace ignored); anything else is false.
-The only source is the live process environment variable
-`LINGTAI_SOUL_FLOW_ENABLED`, with missing or unrecognized input falling back to
-the meaningful default `false`. SHOW rereads the same process value as the
-actual flow gate on every call. An authorized launcher/operator changes it by
-setting or unsetting that variable in the agent launch environment and then
-refreshing or restarting the agent; call SHOW again to verify. SHOW itself
-cannot enable flow.
+`flow_enabled` is false unless the operator sets
+`LINGTAI_SOUL_FLOW_ENABLED` to `1`, `true`, `yes`, or `on` (case-insensitive),
+then refreshes or restarts. The `settings` action cannot enable it.
 
 ### Delay seconds
 
-`delay_seconds` is the live cadence between enabled Soul-flow fires. The
-meaningful default is `999999999.0`. At boot the current value is hydrated from
-`init.json` key `manifest.soul.delay` when authored, otherwise the default;
-after an authorized `config` call, SHOW reads the updated live
-`SoulRuntimePort.soul_delay`. There is no environment peer. The supported
-change procedure accepts a finite JSON number of at least `30`:
-`soul(action="config", input={"delay_seconds":300,"consultation_past_count":null}, reasoning="change Soul cadence")`.
-That action validates and persists the value, updates live state, and restarts
-the pending timer when applicable; call SHOW again to verify. Invalid config
-input returns the existing Soul error and changes nothing. The cadence does not
-enable or disable flow.
+`delay_seconds` is the enabled-flow cadence in seconds, with a minimum of 30;
+`null` leaves it unchanged. It is not an off switch and has no effect while the
+environment gate is off.
 
 ### Consultation past count
 
-`consultation_past_count` is `K`, the number of past-snapshot voices in each
-enabled fire; total fan-out is `1 + K`. The meaningful default is `0`. At boot
-the current value is hydrated from `init.json` key
-`manifest.soul.consultation_past_count` when authored, otherwise the default;
-SHOW then reads that live config value. There is no environment peer. The
-supported change procedure accepts integers from `0` through `5`:
-`soul(action="config", input={"delay_seconds":null,"consultation_past_count":2}, reasoning="change Soul fan-out")`.
-The action rejects out-of-range input without changing state, persists valid
-input, and applies it to the next fire; call SHOW again to verify. The init
-loader type-checks authored values but does not reapply the config action's
-range rule, so SHOW reports the effective live integer rather than silently
-normalizing it.
+`consultation_past_count` is `K`, the number of past-self voices per fire, from
+0 through 5; `null` leaves it unchanged. Each fire fans out to `1 + K` calls.
 
 ### Voice
 
-`voice` selects the consultation profile. The supported `voice` action accepts
-`inner`, `observer`, or `custom`; the meaningful default is `inner`. At boot
-the current value is hydrated from `init.json` key `manifest.soul.voice` when
-authored, otherwise the default; SHOW reads that live config value. There is no
-environment peer. Change a built-in with
-`soul(action="voice", input={"set":"observer","prompt":null}, reasoning="change Soul voice")`,
-or use the atomic custom procedure in the next section. Unknown action input
-returns Soul's existing error and changes nothing. The selection is persisted,
-applies to the next consultation, and should be verified with another SHOW.
+`voice` selects `inner`, `observer`, or `custom`; null reads the current
+profile and resolved prompt. A built-in selection clears a stored custom prompt.
 
 ### Voice prompt
 
-`voice_prompt` is the custom consultation system prompt. The supported `voice`
-action accepts a non-empty string of at most `4000` characters when `voice` is
-`custom`; there is no meaningful prompt default. At boot the live value is
-hydrated from `init.json` key `manifest.soul.voice_prompt`; there is no
-environment peer. Because prompt text is sensitive, SHOW renders both
-`current` and `default` as `<redacted>` and never exposes the private
-sensitivity flag. Change profile and prompt atomically through
-`soul(action="voice", input={"set":"custom","prompt":"<private prompt>"}, reasoning="set my Soul framing")`.
-Switching to a built-in clears the stored custom prompt. Invalid input changes
-nothing; a valid change applies to the next consultation. Call SHOW again to
-verify the redacted row, and use the `voice` read mode only when authorized to
-inspect the actual resolved prompt.
+`voice_prompt` is the custom flow-voice system prompt, capped at 4000
+characters and shown redacted by `settings`. It is required for `custom` and is
+sensitive; use the authorized `voice` read mode for its actual resolved text.
 
-## 1. The soul-flow gate
+## Reference map
 
-**Soul flow does not run unless an operator turns it on.** It is gated by one
-environment variable, `LINGTAI_SOUL_FLOW_ENABLED` — see "Flow enabled" above
-for the exact accepted values and default.
-
-The gate governs **both** firing paths:
-
-1. **The wall-clock timer** — the periodic cadence that would otherwise fire
-   every `delay_seconds` while you are IDLE. When disabled, no timer is armed.
-2. **Voluntary `soul(action='flow', input={})`** — a call you make yourself. When
-   disabled, it returns immediately and never spawns a fire.
-
-A defensive last-line check inside the fire itself means even a stray residual
-caller cannot fire while the gate is off.
-
-## 2. Calling `flow` while disabled
-
-`soul(action='flow', input={})` returns, **before** taking any lock or spawning any
-thread:
-
-```json
-{"status": "disabled", "enabled": false, "env_var": "LINGTAI_SOUL_FLOW_ENABLED", "message": "..."}
-```
-
-**This is expected configuration state, not an error.** Do **not** retry it in
-a loop — the result will not change until an operator sets the env var. If you
-want soul flow, ask the operator to enable it (§4); otherwise use `inquiry` for
-on-demand self-reflection.
-
-## 3. `delay_seconds` is cadence, not an off switch
-
-After the env opt-in, `delay_seconds` (set via
-`soul(action='config', input={'delay_seconds': ..., 'consultation_past_count': null})`) controls **how often** the timer
-fires — e.g. `300` = every 5 minutes, `7200` = every 2 hours; minimum `30`.
-That is *all* it does:
-
-- A **large** `delay_seconds` does not suppress flow — the env gate decides
-  whether flow runs at all.
-- A **small** `delay_seconds` does not enable flow — with the env var unset, no
-  fires occur regardless of the delay.
-- `config` itself never enables flow. It still runs while flow is disabled: it
-  tunes and persists the knobs (`delay_seconds`, `consultation_past_count`) to
-  `init.json`, returns `status: "ok"`, and adds `soul_flow_enabled: false` plus a
-  `note` explaining that the saved knobs produce no fires until the operator
-  enables `LINGTAI_SOUL_FLOW_ENABLED` and refreshes. This is not the
-  `status: "disabled"` result reserved for `flow` (§2). Enabling is an
-  **operator** action.
-
-`delay_seconds` is cadence only. A huge sentinel value (e.g. `999999999`) used to
-be the trust-based mute, but it silenced only the **timer** — the voluntary path
-stayed live and could loop against the sleep gate. The env gate replaced that
-fragile convention with an explicit opt-in covering both paths.
-
-## 4. How to enable / disable
-
-Enabling is an operator/deployment action, not something the agent does to
-itself:
-
-1. Set `LINGTAI_SOUL_FLOW_ENABLED=1` (or `true`/`yes`/`on`) in the agent's
-   runtime environment.
-2. Refresh/restart the agent so the new environment is loaded.
-3. (Optional) tune cadence and voice count with
-   `soul(action='config', input={'delay_seconds': 300, 'consultation_past_count': 2})`.
-
-To **disable** again: unset the variable (or set it to `0`/`false`) and
-refresh/restart. No `delay_seconds` sentinel is needed — the gate is the off
-switch.
-
-## 5. Checking the current state
-
-- **Read without changing anything:** Call
-  `soul(action="settings", input={}, reasoning="check Soul state")`. Its five
-  rows report the current flow gate, cadence, consultation count, voice, and
-  redacted prompt. If any current truth is unavailable or not JSON-safe, the
-  whole action fails with `SETTINGS_UNAVAILABLE`; it never returns partial or
-  placeholder rows.
-- **Check the env from a shell:** use the model-facing shell envelope:
-  `shell(action="run", input={"command": "printenv LINGTAI_SOUL_FLOW_ENABLED"}, reasoning="check Soul flow opt-in")`.
-  Empty output means unset (disabled).
-- **Enabled but no fires?** Fires only happen while you are IDLE and only after
-  `delay_seconds` elapses. Confirm `delay_seconds` is a small, sane value and
-  that you actually reach IDLE between turns.
-
-## 6. Actions that always work (flow disabled or not)
-
-None of these depend on the env gate.
-
-- **`inquiry`** — ask a deep copy of yourself a question; the answer returns in
-  the tool result. Use this for deliberate, on-demand self-reflection instead
-  of waiting on flow. Requires the `inquiry` field.
-- **`config`** — tune `delay_seconds` / `consultation_past_count`; persists to
-  `init.json`. (Does not enable flow — see §3.)
-- **`voice`** — read or set how your own soul-flow voice sounds
-  (`inner`/`observer`/`custom`). Yours to choose; persists to `init.json`.
-- **`dismiss`** — clear the current soul-flow notification from the panel.
-- **`settings`** — show exactly five projected fields for each owned setting;
-  strict empty input, no mutation, and no partial-row success.
-- **`manual`** — return this manual. Reads one file and performs **no** soul
-  operation: no timer change, no consultation, no config/voice/notification
-  write.
-
-## 7. Settings files
-
-`soul` has **no** settings file at either LTP level — there is no
-`settings/soul.json` and no `settings/soul.<action>.json`. Cadence and voice
-live in `init.json` under `manifest.soul` (written by `config`/`voice`), and
-the flow gate lives in the process environment. The read-only `settings`
-action inventories those existing owners; it neither implies nor reads a
-`settings/` file.
-
-## 8. Privacy and cost rationale
-
-Soul flow is **off by default** because each fire runs `M = 1 + K` parallel LLM
-calls — a recurring silent token cost — and because it reads your current chat
-and past-self snapshots to inject involuntary voices into your history. Opt-in
-means an operator consciously decides to spend those tokens and surface that
-reflection. Enable it when the reflection is worth the cost; otherwise reach for
-`inquiry` when you specifically want a considered pause.
+- [Flow and opt-in gate](reference/flow.md) — accepted gate values, disabled/no-retry behavior, operator procedure, cadence, and cost/privacy rationale.
+- [Configuration and voices](reference/configuration.md) — nullable input rules, bounds, persistence, profiles, prompt sensitivity, and the five-row SHOW owner.
+- [Consultation mechanics](reference/consultation.md) — inquiry versus flow, fan-out, IDLE timing, snapshots, notifications, history pairs, and append-only records.

--- a/src/lingtai/tools/soul/manual/reference/configuration.md
+++ b/src/lingtai/tools/soul/manual/reference/configuration.md
@@ -1,0 +1,75 @@
+---
+name: soul-configuration-reference
+description: Detailed Soul cadence, voice, and read-only settings procedures.
+related_files:
+- src/lingtai/tools/soul/manual/SKILL.md
+- src/lingtai/tools/soul/config.py
+- src/lingtai/tools/soul/settings.py
+- src/lingtai/tools/soul/flow.py
+- src/lingtai/tools/soul/__init__.py
+- tests/test_soul_settings.py
+- tests/test_soul.py
+maintenance: |
+  Keep configuration bounds, persistence owners, voice sensitivity, and SHOW behavior aligned with Soul's implementation and router anchors.
+---
+
+# Soul configuration and voices
+
+## `config`
+
+Send both nullable keys and make at least one non-null:
+
+```json
+{"action":"config","input":{"delay_seconds":300,"consultation_past_count":null},"reasoning":"slow the cadence"}
+```
+
+`delay_seconds` is a finite number of at least 30 seconds. It is the interval
+between enabled fires, not an off switch. `consultation_past_count` is an
+integer from 0 through 5; it is `K`, the number of past-self voices in each
+fire. Explicit `null` means leave that knob unchanged. Invalid input changes
+nothing. A valid change updates live state and persists `manifest.soul.delay`
+and/or `manifest.soul.consultation_past_count` in `init.json`; changing delay
+restarts the pending timer when applicable.
+
+`config` does not inspect or modify `LINGTAI_SOUL_FLOW_ENABLED`, and it never
+enables or disables flow. While flow is off it still saves valid knobs and
+reports `status: "ok"`, `soul_flow_enabled: false`, and a note directing the
+operator to the environment gate. Use the [flow reference](flow.md) for the
+operator's enable/disable procedure.
+
+## `voice`
+
+For a read, send both fields as null:
+
+```json
+{"action":"voice","input":{"set":null,"prompt":null},"reasoning":"inspect the Soul voice"}
+```
+
+The built-in profiles are `inner` and `observer`; `custom` requires a non-empty
+prompt of at most 4000 characters. A prompt is ignored when selecting a
+built-in. A valid selection is persisted atomically under `manifest.soul.voice`
+and, for custom, `manifest.soul.voice_prompt`; switching to a built-in clears
+any stored custom prompt. Invalid input leaves the prior profile and prompt
+unchanged. The selected profile applies to the next consultation, while each
+consultation cue still distinguishes current from past-self diary context.
+
+Custom prompt text is sensitive. Do not put it in settings output: `settings`
+redacts both current and default for `voice_prompt`. Use the authorized `voice`
+read response only when inspecting the resolved prompt is appropriate.
+
+## `settings` and owners
+
+Call `soul(action="settings", input={}, reasoning="inspect Soul settings")` for
+a fresh, strict read-only inventory. It returns exactly five rows in this order:
+`flow_enabled`, `delay_seconds`, `consultation_past_count`, `voice`, and
+`voice_prompt`. Each row has exactly `key`, `current`, `default`,
+`configurable`, and `comment`; the comments target the five stable headings in
+the top-level `soul-manual`. Any unavailable, non-finite, non-JSON-safe current
+value fails the whole action with no partial rows.
+
+There is no `settings/soul.json` or action-specific settings file. The flow gate
+belongs to the process environment; cadence, count, voice, and custom prompt
+belong to `init.json` under `manifest.soul`. SHOW reads these owners and writes
+none of them. The flow gate can be changed only by the authorized launcher or
+operator; cadence and count use `config`, and voice uses the atomic `voice`
+procedure.

--- a/src/lingtai/tools/soul/manual/reference/consultation.md
+++ b/src/lingtai/tools/soul/manual/reference/consultation.md
@@ -1,0 +1,72 @@
+---
+name: soul-consultation-reference
+description: Detailed Soul inquiry and periodic consultation data flow, fan-out, and storage.
+related_files:
+- src/lingtai/tools/soul/manual/SKILL.md
+- src/lingtai/tools/soul/manual/reference/flow.md
+- src/lingtai/tools/soul/consultation.py
+- src/lingtai/tools/soul/flow.py
+- src/lingtai/tools/soul/inquiry.py
+- src/lingtai/tools/soul/__init__.py
+- tests/test_soul_consultation.py
+- tests/test_tool_family_soul_migration.py
+maintenance: |
+  Keep consultation roles, read-only snapshot use, notification/history semantics, and append-only storage aligned with Soul's implementation and router.
+---
+
+# Soul consultation mechanics
+
+## Inquiry versus flow
+
+`inquiry` is a deliberate, synchronous mirror session. The submitted non-empty
+question is asked of a deep copy of the current self; the result returns in the
+tool response as `voice`, or `"(silence)"` when no voice is produced. It records
+an entry with `mode: "inquiry"` and does not require the periodic flow opt-in.
+
+`flow` is mechanical and asynchronous. The voluntary action only acknowledges
+a trigger; voices arrive later through the same synthesized Soul-flow history
+shape as timer fires. The gate, no-retry disabled result, and cadence procedure
+are in [the flow reference](flow.md).
+
+## Fire data and fan-out
+
+For `K = consultation_past_count`, each enabled fire runs `M = 1 + K` parallel
+LLM calls: one stepped-back reader of the current diary and `K` voices sampled
+from earlier snapshots. `K=0` is the cheapest insights-only fire; larger values
+increase token cost and history content, up to six calls. Snapshot files are
+read-only consultation substrate; Soul does not create or mutate snapshots.
+
+The configured voice prompt is shared by current and past-self consultations,
+while per-fire cue text tells each call which diary context it is reading. A
+late result after a state change is discarded rather than injected into the new
+context. Calls run as daemon threads and are gated on the agent reaching IDLE;
+no subprocess or PTY is involved.
+
+## Notifications and history
+
+Flow voices are published to `.notification/soul.json`. The kernel's
+notification synchronization surfaces them through the synthesized
+`notification(action="check")` pair. Soul keeps at most its current flow
+notification through the shared notification operations; `dismiss` clears only
+the `soul` channel.
+
+Each flow or inquiry entry appends to `logs/soul_flow.jsonl`. The `mode` field
+distinguishes `flow` from `inquiry`; there is no separate inquiry log. Flow
+fires also append a synthesized `(ToolCallBlock, ToolResultBlock)` pair to chat
+history. The call block uses the current envelope:
+`action: "flow"`, `input: {}`, and host-authored `reasoning` explaining that
+the agent did not initiate it. This keeps replayed history consistent with the
+closed schema.
+
+Relative to the agent working directory, the relevant paths are:
+
+```text
+.notification/soul.json
+logs/soul_flow.jsonl
+history/snapshots/
+init.json (owned by configuration procedures, not consultation)
+```
+
+Flow reads current chat and snapshots but does not create snapshots. Manual and
+settings calls do not start consultation, change timers, write configuration,
+or publish notifications.

--- a/src/lingtai/tools/soul/manual/reference/flow.md
+++ b/src/lingtai/tools/soul/manual/reference/flow.md
@@ -1,0 +1,69 @@
+---
+name: soul-flow-reference
+description: Detailed operator and agent guidance for Soul's opt-in flow gate and cadence.
+related_files:
+- src/lingtai/tools/soul/manual/SKILL.md
+- src/lingtai/tools/soul/flow.py
+- src/lingtai/tools/soul/__init__.py
+- src/lingtai/tools/soul/config.py
+- src/lingtai/tools/soul/manual/reference/consultation.md
+- tests/test_soul.py
+- tests/test_tool_family_soul_migration.py
+maintenance: |
+  Keep the flow gate, disabled-path, cadence, and operator procedure accurate with Soul's implementation and top-level manual router.
+---
+
+# Soul flow and opt-in gate
+
+## Gate
+
+Soul flow has one owner: the process environment variable
+`LINGTAI_SOUL_FLOW_ENABLED`. Missing, blank, or unrecognized values mean
+`false`; `1`, `true`, `yes`, and `on` mean `true`, ignoring case and surrounding
+whitespace. This gate covers both the wall-clock timer and voluntary
+`soul(action="flow", input={})`. No Soul action, including `config`, can change
+it.
+
+Flow is disabled by default. With the gate off, a voluntary `flow` call returns
+`status: "disabled"` before taking the fire lock, waiting for IDLE, or spawning
+a thread. This is expected configuration state, not an error; do not retry in a
+loop. The result identifies `LINGTAI_SOUL_FLOW_ENABLED` and tells the operator
+what must change. A stray timer or caller is also stopped by the defensive gate
+inside the fire path.
+
+## Operator procedure
+
+1. Set `LINGTAI_SOUL_FLOW_ENABLED=1` (or `true`, `yes`, `on`) in the agent's
+   launch environment.
+2. Refresh or restart the agent so the new process environment is loaded.
+3. Optionally use `config` to tune cadence and past-self count; verify with
+   `settings`.
+4. To disable, unset the variable or set it to an unrecognized/false value,
+   then refresh or restart. Do not use a large delay as a mute sentinel.
+
+`settings` reports the live gate but cannot set it. If flow is disabled, use
+`inquiry` for deliberate self-reflection; `inquiry`, `config`, `voice`,
+`dismiss`, `settings`, and `manual` remain available.
+
+## Cadence
+
+`delay_seconds` is only the interval after opt-in. It accepts finite numbers of
+at least 30 seconds through `config`, persists under `manifest.soul.delay`, and
+restarts a pending timer when changed. A small value does not enable flow; a
+large value does not disable it. Enabled timers fire only while the agent is
+IDLE and are started from the IDLE transition. The voluntary path waits for
+IDLE up to the live delay rather than blocking the tool call; an ongoing fire is
+rejected instead of silently duplicated.
+
+Configuration remains meaningful while flow is off: valid cadence/count knobs
+are persisted and return `status: "ok"` plus `soul_flow_enabled: false` and an
+explanatory note. That result is distinct from `flow`'s `status: "disabled"`.
+
+## Cost and privacy
+
+An enabled fire reads current chat and read-only past-self snapshots and fans
+out `M = 1 + K` LLM calls. It can publish involuntary voices into the Soul
+notification and synthesized history pair. Keep the operator opt-in explicit
+when recurring token cost and reflection from prior snapshots are acceptable;
+otherwise use on-demand `inquiry`. See
+[consultation mechanics](consultation.md) for persistence and fan-out details.

--- a/tests/test_tool_family_soul_migration.py
+++ b/tests/test_tool_family_soul_migration.py
@@ -126,6 +126,24 @@ def test_public_actions_include_the_additive_settings_child():
     assert soul.get_schema("en")["properties"]["action"]["enum"] == list(_ACTIONS)
 
 
+def test_compact_description_retains_first_call_safety_and_routes_depth():
+    description = soul.get_description()
+    assert len(description) < 1500
+    for required in (
+        "LINGTAI_SOUL_FLOW_ENABLED",
+        "disabled",
+        "do not retry",
+        "config tunes cadence/count only and cannot enable or disable flow",
+        "inquiry is on-demand self-reflection",
+        "flow is mechanical, asynchronous periodic consultation",
+        "voice reads or sets the flow-voice profile",
+        "config sends both nullable knobs with at least one non-null",
+        "voice sends both nullable fields, where null/null reads",
+        "cost and privacy",
+    ):
+        assert required in description
+
+
 def test_every_action_has_its_own_strict_closed_input_branch():
     schema = soul.get_schema("en")
     branches = schema["properties"]["input"]["anyOf"]

--- a/tests/test_tool_family_soul_migration.py
+++ b/tests/test_tool_family_soul_migration.py
@@ -144,6 +144,21 @@ def test_compact_description_retains_first_call_safety_and_routes_depth():
         assert required in description
 
 
+def test_manual_router_discloses_packaged_soul_references():
+    manual_dir = Path(soul.__file__).with_name("manual")
+    body = manual_dir.joinpath("SKILL.md").read_text(encoding="utf-8")
+    routes = {
+        "reference/flow.md": "# Soul flow and opt-in gate",
+        "reference/configuration.md": "# Soul configuration and voices",
+        "reference/consultation.md": "# Soul consultation mechanics",
+    }
+    assert len(body) < 7000
+    for relative, heading in routes.items():
+        assert relative in body
+        reference = manual_dir.joinpath(relative).read_text(encoding="utf-8")
+        assert heading in reference
+
+
 def test_every_action_has_its_own_strict_closed_input_branch():
     schema = soul.get_schema("en")
     branches = schema["properties"]["input"]["anyOf"]

--- a/tests/test_tool_family_soul_migration.py
+++ b/tests/test_tool_family_soul_migration.py
@@ -137,11 +137,13 @@ def test_compact_description_retains_first_call_safety_and_routes_depth():
         "inquiry is on-demand self-reflection",
         "flow is mechanical, asynchronous periodic consultation",
         "voice reads or sets the flow-voice profile",
-        "config sends both nullable knobs with at least one non-null",
-        "voice sends both nullable fields, where null/null reads",
         "cost and privacy",
     ):
         assert required in description
+    # Strict child schemas own these first-call details; the root prose routes
+    # to the relevant action instead of repeating them a second time.
+    assert "config sends both nullable knobs with at least one non-null" not in description
+    assert "voice sends both nullable fields, where null/null reads" not in description
 
 
 def test_manual_router_discloses_packaged_soul_references():
@@ -153,6 +155,9 @@ def test_manual_router_discloses_packaged_soul_references():
         "reference/consultation.md": "# Soul consultation mechanics",
     }
     assert len(body) < 7000
+    assert "## Actions and routes" in body
+    assert "## Choose a path" not in body
+    assert "## Reference map" not in body
     for relative, heading in routes.items():
         assert relative in body
         reference = manual_dir.joinpath(relative).read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Keep the Soul invocation schema concise while retaining action choice, first-call semantics, opt-in safety, and the cost/privacy warning.
- Consolidate the always-read Soul manual into one self-sufficient action/routing table with stable settings anchors.
- Keep flow, configuration, voice, and consultation depth in the three focused packaged references.
- Preserve disabled-by-default flow, the no-retry disabled result, the configuration-cannot-enable rule, and inquiry versus flow/voice meanings.

## Validation
- Focused Soul/core/manual/package matrix: 225 passed, with one unrelated deprecation warning.
- Soul settings checks: 3 passed, 1 deselected because the existing cross-family opt-in-order assertion disagrees with the registered family set; this PR changes neither that assertion nor another family.
- Documentation governance: 373 documents validated; documentation and architecture tests: 75 passed; diff hygiene is clean.
- Source-built Soul definition: 9,123 chars on the locked base to 6,017 chars at this head; the non-annotation schema is identical.
- The top Soul manual is 12,152 chars on the locked base and 3,964 chars at this head; exact settings comment anchors and packaged-reference links remain valid.

## Review notes
Scope is limited to the Soul family and its focused regression. No runtime, provider, account, configuration, generator, or cross-family behavior changes.