### PR TITLE
docs: progressively disclose psyche guidance

### DIFF
--- a/src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
@@ -3,8 +3,8 @@ name: psyche-manual
 last_changed_at: 2026-09-06T00:00:00Z
 description: >
   Short routing table for the four durable domains — pad, lingtai (灵台), knowledge,
-  and skills — behind one shared file-mutation/rebuild model; routes settings
-  and the separate `.rules` heartbeat-signal protocol to focused references.
+  and skills — with one shared file-mutation/rebuild model; routes settings and the
+  separate `.rules` heartbeat signal to focused references.
 related_files:
 - src/lingtai/tools/psyche/CONTRACT.md
 - src/lingtai/tools/psyche/ANATOMY.md
@@ -25,147 +25,87 @@ related_files:
 maintenance: |
   This is the psyche family's own manual, loaded by
   `psyche(action='manual', input={}, reasoning='...')`.
-  Keep this entry short: it is a routing table, while settings and `.rules`
-  procedures live in the two focused references below. Update it together with
-  src/lingtai/tools/psyche/{CONTRACT,ANATOMY}.md whenever the public action
-  inventory, owned settings, a domain's durable source, or the rebuild model
-  changes. The `.rules` signpost is also targeted by `avatar-manual § 9`;
-  keep it in sync with `src/lingtai/kernel/base_agent/lifecycle.py`'s
-  `_check_rules_file` if that consumer's semantics change.
+  Keep it a short router: settings and `.rules` procedures belong to the two
+  focused references below. Update it with src/lingtai/tools/psyche/{CONTRACT,ANATOMY}.md
+  when the public action inventory, durable-source ownership, or rebuild model
+  changes; keep the `.rules` signpost aligned with `avatar-manual § 9` and
+  `_check_rules_file`.
 ---
 
 # Psyche
 
-Your **psyche** is what survives a molt: the four durable domains that are
-re-read and recomposed into every fresh system prompt.
+`psyche` is the one public root for the four durable domains that survive a molt:
 
 > pad + lingtai + knowledge + skills = psyche
-
-`psyche` is the one public root that teaches them. Its five domain/routing
-actions return manuals; `settings` shows a bounded, fully redacted inventory of
-Psyche's Pad configuration plus its six configurable prompt-owner inputs. Every
-public action is read-only. It owns no lifecycle action: `molt`, `summarize`, and
-`rebuild` belong to `context`, and your name belongs to `system`.
 
 ## Routing table
 
 | Call | Returns | Durable source it teaches |
 |---|---|---|
-| `psyche(action="pad", input={}, reasoning="load Pad guidance")` | `pad-manual` | `system/pad.md` + pinned references in `system/pad_append.json` |
-| `psyche(action="lingtai", input={}, reasoning="load identity guidance")` | `lingtai-manual` | `system/lingtai.md` (your 灵台 / character) |
+| `psyche(action="pad", input={}, reasoning="load Pad guidance")` | `pad-manual` | `system/pad.md` and pinned Pad references |
+| `psyche(action="lingtai", input={}, reasoning="load identity guidance")` | `lingtai-manual` | `system/lingtai.md` (灵台 / character) |
 | `psyche(action="knowledge", input={}, reasoning="load knowledge guidance")` | the knowledge manual | `knowledge/<name>/KNOWLEDGE.md` entries |
-| `psyche(action="skills", input={}, reasoning="load skills guidance")` | the skills manual | `.library/{intrinsic,custom}/` plus configured skills paths |
-| `psyche(action="settings", input={}, reasoning="inspect Psyche prompt configuration")` | eight fully redacted five-field rows | Pad seed plus Psyche's prompt-owner document |
-| `psyche(action="manual", input={}, reasoning="load the routing table")` | this routing table | — |
+| `psyche(action="skills", input={}, reasoning="load skills guidance")` | the skills manual | `.library/{intrinsic,custom}/` and configured skill paths |
+| `psyche(action="settings", input={}, reasoning="inspect Psyche settings")` | a fully redacted settings view | Psyche's owner inputs and applied snapshot |
+| `psyche(action="manual", input={}, reasoning="load the routing table")` | this router | — |
 
-Every action takes a strict empty `input`; any key is rejected before its
-provider or manual loader runs. For a domain you do not already know, load its
-manual first. The domain manuals own their detailed procedures; this entry only
-routes to them.
+All six calls use strict empty `input` (`input={}`); any key is rejected before dispatch.
+Every action is read-only. For an unfamiliar domain, call manual first; the
+returned domain manuals own the detailed procedure.
 
-## The one mutation model
+## One mutation model
 
-`psyche` has **no** mutating action. Durable content is ordinary text and is
-changed by the ordinary text tools:
+`psyche` has no mutating action. To change durable content, use `file.write` for
+a full rewrite or `file.edit` for an exact replacement on the owning source, then
+apply it once with `context(action="rebuild", input={}, reasoning="apply durable changes")`.
+A file mutation never hot-loads the prompt; passive refresh or molt may apply the
+same candidate. There is no per-domain reload, and catalog setup/refresh remains
+owned by Skills or Knowledge.
 
-1. **Write** the domain's durable source with `file.write` (create or full
-overwrite) or `file.edit` (exact replacement).
-2. **Apply** it with one explicit
-   `context(action="rebuild", input={}, reasoning="apply durable changes")`.
+## Lifecycle ownership
 
-File mutation never hot-loads the prompt. A source written but not rebuilt is
-real on disk and not yet visible in context, allowing a batch of edits to land
-atomically. Full rebuild recomposes all enabled canonical sections once;
-passive reconstruction (`system(action="refresh", ...)` and molt) follows the
-same contract. There is no per-domain reload.
-
-Catalog upkeep is not a Psyche action. Skills and Knowledge catalogs are
-rescanned and recomposed by their own setup/refresh/reconstruction paths;
-authoring a new `KNOWLEDGE.md` or `SKILL.md` and then rebuilding is the
-procedure.
-
-## Which domain am I in?
-
-- Working notes, the current task, and the living index you tend every turn —
-  **pad**.
-- Who you are, your voice, and how you carry yourself — **lingtai** (灵台).
-- Something learned, decided, or discovered for after a molt — **knowledge**.
-- A reusable procedure that would help any agent — **skills**.
-
-When the choice is unclear, the domain manuals own the deeper distinction.
-
-## `summarize`
-
-**Short-result.** Manual actions return one exact manual body, and `settings`
-returns eight compact rows. Leave root `summarize` `false`; summarizing loses the
-procedure or inventory you called it for.
+`psyche` owns no lifecycle action: `context` owns `molt`, `summarize`, and
+`rebuild`, while `system` owns identity/name. Full reconstruction composes the
+enabled durable sections together; domain manuals own their own catalog and
+source procedures.
 
 ## Settings
 
-`psyche(action="settings", input={}, reasoning="inspect Psyche prompt configuration")`
-is SHOW only. It returns exactly `pad`, `pad_file`, `base_prompt`,
-`base_prompt_file`, `covenant`, `covenant_file`, `comment`, then `comment_file`.
-Every row has exactly `key`, `current`, `default`, `configurable`, and `comment`.
-Both `current` and `default` are always `<redacted>`, including empty or absent
-values. SHOW reports the last successfully applied full-reconstruction snapshot;
-an ambient edit does not change it until rebuild, refresh, or molt succeeds, and
-a failed reconstruction preserves it. A provider or snapshot failure returns
-only the fixed bounded `SETTINGS_UNAVAILABLE` result.
-
-`settings/psyche.json` is the optional, closed v1 owner document for the six
-prompt-owner fields. It has UTF-8 JSON object shape with integer
-`schema_version: 1`; unknown/duplicate keys, invalid values, unsafe files, and
-read races reject the complete reconstruction. It has no environment layer,
-mutation action, migration, or writeback. The complete grammar, precedence,
-apply timing, and all six setting meanings are in the
-[settings reference](reference/settings/SKILL.md).
+`psyche(action="settings", input={}, reasoning="inspect Psyche settings")` is a
+SHOW-only action with fully redacted values. Read the [settings reference](reference/settings/SKILL.md)
+for the complete owner-document contract and application procedure.
 
 ### Setting pad
-
-The configured UTF-8 seed applies only when the durable Pad is missing or empty;
-a nonempty `system/pad.md` is preserved. See the
-[Pad setting procedure](reference/settings/SKILL.md#setting-pad).
+Owner/default/apply contract: [settings reference](reference/settings/SKILL.md#setting-pad).
 
 ### Setting pad file
-
-A readable pointer supplies the initial Pad seed; it never overwrites a
-nonempty durable Pad. See [Pad file setting](reference/settings/SKILL.md#setting-pad-file).
+Owner/default/apply contract: [settings reference](reference/settings/SKILL.md#setting-pad-file).
 
 ### Setting base prompt
-
-The optional application prompt body is resolved during reconstruction and
-renders after raw `principle`. See [base prompt](reference/settings/SKILL.md#setting-base-prompt).
+Owner/default/apply contract: [settings reference](reference/settings/SKILL.md#setting-base-prompt).
 
 ### Setting base prompt file
-
-A readable pointer wins over inline `base_prompt`; its path and body stay
-redacted. See [base prompt file](reference/settings/SKILL.md#setting-base-prompt-file).
+Owner/default/apply contract: [settings reference](reference/settings/SKILL.md#setting-base-prompt-file).
 
 ### Setting covenant
-
-The optional protected operator contract is resolved during reconstruction and
-uses the existing covenant section. See [covenant](reference/settings/SKILL.md#setting-covenant).
+Owner/default/apply contract: [settings reference](reference/settings/SKILL.md#setting-covenant).
 
 ### Setting covenant file
-
-A readable pointer wins over inline `covenant`; it remains redacted. See
-[covenant file](reference/settings/SKILL.md#setting-covenant-file).
+Owner/default/apply contract: [settings reference](reference/settings/SKILL.md#setting-covenant-file).
 
 ### Setting comment
-
-The optional unprotected comment body has no `system/*.md` mirror; an absent
-owner value removes the section. See [comment](reference/settings/SKILL.md#setting-comment).
+Owner/default/apply contract: [settings reference](reference/settings/SKILL.md#setting-comment).
 
 ### Setting comment file
-
-A readable pointer wins over inline `comment`; it is redacted and has no mirror.
-See [comment file](reference/settings/SKILL.md#setting-comment-file).
+Owner/default/apply contract: [settings reference](reference/settings/SKILL.md#setting-comment-file).
 
 ## Network rules protocol (`.rules`)
 
-`.rules` is a real heartbeat signal, but it is **not** owned by `psyche` or an
-action: there is no `psyche(action='rules')` and no generic instruction API.
-Ordinary Psyche edits use file plus explicit rebuild; an authorized `.rules`
-write is consumed by the target agent's next heartbeat instead. Read the
-[network-rules reference](reference/network-rules/SKILL.md) for the exact
-atomic write, consumption, replacement, persistence, and verification rules.
+`.rules` is a separate heartbeat signal, not a Psyche action or a rebuild API.
+Read the [network-rules reference](reference/network-rules/SKILL.md) before using
+that boundary.
+
+## `summarize`
+
+Use the short-result profile and leave root `summarize` `false`: manual actions
+return exact guidance, while settings returns its redacted view.

--- a/src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: psyche-manual
-last_changed_at: 2026-09-04T00:00:00Z
+last_changed_at: 2026-09-06T00:00:00Z
 description: >
-  Routing table for the four durable domains — pad, lingtai (灵台), knowledge,
-  skills — behind one shared file-mutation/rebuild model; also documents the
-  separate `.rules` heartbeat-signal protocol (not a psyche action).
+  Short routing table for the four durable domains — pad, lingtai (灵台), knowledge,
+  and skills — behind one shared file-mutation/rebuild model; routes settings
+  and the separate `.rules` heartbeat-signal protocol to focused references.
 related_files:
 - src/lingtai/tools/psyche/CONTRACT.md
 - src/lingtai/tools/psyche/ANATOMY.md
@@ -18,18 +18,19 @@ related_files:
 - src/lingtai/kernel/base_agent/lifecycle.py
 - src/lingtai/kernel/base_agent/__init__.py
 - src/lingtai/tools/avatar/manual/SKILL.md
+- src/lingtai/intrinsic_skills/psyche-manual/reference/settings/SKILL.md
+- src/lingtai/intrinsic_skills/psyche-manual/reference/network-rules/SKILL.md
 - tests/test_psyche_family.py
 - tests/test_avatar_rules.py
 maintenance: |
   This is the psyche family's own manual, loaded by
   `psyche(action='manual', input={}, reasoning='...')`.
-  It is a routing table by design: keep it short and keep the depth in the four
-  domain manuals it points to. Update it together with
+  Keep this entry short: it is a routing table, while settings and `.rules`
+  procedures live in the two focused references below. Update it together with
   src/lingtai/tools/psyche/{CONTRACT,ANATOMY}.md whenever the public action
   inventory, owned settings, a domain's durable source, or the rebuild model
-  changes. The `.rules` network-rules protocol section is a signpost target
-  from `avatar-manual` §9 (Avatar owns no rules action or mechanism); keep it
-  in sync with `src/lingtai/kernel/base_agent/lifecycle.py`'s
+  changes. The `.rules` signpost is also targeted by `avatar-manual § 9`;
+  keep it in sync with `src/lingtai/kernel/base_agent/lifecycle.py`'s
   `_check_rules_file` if that consumer's semantics change.
 ---
 
@@ -42,9 +43,9 @@ re-read and recomposed into every fresh system prompt.
 
 `psyche` is the one public root that teaches them. Its five domain/routing
 actions return manuals; `settings` shows a bounded, fully redacted inventory of
-Psyche's Pad configuration plus its six configurable prompt-owner inputs. Every public action is read-only. It owns no
-lifecycle action: molt, summarize, and rebuild belong to `context`, and your
-name belongs to `system`.
+Psyche's Pad configuration plus its six configurable prompt-owner inputs. Every
+public action is read-only. It owns no lifecycle action: `molt`, `summarize`, and
+`rebuild` belong to `context`, and your name belongs to `system`.
 
 ## Routing table
 
@@ -58,241 +59,113 @@ name belongs to `system`.
 | `psyche(action="manual", input={}, reasoning="load the routing table")` | this routing table | — |
 
 Every action takes a strict empty `input`; any key is rejected before its
-provider or manual loader runs.
+provider or manual loader runs. For a domain you do not already know, load its
+manual first. The domain manuals own their detailed procedures; this entry only
+routes to them.
 
 ## The one mutation model
 
-`psyche` has **no** mutating action. That is deliberate, not an omission:
-durable content is ordinary text, so it is changed by the ordinary text tools.
+`psyche` has **no** mutating action. Durable content is ordinary text and is
+changed by the ordinary text tools:
 
-1. **Write** the durable source with `file.write` (create or full overwrite) or
-   `file.edit` (exact replacement).
+1. **Write** the domain's durable source with `file.write` (create or full
+overwrite) or `file.edit` (exact replacement).
 2. **Apply** it with one explicit
    `context(action="rebuild", input={}, reasoning="apply durable changes")`.
 
-File mutation never hot-loads the prompt: a durable change written but not
-rebuilt is real on disk and simply not yet visible in your context — which is what
-makes a batch of edits land atomically instead of one half-composed section at a
-time. A full rebuild recomposes **all** enabled canonical sections once, applies
-pending summaries, then requests provider replay; passive reconstruction
-(`system(action="refresh", ...)` and molt) runs the same contract. There is no
-per-domain reload to call.
+File mutation never hot-loads the prompt. A source written but not rebuilt is
+real on disk and not yet visible in context, allowing a batch of edits to land
+atomically. Full rebuild recomposes all enabled canonical sections once;
+passive reconstruction (`system(action="refresh", ...)` and molt) follows the
+same contract. There is no per-domain reload.
 
-Catalog upkeep is not yours to trigger either. Skills and Knowledge catalogs are
-rescanned and recomposed by that same reconstruction path (and at setup/refresh);
-authoring a new `KNOWLEDGE.md` or `SKILL.md` and then rebuilding is the whole
+Catalog upkeep is not a Psyche action. Skills and Knowledge catalogs are
+rescanned and recomposed by their own setup/refresh/reconstruction paths;
+authoring a new `KNOWLEDGE.md` or `SKILL.md` and then rebuilding is the
 procedure.
 
 ## Which domain am I in?
 
-- Working notes, the current task, the living index you tend every turn → **pad**.
-- Who you are, your voice, how you carry yourself → **lingtai** (灵台).
-- Something you learned, decided, or discovered and want back after a molt,
-  possibly referencing local paths, mail ids, or logs → **knowledge**.
-- A reusable procedure that would help any agent, not just you → **skills**.
+- Working notes, the current task, and the living index you tend every turn —
+  **pad**.
+- Who you are, your voice, and how you carry yourself — **lingtai** (灵台).
+- Something learned, decided, or discovered for after a molt — **knowledge**.
+- A reusable procedure that would help any agent — **skills**.
 
-When the choice is genuinely unclear, the domain manuals own that distinction in
-depth.
+When the choice is unclear, the domain manuals own the deeper distinction.
 
 ## `summarize`
 
-**Short-result.** Manual actions return one manual body, and `settings` returns
-eight compact rows. Leave root `summarize` `false`; summarizing either result loses
-the exact procedure or inventory you called it for.
+**Short-result.** Manual actions return one exact manual body, and `settings`
+returns eight compact rows. Leave root `summarize` `false`; summarizing loses the
+procedure or inventory you called it for.
 
 ## Settings
 
 `psyche(action="settings", input={}, reasoning="inspect Psyche prompt configuration")`
 is SHOW only. It returns exactly `pad`, `pad_file`, `base_prompt`,
 `base_prompt_file`, `covenant`, `covenant_file`, `comment`, then `comment_file`.
-Every row has exactly `key`, `current`, `default`, `configurable`, and `comment`
-in that order. Both `current` and `default` are always `<redacted>` for every
-row, including empty or absent values. The action reports the applied snapshot
-from the last successful full reconstruction. Ambient source edits do not change
-SHOW until rebuild, refresh, or molt applies them; a failed reconstruction keeps
-the last successful snapshot. A provider/snapshot failure returns only the fixed
-bounded `SETTINGS_UNAVAILABLE` failure, never partial rows or parser details.
+Every row has exactly `key`, `current`, `default`, `configurable`, and `comment`.
+Both `current` and `default` are always `<redacted>`, including empty or absent
+values. SHOW reports the last successfully applied full-reconstruction snapshot;
+an ambient edit does not change it until rebuild, refresh, or molt succeeds, and
+a failed reconstruction preserves it. A provider or snapshot failure returns
+only the fixed bounded `SETTINGS_UNAVAILABLE` result.
 
-`settings/psyche.json` is Psyche's deliberately small owner document. It is
-optional: a missing file means schema v1 with all six owner values absent. When
-present it must be UTF-8 JSON object `{"schema_version": 1, ...}` with no keys
-other than `base_prompt`, `base_prompt_file`, `covenant`, `covenant_file`,
-`comment`, and `comment_file`; each present value is a string (including `""`).
-Duplicate/unknown keys, Boolean/non-1 versions, non-regular or symlink files,
-files over 64 KiB, unstable reads, invalid UTF-8/JSON, and read failures reject
-the complete reconstruction before prompt publication. There is no environment
-layer, `set`, `reset`, patch action, migration, or writeback.
-
-The legacy top-level init spellings for these six fields are compatibility-known
-but inert. They neither configure the prompt nor populate SHOW. For each owner
-pair, a readable `*_file` wins; a missing file falls back to inline. `~` expands
-and relative pointers resolve against the agent workdir. Edit the owner document
-with `file.write`/`file.edit`, then use `context.rebuild` (or refresh/molt) to
-apply it atomically.
-
-**Upgrade / external-writer note:** before reconstructing an agent that still
-stores any of these six values in `init.json`, copy them into
-`settings/psyche.json`; the runtime never migrates or writes them back. An
-existing resolved `base_prompt` or `covenant` may continue through its
-`system/base_prompt.md` or `system/covenant.md` mirror, but `comment` has no
-mirror and is removed when the owner document does not supply it. Fresh project,
-recipe, TUI, Avatar, or other external seed writers must emit the Psyche owner
-document instead of relying on the inert init spellings.
+`settings/psyche.json` is the optional, closed v1 owner document for the six
+prompt-owner fields. It has UTF-8 JSON object shape with integer
+`schema_version: 1`; unknown/duplicate keys, invalid values, unsafe files, and
+read races reject the complete reconstruction. It has no environment layer,
+mutation action, migration, or writeback. The complete grammar, precedence,
+apply timing, and all six setting meanings are in the
+[settings reference](reference/settings/SKILL.md).
 
 ### Setting pad
 
-- **Meaning and default:** the configured UTF-8 initial Pad seed. Its meaningful
-  default is the empty string.
-- **Source and precedence:** top-level `pad_file` wins when it names a readable
-  file; otherwise top-level inline `pad` is the fallback. Reconstruction
-  materializes, validates, and path-resolves that shape once; SHOW reports the
-  resulting applied snapshot without rereading either source.
-- **Configurable:** `true`, because the operator may edit the authorized root
-  init source or the file it names. SHOW still fully redacts the effective body.
-- **Apply timing and procedure:** active or passive full reconstruction seeds
-  `system/pad.md` only when that durable body is missing or empty. A nonempty
-  durable Pad is preserved. To replace one, edit `system/pad.md` through the Pad
-  procedure, then call `context(action="rebuild", input={}, reasoning="apply Pad change")`;
-  changing only the configured seed does not overwrite a nonempty durable Pad.
+The configured UTF-8 seed applies only when the durable Pad is missing or empty;
+a nonempty `system/pad.md` is preserved. See the
+[Pad setting procedure](reference/settings/SKILL.md#setting-pad).
 
 ### Setting pad file
 
-- **Meaning and default:** the configured file pointer supplying the initial Pad
-  seed. It has no meaningful default, so its underlying default is `null`.
-- **Source and precedence:** top-level `pad_file` only. `~` expands and a
-  relative path resolves against the agent working directory. A readable file
-  supplies `pad`; a missing or blank pointer falls back to inline `pad`. SHOW
-  fully redacts the resolved pointer as well as the Pad body.
-- **Configurable:** `true`, because the operator may edit the authorized root
-  init source. No environment or settings-file layer exists.
-- **Apply timing and procedure:** the pointer is re-read on full reconstruction,
-  but its content remains only an initial seed for a missing/empty
-  `system/pad.md`. To change a nonempty durable Pad, use the Pad file procedure
-  and rebuild instead of expecting `pad_file` to overwrite it.
-
-A second SHOW before reconstruction deliberately reports the same applied
-snapshot. After an authorized rebuild/refresh/molt succeeds, another SHOW can
-verify that discovery remains available, but because both values are always
-redacted it cannot reveal or compare the underlying content.
+A readable pointer supplies the initial Pad seed; it never overwrites a
+nonempty durable Pad. See [Pad file setting](reference/settings/SKILL.md#setting-pad-file).
 
 ### Setting base prompt
 
-The optional third-party/application prompt body; default `""`, configurable
-`true`. Psyche resolves it once per reconstruction, writes nonempty content to
-`system/base_prompt.md`, and otherwise falls back to that mirror. The kernel
-renders it after raw `principle` and before the remaining Batch 1 sections.
+The optional application prompt body is resolved during reconstruction and
+renders after raw `principle`. See [base prompt](reference/settings/SKILL.md#setting-base-prompt).
 
 ### Setting base prompt file
 
-Optional pointer; default `null`, configurable `true`. A readable file wins
-over `base_prompt`; its path is fully redacted and follows the owner-document
-relative/`~` rules above.
+A readable pointer wins over inline `base_prompt`; its path and body stay
+redacted. See [base prompt file](reference/settings/SKILL.md#setting-base-prompt-file).
 
 ### Setting covenant
 
-Optional protected operator-contract body; default `""`, configurable `true`.
-Nonempty resolved content mirrors to `system/covenant.md` and uses the existing
-protected covenant section; absent owner content falls back to that mirror.
+The optional protected operator contract is resolved during reconstruction and
+uses the existing covenant section. See [covenant](reference/settings/SKILL.md#setting-covenant).
 
 ### Setting covenant file
 
-Optional pointer; default `null`, configurable `true`. A readable file wins
-over `covenant`; the pointer and resolved body remain fully redacted.
+A readable pointer wins over inline `covenant`; it remains redacted. See
+[covenant file](reference/settings/SKILL.md#setting-covenant-file).
 
 ### Setting comment
 
-Optional unprotected comment-section body; default `""`, configurable `true`.
-Unlike base prompt and covenant, comment has no `system/*.md` mirror: an absent
-owner value removes the section on the applied reconstruction.
+The optional unprotected comment body has no `system/*.md` mirror; an absent
+owner value removes the section. See [comment](reference/settings/SKILL.md#setting-comment).
 
 ### Setting comment file
 
-Optional pointer; default `null`, configurable `true`. A readable file wins
-over `comment`; it is fully redacted and has no mirror behavior.
+A readable pointer wins over inline `comment`; it is redacted and has no mirror.
+See [comment file](reference/settings/SKILL.md#setting-comment-file).
 
 ## Network rules protocol (`.rules`)
 
-`.rules` is a real mechanism, but it is **not** owned by `psyche`, `avatar`, or
-any other action tool — there is no `psyche(action='rules')` and no generic
-instruction API for it. It is a plain signal file consumed by an agent's own
-heartbeat loop (`_check_rules_file` in
-`src/lingtai/kernel/base_agent/lifecycle.py`), documented here because it is
-easy to confuse with the ordinary Psyche edit-then-`context.rebuild` model
-above — the two are deliberately different mechanisms:
-
-- **Ordinary Psyche edit:** write a durable source file (`system/pad.md`,
-  `system/lingtai.md`, a `KNOWLEDGE.md`/`SKILL.md`, or the Psyche owner
-  document), then call `context(action="rebuild", ...)` (or wait for
-  refresh/molt) to recompose **all** enabled sections at once.
-- **`.rules`:** use Shell to write a `.rules` file to the explicitly authorized
-  target agent's working-directory root. Its next runnable heartbeat reads and
-  unlinks the signal before deciding whether to apply it; no explicit rebuild
-  or refresh is needed. A read or unlink failure leaves the signal unconsumed
-  and stops processing, so file disappearance alone is not proof of success.
-
-### Write through Shell
-
-First prepare the complete approved UTF-8 rule body and confirm the exact target
-path. For example, in a POSIX shell (use the active shell's equivalent elsewhere):
-
-```sh
-target='/absolute/path/to/authorized-agent'
-body='/absolute/path/to/approved-rules.txt'
-tmp=$(mktemp "$target/.rules.XXXXXX") &&
-  cat "$body" > "$tmp" &&
-  mv "$tmp" "$target/.rules"
-```
-
-The temporary file is in the target directory so the final rename exposes the
-complete signal, not a partly written body. If a command fails, stop and inspect
-that exact temporary file; do not announce success or blindly replay the batch.
-For multiple agents, confirm an explicit target list and perform/report the write
-for each target. There is no automatic descendant broadcast or post-spawn fan-out.
-Do not write `system/rules.md` as a substitute for this live signal workflow.
-
-Consumption semantics, exactly as implemented:
-
-- **Complete replacement, not a merge.** A non-empty `.rules` body entirely
-  replaces the canonical `system/rules.md` content and the protected `rules`
-  prompt section — it is never appended to or merged with prior rules.
-- **Empty is a no-op.** Whitespace-only or empty `.rules` content is consumed
-  (the signal file is deleted either way) but writes nothing and triggers no
-  prompt refresh.
-- **Identical content is a no-flush no-op.** If the `.rules` body (stripped)
-  equals the existing `system/rules.md` (stripped), the signal is consumed
-  but `system/rules.md` is not rewritten and the system prompt is not
-  reflushed.
-- **Changed content persists and flushes.** A genuinely different body
-  overwrites `system/rules.md`, rewrites the protected `rules` prompt
-  section, and flushes the live system prompt — logged as `rules_loaded`.
-  A write failure while persisting the canonical file is logged as
-  `rules_write_error` and aborts before any prompt mutation.
-- **Boot/rebuild injection.** `system/rules.md` is also re-read directly into
-  the protected `rules` prompt section on ordinary agent construction and on
-  every full reconstruction (`context.rebuild`, refresh, molt) — independent
-  of any pending `.rules` signal. This is what makes existing rules survive a
-  molt, refresh, or resume even without a fresh `.rules` write; an empty or
-  missing `system/rules.md` at reconstruction time removes the section.
-
-**Verification.** The canonical value is `system/rules.md` on disk — read it
-directly. The effective (currently composed) value is what the protected
-`rules` prompt section holds; a `.rules` write is only reflected there after
-that *same agent's own* next heartbeat tick actually processed it (or after
-any subsequent boot/rebuild/refresh/molt, which re-reads the same canonical
-file). A `.rules` file that has not yet ticked is real on disk as a pending
-signal, not yet visible in the prompt — the same "written but not applied"
-distinction as an unbuilt Psyche source edit, but on the heartbeat's cadence
-instead of an explicit `context.rebuild` call.
-
-**Cross-agent writes are scoped by what you can reach, not by a privilege
-check.** `avatar` used to own an admin/karma-gated `rules` action that wrote
-`.rules` to a caller's own directory and to every descendant in its avatar
-tree; that action and its authorization check were both **removed**, not
-replaced by a new guard anywhere else. Today, writing a `.rules` file to
-another agent's directory (e.g. a sibling avatar) is an ordinary filesystem
-write — typically via `shell` naming that agent's explicit path — subject
-only to whatever access the same-OS-user trust model already gives you, not
-to any dedicated authorization mechanism. This paragraph is documentation,
-not enforcement: do not treat it, or any other prose, as proof that a write
-outside your own directory is authorized — only the human's actual scope and
-the target's real accessibility decide that.
+`.rules` is a real heartbeat signal, but it is **not** owned by `psyche` or an
+action: there is no `psyche(action='rules')` and no generic instruction API.
+Ordinary Psyche edits use file plus explicit rebuild; an authorized `.rules`
+write is consumed by the target agent's next heartbeat instead. Read the
+[network-rules reference](reference/network-rules/SKILL.md) for the exact
+atomic write, consumption, replacement, persistence, and verification rules.

--- a/src/lingtai/intrinsic_skills/psyche-manual/reference/network-rules/SKILL.md
+++ b/src/lingtai/intrinsic_skills/psyche-manual/reference/network-rules/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: psyche-network-rules-reference
+last_changed_at: 2026-09-06T00:00:00Z
+description: >
+  Deep reference for the separate `.rules` heartbeat signal: authorized atomic
+  writes, consumption, replacement, persistence, verification, and boundaries.
+related_files:
+- src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
+- src/lingtai/kernel/base_agent/lifecycle.py
+- src/lingtai/kernel/base_agent/__init__.py
+- src/lingtai/tools/avatar/manual/SKILL.md
+- tests/test_avatar_rules.py
+maintenance: |
+  Keep this reference synchronized with `_check_rules_file` and the Avatar
+  manual's signpost. `.rules` is not a Psyche action; preserve that boundary and
+  do not turn this reference into a generic instruction or mutation API.
+---
+
+# Psyche network-rules reference
+
+This page is the detailed procedure behind the short `.rules` signpost in
+[`psyche-manual`](../../SKILL.md). It documents a separate heartbeat signal, not
+an action exposed by Psyche.
+
+## Network rules protocol (`.rules`)
+
+`.rules` is a real mechanism, but it is **not** owned by `psyche`, `avatar`, or
+any other action tool — there is no `psyche(action='rules')` and no generic
+instruction API for it. It is a plain signal file consumed by an agent's own
+heartbeat loop (`_check_rules_file` in
+`src/lingtai/kernel/base_agent/lifecycle.py`), documented here because it is
+easy to confuse with the ordinary Psyche edit-then-`context.rebuild` model
+above — the two are deliberately different mechanisms:
+
+- **Ordinary Psyche edit:** write a durable source file (`system/pad.md`,
+  `system/lingtai.md`, a `KNOWLEDGE.md`/`SKILL.md`, or the Psyche owner
+  document), then call `context(action="rebuild", ...)` (or wait for
+  refresh/molt) to recompose **all** enabled sections at once.
+- **`.rules`:** use Shell to write a `.rules` file to the explicitly authorized
+  target agent's working-directory root. Its next runnable heartbeat reads and
+  unlinks the signal before deciding whether to apply it; no explicit rebuild
+  or refresh is needed. A read or unlink failure leaves the signal unconsumed
+  and stops processing, so file disappearance alone is not proof of success.
+
+### Write through Shell
+
+First prepare the complete approved UTF-8 rule body and confirm the exact target
+path. For example, in a POSIX shell (use the active shell's equivalent elsewhere):
+
+```sh
+target='/absolute/path/to/authorized-agent'
+body='/absolute/path/to/approved-rules.txt'
+tmp=$(mktemp "$target/.rules.XXXXXX") &&
+  cat "$body" > "$tmp" &&
+  mv "$tmp" "$target/.rules"
+```
+
+The temporary file is in the target directory so the final rename exposes the
+complete signal, not a partly written body. If a command fails, stop and inspect
+that exact temporary file; do not announce success or blindly replay the batch.
+For multiple agents, confirm an explicit target list and perform/report the write
+for each target. There is no automatic descendant broadcast or post-spawn fan-out.
+Do not write `system/rules.md` as a substitute for this live signal workflow.
+
+Consumption semantics, exactly as implemented:
+
+- **Complete replacement, not a merge.** A non-empty `.rules` body entirely
+  replaces the canonical `system/rules.md` content and the protected `rules`
+  prompt section — it is never appended to or merged with prior rules.
+- **Empty is a no-op.** Whitespace-only or empty `.rules` content is consumed
+  (the signal file is deleted either way) but writes nothing and triggers no
+  prompt refresh.
+- **Identical content is a no-flush no-op.** If the `.rules` body (stripped)
+  equals the existing `system/rules.md` (stripped), the signal is consumed
+  but `system/rules.md` is not rewritten and the system prompt is not
+  reflushed.
+- **Changed content persists and flushes.** A genuinely different body
+  overwrites `system/rules.md`, rewrites the protected `rules` prompt
+  section, and flushes the live system prompt — logged as `rules_loaded`.
+  A write failure while persisting the canonical file is logged as
+  `rules_write_error` and aborts before any prompt mutation.
+- **Boot/rebuild injection.** `system/rules.md` is also re-read directly into
+  the protected `rules` prompt section on ordinary agent construction and on
+  every full reconstruction (`context.rebuild`, refresh, molt) — independent
+  of any pending `.rules` signal. This is what makes existing rules survive a
+  molt, refresh, or resume even without a fresh `.rules` write; an empty or
+  missing `system/rules.md` at reconstruction time removes the section.
+
+**Verification.** The canonical value is `system/rules.md` on disk — read it
+directly. The effective (currently composed) value is what the protected
+`rules` prompt section holds; a `.rules` write is only reflected there after
+that *same agent's own* next heartbeat tick actually processed it (or after
+any subsequent boot/rebuild/refresh/molt, which re-reads the same canonical
+file). A `.rules` file that has not yet ticked is real on disk as a pending
+signal, not yet visible in the prompt — the same "written but not applied"
+distinction as an unbuilt Psyche source edit, but on the heartbeat's cadence
+instead of an explicit `context.rebuild` call.
+
+**Cross-agent writes are scoped by what you can reach, not by a privilege
+check.** `avatar` used to own an admin/karma-gated `rules` action that wrote
+`.rules` to a caller's own directory and to every descendant in its avatar
+tree; that action and its authorization check were both **removed**, not
+replaced by a new guard anywhere else. Today, writing a `.rules` file to
+another agent's directory (e.g. a sibling avatar) is an ordinary filesystem
+write — typically via `shell` naming that agent's explicit path — subject
+only to whatever access the same-OS-user trust model already gives you, not
+to any dedicated authorization mechanism. This paragraph is documentation,
+not enforcement: do not treat it, or any other prose, as proof that a write
+outside your own directory is authorized — only the human's actual scope and
+the target's real accessibility decide that.

--- a/src/lingtai/intrinsic_skills/psyche-manual/reference/settings/SKILL.md
+++ b/src/lingtai/intrinsic_skills/psyche-manual/reference/settings/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: psyche-settings-reference
+last_changed_at: 2026-09-06T00:00:00Z
+description: >
+  Deep reference for Psyche's redacted settings SHOW, strict owner-document
+  grammar, precedence, timing, and the eight setting anchors.
+related_files:
+- src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
+- src/lingtai/tools/psyche/settings.py
+- src/lingtai/tools/psyche/CONTRACT.md
+- src/lingtai/agent.py
+- tests/test_psyche_family.py
+- tests/test_psyche_prompt_settings.py
+maintenance: |
+  Keep this reference aligned with Psyche's applied-snapshot provider,
+  `settings/psyche.json` parser, reconstruction rollback, redaction, and the
+  stable `psyche-manual#setting-*` anchors. The parent psyche manual remains the
+  short router; move depth here rather than expanding that always-sent body.
+---
+
+# Psyche settings reference
+
+This page is the detailed procedure behind the short settings signpost in
+[`psyche-manual`](../../SKILL.md). It owns the exact settings grammar and
+application details; Psyche's public action remains SHOW-only.
+
+## Settings
+
+`psyche(action="settings", input={}, reasoning="inspect Psyche prompt configuration")`
+is SHOW only. It returns exactly `pad`, `pad_file`, `base_prompt`,
+`base_prompt_file`, `covenant`, `covenant_file`, `comment`, then `comment_file`.
+Every row has exactly `key`, `current`, `default`, `configurable`, and `comment`
+in that order. Both `current` and `default` are always `<redacted>` for every
+row, including empty or absent values. The action reports the applied snapshot
+from the last successful full reconstruction. Ambient source edits do not change
+SHOW until rebuild, refresh, or molt applies them; a failed reconstruction keeps
+the last successful snapshot. A provider/snapshot failure returns only the fixed
+bounded `SETTINGS_UNAVAILABLE` failure, never partial rows or parser details.
+
+`settings/psyche.json` is Psyche's deliberately small owner document. It is
+optional: a missing file means schema v1 with all six owner values absent. When
+present it must be UTF-8 JSON object `{"schema_version": 1, ...}` with no keys
+other than `base_prompt`, `base_prompt_file`, `covenant`, `covenant_file`,
+`comment`, and `comment_file`; each present value is a string (including `""`).
+Duplicate/unknown keys, Boolean/non-1 versions, non-regular or symlink files,
+files over 64 KiB, unstable reads, invalid UTF-8/JSON, and read failures reject
+the complete reconstruction before prompt publication. There is no environment
+layer, `set`, `reset`, patch action, migration, or writeback.
+
+The legacy top-level init spellings for these six fields are compatibility-known
+but inert. They neither configure the prompt nor populate SHOW. For each owner
+pair, a readable `*_file` wins; a missing file falls back to inline. `~` expands
+and relative pointers resolve against the agent workdir. Edit the owner document
+with `file.write`/`file.edit`, then use `context.rebuild` (or refresh/molt) to
+apply it atomically.
+
+**Upgrade / external-writer note:** before reconstructing an agent that still
+stores any of these six values in `init.json`, copy them into
+`settings/psyche.json`; the runtime never migrates or writes them back. An
+existing resolved `base_prompt` or `covenant` may continue through its
+`system/base_prompt.md` or `system/covenant.md` mirror, but `comment` has no
+mirror and is removed when the owner document does not supply it. Fresh project,
+recipe, TUI, Avatar, or other external seed writers must emit the Psyche owner
+document instead of relying on the inert init spellings.
+
+### Setting pad
+
+- **Meaning and default:** the configured UTF-8 initial Pad seed. Its meaningful
+  default is the empty string.
+- **Source and precedence:** top-level `pad_file` wins when it names a readable
+  file; otherwise top-level inline `pad` is the fallback. Reconstruction
+  materializes, validates, and path-resolves that shape once; SHOW reports the
+  resulting applied snapshot without rereading either source.
+- **Configurable:** `true`, because the operator may edit the authorized root
+  init source or the file it names. SHOW still fully redacts the effective body.
+- **Apply timing and procedure:** active or passive full reconstruction seeds
+  `system/pad.md` only when that durable body is missing or empty. A nonempty
+  durable Pad is preserved. To replace one, edit `system/pad.md` through the Pad
+  procedure, then call `context(action="rebuild", input={}, reasoning="apply Pad change")`;
+  changing only the configured seed does not overwrite a nonempty durable Pad.
+
+### Setting pad file
+
+- **Meaning and default:** the configured file pointer supplying the initial Pad
+  seed. It has no meaningful default, so its underlying default is `null`.
+- **Source and precedence:** top-level `pad_file` only. `~` expands and a
+  relative path resolves against the agent working directory. A readable file
+  supplies `pad`; a missing or blank pointer falls back to inline `pad`. SHOW
+  fully redacts the resolved pointer as well as the Pad body.
+- **Configurable:** `true`, because the operator may edit the authorized root
+  init source. No environment or settings-file layer exists.
+- **Apply timing and procedure:** the pointer is re-read on full reconstruction,
+  but its content remains only an initial seed for a missing/empty
+  `system/pad.md`. To change a nonempty durable Pad, use the Pad file procedure
+  and rebuild instead of expecting `pad_file` to overwrite it.
+
+A second SHOW before reconstruction deliberately reports the same applied
+snapshot. After an authorized rebuild/refresh/molt succeeds, another SHOW can
+verify that discovery remains available, but because both values are always
+redacted it cannot reveal or compare the underlying content.
+
+### Setting base prompt
+
+The optional third-party/application prompt body; default `""`, configurable
+`true`. Psyche resolves it once per reconstruction, writes nonempty content to
+`system/base_prompt.md`, and otherwise falls back to that mirror. The kernel
+renders it after raw `principle` and before the remaining Batch 1 sections.
+
+### Setting base prompt file
+
+Optional pointer; default `null`, configurable `true`. A readable file wins
+over `base_prompt`; its path is fully redacted and follows the owner-document
+relative/`~` rules above.
+
+### Setting covenant
+
+Optional protected operator-contract body; default `""`, configurable `true`.
+Nonempty resolved content mirrors to `system/covenant.md` and uses the existing
+protected covenant section; absent owner content falls back to that mirror.
+
+### Setting covenant file
+
+Optional pointer; default `null`, configurable `true`. A readable file wins
+over `covenant`; the pointer and resolved body remain fully redacted.
+
+### Setting comment
+
+Optional unprotected comment-section body; default `""`, configurable `true`.
+Unlike base prompt and covenant, comment has no `system/*.md` mirror: an absent
+owner value removes the section on the applied reconstruction.
+
+### Setting comment file
+
+Optional pointer; default `null`, configurable `true`. A readable file wins
+over `comment`; it is fully redacted and has no mirror behavior.

--- a/src/lingtai/tools/psyche/__init__.py
+++ b/src/lingtai/tools/psyche/__init__.py
@@ -1,38 +1,14 @@
 """Psyche's declared official host-plugin slice.
 
-``psyche`` is the mandatory, model-visible LTP v2 root for the four durable
-self domains: ``pad + lingtai + knowledge + skills = psyche``. Its exact action
-set remains ``pad | lingtai | knowledge | skills | settings | manual``:
+``psyche`` is the mandatory model-visible LTP v2 root for the four durable
+self-domains: ``pad + lingtai + knowledge + skills = psyche``. Its six actions
+are four manual routes, redacted ``settings``, and the ``manual`` router; every
+child uses the canonical strict-empty input and is read-only. The declaration
+binds only ``workdir`` and the applied Psyche settings snapshot.
 
-- ``pad``, ``lingtai``, ``knowledge``, and ``skills`` each return that domain's
-  own installed manual;
-- ``settings`` returns eight fully redacted Psyche-owned prompt-configuration
-  rows (Pad plus the three configurable prompt pairs);
-- ``manual`` returns the psyche routing-table manual, which explains the four
-  durable domains and their shared mutation/rebuild model.
-
-Every child takes the canonical strict-empty ``input``. No public action mutates
-disk, prompt state, configuration, or a catalog. The static declaration binds
-the family only to ``workdir`` plus a read-only view of the last successfully
-applied Pad settings snapshot; it receives no Agent or prompt mutation surface.
-
-This root replaces the four former public roots ``pad``, ``lingtai``,
-``knowledge``, and ``skills``. That was a clean break: those roots, the
-``pad.append`` action, and the ``skills.info`` / ``knowledge.info`` actions have
-no alias, wrapper, or compatibility path and now fail as unknown tools/actions.
-The name ``psyche`` was also used by a long-dissolved family; reusing the root
-name grants none of that family's actions.
-
-The capabilities themselves remain private lifecycle owners:
-
-- durable text mutation is ``file.write`` / ``file.edit``;
-- Pad and LingTai keep their private canonical prompt composers;
-- Skills/Knowledge keep their capability-owned catalog composition; and
-- one explicit ``context.rebuild`` or passive refresh/molt reconstruction makes
-  durable content prompt-visible.
-
-The static-plan ``substrate`` prompt contribution is separate from this family;
-the kernel's render slot and mechanics remain unchanged.
+The former public domain roots and dissolved Psyche actions remain retired
+without aliases. Domain lifecycle/composition stays private to its owners, and
+the static-plan ``substrate`` prompt section remains a separate kernel concept.
 """
 from __future__ import annotations
 
@@ -73,16 +49,14 @@ _DECLARED_INPUT_SCHEMAS = {
 }
 
 _ACTION_ENUM_DESCRIPTION = (
-    "Choose one Psyche operation. Every action takes input={} and is strictly "
-    "read-only: no file write, prompt reload, catalog rescan, pin, or install.\n"
+    "Choose one Psyche operation. Every action takes strict input={} and is "
+    "read-only; load the returned manual before acting on an unfamiliar domain.\n"
     "pad: return pad-manual for system/pad.md and pinned Pad references.\n"
     "lingtai: return lingtai-manual for system/lingtai.md (灵台 / character).\n"
     "knowledge: return the knowledge manual for durable KNOWLEDGE.md entries.\n"
     "skills: return the skills manual for the configured .library catalog.\n"
-    "settings: show the applied, fully redacted Psyche-owned inventory.\n"
-    "manual: return the psyche routing table and shared rebuild model.\n"
-    "For durable changes, use file.write or file.edit on the domain source, "
-    "then one explicit context.rebuild; mutation never hot-loads the prompt."
+    "settings: show Psyche's fully redacted settings view.\n"
+    "manual: return the psyche routing table."
 )
 
 
@@ -117,16 +91,15 @@ _FAMILY = _build_family(None)
 
 def get_description(lang: str = "en") -> str:
     return (
-        "SIGNPOST ONLY: your psyche is your four durable domains — pad, "
-        "lingtai (灵台), knowledge, and skills. Each action takes input={} and "
-        "returns exact domain guidance or a compact redacted settings inventory. "
-        "It never authors, edits, pins, installs, rescans, or loads anything. "
-        "Read the relevant manual before acting on a domain you do not already "
-        "know. Change durable content with file.write (full rewrite) or "
-        "file.edit (exact replacement) on that domain's source, then apply it "
-        "with one explicit context.rebuild or passive refresh/molt "
-        "reconstruction; file mutation never hot-loads the prompt. Results are "
-        "exact guidance — leave root summarize false."
+        "SIGNPOST ONLY: psyche routes four durable domains — pad, lingtai "
+        "(灵台), knowledge, and skills. Every action takes strict input={} and is "
+        "read-only; it never authors, edits, pins, installs, rescans, or loads "
+        "anything. Call manual first for an unfamiliar domain. Durable changes "
+        "use file.write for a full rewrite or file.edit for an exact replacement, "
+        "then one explicit context.rebuild (or passive refresh/molt); file "
+        "mutation never hot-loads the prompt. Psyche owns no lifecycle action: "
+        "context owns rebuild/molt and system owns identity. Results are exact; "
+        "leave root summarize false."
     )
 
 

--- a/src/lingtai/tools/psyche/__init__.py
+++ b/src/lingtai/tools/psyche/__init__.py
@@ -73,23 +73,16 @@ _DECLARED_INPUT_SCHEMAS = {
 }
 
 _ACTION_ENUM_DESCRIPTION = (
-    "Required Psyche operation. Every action takes an empty input object and "
-    "is strictly read-only — none of them writes a file, "
-    "reloads the prompt, or rescans a catalog.\n"
-    "pad: return pad-manual (the sketchboard body at system/pad.md and its "
-    "pinned read-only references).\n"
-    "lingtai: return lingtai-manual (your 灵台 / character at system/lingtai.md).\n"
-    "knowledge: return the knowledge manual (private durable entries under "
-    "knowledge/<name>/KNOWLEDGE.md).\n"
-    "skills: return the skills manual (your catalog under .library/ plus any "
-    "configured skills paths).\n"
-    "settings: return the redacted inventory of Psyche-owned Pad and "
-    "prompt-owner configuration.\n"
-    "manual: return the psyche routing table — which action loads which "
-    "domain manual, and the shared mutation/rebuild model.\n"
-    "To CHANGE any durable source, use file.write for a full rewrite or "
-    "file.edit for exact replacement, then apply it with one explicit "
-    "context.rebuild; file mutation never hot-loads the prompt."
+    "Choose one Psyche operation. Every action takes input={} and is strictly "
+    "read-only: no file write, prompt reload, catalog rescan, pin, or install.\n"
+    "pad: return pad-manual for system/pad.md and pinned Pad references.\n"
+    "lingtai: return lingtai-manual for system/lingtai.md (灵台 / character).\n"
+    "knowledge: return the knowledge manual for durable KNOWLEDGE.md entries.\n"
+    "skills: return the skills manual for the configured .library catalog.\n"
+    "settings: show the applied, fully redacted Psyche-owned inventory.\n"
+    "manual: return the psyche routing table and shared rebuild model.\n"
+    "For durable changes, use file.write or file.edit on the domain source, "
+    "then one explicit context.rebuild; mutation never hot-loads the prompt."
 )
 
 
@@ -125,17 +118,14 @@ _FAMILY = _build_family(None)
 def get_description(lang: str = "en") -> str:
     return (
         "SIGNPOST ONLY: your psyche is your four durable domains — pad, "
-        "lingtai (灵台), knowledge, and skills. Domain actions "
-        "(pad/lingtai/knowledge/skills, input={}) return that domain's "
-        "manual; settings (input={}) returns one compact redacted inventory "
-        "of Psyche-owned Pad and prompt settings; manual (input={}) returns "
-        "the routing table that says which action you want and how the "
-        "domains relate. It never authors, edits, pins, installs, rescans, "
-        "or loads anything. Durable content is changed with file.write (full "
-        "rewrite) or file.edit (exact replacement) on the domain's own "
-        "source, and becomes visible only after an explicit context.rebuild "
-        "or passive refresh/molt reconstruction. Read the relevant manual "
-        "before acting on a domain you do not already know. Results are "
+        "lingtai (灵台), knowledge, and skills. Each action takes input={} and "
+        "returns exact domain guidance or a compact redacted settings inventory. "
+        "It never authors, edits, pins, installs, rescans, or loads anything. "
+        "Read the relevant manual before acting on a domain you do not already "
+        "know. Change durable content with file.write (full rewrite) or "
+        "file.edit (exact replacement) on that domain's source, then apply it "
+        "with one explicit context.rebuild or passive refresh/molt "
+        "reconstruction; file mutation never hot-loads the prompt. Results are "
         "exact guidance — leave root summarize false."
     )
 

--- a/tests/test_psyche_family.py
+++ b/tests/test_psyche_family.py
@@ -218,6 +218,38 @@ def test_router_manual_discloses_depth_and_first_call_guard(tmp_path):
         agent.stop(timeout=1.0)
 
 
+def test_router_keeps_settings_anchors_as_reference_pointers(tmp_path):
+    """R2 keeps stable anchors while moving settings depth to its owner page."""
+    import re
+
+    agent = _agent(tmp_path)
+    try:
+        result = _call(agent, "manual")
+        body = result["manual"]
+        anchors = (
+            "pad", "pad-file", "base-prompt", "base-prompt-file",
+            "covenant", "covenant-file", "comment", "comment-file",
+        )
+        for anchor in anchors:
+            heading = f"### Setting {anchor.replace('-', ' ')}"
+            assert len(re.findall(rf"^{re.escape(heading)}$", body, flags=re.M)) == 1
+            assert len(
+                re.findall(
+                    rf"reference/settings/SKILL\.md#setting-{re.escape(anchor)}\)",
+                    body,
+                )
+            ) == 1
+
+        assert "## Which domain am I in?" not in body
+        settings_reference = (
+            Path(result["manual_path"]).parent / "reference/settings/SKILL.md"
+        ).read_text(encoding="utf-8")
+        assert "key`, `current`, `default`, `configurable`, and `comment`" in settings_reference
+        assert '"schema_version": 1' in settings_reference
+    finally:
+        agent.stop(timeout=1.0)
+
+
 # ---------------------------------------------------------------------------
 # Owner settings discovery
 # ---------------------------------------------------------------------------

--- a/tests/test_psyche_family.py
+++ b/tests/test_psyche_family.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import hashlib
 import importlib
 import json
+from pathlib import Path
 
 import pytest
 
@@ -195,6 +196,24 @@ def test_router_manual_is_a_routing_table_naming_all_four_domains(tmp_path):
         # the domain manuals it points at.
         assert "file.write" in body and "file.edit" in body
         assert 'context(action="rebuild"' in body
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_router_manual_discloses_depth_and_first_call_guard(tmp_path):
+    """The resident router points to depth and keeps the safe first call."""
+    agent = _agent(tmp_path)
+    try:
+        result = _call(agent, "manual")
+        body = result["manual"]
+        assert "reference/settings/SKILL.md" in body
+        assert "reference/network-rules/SKILL.md" in body
+        assert "strict empty `input`" in body
+        assert "manual first" in body
+        assert len(body) < 10000
+        manual_path = Path(result["manual_path"])
+        assert (manual_path.parent / "reference/settings/SKILL.md").is_file()
+        assert (manual_path.parent / "reference/network-rules/SKILL.md").is_file()
     finally:
         agent.stop(timeout=1.0)
 


### PR DESCRIPTION
## Summary
- Round 2 tightens the Psyche-only progressive-disclosure router: one six-action table, strict-empty/manual-first/read-only guidance, explicit lifecycle ownership, and one concise file-mutation/rebuild model.
- The eight stable `### Setting ...` anchors are each retained exactly once as brief pointers; row shape/order, applied-snapshot rollback, owner-document grammar, precedence, and per-setting behavior remain in the settings reference.
- The `.rules` signpost is now only a separate-heartbeat boundary/link; its atomic write, replacement, persistence, authorization, and verification procedure remains in the network-rules reference.
- Root family/action prose no longer repeats the shared mutation/rebuild model; schema structure, action names, ownership, redaction, and refresh/rebuild behavior are unchanged.

## Validation
- Focused Psyche matrix (`tests/test_psyche_family.py`, `tests/test_psyche_prompt_settings.py`, `tests/test_signpost_tool_descriptions.py`): **118 passed**, one dependency deprecation warning.
- Docs governance: passed (372 documents plus `docs.yaml`).
- Recursive non-annotation schema traversal: baseline, R1, and R2 equal; normalized Python AST: baseline, R1, and R2 equal.
- Source-built `{name,description,parameters}` JSON (`ensure_ascii=false`, compact separators): R1 **3,744 Unicode chars / 3,756 UTF-8 bytes** to R2 **3,498 Unicode chars / 3,508 UTF-8 bytes**. Locked baseline was **4,146 chars / 4,162 bytes**.
- Resident manual: R1 **8,257 Unicode chars / 8,284 UTF-8 bytes** to R2 **5,139 Unicode chars / 5,154 UTF-8 bytes**. Exact eight headings/link targets, package inclusion, source provenance, and `git diff --check` passed.

Base remains the locked `891e7134589652b21e00473b334ac1e439abbf6e`; this update is on the existing Psyche PR only.