### PR TITLE
docs(notification): progressively disclose notification protocol

### DIFF
--- a/src/lingtai/tools/notification/manual/SKILL.md
+++ b/src/lingtai/tools/notification/manual/SKILL.md
@@ -5,7 +5,7 @@ description: >
   `notification` tool: read when interpreting `.notification/<channel>.json`,
   choosing producer-specific handling, or safely dismissing a mirror.
   Large-result/context compaction belongs to `context-manual`, not here.
-version: 0.14.0
+version: 0.15.0
 tags: [lingtai, notifications, channels, dismiss, delay, alarm, settings, manual, force, stale, nudge, hooks, whitelist]
 last_changed_at: "2026-09-06T00:00:00Z"
 related_files:
@@ -26,12 +26,12 @@ maintenance: |
 
 `notification` is the sole agent-callable surface for reading and clearing the
 current `.notification/<channel>.json` mirrors. `system` has no notification or
-dismiss alias; context compaction is `context(action='summarize')`.
+dismiss alias; compaction is `context(action='summarize')`.
 
 ## Quick start
 
-The resident schema is the source of truth for the eleven actions and their
-strict `action` + `input` + `reasoning` envelope. Begin with:
+The resident schema is the source of truth for eleven strict actions in the
+`action` + `input` + `reasoning` envelope. Begin with:
 
 ```text
 notification(action='check', input={}, reasoning='inspect current notifications')
@@ -39,15 +39,16 @@ notification(action='check', input={}, reasoning='inspect current notifications'
 
 `check` is read-only and returns a placeholder whose live payload is attached by
 the kernel. After handling a notification, use the narrowest matching dismiss
-action and do not call `check` merely to confirm the clear. Prefer a producer's
+action and do not call `check` merely to confirm the clear. Follow a producer's
 own read/dismiss verb when `instructions` names one: generic dismissal clears
-the mirror only, never producer state. Read the safety reference before using
-`force=true`, and read the channel-model reference when interpreting payloads,
-hooks, delay, or delivery.
+the mirror only, never producer state. Reread current state after a stale
+refusal; use `force=true` only for a confirmed stale mirror, never for producer
+or protected state. Read the dismissal-safety reference before forcing and the
+channel-model reference when interpreting payloads, hooks, delay, or delivery.
 
 Optional fields are required-but-nullable in the provider schema; `null` means
-omitted. `dismiss_event` and `dismiss_ref` default to `system`; a
-`dismiss_channel` call requires `channel`. A post-molt dismissal requires a
+omitted. `dismiss_channel` requires `channel`; `dismiss_event` and
+`dismiss_ref` default `channel` to `system`. A post-molt dismissal requires a
 non-empty `continue|defer|obsolete: ...` reason. `manual` and `settings` accept
 only `input={}` and are read-only.
 
@@ -57,11 +58,11 @@ only `input={}` and are read-only.
 hides consumer delivery for one allowed target only. `seconds: 0` cancels the
 matching delay; a nonzero call replaces the previous live delay. Producer files
 keep receiving updates. The live cap is
-`LINGTAI_NOTIFICATION_DELAY_MAX_SECONDS` (default `600`); `delay-alarm` cannot
-be targeted. Delaying `daemon` masks attention while keeping its payload and
-summary readable. At expiry or recovery, delivery resumes and one high-priority
-`delay-alarm` mirror records bounded evidence. See
-`reference/channel-model/SKILL.md` for persistence, recovery, and alarm details.
+`LINGTAI_NOTIFICATION_DELAY_MAX_SECONDS` (default `600`); missing, blank,
+non-numeric, non-positive, or non-finite values use that default. `delay-alarm`
+cannot be targeted. At expiry or recovery, delivery resumes and one
+high-priority `delay-alarm` mirror records bounded evidence; persistence and
+recovery details belong to the channel-model reference.
 
 The SHOW row is `notification.delay_max_seconds`: `current` is the effective
 positive integer from the live environment or the default `600`, and invalid
@@ -90,7 +91,9 @@ settings rows.
 
 Notification is a short-result family. Leave the root `summarize` boolean false
 when retrieving `manual`, because exact procedures and constraints matter. Use
-`context(action='summarize')` for tool-result compaction and recovery.
+`context(action='summarize')` for tool-result compaction and recovery; the
+legacy `large_tool_result` reminder is only an escape hatch and never changes
+producer state.
 
 ## Installed manual retrieval
 
@@ -111,8 +114,8 @@ External hooks must be registered with `add` before their channel is accepted.
 The effective allowlist is the built-in set, `mcp.*`, and channels registered by
 this agent's workdir; it is not process-global. `drop` revokes registration but
 never stops the hook process. Use the manifest's `how_to_cancel` to stop it.
-See `reference/channel-model/SKILL.md` for the setup flow, manifest fields,
-registry behavior, and blocked-channel warn-and-flag details.
+The channel-model reference owns the setup flow, manifest fields, registry
+behavior, and blocked-channel warn-and-flag details.
 
 ## Block size cap (persistent and attention lanes)
 
@@ -122,26 +125,14 @@ live environment `LINGTAI_NOTIFICATION_MAX_CHARS`, then valid System-v2
 `notification_max_chars`, then the default; malformed values fall through.
 Oversized payloads are atomically spilled and compacted while preserving routing
 ids, with a marker-only fallback when necessary. This is a context-size control,
-not delivery or access control. Change only through the existing authorized
-environment or closed System-v2 owner procedure; do not add Notification or
-`init.json` settings. See the channel-model reference for spill names,
-compaction order, and recovery behavior.
+not delivery or access control. Spill names, compaction order, and recovery are
+owned by the channel-model reference.
 
-## Nested reference catalog
-
-```yaml
-- name: notification-manual-channel-model
-  location: reference/channel-model/SKILL.md
-  description: |
-    Channel filenames and envelopes, effective per-agent allowlist, external
-    hooks, nudge routing, check/sync delivery, delay/alarm recovery, block caps,
-    settings sources, and producer mirror boundaries.
-- name: notification-manual-dismissal-safety
-  location: reference/dismissal-safety/SKILL.md
-  description: |
-    Producer-first handling, atomic targets, stale-version refusal, force rules,
-    protected channels, post-molt acknowledgement, and legacy reminders.
-```
+The SHOW row `notification.max_chars` reports that same effective clamped value.
+Change only through the existing authorized environment or closed System-v2 owner
+procedure; an environment/launcher change needs the authorized refresh or
+relaunch, while the file layer is hot-read. SHOW itself never writes, refreshes,
+adds an `init.json` field, or creates a Notification settings file.
 
 ## Routing table
 
@@ -150,13 +141,4 @@ compaction order, and recovery behavior.
 | First read; channel names; `.notification/*.json`; envelopes; `check`; delivery; allowlist; hooks; delay; block cap; settings sources | `reference/channel-model/SKILL.md` |
 | Which dismiss action; producer-specific handling; stale mirror; `force`; protected `goal`; post-molt reason; legacy `large_tool_result` | `reference/dismissal-safety/SKILL.md` |
 | Tool-result ranking, digest quality, `context(action='summarize')`, recovery by `tool_call_id` | `../context-manual/reference/summarize-manual/SKILL.md` |
-| Active goal cancellation/completion | `../system-manual/reference/goal-manual/SKILL.md` |
-| Runtime/kernel update nudges | `../system-manual/reference/runtime-update-checks/SKILL.md` |
-
-## Safety boundaries to keep resident
-
-Neither `check`, `settings`, nor `manual` writes notification state or runtime
-configuration. Generic dismissal affects only a mirror. A producer-specific
-verb remains preferred; a non-force stale refusal requires rereading current
-state before any deliberate `force=true`, and force never overrides protected
-source-of-truth channels.
+| Active goal cancellation/completion; runtime/kernel update nudges | `../system-manual/reference/goal-manual/SKILL.md` and `../system-manual/reference/runtime-update-checks/SKILL.md` |

--- a/src/lingtai/tools/notification/manual/SKILL.md
+++ b/src/lingtai/tools/notification/manual/SKILL.md
@@ -3,11 +3,11 @@ name: notification-manual
 description: >
   Router for the notification filesystem protocol and the standalone
   `notification` tool: read when interpreting `.notification/<channel>.json`,
-  or choosing producer-specific handling vs safe mirror dismissal.
+  choosing producer-specific handling, or safely dismissing a mirror.
   Large-result/context compaction belongs to `context-manual`, not here.
-version: 0.13.0
+version: 0.14.0
 tags: [lingtai, notifications, channels, dismiss, delay, alarm, settings, manual, force, stale, nudge, hooks, whitelist]
-last_changed_at: "2026-08-29T00:00:00Z"
+last_changed_at: "2026-09-06T00:00:00Z"
 related_files:
 - src/lingtai/prompts/meta_guidance/catalog/notification_handling.md
 - src/lingtai/tools/notification/ANATOMY.md
@@ -24,79 +24,55 @@ maintenance: |
 
 # Notification Manual — Router
 
-LingTai notifications are a filesystem protocol: producers publish allowlisted
-`.notification/<channel>.json` surfaces, and the kernel exposes their current
-model-visible state. The always-available `notification` tool is the sole
-agent-callable home for reading and clearing those surfaces. `system` has no
-notification or dismiss alias, and context hygiene is not a notification
-operation either — that is `context(action='summarize')`.
+`notification` is the sole agent-callable surface for reading and clearing the
+current `.notification/<channel>.json` mirrors. `system` has no notification or
+dismiss alias; context compaction is `context(action='summarize')`.
 
 ## Quick start
 
-The resident tool schema is the source of truth for the eleven actions, their
-per-action `input` fields, and the `action` + `input` + `reasoning` envelope
-(arguments live inside `input`, never at the root). What it does not say:
+The resident schema is the source of truth for the eleven actions and their
+strict `action` + `input` + `reasoning` envelope. Begin with:
 
-- `manual` returns **this router body** — it is documentation retrieval, not a
-  notification-state read.
-- `settings` accepts exactly `input={}` and only shows current configuration;
-  it has no set, reset, or other mutation form.
-- Optional fields are declared required-but-nullable, and `null` is treated
-  exactly like omission. The one trap: `reason: null` does **not** satisfy the
-  post-molt acknowledgement requirement.
-- After handling a notification, use the narrowest correct dismiss action and end
-  the turn; do not voluntarily call `check` again merely to confirm the clear.
+```text
+notification(action='check', input={}, reasoning='inspect current notifications')
+```
+
+`check` is read-only and returns a placeholder whose live payload is attached by
+the kernel. After handling a notification, use the narrowest matching dismiss
+action and do not call `check` merely to confirm the clear. Prefer a producer's
+own read/dismiss verb when `instructions` names one: generic dismissal clears
+the mirror only, never producer state. Read the safety reference before using
+`force=true`, and read the channel-model reference when interpreting payloads,
+hooks, delay, or delivery.
+
+Optional fields are required-but-nullable in the provider schema; `null` means
+omitted. `dismiss_event` and `dismiss_ref` default to `system`; a
+`dismiss_channel` call requires `channel`. A post-molt dismissal requires a
+non-empty `continue|defer|obsolete: ...` reason. `manual` and `settings` accept
+only `input={}` and are read-only.
 
 ## Consumer delay and expiry alarm
 
-`notification(action='delay', input={'channel': '<allowed>', 'seconds': 1..LINGTAI_NOTIFICATION_DELAY_MAX_SECONDS},
-reasoning='...')` hides **only consumer delivery** for one allowed target while
-the timer is live. The nonzero cap is read live from
-`LINGTAI_NOTIFICATION_DELAY_MAX_SECONDS` (default `600` seconds), so a current
-environment setting applies to each action without restart; blank, invalid, zero,
-or negative values log a fallback to `600`. It does not clear, rewrite, or pause
-the producer; target messages keep accumulating in their original channel file. Every other channel
-continues delivering normally. A nonzero call explicitly replaces the one prior
-live delay. Use `seconds: 0` with that same channel to cancel early and
-re-expose it.
+`notification(action='delay', input={'channel': '<allowed>', 'seconds': 0 or a positive configured cap}, reasoning='...')`
+hides consumer delivery for one allowed target only. `seconds: 0` cancels the
+matching delay; a nonzero call replaces the previous live delay. Producer files
+keep receiving updates. The live cap is
+`LINGTAI_NOTIFICATION_DELAY_MAX_SECONDS` (default `600`); `delay-alarm` cannot
+be targeted. Delaying `daemon` masks attention while keeping its payload and
+summary readable. At expiry or recovery, delivery resumes and one high-priority
+`delay-alarm` mirror records bounded evidence. See
+`reference/channel-model/SKILL.md` for persistence, recovery, and alarm details.
 
-At expiry (including after a refresh/restart recovery) the target becomes visible
-in the same consumer sync that adds one high-priority `delay-alarm` mirror. The
-alarm records target, requested/actual duration, changed/no-change, and only
-conservative current measurements: producer-reported counts and retained event
-entries are never asserted to be an exact total for overwritten/capped mirrors.
-Handle the re-exposed target, then dismiss `delay-alarm` as a mirror when done.
-Delaying `daemon` is the one exception to hiding: the daemon channel stays
-readable (check, snapshot, and the bounded daemon summary keep working) and only
-stops waking you until the delay ends. `delay-alarm` itself cannot be delayed. A damaged private delay record fails open
-(target visible) rather than silently suppressing notification delivery.
-
-The five-field SHOW row is `notification.delay_max_seconds`. Its meaning is the
-finite nonzero delay ceiling described above; `current` is the live effective
-integer and `default` is `600`. Resolution is
-`LINGTAI_NOTIFICATION_DELAY_MAX_SECONDS` followed by the fixed default.
-Accepted configured values are positive integer strings. Missing uses `600`;
-blank, non-numeric, zero, and negative input fall back to `600`; the delay
-action logs its existing bounded diagnostic, while SHOW performs no log write.
-The value is non-sensitive and is read at every delay action, so an environment
-value already present in the process applies to the next call. The row is
-`configurable: true` because the existing launcher or configured `env_file`
-procedure can change that source outside SHOW.
-
-To change it, obtain the configuration owner's approval, then edit the exact
-variable in the agent's existing `env_file` or launcher/supervisor environment.
-Do not add an `init.json` field or create a Notification settings file. An
-`env_file` edit or launcher change needs the normal authorized refresh/relaunch
-to enter the process. Call `notification(action='settings', input={},
-reasoning='verify delay ceiling')` again and confirm
-`notification.delay_max_seconds.current`; SHOW never writes the environment or
-performs the refresh.
+The SHOW row is `notification.delay_max_seconds`: `current` is the effective
+positive integer from the live environment or the default `600`, and invalid
+input falls back to `600`. SHOW does not write or refresh anything. Change the
+existing launcher or `env_file` only with configuration-owner approval, then
+perform the authorized refresh/relaunch and verify with `settings`.
 
 ## Notification settings
 
-`notification(action='settings', input={}, reasoning='inventory')` is a
-read-only progressive-disclosure action. Normal success contains exactly these
-rows and exactly the five projected fields `key`, `current`, `default`,
+`notification(action='settings', input={}, reasoning='inventory')` is read-only.
+It returns exactly two rows, in order, each with only `key`, `current`, `default`,
 `configurable`, and `comment`:
 
 - `notification.max_chars` →
@@ -104,19 +80,17 @@ rows and exactly the five projected fields `key`, `current`, `default`,
 - `notification.delay_max_seconds` →
   `notification-manual#consumer-delay-and-expiry-alarm`
 
-The `comment` pointer is where meaning, accepted values, precedence, canonical
-source names, apply timing, sensitivity, authorization notes, and the real
-change procedure live. Neither row is sensitive; channel payloads, events,
-accounts, file paths, delay state, hook manifests, and session state are not
-settings rows. If either effective value cannot be resolved or serialized, the
-whole call fails with the fixed `SETTINGS_UNAVAILABLE` result; there are no
-partial rows or per-row unavailable placeholders.
+The comment targets are the source of truth for meaning, precedence, accepted
+values, and authorized change/verification procedures. If either current value
+is unavailable, the whole action fails; it never returns partial rows. Channel
+payloads, accounts, hook manifests, delay state, and session state are not
+settings rows.
 
 ## Root `summarize`
 
-Notification is a **short-result** family, so leave the root `summarize` boolean
-false — especially for `manual`, where summarizing would drop the exact
-procedures and constraints you called it for.
+Notification is a short-result family. Leave the root `summarize` boolean false
+when retrieving `manual`, because exact procedures and constraints matter. Use
+`context(action='summarize')` for tool-result compaction and recovery.
 
 ## Installed manual retrieval
 
@@ -127,172 +101,31 @@ procedures and constraints you called it for.
 ```
 
 Success returns exactly `status`, `notification_manual`, and `manual_path`. A
-missing installed file returns `status: degraded`, an empty
-`notification_manual`, the same fixed `manual_path`, and an actionable `error`
-naming an initializer or capability-install problem. It never falls back to a
-source checkout, and it touches neither notification nor producer state.
+missing installed file is degraded with an empty body and an actionable `error`;
+there is no source-checkout fallback. Manual retrieval neither reads nor writes
+`.notification/`, producer state, delay state, or logs.
 
 ## Hooks & whitelist
 
-External hooks deliver notifications through channels that are **not** on the
-static allowlist (which covers kernel intrinsics and `mcp.` bridge servers).
-Registering a hook is the whitelist gate: only registered hook channels pass
-through; everything else is ignored (and, when the kernel observes a blocked
-attempt, surfaced as a warn-and-flag system event so the agent can investigate).
-
-Hook channels are **per-agent**: registering a hook allowlists its channel for
-this agent's working directory only — a hook channel is not visible to other
-agents' workdirs. The registry (`.notification/hooks.json`) is re-read whenever
-its `(mtime, size)` stat changes, so an out-of-band write by another process (a
-sibling CLI, the Telegram server, or the hook installer itself) is picked up on
-the next sync without a restart.
-
-### Setup flow
-
-1. **Write the hook script** that polls a source (a file, a service, a remote
-   node) and, on an event, publishes `.notification/<channel>.json` with the
-   standard envelope (`header`, `icon`, `priority`, `published_at`, `data`,
-   optional `instructions`).
-2. **Register its manifest** with the notification tool:
-   `notification(action='add', input={...})`. `add` validates the manifest,
-   appends it to the disk registry (`.notification/hooks.json`), and
-   **allowlists the manifest's `channel`** — from then on the channel passes
-   the kernel's allow predicate.
-3. **Publish** `.notification/<channel>.json` from the hook process. The
-   notification now appears in `check` / the meta-block payload like any other
-   channel.
-4. **Read and dismiss** per the producer's `instructions` / the manifest's
-   `description`, using the narrowest correct dismiss action. Dismissing the
-   mirror does not touch the hook process; `drop` only revokes the
-   registration.
-
-### Manifest fields
-
-- `name` — unique hook identifier (required).
-- `channel` — the `.notification/<channel>.json` stem this hook owns
-  (required; must be unique across hooks). It must not be a built-in static
-  channel (`system`/`email`/`soul`/`goal`/`molt`/`nudge`/`post-molt`/`bash`/`btw`/`cron`/`daemon`/`delay-alarm`/`tool_loop_guard`)
-  nor a Store-reserved non-channel stem (`hooks`/`large_result_acks`); `add`
-  refuses those with a clear error.
-- `source` — what the hook polls (required, e.g. `G:`).
-- `description` — one-line purpose (required).
-- `how_to_modify` / `how_to_cancel` — how the agent updates or stops the hook
-  (required; cancellation is the owner's job — `drop` never kills a process).
-- `version` — manifest version (optional, defaults to `1.0.0`).
-- `instructions` — agent-facing handling guidance (optional).
-
-### drop / edit / list semantics
-
-- `list` — read-only; returns the registered manifests in registry order, or
-  `hook_registry_load_failed` when the registry is corrupt or unreadable.
-- `edit` — update a manifest's fields by `name`; changing `channel` moves the
-  allowlist entry (and is refused with `channel_in_use` if another hook owns
-  that channel). Moving `channel` onto a built-in static channel or a
-  Store-reserved stem (`hooks`/`large_result_acks`) is refused with
-  `invalid_manifest`. An `edit` providing no non-null fields is a `no_change`
-  no-op.
-- `drop` — remove the manifest **and revoke its channel** from the allowlist;
-  unknown names return `not_found`. `drop` is registration evidence only —
-  stopping the hook process follows the manifest's `how_to_cancel`.
-
-### Warn-and-flag
-
-When a channel that is neither statically allowlisted nor registered attempts
-notification, the kernel emits one `notification_hook` system event
-(`ref_id: blocked_channel:<channel>`) per workdir+channel — deduped until the
-channel registers (then a later re-block can warn again). The scan only flags
-stems that can become channels: kernel-private dotfiles (`.nudge_state.json`),
-non-`.json` entries, and syntactically invalid stems are skipped. If you see
-such an event, run `list` to inspect hooks and
-`add` to register the hook if the producer is legitimate.
-
-### Worked example: `comm_watcher`
-
-```text
-1. A watcher script polls a G: node (source) for changes.
-2. On a change it writes .notification/comm_watcher.json with the standard
-   envelope and instructions (e.g. "read the relayed message, then dismiss").
-3. The agent (or operator) registers it once:
-   notification(action='add', input={
-     'name': 'comm_watcher', 'channel': 'comm_watcher', 'source': 'G:',
-     'description': 'poll G: node and relay',
-     'how_to_modify': 'notification(action=edit, ...)',
-     'how_to_cancel': 'stop the watcher process',
-     'instructions': 'read the relayed message and dismiss the channel'})
-4. The channel is now allowlisted: notifications pass through to check, and
-   the agent reads/dismisses per the manifest's instructions.
-5. To decommission: notification(action='drop', input={'name': 'comm_watcher'})
-   revokes the channel, then stop the watcher process per how_to_cancel.
-```
+External hooks must be registered with `add` before their channel is accepted.
+The effective allowlist is the built-in set, `mcp.*`, and channels registered by
+this agent's workdir; it is not process-global. `drop` revokes registration but
+never stops the hook process. Use the manifest's `how_to_cancel` to stop it.
+See `reference/channel-model/SKILL.md` for the setup flow, manifest fields,
+registry behavior, and blocked-channel warn-and-flag details.
 
 ## Block size cap (persistent and attention lanes)
 
-Two model-visible notification envelopes are re-serialized into provider
-context: the persistent block
-(`_meta.agent_meta.notifications.persistent`, the `notification_persistent`
-block, rebuilt per payload build) and the attention lane
-(`_meta.agent_meta.notifications.attention`, the transient per-channel routing
-payload re-stamped on every eligible tool batch and every IDLE/ASLEEP pair).
-A busy hub agent with many unread emails plus several IM lanes could otherwise
-grow context fast and pay a large per-call cache miss. The kernel caps BOTH
-lanes with ONE shared bar (`LINGTAI_NOTIFICATION_MAX_CHARS`):
-
-- **At or under the cap** (default `10000` characters): the block is delivered
-  byte-identical, no spill file, no marker.
-- **Over the cap - persistent lane**: the FULL block is written atomically to
-  `<workdir>/logs/notification-overflow-<ts>.json`, and the model-visible copy
-  is compacted (heavy free-text fields 200 → 100 → 50 → 0, then id-only
-  message stubs) until it fits; a terminal marker-only envelope with the exact
-  spill basename is returned BY CONSTRUCTION when even id-only stubs exceed
-  the cap. The compacted block carries an `overflow` marker
-  `{path, full_chars, truncated}` (and `path_omitted` + `spill_file` when the
-  absolute path is stripped). Message ids are never dropped, so delivery
-  tracking still sees every message and never re-delivers a truncated one.
-- **Over the cap - attention lane**: the FULL lane is written once to
-  `<workdir>/logs/notification-attention-overflow-<digest8>.json` — the name
-  is content-addressed (short sha256 of the lane's canonical serialization),
-  so an unchanged oversized lane reuses the SAME file instead of re-spilling
-  every batch, and exclusive creation never overwrites an existing recovery
-  handle (a different-content collision allocates `<digest8>-<N>.json`; the
-  exact allocated basename, including any `-N` suffix, is returned as
-  `overflow.spill_file`). The model-visible copy is compacted (heavy fields
-  truncated; routing ids including `message_ids` preserved) and carries the
-  same `overflow` marker. If even the routing stub cannot fit, the lane
-  degrades deterministically to a marker-only envelope that is capped BY
-  CONSTRUCTION: a pathologically long absolute spill path is stripped from the
-  marker (`path = None`, `path_omitted`, exact `spill_file` basename retained)
-  so the envelope always satisfies the cap; the full payload remains on disk
-  under the deterministic content-addressed name. If the spill file itself
-  cannot be written, the marker carries `spill_failed` and the block points
-  the agent at the producer tool for the full content.
-
-The five-field SHOW row is `notification.max_chars`. `current` is the same
-effective clamped value the live Agent consumes and `default` is `10000`.
-Resolution is a valid live `LINGTAI_NOTIFICATION_MAX_CHARS` value, then the
-existing `notification_max_chars` field in closed-v2
-`<agent>/settings/system.json` through `Agent.resolve_notification_max_chars()`,
-then `10000`. Positive values above `10000` clamp back to `10000`; values below
-`2048` clamp up to `2048` on both lanes. A missing, blank, non-numeric, zero, or
-negative environment value falls through to the valid System-v2 field, then
-the default. A malformed, unknown-field, wrong-version, or otherwise invalid
-System document is rejected whole and contributes no file-layer value. The
-value is non-sensitive, both sources are consulted at every payload build, and
-the row is `configurable: true` through these existing owner procedures.
-
-To change the environment source, obtain the configuration owner's approval
-and edit `LINGTAI_NOTIFICATION_MAX_CHARS` in the existing `env_file` or
-launcher/supervisor environment; refresh/relaunch is required for an `env_file`
-or launcher change to enter the process. To change the file layer instead, use
-the existing authorized File/Shell procedure to edit
-`<agent>/settings/system.json` as a closed `schema_version: 2` document and set
-only its `notification_max_chars` field while preserving any other valid v2
-fields. Do not add a Notification JSON document or an `init.json` field, and do
-not widen the closed System grammar. The file layer is hot-read. Call
-`notification(action='settings', input={}, reasoning='verify notification
-cap')` again and confirm `notification.max_chars.current`; SHOW itself never
-writes configuration, refreshes, or launches anything. This is a context-size
-steering knob only: it never grants access and never changes which messages are
-considered delivered.
+`notification.max_chars` is one shared character cap (default `10000`, bounded
+`2048..10000`) for the persistent and attention lanes. The effective value reads
+live environment `LINGTAI_NOTIFICATION_MAX_CHARS`, then valid System-v2
+`notification_max_chars`, then the default; malformed values fall through.
+Oversized payloads are atomically spilled and compacted while preserving routing
+ids, with a marker-only fallback when necessary. This is a context-size control,
+not delivery or access control. Change only through the existing authorized
+environment or closed System-v2 owner procedure; do not add Notification or
+`init.json` settings. See the channel-model reference for spill names,
+compaction order, and recovery behavior.
 
 ## Nested reference catalog
 
@@ -300,42 +133,30 @@ considered delivered.
 - name: notification-manual-channel-model
   location: reference/channel-model/SKILL.md
   description: |
-    Nested notification-manual reference for the filesystem channel protocol,
-    allowlist, envelopes and instructions, nudge routing, kernel sync, voluntary
-    check behavior, and producer canonical-state versus mirror boundaries. Read
-    this when interpreting or producing notification payloads.
+    Channel filenames and envelopes, effective per-agent allowlist, external
+    hooks, nudge routing, check/sync delivery, delay/alarm recovery, block caps,
+    settings sources, and producer mirror boundaries.
 - name: notification-manual-dismissal-safety
   location: reference/dismissal-safety/SKILL.md
   description: |
-    Nested notification-manual reference for atomic dismissal, producer-specific
-    verbs, stale-version and force rules, protected channels, post-molt
-    acknowledgement, and legacy large_tool_result reminder escape hatches. Read
-    this before clearing notification state or diagnosing a refusal.
+    Producer-first handling, atomic targets, stale-version refusal, force rules,
+    protected channels, post-molt acknowledgement, and legacy reminders.
 ```
 
 ## Routing table
 
 | Need / keywords | Read |
 |---|---|
-| Channel names; `.notification/*.json`; allowlist; `mcp.` channels; envelope fields; `instructions`; nudge/update checks; `_meta.agent_meta.notifications.attention`; voluntary `check`; producer state versus mirror | `reference/channel-model/SKILL.md` |
-| `notification_persistent` and `notification.attention` block size cap; `LINGTAI_NOTIFICATION_MAX_CHARS` (floor `2048` / ceiling `10000`); `notification-overflow-<ts>.json` and `notification-attention-overflow-<digest8>.json` spill files; compacted copy; message-id preservation; marker-only degradation | this section (`Block size cap (persistent and attention lanes)`) |
-| External-hook registration; `.notification/hooks.json`; `add`/`drop`/`edit`/`list`; whitelist gate; warn-and-flag on blocked channels | this section (`Hooks & whitelist`) + `reference/channel-model/SKILL.md` (effective allowlist) |
-| Temporarily hide one channel; `delay`; 0 or live configured seconds (default cap 600); replacement/cancellation; expiry, restart recovery, or `delay-alarm` | this section (`Consumer delay and expiry alarm`) + `reference/channel-model/SKILL.md` |
-| Show Notification settings; exact five fields; `notification.max_chars`; `notification.delay_max_seconds`; authorized change and verification procedures | this section (`Notification settings`) and each row's exact `comment` target |
-| Which dismiss action; producer-specific handling; guarded/stale mirror; `force`; protected `goal`; post-molt reason; legacy `large_tool_result` event | `reference/dismissal-safety/SKILL.md` |
-| Tool-result ranking, digest quality, `context(action='summarize')`, recovery by `tool_call_id`, summarize versus molt | `../context-manual/reference/summarize-manual/SKILL.md` |
-| Active goal source-of-truth and cancellation/completion | `../system-manual/reference/goal-manual/SKILL.md` |
+| First read; channel names; `.notification/*.json`; envelopes; `check`; delivery; allowlist; hooks; delay; block cap; settings sources | `reference/channel-model/SKILL.md` |
+| Which dismiss action; producer-specific handling; stale mirror; `force`; protected `goal`; post-molt reason; legacy `large_tool_result` | `reference/dismissal-safety/SKILL.md` |
+| Tool-result ranking, digest quality, `context(action='summarize')`, recovery by `tool_call_id` | `../context-manual/reference/summarize-manual/SKILL.md` |
+| Active goal cancellation/completion | `../system-manual/reference/goal-manual/SKILL.md` |
 | Runtime/kernel update nudges | `../system-manual/reference/runtime-update-checks/SKILL.md` |
 
 ## Safety boundaries to keep resident
 
-The producer-verb preference and `force` semantics are resident (meta_guidance
-`notification_handling` and the schema's `_FORCE_DESCRIPTION`). The two facts
-neither of them states:
-
-- Neither `check`, `settings`, nor `manual` writes notification state or runtime
-  configuration.
-- `force=true` does **not** override protected source-of-truth channels.
-
-Producer guards exist so that clearing a mirror is never mistaken for handling
-the producer's canonical state.
+Neither `check`, `settings`, nor `manual` writes notification state or runtime
+configuration. Generic dismissal affects only a mirror. A producer-specific
+verb remains preferred; a non-force stale refusal requires rereading current
+state before any deliberate `force=true`, and force never overrides protected
+source-of-truth channels.

--- a/src/lingtai/tools/notification/manual/reference/channel-model/SKILL.md
+++ b/src/lingtai/tools/notification/manual/reference/channel-model/SKILL.md
@@ -8,7 +8,7 @@ description: >
   producing, or debugging notification payloads; skip for dismissal policy.
 version: 0.6.0
 tags: [lingtai, notifications, channels, protocol, sync, delay, alarm, nudge, hooks, whitelist]
-last_changed_at: "2026-09-04T00:00:00Z"
+last_changed_at: "2026-09-06T00:00:00Z"
 related_files:
 - src/lingtai/tools/notification/manual/SKILL.md
 - src/lingtai/tools/notification/schema.py

--- a/src/lingtai/tools/notification/manual/reference/channel-model/SKILL.md
+++ b/src/lingtai/tools/notification/manual/reference/channel-model/SKILL.md
@@ -6,7 +6,7 @@ description: >
   kernel sync, voluntary check behavior, and canonical producer state versus
   notification mirrors. Read after notification-manual when interpreting,
   producing, or debugging notification payloads; skip for dismissal policy.
-version: 0.6.0
+version: 0.7.0
 tags: [lingtai, notifications, channels, protocol, sync, delay, alarm, nudge, hooks, whitelist]
 last_changed_at: "2026-09-06T00:00:00Z"
 related_files:
@@ -31,37 +31,27 @@ A channel is the filename stem in `.notification/<channel>.json`:
 
 The kernel accepts built-in channels including `email`, `system`, `soul`,
 `nudge`, `post-molt`, `tool_loop_guard`, `bash`, `btw`, `cron`, `molt`, `goal`,
-`daemon`, and `delay-alarm`; MCP bridge channels use the `mcp.` prefix. The **effective allowlist**
-is `static ∪ mcp.* ∪ the agent's own registered hook channels`, and it is
-**per-agent, not process-global**: a hook channel is allowed only for the agent
-whose workdir registered it (external hooks register manifests via
-`notification(action='add', ...)`, which appends to
-`.notification/hooks.json` and allowlists the manifest's `channel` for that
-workdir — see the
-parent manual's `Hooks & whitelist` section). Unknown JSON filenames are
-ignored by collection, and kernel publish/dismiss helpers reject names outside
-the effective allowlist, so arbitrary workdir files cannot enter the
-model-visible notification lane. Blocked attempts by unregistered channels are
-now observable: the kernel emits a deduped `notification_hook` system
-warn-and-flag event (`ref_id: blocked_channel:<channel>`) so the agent can
-investigate and register the hook if legitimate.
+`daemon`, and `delay-alarm`; MCP bridge channels use the `mcp.` prefix. The
+**effective allowlist** is `static ∪ mcp.* ∪ the agent's own registered hook
+channels`, and is **per-agent, not process-global**: a hook channel is allowed
+only for the agent whose workdir registered it. External hooks register
+manifests via `notification(action='add', ...)`, which appends to
+`.notification/hooks.json` and allowlists the manifest's `channel`.
 
-The D2 warn-and-flag scan runs only when a present channel file appears for a
-channel that is not on the effective allowlist, and only for stems that can
-actually become channels: kernel-private dotfiles (e.g. `.nudge_state.json`),
-non-`.json` entries, and syntactically invalid stems are skipped, so no
-unresolvable "register this hook" event is emitted for files that could never
-be a channel.
+Unknown JSON filenames are ignored by collection, and kernel publish/dismiss
+helpers reject names outside the effective allowlist, so arbitrary workdir files
+cannot enter the model-visible lane. A blocked present channel is observable:
+the kernel emits one deduplicated `notification_hook` system warn-and-flag event
+(`ref_id: blocked_channel:<channel>`) per workdir and channel until registration.
+The scan skips kernel-private dotfiles (for example `.nudge_state.json`),
+non-`.json` entries, and syntactically invalid stems because they cannot become
+channels.
 
-`nudge` is the formal channel for mechanical, throttled checks: runtime update
-checks publish `data.nudges[]` entries with `kind: kernel_version`, and
-source-freshness checks may publish `kind: source_drift` — which stays local and
-never enters release-migration routing. The sole normal install/update route is
-`https://lingtai.ai/install.sh` (let Shell run its `--help` and follow that), and
-real updates, configuration writes, and refresh require
-explicit human/config-owner authority. Those rules are owned in full by
-`../../../system-manual/reference/runtime-update-checks/SKILL.md`; this manual
-owns only the generic channel protocol.
+`nudge` is the formal channel for throttled checks: runtime update checks publish
+`data.nudges[]` entries with `kind: kernel_version`, and source-freshness checks
+may publish `kind: source_drift`; the latter stays local and never enters
+release-migration routing. Runtime update, configuration, and refresh policy is
+owned by `../../../system-manual/reference/runtime-update-checks/SKILL.md`.
 
 ## Envelope and producer instructions
 
@@ -84,8 +74,8 @@ cleared. Producers own that directive because only they know whether the file is
 a disposable output, a mirror over canonical state, a coalesced event summary,
 or protected source of truth.
 
-External producers that can write the workdir may publish the same envelope to
-an allowlisted `mcp.<server>.json` path. They must use atomic sibling-temp
+External producers that can write the workdir may publish the same envelope to an
+allowlisted `mcp.<server>.json` path. They must use atomic sibling-temp
 replacement so readers never observe a partial JSON file.
 
 ## Voluntary check and model-visible delivery
@@ -95,38 +85,44 @@ canonical live payload; the handler assembles no second channel representation
 and writes no notification state.
 
 When notifications arrive while an agent is IDLE or ASLEEP, the kernel can
-synthesize the same `notification(action='check')` tool-call/result shape —
-same `action`/`input`/`reasoning` envelope, indistinguishable from a read you
-issued yourself — and wake the agent. During ACTIVE work the post-hook moves the
-single live payload onto a suitable dict-shaped tool result only on first
-appearance, material change, or a deliberate check. Delivery fingerprints and
-the live holder belong to kernel synchronization, not to the `manual` action.
+synthesize the same `notification(action='check')` tool-call/result shape—same
+`action`/`input`/`reasoning` envelope, indistinguishable from a read you issued
+yourself—and wake the agent. During ACTIVE work the post-hook moves the single
+live payload onto a suitable dict-shaped tool result only on first appearance,
+material change, or a deliberate check. Delivery fingerprints and the live
+holder belong to kernel synchronization, not to the `manual` action.
 
-## Consumer delay filtering
+## Consumer delay filtering and expiry recovery
 
-The `daemon` target is masked, not filtered: its payload and byte version stay
-visible while its attention entry collapses to a constant token, so daemon
-arrivals stay readable but do not wake until the delay expires.
+The `daemon` target is masked, not filtered: its payload, byte version, and
+bounded summary stay visible while its attention entry collapses to a constant
+token, so daemon arrivals stay readable but do not wake until delay expires.
+Independent channels continue to wake.
 
-`notification(action='delay', input={'channel': ..., 'seconds': 0 or a live configured cap})` is
-not a producer operation. Its private `.notification/.delay_state.json` record
-causes the coherent consumer snapshot, delivery fingerprint, synthetic wake, and
-voluntary `check` projection to omit exactly one allowed target while it is live;
-the target file itself continues receiving and retaining producer updates. A
-nonzero delay replaces the prior one, and `seconds: 0` cancels the matching target
-and makes it visible again. See `notification-manual` → "Consumer delay and
-expiry alarm" for the exact nonzero-cap source, default, and precedence.
+`notification(action='delay', input={'channel': ..., 'seconds': 0 or a live configured cap})`
+is not a producer operation. Its private `.notification/.delay_state.json`
+record causes the coherent consumer snapshot, delivery fingerprint, synthetic
+wake, and voluntary `check` projection to omit exactly one allowed target while
+it is live; the target file continues receiving and retaining producer updates.
+A nonzero delay replaces the prior one, and `seconds: 0` cancels only the
+matching target and makes it visible again. The target file is never rewritten.
 
-The process timer is only a prompt path. Every coherent sync also recovers a
-persisted overdue delay. Recovery stops filtering and publishes one high-priority
-`delay-alarm` mirror in the same read/wake cycle. Its state uses the established
-native notification mutation lock plus atomic sibling replacement, and a stable
-request id makes a stale callback/restart retry overwrite the same latest-only
-alarm rather than append a duplicate. The alarm contains only byte-level change
-comparison plus producer-reported or retained-event measurements; such values are
-not claimed to be exact totals for overwrite/capped payloads. `delay-alarm` is a
-built-in mirror consumers may dismiss, but it cannot itself be delayed. Missing or
-malformed delay state fails toward visible target delivery.
+The finite nonzero cap is read live from
+`LINGTAI_NOTIFICATION_DELAY_MAX_SECONDS`; a missing, blank, non-numeric,
+non-positive, or non-finite value falls back to `600` with the existing bounded
+diagnostic. The process timer is only a prompt path. Every coherent sync also
+recovers a persisted overdue delay: recovery stops filtering and publishes one
+high-priority `delay-alarm` mirror in the same read/wake cycle. Its state uses
+the established native notification mutation lock plus atomic sibling
+replacement, and a stable request id makes a stale callback or restart retry
+overwrite the same latest-only alarm rather than append a duplicate.
+
+The alarm contains only byte-level change comparison plus producer-reported or
+retained-event measurements; these values are not claimed to be exact totals for
+overwrite or capped payloads. `delay-alarm` is a built-in mirror consumers may
+dismiss, but it cannot itself be delayed. Malformed or unreadable delay state
+fails open to visible target delivery. A `daemon` delay masks only its attention
+token; payload, delivered version, and bounded summary remain readable.
 
 ## Canonical producer state versus mirror
 
@@ -164,35 +160,18 @@ A blocked present JSON channel emits one deduplicated
 channel until registration. Kernel-private dotfiles, non-JSON entries, and
 invalid stems are skipped by this scan.
 
-## Delay cap and recovery detail
-
-The finite nonzero delay cap is read live from
-`LINGTAI_NOTIFICATION_DELAY_MAX_SECONDS`; a missing, blank, non-numeric,
-non-positive, or non-finite value falls back to `600` with the existing bounded
-diagnostic. The target file is never rewritten. A nonzero request replaces the
-one prior live request, while `seconds: 0` cancels only the matching target.
-
-The process timer is only a prompt path: coherent synchronization also recovers
-an overdue persisted record. Recovery removes filtering and publishes one
-high-priority latest-only `delay-alarm` mirror with target, requested/actual
-duration, byte-level change, and conservative producer/retained-event
-measurements. Stable request identity and the notification mutation lock prevent
-stale callbacks or restart recovery from duplicating alarms. Malformed or
-unreadable delay state fails open to visible delivery. A `daemon` delay masks
-only its attention token; payload, delivered version, and bounded summary remain
-readable, and independent channels still wake.
-
 ## Block-cap and settings detail
 
 The persistent block (`notification_persistent`) and transient attention lane
 share `LINGTAI_NOTIFICATION_MAX_CHARS` (default `10000`, clamped to `2048..10000`).
 Resolution is live environment, then valid closed System-v2
-`notification_max_chars`, then default. Invalid or malformed values contribute no
-layer value. At or under the cap, serialization is byte-identical. Above it, the
-full persistent payload is atomically spilled to
+`notification_max_chars`, then default. Invalid or malformed values contribute
+no layer value. At or under the cap, serialization is byte-identical. Above it,
+the full persistent payload is atomically spilled to
 `logs/notification-overflow-<ts>.json`; the attention lane uses a
 content-addressed `notification-attention-overflow-<digest8>.json` (with a
-collision suffix) and both model copies compact while preserving routing ids.
+collision suffix), and both model copies compact while preserving routing ids.
+
 Heavy free text is reduced in stages; if an id-only copy cannot fit, a marker-only
 envelope retains the exact spill basename, and a failed spill points back to the
 producer tool. The cap is a context-size control, not delivery accounting.
@@ -211,5 +190,5 @@ notification metadata such as legacy acknowledgement state
 (`.notification/hooks.json`, a single non-channel file invisible to collection),
 and consumer-delay state (`.notification/.delay_state.json`, a private dotfile
 invisible to collection). Inspect it read-only before diagnosing a producer.
-Never delete the directory or bulk-remove files — that bypasses the guards and
+Never delete the directory or bulk-remove files—doing so bypasses the guards and
 stale checks that only the producer verb or an atomic notification action honor.

--- a/src/lingtai/tools/notification/manual/reference/channel-model/SKILL.md
+++ b/src/lingtai/tools/notification/manual/reference/channel-model/SKILL.md
@@ -6,7 +6,7 @@ description: >
   kernel sync, voluntary check behavior, and canonical producer state versus
   notification mirrors. Read after notification-manual when interpreting,
   producing, or debugging notification payloads; skip for dismissal policy.
-version: 0.5.1
+version: 0.6.0
 tags: [lingtai, notifications, channels, protocol, sync, delay, alarm, nudge, hooks, whitelist]
 last_changed_at: "2026-09-04T00:00:00Z"
 related_files:
@@ -140,6 +140,69 @@ This separation is deliberate: the filesystem protocol gives the kernel one
 current high-attention surface, while canonical state remains under the
 producer's own schema and lifecycle.
 
+## Hook registration workflow
+
+An external hook follows this sequence:
+
+1. Write a watcher that publishes the standard envelope atomically to an
+   allowlisted `.notification/<channel>.json` path.
+2. Call `notification(action='add', input={...})` with `name`, `channel`,
+   `source`, `description`, `how_to_modify`, and `how_to_cancel`; optional
+   `version` defaults to `1.0.0`, and `instructions` teaches handling.
+3. Read the resulting channel with `check`, then use the producer instruction or
+   narrowest dismiss action. `drop` revokes registration but does not kill the
+   process.
+
+`list` returns manifests in registry order. `edit` changes named fields and
+revalidates channel uniqueness; a null-only edit is a no-op. Corrupt or
+unreadable `hooks.json` makes `list`, `add`, `drop`, and `edit` return a bounded
+load-failed result. Built-in channels and Store-reserved stems (`hooks` and
+`large_result_acks`) cannot be registered.
+
+A blocked present JSON channel emits one deduplicated
+`notification_hook` event with `ref_id: blocked_channel:<channel>` per workdir and
+channel until registration. Kernel-private dotfiles, non-JSON entries, and
+invalid stems are skipped by this scan.
+
+## Delay cap and recovery detail
+
+The finite nonzero delay cap is read live from
+`LINGTAI_NOTIFICATION_DELAY_MAX_SECONDS`; a missing, blank, non-numeric,
+non-positive, or non-finite value falls back to `600` with the existing bounded
+diagnostic. The target file is never rewritten. A nonzero request replaces the
+one prior live request, while `seconds: 0` cancels only the matching target.
+
+The process timer is only a prompt path: coherent synchronization also recovers
+an overdue persisted record. Recovery removes filtering and publishes one
+high-priority latest-only `delay-alarm` mirror with target, requested/actual
+duration, byte-level change, and conservative producer/retained-event
+measurements. Stable request identity and the notification mutation lock prevent
+stale callbacks or restart recovery from duplicating alarms. Malformed or
+unreadable delay state fails open to visible delivery. A `daemon` delay masks
+only its attention token; payload, delivered version, and bounded summary remain
+readable, and independent channels still wake.
+
+## Block-cap and settings detail
+
+The persistent block (`notification_persistent`) and transient attention lane
+share `LINGTAI_NOTIFICATION_MAX_CHARS` (default `10000`, clamped to `2048..10000`).
+Resolution is live environment, then valid closed System-v2
+`notification_max_chars`, then default. Invalid or malformed values contribute no
+layer value. At or under the cap, serialization is byte-identical. Above it, the
+full persistent payload is atomically spilled to
+`logs/notification-overflow-<ts>.json`; the attention lane uses a
+content-addressed `notification-attention-overflow-<digest8>.json` (with a
+collision suffix) and both model copies compact while preserving routing ids.
+Heavy free text is reduced in stages; if an id-only copy cannot fit, a marker-only
+envelope retains the exact spill basename, and a failed spill points back to the
+producer tool. The cap is a context-size control, not delivery accounting.
+
+The SHOW row `notification.max_chars` reports that same effective clamped value.
+To change it, obtain owner approval and use the existing environment launcher or
+closed System-v2 procedure; an environment/launcher change needs the authorized
+refresh or relaunch, while the file layer is hot-read. SHOW itself never writes,
+refreshes, adds an `init.json` field, or creates a Notification settings file.
+
 ## Footprint
 
 The protocol footprint is `.notification/<channel>.json` plus kernel-owned
@@ -147,7 +210,6 @@ notification metadata such as legacy acknowledgement state
 (`.notification/large_result_acks.json`), the hook-manifest registry
 (`.notification/hooks.json`, a single non-channel file invisible to collection),
 and consumer-delay state (`.notification/.delay_state.json`, a private dotfile
-invisible to collection). Inspect it read-only
-before diagnosing a producer. Never delete the directory or bulk-remove files —
-that bypasses the guards and stale checks that only the producer verb or an
-atomic notification action honor.
+invisible to collection). Inspect it read-only before diagnosing a producer.
+Never delete the directory or bulk-remove files — that bypasses the guards and
+stale checks that only the producer verb or an atomic notification action honor.

--- a/src/lingtai/tools/notification/schema.py
+++ b/src/lingtai/tools/notification/schema.py
@@ -30,18 +30,13 @@ from typing import Any
 from ..tool_family.manual import MANUAL_INPUT_SCHEMA
 
 LARGE_RESULT_DISMISS_ACTION_NOTE = (
-    "Legacy: the kernel no longer raises large_tool_result reminders — large "
-    "results are ranked under _meta.agent_meta.agent_state.current_tool_result_chars and "
-    "compacted via system(action=summarize). Any large_tool_result event still "
-    "present (e.g. persisted before this change or pre-molt) can be dismissed "
-    "as an escape hatch. Dismissal only clears the notification surface; the "
-    "original result stays in chat history and events.jsonl. See "
-    "notification-manual."
+    "Legacy large_tool_result reminders are an escape hatch only: prefer "
+    "context(action='summarize'); any dismiss clears the mirror, not the original "
+    "result. See notification-manual."
 )
 
 LARGE_RESULT_FORCE_NOTE = (
-    "Does not affect large_tool_result reminder dismissal; that escape hatch "
-    "is always allowed and clears only the reminder surface."
+    "The legacy large_tool_result escape hatch always clears only its mirror."
 )
 
 # The canonical action order. This is the single source for the schema's
@@ -67,24 +62,16 @@ NOTIFICATION_DECLARED_ACTIONS = (
 ACTION_ORDER = (*NOTIFICATION_DECLARED_ACTIONS, "settings", "manual")
 
 _CHANNEL_DESCRIPTION = (
-    "Notification channel to act on (e.g. soul, system, mcp.telegram). "
-    "Required for dismiss_channel; for dismiss_event/dismiss_ref it defaults "
-    "to 'system'. For producer-owned channels like email, prefer the "
-    "producer's own verb (email(read/dismiss))."
+    "Target channel; required here, defaults to system for event/ref. Prefer its "
+    "producer verb; generic dismissal clears only this mirror."
 )
 
 _FORCE_DESCRIPTION = (
-    "Optional for dismiss verbs. When true, bypasses a producer-registered "
-    "generic-dismiss guard and the stale-channel-version refusal. Use only "
-    "when knowingly clearing a stale mirror; producer-owned state is never "
-    "changed. " + LARGE_RESULT_FORCE_NOTE
+    "Optional true only after rereading a stale mirror; bypasses generic/stale "
+    "guards, never producer or protected state. " + LARGE_RESULT_FORCE_NOTE
 )
 
-_REASON_DESCRIPTION = (
-    "Optional acknowledgement reason, logged to the event log. Required when "
-    "dismissing the post-molt continuation channel (use "
-    "reason='<continue|defer|obsolete>: ...')."
-)
+_REASON_DESCRIPTION = "Optional ack reason; post-molt requires continue|defer|obsolete: ... ."
 
 _CHECK_INPUT_SCHEMA: dict[str, Any] = {
     "type": "object",
@@ -93,48 +80,25 @@ _CHECK_INPUT_SCHEMA: dict[str, Any] = {
     "additionalProperties": False,
 }
 
-_HOOK_NAME_DESCRIPTION = (
-    "Unique hook name within this agent (e.g. 'comm_watcher'). Required for "
-    "add/drop/edit; used to match manifests in .notification/hooks.json."
-)
+_HOOK_NAME_DESCRIPTION = "Hook name; required by add/drop/edit and matched in hooks.json."
 
 _HOOK_CHANNEL_DESCRIPTION = (
-    "Channel the hook publishes into (e.g. 'mcp.comm_watcher'). Must match "
-    "the .notification/<channel>.json file the hook writes. Registering it "
-    "here allowlists it for this agent."
+    "Published channel/file stem; registration allowlists it for this agent."
 )
 
-_HOOK_STRING_FIELD_DESCRIPTION = "Human-readable field on the hook manifest."
+_HOOK_STRING_FIELD_DESCRIPTION = "Hook manifest text field."
 
 _ADD_INPUT_SCHEMA: dict[str, Any] = {
     "type": "object",
     "properties": {
         "name": {"type": "string", "description": _HOOK_NAME_DESCRIPTION},
         "channel": {"type": "string", "description": _HOOK_CHANNEL_DESCRIPTION},
-        "source": {
-            "type": "string",
-            "description": "Who/what produces the notifications (e.g. 'comm_watcher.py').",
-        },
-        "description": {
-            "type": "string",
-            "description": "What this hook watches and why (one or two sentences).",
-        },
-        "how_to_modify": {
-            "type": "string",
-            "description": "How to change the hook (config file, env var, command).",
-        },
-        "how_to_cancel": {
-            "type": "string",
-            "description": "How to stop the hook (pid/kill, unregister, config toggle).",
-        },
-        "version": {
-            "type": ["string", "null"],
-            "description": "Optional manifest version (default '1.0.0').",
-        },
-        "instructions": {
-            "type": ["string", "null"],
-            "description": "Optional agent-facing handling guidance for this hook's notifications.",
-        },
+        "source": {"type": "string", "description": "Producer/source identifier."},
+        "description": {"type": "string", "description": "What the hook watches."},
+        "how_to_modify": {"type": "string", "description": "How to modify it."},
+        "how_to_cancel": {"type": "string", "description": "How to stop it; drop never kills it."},
+        "version": {"type": ["string", "null"], "description": "Optional version; default 1.0.0."},
+        "instructions": {"type": ["string", "null"], "description": "Optional handling guidance."},
     },
     "required": [
         "name",
@@ -186,19 +150,12 @@ _DELAY_INPUT_SCHEMA: dict[str, Any] = {
     "properties": {
         "channel": {
             "type": "string",
-            "description": (
-                "Allowed notification channel whose consumer delivery is temporarily "
-                "hidden. delay-alarm is an alarm mirror and cannot be delayed."
-            ),
+            "description": "Allowed target; delay-alarm cannot be delayed.",
         },
         "seconds": {
             "type": "integer",
             "minimum": 0,
-            "description": (
-                "Delay duration. 0 cancels the currently delayed channel; a nonzero "
-                "value is bounded by live LINGTAI_NOTIFICATION_DELAY_MAX_SECONDS "
-                "(default 600 seconds)."
-            ),
+            "description": "Seconds; 0 cancels, otherwise live cap LINGTAI_NOTIFICATION_DELAY_MAX_SECONDS (default 600).",
         },
     },
     "required": ["channel", "seconds"],
@@ -281,57 +238,49 @@ INPUT_SCHEMAS: dict[str, dict[str, Any]] = {
 }
 
 ACTION_ENUM_DESCRIPTION = (
-    "check: read all notification channels (input={}). Returns a placeholder; " +
-    "the live payload is stamped onto this same result under " +
-    "`_meta.agent_meta.notifications.attention` and " +
-    "`_meta.agent_meta.guidance.transient`. Replace-only — do not call " +
-    "voluntarily after handling; dismiss instead, preferably coalesced with " +
-    "other tool work you already need this turn." +
-
-    "dismiss_channel: clear one notification channel whole (input={'channel': " +
-    "'<name>', ...}). Prefer a producer-specific verb first (e.g. " +
-    "email(read/dismiss)); guarded channels require force=true only for stale " +
-    "mirrors. Does not accept event_id/ref_id — use dismiss_event/dismiss_ref " +
-    "for those." +
-
-    "dismiss_event: remove a single system event by event_id from " +
-    ".notification/system.json (channel defaults to 'system' when null)." +
-
-    "dismiss_ref: remove system event(s) by ref_id from " +
-    ".notification/system.json (channel defaults to 'system' when null)." +
-
-    "add: register an external hook (input={'name', 'channel', 'source', " +
-    "'description', 'how_to_modify', 'how_to_cancel', ...}), writing the " +
-    "manifest to .notification/hooks.json and allowlisting its channel. " +
-    "Agent self-service: add your own hooks." +
-
-    "drop: unregister a hook by name (input={'name': ...}); removes its " +
-    "manifest and revokes the channel from the effective allowlist. Never " +
-    "kills the hook process itself — use the manifest's how_to_cancel." +
-
-    "edit: update one hook's fields by name (input={'name': ..., ...fields}); " +
-    "channel edits re-validate uniqueness." +
-
-    "list: return the registered hook manifests (input={}), showing what is " +
-    "whitelisted and how each hook is modified/cancelled." +
-
-    "delay: temporarily hide one allowed target channel from consumer delivery " +
-    "(input={'channel': '<name>', 'seconds': 0 or a live-configured positive " +
-    "cap}); 0 cancels the current matching delay. Target producer state is " +
-    "never changed; expiry re-exposes it and raises one high-priority " +
-    "delay-alarm mirror. delay-alarm itself cannot be targeted." +
-
-    "settings: show the Notification-owned effective settings as exact " +
-    "key/current/default/configurable/comment rows (input={}); read-only. " +
-    "Read the comment-targeted manual sections for meaning/change procedures." +
-
-    "manual: call notification(action='manual', input={}) to return the " +
-    "installed notification-manual skill body. Strictly read-only."
+    "Actions take their strict arguments in input; nullable optionals mean absent. "
+    "check: first read of current channels (input={}); it returns a placeholder "
+    "whose live payload is stamped under `_meta.agent_meta.notifications.attention` "
+    "and `_meta.agent_meta.guidance.transient`, so dismiss after handling rather "
+    "than checking again just to confirm. "
+    "dismiss_channel: clear one whole mirror (input={'channel': '<name>', ...}); "
+    "use the producer's own verb first when offered. A non-force stale-version or "
+    "producer guard refusal means reread; force=true is only for a confirmed stale "
+    "mirror and never changes producer/protected state. "
+    "dismiss_event: remove one system event by event_id; channel defaults to system. "
+    "dismiss_ref: remove matching system events by ref_id; channel defaults to system. "
+    "add: register a hook manifest and allowlist its channel. "
+    "drop: unregister a hook and revoke its channel; never stop its process. "
+    "edit: update a named hook and revalidate channel uniqueness. "
+    "list: show registered hook manifests. "
+    "delay: hide one allowed consumer channel for seconds (0 cancels; nonzero uses "
+    "the live configured cap); producer state is unchanged and expiry emits one "
+    "delay-alarm mirror, which cannot itself be delayed. "
+    "settings: read-only effective key/current/default/configurable/comment rows; "
+    "follow the linked manual sections for meaning or changes. "
+    "manual: call notification(action='manual', input={}) to return the installed "
+    "notification manual; read-only. "
+    "Post-molt dismissal requires a continue|defer|obsolete reason."
 ) + "\n\n" + LARGE_RESULT_DISMISS_ACTION_NOTE
 
 
 def get_description(lang: str = "en") -> str:
-    return "Notification surface — inspect and acknowledge the agent's notification channels, and manage external-hook registrations. Self-actions, no permissions needed. This is the only tool that exposes notification verbs; the system tool no longer offers notification or dismiss aliases. Every call takes action + input + reasoning; input is the strict argument object for the selected action. Prefer a producer's own read/dismiss (e.g. email) over the generic dismiss verbs here when one exists; check is inspection only, not a clearing operation. Guarded channels require force=true only for known-stale mirrors, and dismissal after a molt needs a continuation reason. add/edit/drop/list manage the hook manifest only — drop never stops the hook's own process. delay suppresses consumer delivery only for one allowed channel (0 cancels) and cannot target delay-alarm. Use notification(action='settings', input={}, reasoning='...') and notification(action='manual', input={}, reasoning='...') for the read-only settings rows and the installed manual — neither changes notification state, and call manual with summarize=false. Context compaction is not here — use context(action='summarize')."
+    return (
+        "Notification is the sole tool for current-channel inspection, atomic "
+        "mirror dismissal, hook registration, and consumer delay. Calls use "
+        "action + input + reasoning; input is the selected action's strict object. "
+        "Start with notification(action='check', input={}, reasoning='...') to "
+        "inspect. Prefer a producer's own read/dismiss when offered: generic "
+        "dismiss clears only the mirror. Reread after a stale refusal; force=true "
+        "is only for a known-stale mirror and never changes producer/protected "
+        "state. Post-molt dismissal needs a continue/defer/obsolete reason. "
+        "Hook drop never stops its process; delay hides consumer delivery only "
+        "(0 cancels), and delay-alarm cannot be targeted. "
+        "notification(action='settings', input={}, reasoning='...') is read-only; "
+        "notification(action='manual', input={}, reasoning='...') returns the "
+        "installed manual. Both are read-only; use context(action='summarize') "
+        "for compaction."
+    )
 
 
 # NOTE: ``get_schema`` is deliberately NOT defined here. The model-facing

--- a/src/lingtai/tools/notification/schema.py
+++ b/src/lingtai/tools/notification/schema.py
@@ -3,9 +3,9 @@
 The notification tool exposes ``check``, the three atomic dismiss verbs
 (``dismiss_channel``, ``dismiss_event``, ``dismiss_ref``), read-only settings
 discovery, and the strictly read-only progressive-disclosure action ``manual``.
-``summarize`` is *not* a notification verb — it remains a ``system`` action;
-the root ``summarize`` boolean is the cross-cutting LTP v2 result-post-processing
-control, not an action.
+``summarize`` is *not* a notification verb; compaction is owned by
+``context(action='summarize')``. The root ``summarize`` boolean is the
+cross-cutting LTP v2 result-post-processing control, not an action.
 
 This module holds only data: each action's own canonical strict
 ``input_schema`` (:data:`INPUT_SCHEMAS`) and the canonical English prose.
@@ -35,9 +35,7 @@ LARGE_RESULT_DISMISS_ACTION_NOTE = (
     "result. See notification-manual."
 )
 
-LARGE_RESULT_FORCE_NOTE = (
-    "The legacy large_tool_result escape hatch always clears only its mirror."
-)
+LARGE_RESULT_FORCE_NOTE = ""
 
 # The canonical action order. This is the single source for the schema's
 # ``action`` enum order, the ``input`` disclosure/``allOf`` branch order, and the
@@ -62,16 +60,16 @@ NOTIFICATION_DECLARED_ACTIONS = (
 ACTION_ORDER = (*NOTIFICATION_DECLARED_ACTIONS, "settings", "manual")
 
 _CHANNEL_DESCRIPTION = (
-    "Target channel; required here, defaults to system for event/ref. Prefer its "
-    "producer verb; generic dismissal clears only this mirror."
+    "Target channel; required for whole-channel clear; event/ref default to system. "
+    "Follow its producer verb first; generic clear is mirror-only."
 )
 
 _FORCE_DESCRIPTION = (
-    "Optional true only after rereading a stale mirror; bypasses generic/stale "
-    "guards, never producer or protected state. " + LARGE_RESULT_FORCE_NOTE
+    "Optional true only after rereading a confirmed stale mirror; never producer or "
+    "protected state. " + LARGE_RESULT_FORCE_NOTE
 )
 
-_REASON_DESCRIPTION = "Optional ack reason; post-molt requires continue|defer|obsolete: ... ."
+_REASON_DESCRIPTION = "Optional ack reason; post-molt: continue|defer|obsolete: ... ."
 
 _CHECK_INPUT_SCHEMA: dict[str, Any] = {
     "type": "object",
@@ -80,13 +78,11 @@ _CHECK_INPUT_SCHEMA: dict[str, Any] = {
     "additionalProperties": False,
 }
 
-_HOOK_NAME_DESCRIPTION = "Hook name; required by add/drop/edit and matched in hooks.json."
+_HOOK_NAME_DESCRIPTION = "Hook name; matched in hooks.json."
 
-_HOOK_CHANNEL_DESCRIPTION = (
-    "Published channel/file stem; registration allowlists it for this agent."
-)
+_HOOK_CHANNEL_DESCRIPTION = "Published channel stem; registration allowlists it."
 
-_HOOK_STRING_FIELD_DESCRIPTION = "Hook manifest text field."
+_HOOK_STRING_FIELD_DESCRIPTION = "Hook manifest field."
 
 _ADD_INPUT_SCHEMA: dict[str, Any] = {
     "type": "object",
@@ -238,48 +234,40 @@ INPUT_SCHEMAS: dict[str, dict[str, Any]] = {
 }
 
 ACTION_ENUM_DESCRIPTION = (
-    "Actions take their strict arguments in input; nullable optionals mean absent. "
-    "check: first read of current channels (input={}); it returns a placeholder "
-    "whose live payload is stamped under `_meta.agent_meta.notifications.attention` "
-    "and `_meta.agent_meta.guidance.transient`, so dismiss after handling rather "
-    "than checking again just to confirm. "
-    "dismiss_channel: clear one whole mirror (input={'channel': '<name>', ...}); "
-    "use the producer's own verb first when offered. A non-force stale-version or "
-    "producer guard refusal means reread; force=true is only for a confirmed stale "
-    "mirror and never changes producer/protected state. "
+    "Strict action selector: each action takes its own object in input; nullable "
+    "optionals mean absent. "
+    "check: read current channels and return the live placeholder. "
+    "dismiss_channel: clear one named mirror. "
     "dismiss_event: remove one system event by event_id; channel defaults to system. "
     "dismiss_ref: remove matching system events by ref_id; channel defaults to system. "
     "add: register a hook manifest and allowlist its channel. "
-    "drop: unregister a hook and revoke its channel; never stop its process. "
+    "drop: unregister a hook; it never stops the process. "
     "edit: update a named hook and revalidate channel uniqueness. "
     "list: show registered hook manifests. "
-    "delay: hide one allowed consumer channel for seconds (0 cancels; nonzero uses "
-    "the live configured cap); producer state is unchanged and expiry emits one "
-    "delay-alarm mirror, which cannot itself be delayed. "
-    "settings: read-only effective key/current/default/configurable/comment rows; "
-    "follow the linked manual sections for meaning or changes. "
+    "delay: hide one allowed consumer channel (0 cancels; nonzero uses the live "
+    "cap); producer state is unchanged and expiry emits one non-delayable alarm. "
+    "settings: read-only effective setting rows. "
     "manual: call notification(action='manual', input={}) to return the installed "
-    "notification manual; read-only. "
-    "Post-molt dismissal requires a continue|defer|obsolete reason."
+    "notification manual; read-only."
 ) + "\n\n" + LARGE_RESULT_DISMISS_ACTION_NOTE
 
 
 def get_description(lang: str = "en") -> str:
     return (
-        "Notification is the sole tool for current-channel inspection, atomic "
-        "mirror dismissal, hook registration, and consumer delay. Calls use "
-        "action + input + reasoning; input is the selected action's strict object. "
-        "Start with notification(action='check', input={}, reasoning='...') to "
-        "inspect. Prefer a producer's own read/dismiss when offered: generic "
-        "dismiss clears only the mirror. Reread after a stale refusal; force=true "
-        "is only for a known-stale mirror and never changes producer/protected "
-        "state. Post-molt dismissal needs a continue/defer/obsolete reason. "
-        "Hook drop never stops its process; delay hides consumer delivery only "
-        "(0 cancels), and delay-alarm cannot be targeted. "
-        "notification(action='settings', input={}, reasoning='...') is read-only; "
-        "notification(action='manual', input={}, reasoning='...') returns the "
-        "installed manual. Both are read-only; use context(action='summarize') "
-        "for compaction."
+        "Notification reads current channel mirrors, manages hook registrations, "
+        "and controls consumer delay. Calls use the strict action + input + "
+        "reasoning envelope; begin with notification(action='check', input={}, "
+        "reasoning='...') to inspect. Its live payload is stamped under "
+        "`_meta.agent_meta.notifications.attention` and "
+        "`_meta.agent_meta.guidance.transient`. Follow producer-specific handling "
+        "before generic dismissal: generic clear is mirror-only; reread after a "
+        "stale refusal, and use force=true only for a confirmed stale mirror, never "
+        "producer or protected state. Post-molt dismissal needs a non-empty "
+        "continue|defer|obsolete: ... reason; drop never stops its process; delay "
+        "hides consumer delivery only (0 cancels), and delay-alarm cannot be "
+        "targeted. notification(action='settings', input={}, reasoning='...') and "
+        "notification(action='manual', input={}, reasoning='...') are read-only; "
+        "use context(action='summarize') for compaction."
     )
 
 


### PR DESCRIPTION
## Summary
- R2 keeps Notification's strict eleven-action envelope and safety semantics while making progressive disclosure real: one concise resident first-read introduction, one compact action selector, and one routed manual table.
- Repeated dismiss/hook field prose is shorter; required whole-channel targeting and nullable event/ref `system` defaults are explicit, and the legacy `large_tool_result` reminder note has one resident schema owner.
- The top manual retains both exact settings-comment anchors and first-use producer/mirror/stale/force guidance. The channel-model reference now owns one consolidated delay/cap/expiry-recovery section plus the protocol, allowlist, hooks, spill, and mirror details.

## Validation
- Source-built full definition: locked base 19,745 Unicode chars / 19,761 UTF-8 bytes; R1 14,583 / 14,583; R2 13,081 / 13,081.
- R2 compact `get_schema()` is 12,089 Unicode chars / 12,089 UTF-8 bytes; recursive non-annotation schema equality holds for base/R1/R2, and schema AST equality holds after string-literal normalization.
- Focused Notification/settings/declaration matrix: 121 passed, 1 warning; sync/delay-alarm/wire matrix: 94 passed; manual routes: 8 passed.
- Standalone documentation governance: 370 documents validated. Package-data wheel-only checks: 13 passed.
- The supplied test environment does not provide the documented sdist fixture dependency, so no sdist subcase is claimed. A host docs-governance pytest run stopped after 67 passing tests on an unrelated installed MCP API mismatch.

## Scope and safety
- Only Notification schema/manual/channel-model documentation changed; dispatch, handlers, settings implementation, provider serialization, runtime state, and other families were not changed.
- The normal canonical-identity commit is `3e3d0df722273c34aefa912753923f92ebc46c3f` on `docs/progressive-disclosure-notification-20260906`. No merge, rebase, force push, tag, release, or deletion was performed.