### PR TITLE
docs: progressively disclose context procedures

### DIFF
--- a/src/lingtai/tools/context/ANATOMY.md
+++ b/src/lingtai/tools/context/ANATOMY.md
@@ -4,6 +4,7 @@ related_files:
   - src/lingtai/tools/context/manual/assets/molt-template.md
   - src/lingtai/tools/context/manual/assets/session-journal-entry-template.md
   - src/lingtai/tools/context/manual/reference/summarize-manual/SKILL.md
+  - src/lingtai/tools/context/manual/reference/molt-manual/SKILL.md
   - src/lingtai/kernel/tool_plugin/ANATOMY.md
   - src/lingtai/adapters/tool_plugin_host.py
   - src/lingtai/tools/ANATOMY.md

--- a/src/lingtai/tools/context/CONTRACT.md
+++ b/src/lingtai/tools/context/CONTRACT.md
@@ -18,6 +18,7 @@ related_files:
   - src/lingtai/tools/pad/CONTRACT.md
   - src/lingtai/tools/lingtai/CONTRACT.md
   - src/lingtai/tools/context/manual/SKILL.md
+  - src/lingtai/tools/context/manual/reference/molt-manual/SKILL.md
   - src/lingtai/kernel/tool_plugin/CONTRACT.md
   - src/lingtai/adapters/tool_plugin_host.py
   - tests/test_context_ownership_redesign.py

--- a/src/lingtai/tools/context/__init__.py
+++ b/src/lingtai/tools/context/__init__.py
@@ -89,20 +89,20 @@ _MOLT_INPUT_SCHEMA: dict[str, Any] = {
     "properties": {
         "summary": {
             "type": "string",
-            "description": 'Your session retrospective (~10,000 tokens). Write as a record — what happened, what you learned, what remains. The four stores must be tended BEFORE molt. Saved to `system/summaries/molt_<count>_<ts>.md` and replayed to the next you. See context-manual for full writing guidance. This is domain input the molt itself consumes, not the root `summarize` post-processing control.',
+            "description": 'Required retrospective for the next session. Tend all four durable stores and write the session-journal entry before calling molt. See context-manual and its molt reference.',
         },
         "session_journal_path": {
             "type": "string",
-            "description": 'REQUIRED. The path to the session-journal entry you wrote for the just-finished segment BEFORE molting: knowledge/session-journal/<entry>/KNOWLEDGE.md (a per-segment sub-entry, NOT the parent index). Must be inside your workdir, exist, be non-empty UTF-8, have valid YAML frontmatter with `name` and `description`, and identify itself as session knowledge via `type: session-journal` or `session_journal: true`. The molt is refused before any context is shed if this is missing or invalid. See context-manual §4.',
+            "description": 'REQUIRED pre-molt path: knowledge/session-journal/<entry>/KNOWLEDGE.md, a per-segment child inside the workdir (not the parent index). It must be non-empty UTF-8 with `name`/`description` frontmatter and `type: session-journal` or `session_journal: true`; missing or invalid input is refused before shedding. See context-manual and its molt reference.',
         },
         "keep_tool_calls": {
             "type": ["array", "null"],
             "items": {"type": "string"},
-            "description": 'Optional list of tool-call IDs to replay across the molt, in your chosen order. If any ID is not found, molt is refused before anything is shed. Keep short — durable stores are primary persistence. Pass null to keep none. See context-manual.',
+            "description": 'Optional ordered prior tool-call IDs to replay; unknown IDs refuse before shedding. Pass null to keep none. Keep short because durable stores are primary persistence. See context-manual\'s molt reference.',
         },
         "keep_last": {
             "type": ["integer", "null"],
-            "description": 'Optional requested minimum number of recent conversation entries to replay into the fresh session (default: 20 when null). The retained suffix may contain more entries when needed to preserve one adjacent assistant tool-call/result batch whole. Pass 0 to archive everything. Overlapping entries with keep_tool_calls are deduplicated. See context-manual.',
+            "description": 'Optional minimum recent entries to replay (null defaults to 20; 0 archives all). A retained suffix may expand to keep one assistant tool-call/result batch whole, and overlaps with keep_tool_calls are deduplicated. See context-manual\'s molt reference.',
         },
     },
     "required": ["summary", "session_journal_path", "keep_tool_calls", "keep_last"],
@@ -154,24 +154,17 @@ _ITEM_SCHEMA: dict[str, Any] = {
 }
 
 _SUMMARIZE_ITEMS_DESCRIPTION = (
-    "REQUIRED, non-empty. The tool results to replace with your own compact "
-    "summaries, each with 'tool_call_id' (the id of the prior tool-result "
-    "block) and 'summary' (your agent-authored text). Supports multiple items "
-    "per call. The original is NOT deleted — it remains retrievable from "
-    "events.jsonl by tool_call_id. Pick targets from "
-    "`_meta.agent_meta.agent_state.current_tool_result_chars.top_results`. "
-    "This action RECORDS ONLY: the active provider context may still carry "
-    "the old raw results until context(action='rebuild') applies them."
+    "REQUIRED, non-empty list of {tool_call_id, summary} items. Each ID names a "
+    "prior tool-result block and each summary is agent-authored. The raw event "
+    "remains retrievable; this action records only and does not rebuild. See "
+    "context-manual/reference/summarize-manual."
 )
 
 _REBUILD_ITEMS_DESCRIPTION = (
-    "Optional — omit it entirely for the ordinary call. Every rebuild first "
-    "re-reads and recomposes ALL canonical system-prompt sections from durable "
-    "and configured sources, then applies summaries, then requests provider "
-    "replay with the new prompt/history. context(action='rebuild', input={}) is "
-    "valid even with zero pending summaries; an explicit null means the same. "
-    "Pass items to record those summaries after prompt composition and apply "
-    "them in the same call. Same item shape as context(action='summarize')."
+    "Optional list of the same {tool_call_id, summary} items; omit it for the "
+    "ordinary bare input={} call (explicit null is equivalent). Rebuild composes "
+    "all canonical prompt sources, then applies pending/new summaries, then "
+    "requests provider replay. See context-manual/reference/summarize-manual."
 )
 
 _SUMMARIZE_INPUT_SCHEMA: dict[str, Any] = {
@@ -350,26 +343,28 @@ def _build_family(
 #: guidance the model actually needs to pick an action replaces it in
 #: :func:`get_schema` rather than being lost.
 _ACTION_ENUM_DESCRIPTION = (
-    'Required operation. '
-    'molt: shed your conversation context, keep the durable stores. Requires '
-    '`summary` and a valid `session_journal_path` — tend the four stores '
-    'BEFORE molting. See context-manual.\n'
-    'summarize: record your own compact replacements for prior tool results in '
-    'runtime history. RECORD ONLY — it does not rebuild, so the active '
-    'provider context may still carry the old raw results.\n'
-    'rebuild: re-read and recompose ALL canonical prompt sources, then apply '
-    'pending/new summaries, then replay provider context with the new prompt and '
-    'history. Bare input={} is valid even with zero pending summaries. Prefer '
-    'one tactical rebuild; do not loop rebuild.\n'
-    'manual: return the installed context-manual skill without performing any '
-    'context operation.\n'
-    'Identity/lifecycle actions are not here: use '
-    'system(action=\'name_set\'|\'name_nickname\').'
+    "Required operation. "
+    "molt sheds conversation while retaining durable stores; it requires a "
+    "retrospective and valid session-journal path. See context-manual.\n"
+    "summarize records compact prior tool-result replacements only; it does not "
+    "rebuild provider context.\n"
+    "rebuild recomposes canonical prompt sources, then applies summaries, then "
+    "requests provider replay; bare input={} is valid. Make one tactical call.\n"
+    "manual returns the installed context-manual without a lifecycle operation. "
+    "Name actions belong to system."
 )
 
 
 def get_description(lang: str = "en") -> str:
-    return 'Your context: shed it, compact it, rebuild it. Four actions, each with its own strict input object. molt (凝蜕): shed the conversation, keep the durable stores; requires a written session journal. summarize: record compact replacements for bulky prior tool results — records only, does NOT rebuild. rebuild: re-read and recompose every canonical prompt source, apply pending/new summaries, then replay provider context with the new prompt/history; bare input={} is valid even with zero pending summaries. manual: return the installed context-manual skill. Identity/lifecycle actions are not here — use system(action=\'name_set\'|\'name_nickname\'). Note the two levels: the ACTION named summarize is this domain operation, while the optional ROOT summarize boolean is the unrelated result-presentation control — leave it false here (results are small), including for manual, so the exact molt procedure is not summarized away.'
+    return (
+        "Context lifecycle: molt sheds conversation while retaining durable stores; "
+        "summarize records compact tool-result replacements only; rebuild "
+        "recomposes canonical prompt sources, applies summaries, and requests "
+        "provider replay; manual returns context-manual. Read the manual before "
+        "molt/rebuild. The action named summarize is unrelated to the optional "
+        "root summarize boolean presentation control; leave that boolean false "
+        "for Context results."
+    )
 
 
 def get_schema(lang: str = "en") -> dict:

--- a/src/lingtai/tools/context/manual/SKILL.md
+++ b/src/lingtai/tools/context/manual/SKILL.md
@@ -11,214 +11,91 @@ related_files:
 - src/lingtai/tools/system/summarize.py
 - src/lingtai/agent.py
 - src/lingtai/tools/psyche/CONTRACT.md
+- src/lingtai/tools/context/manual/reference/molt-manual/SKILL.md
+- src/lingtai/tools/context/manual/reference/summarize-manual/SKILL.md
+- src/lingtai/tools/context/manual/assets/molt-template.md
+- src/lingtai/tools/context/manual/assets/session-journal-entry-template.md
 maintenance: |
   This package is the canonical Context manual source and runtime-installed owner.
-  Update it when the tool/capability behavior changes.
+  Keep this entry a short router: put complete procedures in the focused
+  references and update those references when the tool/capability behavior changes.
 ---
 
 # Context Manual
 
-This manual is the router for `context` operations — `molt`, `summarize`, and `rebuild`. Keep routine guidance here; load the supporting asset or reference only when you need the full scaffold or the detailed summarize/rebuild procedure.
+This is the short router for `context`: `molt`, `summarize`, `rebuild`, and
+`manual`. Use the action that matches the job; load the focused reference before
+an involved operation. The manual action is directly callable as
+`context(action="manual", input={}, reasoning="load context guidance")` and has
+no pre-read dependency.
 
-## Reference catalog
+## First-call essentials
 
-| Reference | When to load |
-|---|---|
-| `reference/summarize-manual/SKILL.md` | Compacting bulky tool results with `context(action='summarize')`, applying them during a full `context(action='rebuild')`, recovery by `tool_call_id`, and summarize-versus-molt tradeoffs |
+Every call uses the closed envelope: `action`, that action's strict `input`
+object, and root `reasoning`. The optional root `summarize` is a boolean presentation
+control; it is **not** child input and should normally be `false` here. It is
+unrelated to the `summarize` action below.
 
-## Full context rebuild
-
-`context(action="rebuild", ...)` is the **one active full reconstruction operation**: recompose every canonical prompt source → apply pending summaries → provider replay. The tool description and the `rebuild` schema carry the exact contract, including that bare `{}` is valid.
-
-The fact that is only here: **generic durable mutations do not hot-load.** Write with `file.write`/`file.edit`, then rebuild when the change must apply now — that is the only mutation path for all four durable stores (no per-store append, info, or reload action). Passive refresh and molt invoke the same internal reconstruction contract with their own lifecycle effects. Do not loop rebuild.
-
-## Asset catalog
-
-| Asset | When to load | What it contains |
+| Action | Use this first | Load for depth |
 |---|---|---|
-| `assets/session-journal-entry-template.md` (read from this skill directory) | Whenever you write the molt-history record for a session segment before a molt | Frontmatter + section template for a `knowledge/session-journal/<YYYY-MM-DD>-molt-<molt-count>-<slug>/KNOWLEDGE.md` entry |
-| `assets/molt-template.md` (read from this skill directory) | Consequential molt, long-running task, multiple collaborators, pending human commitments, open worktrees/artifacts, active background jobs, or any successor briefing that would be risky to improvise | 9-section summary scaffold plus pre-molt verification checklist |
+| `molt` | Shed conversation while retaining durable stores. `input.summary` and a valid `input.session_journal_path` are required before anything is shed. | `reference/molt-manual/SKILL.md` and `assets/session-journal-entry-template.md`; for a consequential handoff also `assets/molt-template.md`. |
+| `summarize` | Record one or more non-empty `{tool_call_id, summary}` replacements. The raw event remains retrievable and this action does **not** rebuild the provider context. | `reference/summarize-manual/SKILL.md`. |
+| `rebuild` | The ordinary call is `input={}` (or `{"items": null}`): it is schema-valid even with zero pending summaries. It recomposes all canonical prompt sources, then applies summaries, then requests provider replay. Make one tactical call; do not loop. | `reference/summarize-manual/SKILL.md` for delayed reconstruction and recovery. |
+| `manual` | Use strict `input={}`; it returns this installed manual without a lifecycle operation. | The reference named by the need. |
 
-## 1. Molt Overview
+## Molt gate
 
-Molt is yours to perform. The covenant teaches the philosophy (§V); this is the recipe.
+Before `molt`, tend the four durable stores (Pad, LingTai/character,
+Knowledge, and Skills) and write the session-journal **sub-entry** first. The
+path must be inside the workdir and look like
+`knowledge/session-journal/<entry>/KNOWLEDGE.md`; it must be non-empty UTF-8,
+have `name`/`description` frontmatter, and carry `type: session-journal` (or
+`session_journal: true`). The parent index is not a valid argument. A missing
+or invalid journal is refused before snapshot, archive, wipe, or count mutation.
+The full store rhythm, journal format, keep-field semantics, summary scaffold,
+and post-molt checklist are in `reference/molt-manual/SKILL.md`.
 
-Save anything you need to pad, lingtai, knowledge, and skills beforehand, then molt. Molt is not routine housekeeping: do it once context pressure (≥85%), an explicit human request, or conversation confusion actually makes the fresh briefing worth its cost (see `reference/summarize-manual/SKILL.md`) — not merely because the window still has room. Once a molt is actually warranted, tending the stores and molting promptly still saves tokens over a rushed, late one.
+`keep_tool_calls` is an optional ordered list of prior IDs (`null` keeps none);
+an unknown ID refuses the molt before shedding. `keep_last` is an optional
+minimum recent-entry count (`null` defaults to 20, `0` archives everything);
+whole assistant tool-call/result batches may expand the retained suffix and
+overlaps are deduplicated. Do not improvise a consequential summary: use
+`assets/molt-template.md`.
 
-**Tend the stores first, every time.** The four stores are the real persistence and the summary is only the briefing on top of them: molt without tending them and the next you wakes with the briefing alone — no character evolution, no pad state, no new knowledge, no new skills.
+## Mutation and recovery rules
 
-## 2. Store-Tending Rhythm
+Generic durable mutations do not hot-load. Use `file.write` or `file.edit`, then
+make one explicit `context(action="rebuild", input={}, ...)` call when the
+change must apply now; there is no per-store append/info/reload action. Passive
+refresh and molt use the same canonical reconstruction contract while retaining
+their distinct lifecycle effects. If reconstruction fails, it must not apply
+summaries or request provider replay; follow the recovery guidance in the
+focused references.
 
-For `lingtai` and `knowledge`, tending happens *once* per task, at the end — not mid-task. Hold updates in your head while working, then commit them in a single pass before going idle (or before molting). Mid-task edits create noise and waste tokens. The exception is a long-running task where a crash would genuinely destroy work — checkpoint deliberately in that case.
+Summarize is not durable memory and neither summarize mode updates Pad,
+character, Knowledge, Skills, or the session journal. At a whole-session
+boundary, tend those stores and molt deliberately rather than using summarize
+as a mini memory layer. For sustained context pressure, delayed rebuild,
+cache-miss budget, or post-wipe recovery, load
+`reference/summarize-manual/SKILL.md` and `reference/molt-manual/SKILL.md` as
+appropriate.
 
-Pad has a different rhythm — update it whenever the index meaningfully changes. See §5 below.
+## Reference and asset catalog
 
-All four durable stores are taught by manuals loaded through the one `psyche` root (pad + lingtai + knowledge + skills = psyche); generic mutation belongs to `file`. §3 below is the per-store how-to.
+Focused references keep detailed recipes, field semantics, thresholds, recovery
+steps, and troubleshooting out of this first response:
 
-## 3. Step 1 — Tend the Four Durable Stores and Session Journal
+- `reference/molt-manual/SKILL.md` — durable-store tending, session-journal
+  format/gate, summary and keep-field recipes, pressure reminder, and post-wipe
+  recovery.
+- `reference/summarize-manual/SKILL.md` — a-priori versus a-posteriori
+  summarization, delayed provider reconstruction, thresholds, raw-result
+  recovery, and the summarize-versus-molt decision.
+- `assets/session-journal-entry-template.md` — write the required journal
+  sub-entry before the molt.
+- `assets/molt-template.md` — nine-section scaffold and pre-molt verification
+  checklist for consequential handoffs.
 
-- **lingtai** — carry forward your complete identity in `system/lingtai.md` using `file.write` (full rewrite) or `file.edit` (exact replacement). Read `psyche(action="lingtai", input={}, reasoning="...")` for forced/self-evolve behavior.
-- **pad** — keep the living index in `system/pad.md` via `file.write`/`file.edit`; edit `system/pad_append.json` the same way for the durable pinned-reference list. See `psyche(action="pad", input={}, reasoning="...")`.
-- **knowledge** — write to `knowledge/<name>/KNOWLEDGE.md` for long-term private context using `file.write`/`file.edit`.
-- **skills** — write `.library/custom/<name>/SKILL.md` (with YAML frontmatter: `name`, `description`, `version`) for any reusable procedure the next you (or a peer) might need, then rebuild to refresh the catalog. Share by sending the skill source/artifact so peers install it into their own `.library/custom/<name>/` and refresh; use `../.library_shared/<name>/` only as an explicit opt-in local-network shared root.
-- **session journal** — append a substantial sub-entry under `knowledge/session-journal/` describing what you did this session. See §4 for the full practice.
-
-All five happen *before* the molt call. They are not optional. Without them, the molt sheds everything.
-
-## 4. Session Journal
-
-The four stores capture *who you are*, *what you're working on*, *verifiable truths*, and *reusable procedures*. None of them captures the *story* of a session. The session journal is that missing layer — it is also your **molt history**: each sub-entry is the record of one session segment that you write *before* you molt, so the chain of entries reconstructs how you got here across many molts.
-
-Write it as a **routing parent with sub-knowledge children** under
-`knowledge/session-journal/` — the routing/index shape from the knowledge manual's
-"Nesting and sub-knowledge" section. Do **not** create each session as its own
-top-level knowledge entry; that floods the catalog. The parent is routing-only;
-the children carry the substance:
-
-```
-knowledge/session-journal/
-├── KNOWLEDGE.md                                            # top-level routing/index ONLY
-├── 2026-05-13-molt-7-nudge-service/KNOWLEDGE.md            # sub-knowledge — one session
-├── 2026-05-13-molt-8-procedures-to-kernel/KNOWLEDGE.md     # sub-knowledge — same day
-└── 2026-05-14-molt-9-wechat-fixes/KNOWLEDGE.md             # sub-knowledge — ...
-```
-
-Because `session-journal/` has its own `KNOWLEDGE.md`, the knowledge scanner
-treats it as a single entry and does **not** descend into the children — they are
-reachable only through the parent index. That is why the parent must list every
-child explicitly. See the knowledge manual's "Nesting and sub-knowledge" section
-(`.library/intrinsic/capabilities/knowledge/SKILL.md`) for the structural rule.
-
-The directory name is `<YYYY-MM-DD>-molt-<molt-count>-<slug>`. Read `<molt-count>` from your resident system prompt's identity section — "You have undergone N molts since birth." Use that N: the entry records the pre-molt segment. Embedding the count keeps chronology stable when you molt more than once on the same date, which the date alone cannot order.
-
-**The parent `knowledge/session-journal/KNOWLEDGE.md` is routing-only** — short,
-scannable, progressive-disclosure. It is a table of contents, not a journal. One
-line per sub-entry: date, slug, one-sentence hook, and the child's *relative* path
-(`2026-05-13-molt-7-nudge-service/KNOWLEDGE.md`), never an absolute local path.
-Never let narrative leak into the parent — if a line grows past its hook, the
-detail belongs in the child.
-
-**The sub-entry `<YYYY-MM-DD>-molt-<molt-count>-<slug>/KNOWLEDGE.md` is the substance** — write it as the molt-history record of the segment, *before* you molt, via `write`/`edit` directly. Read `assets/session-journal-entry-template.md` from this skill directory for the frontmatter (including `molt_count`, the required `type: session-journal` marker, and the YAML block-scalar `description` that keeps a `: ` in the text from breaking the gate) and the section layout. It is a journal, not a transcript. Several thousand tokens is fine when the segment was rich; keep it concise when it was small.
-
-This sub-entry's path is what you pass as `context(action='molt', input={'session_journal_path': ...})`, and the kernel validates it before letting the molt proceed (see §6).
-
-Updating the parent index at each session is part of the practice — append one line referencing the new sub-entry. Then write the successor summary (§6), which points back at this entry's path.
-
-## 5. Tending the Pad
-
-**Pad has its own manual — read `psyche(action="pad", input={}, reasoning="load Pad guidance")` for the full practice.** It owns what belongs in the pad and what does not, the tending rhythm, how the `system/pad_append.json` pinned list works, and how to archive a completed pad.
-
-What matters here is only the molt-relevant fact: pad is one of the four durable stores, it survives the molt and is reloaded into the fresh session's system prompt, so it must be accurate **before** you molt. A stale pad is the fastest way to make the next you lose the thread.
-
-Your 灵台 is likewise taught by a manual — call `psyche(action="lingtai", input={}, reasoning="load identity guidance")` for identity modes and file/rebuild guidance.
-
-## 6. Step 2 — Write the Summary and Molt
-
-```
-context(
-    action="molt",
-    input={
-        "summary": <your charge to the next you>,
-        "session_journal_path": "knowledge/session-journal/<entry>/KNOWLEDGE.md",
-        "keep_tool_calls": null,
-        "keep_last": null,
-    },
-    reasoning="why you are molting now",
-)
-```
-
-Every `context` call uses this one envelope: a single `action`, that action's
-own strict `input` object, and a root `reasoning`. The four actions are `molt`,
-`summarize`, `rebuild`, and `manual`. Leave the root `summarize` **boolean**
-false: `context` results are small (short-result profile), and summarizing a
-`manual` call would drop the exact procedure you called it for.
-
-(The action-`summarize` versus root-`summarize` distinction is stated in the
-resident tool description; no action takes `summarize` as input.)
-
-`context` owns only your context. Your name is `system(action='name_set')` /
-`system(action='name_nickname')`. Your four durable stores share one read-only
-root. `psyche(action="pad"|"lingtai"|"knowledge"|"skills"|"manual", input={},
-reasoning="...")` returns the matching manual;
-`psyche(action="settings", input={}, reasoning="...")` returns the two fully
-redacted Psyche-owned Pad configuration rows. Use `file.write`/`file.edit` for
-durable files, then rebuild explicitly when needed.
-
-**Required pre-molt order (enforced by the kernel):** write the session journal
-sub-entry first (§4) → pass its path as `session_journal_path` → the kernel
-validates it → only then does the molt proceed. `session_journal_path` is a
-**mandatory** structured argument for agent-initiated molt. If it is missing or
-the journal fails validation, the molt is **refused before any context is shed**
-and your `molt_count`/history are untouched — you get an actionable recovery
-message instead. The validator (a signpost, not a grader) checks what the schema
-describes: path inside your workdir resolving to
-`knowledge/session-journal/<entry>/KNOWLEDGE.md` (the per-segment sub-entry, not
-the parent index and not a scratch file), non-empty UTF-8, frontmatter with
-`name` + `description`, and the marker `type: session-journal` or
-`session_journal: true` — see the template in §4.
-
-The accepted path is recorded in the molt result, the persisted summary
-frontmatter (`session_journal_path:`), and the post-molt notification, so later
-recovery and audits can see which journal backed each molt.
-
-The `summary` is the only *conversation-layer* thing the next you will see. Aim for the ~10,000 tokens the schema suggests. The summary is not a recap of conversation. It is your charge to the self that comes after you — anchored in the four stores, which are already waiting in the fresh session.
-
-For a routine molt, include:
-
-- **What you are working on** — current task, current state, the next concrete step
-- **What you have accomplished** — completed pieces, key decisions made
-- **What remains** — pending items, blockers, open questions
-- **Who to contact** — collaborators, who is waiting on what
-- **Which knowledge entries and skills matter** — paths the next you should load
-- **The session journal sub-entry path** — so the next you can read the full narrative
-- **Anything else worth carrying forward** — insights, gotchas
-
-Quick routing:
-
-| Need | Use |
-|---|---|
-| Routine molt | The short bullet list above. |
-| Consequential molt / successor handoff — long-running task, multiple collaborators, pending human commitments, open worktrees/artifacts, or any handoff the next you could not reconstruct quickly | Read `assets/molt-template.md` from this skill directory; use its full scaffold and checklist. Fill every section; write `None` rather than omitting one. |
-| Unsure whether the handoff is complex | Use the asset; extra structure is cheaper than a bad handoff. |
-
-Before you call `context(action="molt", ...)`, verify at minimum:
-
-- The session-journal sub-entry for the just-finished segment exists and was
-  written *before* the summary (§4) — it is the narrative the summary points
-  back to, and its path is the validated `session_journal_path`.
-- Durable stores were tended before the summary was written.
-- The first five minutes after wake are obvious.
-
-`assets/molt-template.md` carries the full pre-molt verification checklist
-(outstanding tasks, collaborators, background work, key paths).
-
-**`keep_tool_calls`** — see the schema description for the exact semantics (refusal on an unknown ID, replay order). Keep the list short: the durable stores are the primary persistence.
-
-**`keep_last`** — see the schema description (default 20, backward expansion to keep a tool-call batch whole, `0` to archive everything, dedupe against `keep_tool_calls`).
-
-## 7. Context Pressure Reminder
-
-Context pressure is agent state, not a dismissible notification. Tool results surface a natural-language reminder under `_meta.agent_meta.agent_state.context.molt` only after context has stayed high for several consecutive fresh provider rounds (the sustained-pressure threshold is 85%). It rides on the current `agent_meta` snapshot (carried on the designated final result of each batch; restamped there while active) so the reminder persists. The field name is historical: the reminder is a context-pressure action, not an early staged molt order or a machine-readable tag block.
-
-When this reminder appears, follow the urgent cadence in `reference/summarize-manual/SKILL.md` (which owns the summarize cadence, rebuild semantics, and recovery target). The molt decision is yours: if a batched summarize/rebuild pass still leaves context above 85%, stop repeating summarize, tend durable stores, and molt deliberately. If context falls below 85% but stays above the recovery target, continue only when the current task still needs the carried context; otherwise molt at a natural task boundary.
-
-### Cache-miss budget
-
-The soft **cache-miss token budget** (default 2,000,000, System-owned via `<agent-workdir>/settings/system.json`, cumulative since your last molt, surfaced as `cache miss budget {N} reached, molt now`) is owned by the resident `meta_guidance` token-efficiency guidance. Two details only documented here:
-
-- It is **overridable at runtime** by `LINGTAI_CACHE_MISS_BUDGET` (positive int, read live at every budget resolution, so `env_file` + refresh applies it without a file edit; an invalid or non-positive value silently falls back to the System file, then the fixed default). Legacy `manifest.cache_miss_budget` in `init.json` is ignored. `_meta.agent_meta.agent_state.context` reports the effective `cache_miss_budget` and the current `cache_miss_tokens`. The `system-manual` owns the file format.
-- The total **survives a refresh/restart** — it is not the since-refresh runtime delta, so refreshing does not reset the remaining budget. If the sustained context-pressure reminder is also active, both warnings are preserved in `context.molt`.
-
-## 8. Post-Wipe Recovery
-
-If you wake up after a *system-performed* molt (triggered by karma, `.clear`, or operator — NOT by context-pressure reminders), the post-molt notification points at a system-authored summary in `system/summaries/`. All canonical prompt sources (including character and Pad) were reconstructed, and recent conversation may be gone except for any entries the system explicitly kept. To reconstruct:
-
-1. Read the `summary_path` from the post-molt notification
-2. `email(check)` — see what arrived while you were down
-3. Check `knowledge/session-journal/KNOWLEDGE.md` — your session history index
-4. Read the `skills` section of your system prompt — it lists every skill you have
-5. `shell({"command": "tail -n 200 logs/events.jsonl | grep ..."})` — surgical reads if needed
-
-Reconstruct your situation from these sources.
-
-If you ever need to retrieve specific prior context, the full activity log is at `logs/events.jsonl` — read tactically (grep/tail/filter), not whole.
+Read only the reference that answers the current need. The installed root
+manual remains the canonical entry point and its relative links are packaged
+with it.

--- a/src/lingtai/tools/context/manual/reference/molt-manual/SKILL.md
+++ b/src/lingtai/tools/context/manual/reference/molt-manual/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: molt-manual
+description: >-
+  Detailed Context molt procedure: durable-store tending, session-journal
+  validation, keep-set semantics, consequential handoffs, pressure recovery,
+  and post-wipe continuation.
+last_changed_at: "2026-09-06T00:00:00Z"
+related_files:
+- src/lingtai/tools/context/manual/SKILL.md
+- src/lingtai/tools/context/manual/assets/molt-template.md
+- src/lingtai/tools/context/manual/assets/session-journal-entry-template.md
+- src/lingtai/tools/context/_molt.py
+- src/lingtai/tools/context/_session_journal.py
+- src/lingtai/tools/context/_snapshots.py
+- src/lingtai/tools/system/summarize.py
+- src/lingtai/agent.py
+- src/lingtai/tools/context/manual/reference/summarize-manual/SKILL.md
+maintenance: |
+  Owns the detailed Context molt and recovery procedure routed by the canonical
+  context-manual. Keep safety gates and field semantics aligned with the Context
+  implementation and its focused tests; keep the top manual a short router.
+---
+
+# Context Molt Manual
+
+Load this reference for a deliberate `context(action="molt", ...)`, especially
+when a handoff is consequential. The top-level `context-manual` keeps only the
+first-call guard and routes here; this page owns the full recipe. Molt is not
+routine housekeeping: do it when context pressure (at least 85%), an explicit
+human request, or conversation confusion makes a fresh briefing worth its cost.
+
+## 1. Tend durable stores before molt
+
+The four durable stores are the real persistence; the summary is only the
+briefing layered over them. Tend them before every agent-initiated molt:
+
+- **LingTai/character** — carry forward the complete identity in
+  `system/lingtai.md` with `file.write` (full rewrite) or `file.edit` (exact
+  replacement). Read `psyche(action="lingtai", input={}, reasoning="...")` for
+  identity-mode and self-evolution guidance.
+- **Pad** — maintain `system/pad.md` with `file.write`/`file.edit`, and update
+  `system/pad_append.json` the same way for the pinned-reference list. Read
+  `psyche(action="pad", input={}, reasoning="...")` for Pad ownership and
+  archiving practice.
+- **Knowledge** — write durable long-term context to
+  `knowledge/<name>/KNOWLEDGE.md` with `file.write`/`file.edit`.
+- **Skills** — write reusable procedures to
+  `.library/custom/<name>/SKILL.md` with `name`, `description`, and `version`
+  frontmatter, then rebuild when the catalog must refresh. Share source or
+  artifacts so a peer installs the skill in its own custom library.
+
+For `lingtai` and `knowledge`, hold ordinary updates until the end of the task
+and commit them in one pass; checkpoint early only when a long task could lose
+work in a crash. Update Pad whenever its index meaningfully changes. Generic
+mutation belongs to `file`; there is no per-store append, info, or reload action.
+
+## 2. Write the session-journal child first
+
+A session journal records the story of this segment, which the four stores do
+not capture. Write one **sub-entry** under `knowledge/session-journal/`, not a
+new top-level Knowledge entry:
+
+```
+knowledge/session-journal/
+├── KNOWLEDGE.md
+└── <YYYY-MM-DD>-molt-<molt-count>-<slug>/KNOWLEDGE.md
+```
+
+The parent `KNOWLEDGE.md` is a short routing index: add one line containing the
+date, slug, one-sentence hook, and the child's relative path. The child is the
+substance and must be written before the molt summary. Use
+`assets/session-journal-entry-template.md` for its required frontmatter and
+sections. Read the current count from the resident identity statement (“You
+have undergone N molts since birth”) and use that N in the pre-molt child name;
+the result after molt reports N+1 for the next segment.
+
+The path passed as `session_journal_path` must be the child path
+`knowledge/session-journal/<entry>/KNOWLEDGE.md`, inside the workdir. It must
+exist, be non-empty UTF-8, have valid YAML frontmatter with `name` and
+`description`, and identify itself with `type: session-journal` or
+`session_journal: true`. The parent index, a scratch file, or an absolute path
+outside the workdir is not a valid substitute. The kernel validates this before
+snapshot/archive/wipe or `molt_count` mutation. If the gate fails, the molt is
+refused and context remains untouched.
+
+Write a journal, not a transcript: capture what happened and why, point at
+paths, branches, PRs, message IDs, or other anchors, and do not paste secrets or
+large file contents. Fill the template sections with `None` rather than silently
+omitting a consequential fact.
+
+## 3. Write the summary and call molt
+
+The summary is the only conversation-layer material the next you receives. It
+should be a charge anchored in the stores, not a transcript. For a routine molt,
+cover:
+
+- current task, state, and next concrete step;
+- completed work and key decisions;
+- pending items, blockers, and open questions;
+- collaborators and who is waiting on what;
+- Knowledge, skill, Pad, or journal paths the next you should load; and
+- the session-journal child path plus useful gotchas.
+
+For a long-running task, multiple collaborators, pending human commitments,
+open artifacts/worktrees, active jobs, or any hard-to-reconstruct handoff, read
+`assets/molt-template.md`. It has the complete nine-section scaffold and
+pre-molt checklist; fill every section and write `None` when a section does not
+apply.
+
+The call shape is:
+
+```text
+context(
+    action="molt",
+    input={
+        "summary": <briefing for the next you>,
+        "session_journal_path": "knowledge/session-journal/<entry>/KNOWLEDGE.md",
+        "keep_tool_calls": null,
+        "keep_last": null,
+    },
+    reasoning="why you are molting now",
+)
+```
+
+The envelope always has one public `action`, that action's strict `input`, and a
+root `reasoning`. The root `summarize` **boolean** is an unrelated result-
+presentation control; it is never action input. Leave it false for Context's
+small results, including `manual`, so the exact procedure is not summarized
+away. `context(action="summarize")` is a separate record-only action; read
+`reference/summarize-manual/SKILL.md` for its cadence and rebuild boundary.
+
+### Input field dictionary
+
+| Field | Semantics |
+|---|---|
+| `summary` | Required non-empty retrospective for the next session. The four stores and journal are tended before this call. |
+| `session_journal_path` | Required validated per-segment child path. Missing or invalid input refuses before any context is shed. |
+| `keep_tool_calls` | Nullable optional ordered list of prior tool-call IDs to replay. An unknown ID refuses before shedding; `null` keeps none. Keep this list short because durable stores are primary. |
+| `keep_last` | Nullable optional minimum count of recent conversation entries. `null` means 20; `0` archives everything. The retained suffix can expand to keep an adjacent assistant tool-call/result batch whole; overlap with `keep_tool_calls` is deduplicated. |
+
+The private `_tc_id` metadata injected by the kernel is not a public input field.
+Molt uses it to locate and replay its precise ToolCallBlock. The true
+system-forced `context_forget` path is distinct and synthesizes its own
+model-visible call/result pair; do not imitate it as an agent-initiated molt.
+
+## 4. What survives and what changes
+
+Validation and keep-list checks happen before snapshot, archive, wipe, or count
+mutation. A successful agent molt preserves the four stores, the session-journal
+child, history under `history/`, summaries under `system/summaries/`, and
+notification files under `.notification/`. It archives and replays according to
+the accepted keep set, updates `molt_count`, writes the molt summary when it
+can, runs the one canonical reconstruction hook before the fresh session, and
+publishes the post-molt continuation notification. The durable molt event key is
+unchanged; only the public action/root names are current.
+
+`context(action="molt")` does not update the stores for you. Neither summarize
+mode nor molt is a substitute for tending Pad, character, Knowledge, Skills, or
+the session journal. If a required write fails, stop and recover before trying
+to shed context.
+
+## 5. Pressure, rebuild, and when to molt
+
+Context pressure is a decision aid, not an automatic molt order. The reminder is
+stamped only after sustained high usage; read
+`reference/summarize-manual/SKILL.md` for the urgent/idle cadence, a-priori versus
+a-posteriori summarization, delayed provider reconstruction, and the 0.85/1.0
+boundaries. If a summarize/rebuild pass still leaves context above its recovery
+target, tend the stores and molt deliberately rather than looping summarize or
+rebuild.
+
+The cache-miss budget is System-owned guidance. `LINGTAI_CACHE_MISS_BUDGET` may
+override the positive integer at runtime; an invalid value falls back to the
+System file and then the fixed default. The cumulative total survives refresh or
+restart. Read `system-manual` for the file format; keep both a cache-budget and
+context-pressure warning when both are active.
+
+## 6. After a system-performed molt
+
+A system-forced molt (karma, `.clear`, or operator; not a context-pressure
+reminder) publishes a post-molt notification pointing at a system-authored
+summary under `system/summaries/`. Canonical prompt sources, including character
+and Pad, were reconstructed; recent conversation may be gone except for entries
+the system explicitly retained. Recover in this order:
+
+1. Read `summary_path` from the post-molt notification.
+2. Call `email(check)` to see what arrived while you were down.
+3. Check `knowledge/session-journal/KNOWLEDGE.md` for the session-history index.
+4. Read the `skills` section of the system prompt for installed procedures.
+5. Inspect the relevant tail or filtered lines of `logs/events.jsonl` only when
+   needed; do not load the whole log.
+
+Reconstruct the situation from those durable sources. The full activity log is
+evidence, not a durable-memory substitute; use a surgical lookup by
+`tool_call_id` or another known anchor.
+
+## Pre-molt checklist
+
+Before the call, verify:
+
+- Pad, LingTai/character, Knowledge, Skills, and the journal child are updated
+  where needed.
+- The parent session-journal index has a new relative-path hook, and the child
+  was written before the summary.
+- The summary names every outstanding task, matching action, collaborator,
+  recipient/channel, and useful path.
+- Active background work, pending replies, authorization limits, and
+  secret/privacy constraints are explicit.
+- The first five minutes after wake are obvious.

--- a/src/lingtai/tools/context/manual/reference/molt-manual/SKILL.md
+++ b/src/lingtai/tools/context/manual/reference/molt-manual/SKILL.md
@@ -47,7 +47,9 @@ briefing layered over them. Tend them before every agent-initiated molt:
 - **Skills** — write reusable procedures to
   `.library/custom/<name>/SKILL.md` with `name`, `description`, and `version`
   frontmatter, then rebuild when the catalog must refresh. Share source or
-  artifacts so a peer installs the skill in its own custom library.
+  artifacts so peers install it into their own `.library/custom/<name>/` and
+  refresh; use `../.library_shared/<name>/` only as an explicit opt-in
+  local-network shared root.
 
 For `lingtai` and `knowledge`, hold ordinary updates until the end of the task
 and commit them in one pass; checkpoint early only when a long task could lose

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -7,6 +7,7 @@ moved to `system` (`tests/test_tool_family_system_migration.py`).
 """
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -281,6 +282,45 @@ def test_context_schema_has_session_journal_path_only_on_molt():
     )
     molt_required = molt_branch["then"]["properties"]["input"]["required"]
     assert "summary" in molt_required and "session_journal_path" in molt_required
+
+
+def test_context_manual_is_a_short_router_to_focused_references():
+    """The first manual response routes depth instead of duplicating recipes."""
+    manual_path = Path(__file__).resolve().parents[1] / "src/lingtai/tools/context/manual/SKILL.md"
+    body = manual_path.read_text(encoding="utf-8")
+    assert len(body) < 8_000
+    assert "context(action=\"manual\", input={}, reasoning=\"load context guidance\")" in body
+    assert "reference/molt-manual/SKILL.md" in body
+    assert "reference/summarize-manual/SKILL.md" in body
+    assert "assets/session-journal-entry-template.md" in body
+    assert "assets/molt-template.md" in body
+
+    molt_reference = manual_path.parent / "reference" / "molt-manual" / "SKILL.md"
+    detail = molt_reference.read_text(encoding="utf-8")
+    assert "## 2. Write the session-journal child first" in detail
+    assert "## Input field dictionary" in detail
+    assert "## Pre-molt checklist" in detail
+    assert "type: session-journal" in detail
+
+
+def test_context_schema_keeps_first_call_safety_signposts():
+    """Schema prose retains only the facts needed to choose a safe first call."""
+    from lingtai.tools.context import get_schema
+
+    schema = get_schema("en")
+    root_description = schema["properties"]["action"]["description"]
+    assert "molt" in root_description and "summarize" in root_description
+    assert "rebuild" in root_description and "manual" in root_description
+    assert "bare input={}" in root_description
+
+    branches = {
+        branch["if"]["properties"]["action"]["const"]: branch["then"]["properties"]["input"]["properties"]
+        for branch in schema["allOf"]
+    }
+    assert "before shedding" in branches["molt"]["session_journal_path"]["description"]
+    assert "not the parent index" in branches["molt"]["session_journal_path"]["description"]
+    assert "does not rebuild" in branches["summarize"]["items"]["description"]
+    assert "bare input={}" in branches["rebuild"]["items"]["description"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -417,10 +417,18 @@ def test_skills_setup_hard_copies_standalone_intrinsic_skills(tmp_path):
         assert context_manual_md.is_file()
         context_manual_body = context_manual_md.read_text(encoding="utf-8")
         assert "name: context-manual" in context_manual_body
-        assert "## Asset catalog" in context_manual_body
+        assert "## Reference and asset catalog" in context_manual_body
+        assert "reference/molt-manual/SKILL.md" in context_manual_body
+        assert "reference/summarize-manual/SKILL.md" in context_manual_body
         assert "assets/molt-template.md" in context_manual_body
-        assert "9-section summary scaffold" in context_manual_body
         assert "9. **Context Status**" not in context_manual_body
+        molt_reference = context_manual_md.parent / "reference" / "molt-manual" / "SKILL.md"
+        assert molt_reference.is_file()
+        molt_reference_body = molt_reference.read_text(encoding="utf-8")
+        assert "name: molt-manual" in molt_reference_body
+        assert "nine-section scaffold" in molt_reference_body
+        assert "## Input field dictionary" in molt_reference_body
+        assert "type: session-journal" in molt_reference_body
 
         file_manual_md = (
             workdir
@@ -1165,12 +1173,16 @@ def test_skills_manual_documents_external_skill_intake_default():
 
 
 def test_context_manual_routes_skill_sharing_through_custom_by_default():
-    manual = (
-        Path(__file__).resolve().parents[1]
-        / "src/lingtai/tools/context/manual/SKILL.md"
-    ).read_text(encoding="utf-8")
-    assert "peers install it into their own `.library/custom/<name>/`" in manual
-    assert "explicit opt-in local-network shared root" in manual
+    root = Path(__file__).resolve().parents[1]
+    manual_path = root / "src/lingtai/tools/context/manual/SKILL.md"
+    manual = manual_path.read_text(encoding="utf-8")
+    assert "reference/molt-manual/SKILL.md" in manual
+    detail = (manual_path.parent / "reference" / "molt-manual" / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    assert "peers install it into their own `.library/custom/<name>/`" in detail
+    assert "explicit opt-in" in detail
+    assert "local-network shared root" in detail
 
 
 def test_resident_layers_query_settings_instead_of_copying_adjustable_defaults():


### PR DESCRIPTION
## Summary
- Reduce the Context tool entry schema to action-choice and first-call safety guidance while preserving the closed envelope and all non-annotation schema structure.
- Keep the root context-manual as a directly callable router and move the detailed molt/store/journal/keep-field/recovery recipe to a focused reference.
- Preserve durable-store and session-journal gates, rebuild ordering and bare-input compatibility, and distinguish action `summarize` from root result-presentation `summarize`.

## Focused validation
- Context lifecycle, migration, reconstruction, split, and declared-plugin tests: 115 passed.
- Manual ownership, installed-skill routing, and disclosure tests: 48 passed.
- Documentation governance: 70 tests passed; the governance script validated 371 documents.
- Architecture graph checks: 5 passed.
- Context prose placement and package wheel checks: 13 passed.
- `git diff --check` passes.
- Source-built compact Context schema is reduced from 10,614 to 7,828 characters (26.25%); non-annotation schemas are identical.
- Context manual router is reduced from 17,404 to 5,635 Unicode characters (67.62%); detailed procedures remain in the packaged focused reference.

## Limitation
The sdist archive check is not runnable in the supplied test environment because its `build` package has no `build.__main__`; the source and wheel checks pass. The PR remains Draft for review of this environment limitation.