### PR TITLE
Shorten Task Card schema and route manual detail

### DIFF
--- a/src/lingtai/tools/task_card/ANATOMY.md
+++ b/src/lingtai/tools/task_card/ANATOMY.md
@@ -5,6 +5,9 @@ related_files:
   - src/lingtai/tools/task_card/CONTRACT.md
   - src/lingtai/tools/task_card/__init__.py
   - src/lingtai/tools/task_card/manual/SKILL.md
+  - src/lingtai/tools/task_card/manual/reference/lifecycle.md
+  - src/lingtai/tools/task_card/manual/reference/notifications.md
+  - src/lingtai/tools/task_card/manual/reference/settings.md
   - src/lingtai/tools/ANATOMY.md
   - src/lingtai/tools/CONTRACT.md
   - src/lingtai/mcp_servers/telegram/task_card/ANATOMY.md

--- a/src/lingtai/tools/task_card/CONTRACT.md
+++ b/src/lingtai/tools/task_card/CONTRACT.md
@@ -7,6 +7,9 @@ related_files:
   - src/lingtai/tools/task_card/BEHAVIORS.md
   - src/lingtai/tools/task_card/__init__.py
   - src/lingtai/tools/task_card/manual/SKILL.md
+  - src/lingtai/tools/task_card/manual/reference/lifecycle.md
+  - src/lingtai/tools/task_card/manual/reference/notifications.md
+  - src/lingtai/tools/task_card/manual/reference/settings.md
   - src/lingtai/tools/CONTRACT.md
   - src/lingtai/tools/registry.py
   - src/lingtai/kernel/tool_plugin/CONTRACT.md

--- a/src/lingtai/tools/task_card/__init__.py
+++ b/src/lingtai/tools/task_card/__init__.py
@@ -284,25 +284,18 @@ _DECLARED_INPUT_SCHEMAS: dict[str, dict[str, Any]] = {
 }
 
 _DESCRIPTION = (
-    "Manage the intrinsic declarative Task Card artifact. Provide a Python "
-    "renderer under your working directory whose stdout is the full Task Card "
-    "body to write into taskcard/taskcard.md. The capability writes taskcard/"
-    "taskcard.md atomically, writes taskcard/status as exact active/inactive, "
-    "keeps at most one active watch per agent, and leaves projection to "
-    "channel-specific readers. Use it proactively for meaningful long-running, "
-    "multi-step, or parallel work so a human can follow progress; skip it for "
-    "quick single-step work, ritual updates, or a body you cannot keep truthful "
-    "and current. Restart a new watch when one expires mid-task. Use stop to "
-    "pause a watch while preserving its last body, and remove once the work is "
-    "completed, cancelled, or abandoned so the artifact cannot mislead a consumer "
-    "as stale. Actions: start, inspect, retry, stop, remove, settings, manual."
+    "Maintain one channel-neutral Task Card per agent. start runs an existing "
+    "Python renderer inside the working directory; non-empty stdout is the full "
+    "body written atomically to taskcard/taskcard.md, then exact active is written "
+    "to taskcard/status. One watch only. Keep output truthful for meaningful "
+    "long-running, multi-step, or parallel work, not quick ritual updates. stop "
+    "pauses/preserves; remove retires then deletes. Consumers project state "
+    "independently. Restart after expiry; use settings and manual for detail."
 )
 
 _ACTION_DESCRIPTION = (
-    "Declarative Task Card action. start keeps one renderer watch writing the "
-    "agent-local taskcard/status and taskcard/taskcard.md files; inspect, retry, "
-    "and stop read or control that one artifact; remove is the terminal lifecycle "
-    "cleanup; settings shows current owner policy; manual explains the full contract."
+    "Task Card action: start/run, inspect/read, retry/refresh, stop/pause, "
+    "remove/retire, settings/SHOW, or manual/router."
 )
 
 

--- a/src/lingtai/tools/task_card/__init__.py
+++ b/src/lingtai/tools/task_card/__init__.py
@@ -289,8 +289,9 @@ _DESCRIPTION = (
     "body written atomically to taskcard/taskcard.md, then exact active is written "
     "to taskcard/status. One watch only. Keep output truthful for meaningful "
     "long-running, multi-step, or parallel work, not quick ritual updates. stop "
-    "pauses/preserves; remove retires then deletes. Consumers project state "
-    "independently. Restart after expiry; use settings and manual for detail."
+    "pauses/preserves; remove retires then deletes, so use it only after completion, "
+    "cancellation, or abandonment. Consumers project state independently. Restart "
+    "after expiry by starting a new watch if work continues. Use settings and manual for detail."
 )
 
 _ACTION_DESCRIPTION = (

--- a/src/lingtai/tools/task_card/manual/SKILL.md
+++ b/src/lingtai/tools/task_card/manual/SKILL.md
@@ -35,7 +35,7 @@ public actions are `start`, `inspect`, `retry`, `stop`, `remove`, `settings`, an
 `manual`; `manual` takes `{}` and is directly callable.
 
 For `start`, provide an existing Python `renderer_path` inside the working
-directory. The renderer must exit successfully and print a non-empty full body to
+directory. The renderer must exit successfully and print a nonempty full body to
 stdout. The producer writes that body atomically to `taskcard/taskcard.md`, then
 writes exact `active` to `taskcard/status`. It permits one active watch per
 agent. Keep its output truthful and current: start a watch for meaningful

--- a/src/lingtai/tools/task_card/manual/SKILL.md
+++ b/src/lingtai/tools/task_card/manual/SKILL.md
@@ -2,251 +2,90 @@
 name: task_card-manual
 description: >
   Read before managing the declarative Task Card / progress-watch artifact;
-  owns the renderer watch lifecycle, one-card-per-agent contract, and
-  stop/remove semantics.
-last_changed_at: 2026-09-04T00:00:00Z
+  routes renderer lifecycle, settings, and projection detail while preserving
+  the one-card-per-agent contract and stop/remove distinction.
+last_changed_at: 2026-09-06T00:00:00Z
 related_files:
 - src/lingtai/tools/task_card/__init__.py
 - src/lingtai/tools/task_card/ANATOMY.md
 - src/lingtai/tools/task_card/CONTRACT.md
+- src/lingtai/tools/task_card/manual/reference/lifecycle.md
+- src/lingtai/tools/task_card/manual/reference/settings.md
+- src/lingtai/tools/task_card/manual/reference/notifications.md
 - src/lingtai/kernel/tool_plugin/CONTRACT.md
 maintenance: |
-  Keep this manual aligned with the intrinsic task_card capability's actual
-  action/settings surface, the exact taskcard/status and taskcard/taskcard.md
-  file contract, and the one-card-per-agent lifecycle. Update it with the
-  paired Anatomy/Contract whenever the renderer contract, settings, file paths,
-  or stop/order semantics change.
+  Keep this router aligned with the intrinsic task_card action/settings surface,
+  exact taskcard/status and taskcard/taskcard.md paths, one-card lifecycle, and
+  the focused references it routes to. Update it with the paired Anatomy/Contract
+  whenever those contracts or the renderer boundary change.
 ---
 
 # task_card manual
 
-Use `task_card` to maintain one agent-local declarative Task Card artifact.
+Use `task_card` to maintain one agent-local, channel-neutral Task Card artifact.
+The capability is producer-first: it runs your renderer and writes the body and
+status; Telegram, Feishu, and other consumers decide how to read or project that
+producer state.
+
+## First call
+
+`task_card` is a strict LTP-v2 family. Pass `action`, that action's strict
+`input` object, and root `reasoning`; optional `summarize` is root-only. The
+public actions are `start`, `inspect`, `retry`, `stop`, `remove`, `settings`, and
+`manual`; `manual` takes `{}` and is directly callable.
+
+For `start`, provide an existing Python `renderer_path` inside the working
+directory. The renderer must exit successfully and print a non-empty full body to
+stdout. The producer writes that body atomically to `taskcard/taskcard.md`, then
+writes exact `active` to `taskcard/status`. It permits one active watch per
+agent. Keep its output truthful and current: start a watch for meaningful
+long-running, multi-step, or parallel work, not ritual noise.
+
+Read [lifecycle and truthful producer use](reference/lifecycle.md) for renderer
+path gates, action ordering, restart resume, and the complete stop/remove
+lifecycle. Read [settings and cadence](reference/settings.md) for owner policy,
+ceilings, and body limits. Read [notifications and projection](reference/notifications.md)
+for typed producer events, reminders, and consumer boundaries.
 
 ## When to use it
 
-Start a watch proactively — without waiting to be asked — whenever a human is
-following meaningful long-running, multi-step, or parallel work and a durable
-progress view would materially help them track it: multi-daemon fleets (two or
-more), multi-PR batches, long review→merge flows, anything running past
-roughly ten minutes. Skip it for quick single-step work or ritual updates:
-starting a watch you will stop moments later is ritual noise, not progress
-reporting. Only keep a watch running while you can make its renderer output
-truthful and current; a stale or inaccurate card misleads more than no card at
-all. When a watch expires mid-task (`max_refreshes`), start a new watch rather
-than letting the card go dark. Optionally `retry` once more to publish a final
-state before winding down. Use `stop` to pause a watch while preserving its
-last body for a possible later `retry`/inspection; use `remove` once the
-underlying work is completed, cancelled, or abandoned, so `/taskcard` and
-other consumers cannot keep exposing a stale card — never reach around it with
-a shell/file-tool delete.
-
-The capability owns exactly two files under your working directory:
-
-- `taskcard/status`
-- `taskcard/taskcard.md`
-
-While a watch is active it also keeps one restart descriptor at
-`taskcard/watch.json`, so the card survives `refresh`/molt/agent-stop: the next
-boot rehydrates the same watch (same `watch_id`, renderer, cadence, ceilings,
-and remaining refresh budget), reruns the renderer to refresh the body, marks
-`active`, and resumes the updater. `stop`, `remove`, and refresh-limit
-exhaustion clear the descriptor because those are deliberate ends of the watch;
-a stale descriptor (renderer gone, budget exhausted, corrupt file) is cleared
-on boot and leaves the card `inactive` rather than silently resurrecting a
-dead watch.
-
-Actions are `start`, `inspect`, `retry`, `stop`, `remove`, `settings`, and
-`manual`. The declaration inserts `settings` immediately before `manual`.
-
-## Call shape and packaged manual
-
-`task_card` is one strict LTP-v2 family: pass `action`, that action's strict
-`input` object, and root `reasoning`; optional `summarize` is root-only.
-`manual` takes `{}`. This document is the package-owned manual named by the
-static official `task_card` declaration. Its reserved `manual` child reads the
-installed `capabilities/task_card/SKILL.md` through the granted workdir port;
-it does not enter the watch manager or require a whole Agent. The declaration
-also fixes the public action inventory, so the schema, dispatch family, and
-manual cannot silently drift.
+Start proactively when a durable progress view materially helps a human follow
+ongoing work. Skip quick single-step work or any watch whose renderer cannot
+remain truthful. If a watch expires while work continues, restart a new watch;
+use `stop` to pause while preserving the last body, and `remove` after work is
+completed, cancelled, or abandoned. Never delete the body with Shell or File.
 
 ## Settings
 
-Call `settings` with exact `input={}` to SHOW the five numeric policies owned
-by `taskcard/taskcard.json`. Every row contains only `key`, `current`,
-`default`, `configurable`, and `comment`; the comment points back to one exact
-section below for meaning, source, validation, application timing, and change
-procedure.
+Call `settings` with exact `input={}` to SHOW the five numeric policies owned by
+`taskcard/taskcard.json`. SHOW is read-only: it never writes or migrates that
+file, and it has no set/reset form. Every row contains only `key`, `current`,
+`default`, `configurable`, and `comment`; after an authorized owner edit, call
+SHOW again. Effective truth is whole-action or failure, never partial.
 
-SHOW is read-only. It never creates or changes `taskcard/taskcard.json`, never
-runs the one-time migration, and has no set/reset form. A `configurable: true`
-row means an authorized owner may create the JSON object when absent or edit it
-with File or Shell outside SHOW, preserving all other fields; it does not grant
-that authority. After an authorized change, call `settings(input={})` again to
-verify the fresh effective value. An invalid or missing field falls back
-independently to its built-in default. If effective truth is unavailable, the
-whole inventory fails with no partial rows or raw exception detail.
+The stable row comments retain these anchors; their detail is in the focused
+settings reference:
 
 ### interval-s
-
-- Meaning: default polling cadence in seconds for a newly started or resumed
-  watch. An explicit `start.interval_s` replaces it, subject to the same
-  one-second floor.
-- Source/default: valid `taskcard/taskcard.json` `interval_s`, otherwise `5`.
-  It must be a non-boolean finite number at least `1`.
-- Application/change: read for each `start` and persisted-watch resume; an
-  already-running watch keeps its captured cadence. An authorized owner edits
-  only `interval_s` in the owner document, preserves sibling fields, then
-  verifies with a second SHOW.
+See [interval-s](reference/settings.md#interval-s).
 
 ### timeout-s
-
-- Meaning: per-render execution ceiling in seconds for a newly started or
-  resumed watch. An explicit `start.timeout_s` may lower but never raise it.
-- Source/default: valid `taskcard/taskcard.json` `timeout_s`, otherwise `10`.
-  It must be a non-boolean finite number at least `0.1`.
-- Application/change: read for each `start` and persisted-watch resume; an
-  already-running watch keeps its captured ceiling. An authorized owner edits
-  only `timeout_s`, preserves sibling fields, then verifies with a second SHOW.
+See [timeout-s](reference/settings.md#timeout-s).
 
 ### max-refreshes
-
-- Meaning: refresh ceiling for a newly started or resumed watch. An explicit
-  `start.max_refreshes` may lower but never raise it.
-- Source/default: valid positive integer `taskcard/taskcard.json`
-  `max_refreshes`, otherwise `2000`. Before the intrinsic document exists, a
-  genuinely customized positive legacy Telegram ceiling is the effective
-  one-time migration preview; the untouched legacy default `1000` is ignored.
-- Application/change: read for each `start` and persisted-watch resume; an
-  existing watch keeps its captured budget. SHOW previews the migration result
-  without writing it. An authorized owner edits only `max_refreshes`, preserves
-  sibling fields, then verifies with a second SHOW.
+See [max-refreshes](reference/settings.md#max-refreshes).
 
 ### reminder-turns
-
-- Meaning: completed text turns between absent-or-stale Task Card reminders.
-- Source/default: valid positive integer `taskcard/taskcard.json`
-  `reminder_turns`, otherwise `10`.
-- Application/change: read on every completed text turn. An authorized owner
-  edits only `reminder_turns`, preserves sibling fields, then verifies with a
-  second SHOW.
+See [reminder-turns](reference/settings.md#reminder-turns).
 
 ### max-body-chars
+See [max-body-chars](reference/settings.md#max-body-chars).
 
-- Meaning: maximum rendered Task Card body accepted by the producer;
-  oversized bodies are refused rather than truncated.
-- Source/default: integer `taskcard/taskcard.json` `max_body_chars` at least
-  `100`, otherwise `2000`.
-- Application/change: read on every body publication. An authorized owner
-  edits only `max_body_chars`, preserves sibling fields, then verifies with a
-  second SHOW. Body content, renderer paths, and unrelated document fields are
-  never settings rows.
+## Boundary reminder
 
-## Typed notification boundary
-
-The producer may emit only its own typed notification operations: an error
-(`TaskCardErrorNotification`), a recovery (`TaskCardRecoveredNotification`),
-or refresh exhaustion (`TaskCardLimitNotification`). The family adapter hands
-these to the host's five closed native operations, and the host pins them to
-the system channel and the established wire sources: `task_card.error` carries
-both `error` and `recovered` states (the latter is distinguished by its
-`extra.state` and idempotency key), while `task_card.limit` carries refresh
-exhaustion. The port also exposes only `submit_reminder(turns)` and
-`clear_reminder()` for absent/stale reminders. There is deliberately no
-`source`, `channel`, arbitrary `extra`, generic enqueue, or keyword field in
-either a typed event or a native operation, so Task Card code cannot publish a
-foreign source or another channel through this capability.
-
-## Resident meta projection and the body-length cap
-
-The card body is projected into the agent's own meta block as
-`_meta.agent_meta.taskcard`, so the human (via Telegram/Feishu/etc) and the
-agent always see the same card. Projection is **change-gated**: an unchanged
-body is not re-injected every turn; only material body/status changes or the
-first appearance attach a fresh payload. When no card is present the meta block
-carries a generic hint (`no taskcard present, consider maintaining one, see
-task_card manual`).
-
-A rendered body longer than the configured `max-body-chars` (see above) is
-**refused, never truncated**. This keeps the card a bounded, high-attention
-goal. Treat the card itself as a progressive-disclosure summary: keep the top
-of the card to the current goal, status, and the single next step, and push
-complex progress detail into files (reports, logs, checklists) referenced
-from the card rather than into the card body. If a renderer tries to publish
-an over-limit body, `start`/`retry` refuse that update and keep the last
-valid body.
-
-## Absent / stale reminders
-
-After every `reminder_turns` completed text turns (default **10**, configured
-at `taskcard/taskcard.json`), the producer emits a system notification
-("Task Card reminder") telling the agent to check whether the card is **absent
-or stale**, then update it or retire it only if useful. This is the loop that
-keeps the shared agent-human view honest without re-injecting the card body
-itself: the resident meta projection stays change-gated (identical bytes are
-not re-sent every turn), while the reminder re-surfaces the *question* on a
-coarse cadence. When a card is absent, treat the reminder as the prompt to
-decide whether the current work is meaningful enough to warrant a card; when a
-card is present but its body has not changed for many turns, treat it as the
-prompt to update it or `remove` it if the underlying task is done.
-
-The counter resets whenever the card is successfully published (`start`, a
-successful watch refresh, or restart resume), so an actively refreshing watch
-never reaches the threshold — the reminder surfaces only when the card is
-absent, retired, or its updates have stopped landing.
-
-`start` runs a Python renderer under your working directory. The renderer must
-exit `0` and print a nonempty full body to stdout; that body is written to
-`taskcard/taskcard.md`. After the body is written atomically, the capability
-writes `taskcard/status` as the exact text `active`.
-
-`retry` reruns the renderer now for the same watch. Successful updates replace
-only `taskcard/taskcard.md` atomically; the status stays `active`.
-
-`stop` writes `taskcard/status` as `inactive` before stopping the updater. The
-last body stays on disk. Consumers treat non-`active` status as no-op. `stop`
-is for pausing/preserving a card you may still `retry` or reinspect — it is
-not lifecycle cleanup.
-
-`remove` is the terminal lifecycle action: it retires any active watch exactly
-like `stop` (write `inactive`, then wait for the updater to quiesce) and then
-deletes `taskcard/taskcard.md`, so it never races the updater into recreating
-a body it just removed. It takes no `watch_id` — it targets your one artifact,
-not a specific in-memory watch — so it still works after a restart lost the
-watch handle. Call `remove`, not a shell/file-tool delete, once the underlying
-work is completed, cancelled, or abandoned, so `/taskcard` and other consumers
-cannot keep exposing a stale card. `remove` is idempotent: calling it again
-after a successful removal, or when no watch was ever started, still leaves
-`status` at exact `inactive` and reports no body to delete, never an error. If
-the watch will not quiesce (the same failure `stop` can report), `remove`
-reports that failure and leaves the body untouched so you can retry once the
-updater is actually stopped.
-
-## Cadence and safety defaults
-
-`start` accepts optional `interval_s`, `timeout_s` (one renderer execution,
-not the watch's whole lifetime), and `max_refreshes`; see the `interval-s` /
-`timeout-s` / `max-refreshes` / `reminder-turns` settings sections above for
-their exact sources and defaults.
-
-`timeout_s` and `max_refreshes` are safety ceilings: an explicit value may
-lower the configured ceiling but never exceed it — a request above the
-ceiling is silently capped to it, it is not an error. `interval_s` has no
-ceiling; only the absolute floor of 1 second applies, so requesting a slower
-(larger) interval than the default is always honored — a numerically larger
-interval is a safer, not a forbidden, choice.
-
-Guidelines:
-
-- Keep one active watch per agent. A second `start` is refused until the first
-  watch is stopped.
-- Restart a watch that expires mid-task. Exhausting `max_refreshes` retires the
-  watch and sends one typed `task_card.limit` notification; if the underlying
-  work is still ongoing, `start` a new watch rather than letting the card go dark.
-- Write the body you want projected. The producer is channel-neutral and does
-  not own Telegram/Feishu/portal layout details.
-- Keep renderer output truthful and complete. Projection channels may compare
-  file content byte-for-byte and update only on real changes. A channel that
-  skips unchanged bytes still performs a real update whenever your renderer's
-  output actually changes — choose `interval_s` and how often your renderer's
-  output changes deliberately, since some consumer transports (e.g. Telegram)
-  enforce their own message-edit/send rate limits on real changes.
+The producer owns its artifact and typed Task Card notifications only. It does
+not own transport-specific IDs, retries, layout, or a promise that an external
+channel will display every state. Consumers read `taskcard/status` and
+`taskcard/taskcard.md` independently. Keep the card a concise progressive-
+disclosure summary and put complex evidence in referenced files; see the
+[projection reference](reference/notifications.md).

--- a/src/lingtai/tools/task_card/manual/reference/lifecycle.md
+++ b/src/lingtai/tools/task_card/manual/reference/lifecycle.md
@@ -50,10 +50,12 @@ configured body limit is a refusal, never truncation; see [settings](settings.md
 `start` runs the renderer first, atomically writes the complete body, then
 atomically writes exact `active`, and only then starts the updater and persists
 its descriptor. `retry` reruns the same renderer and atomically replaces only
-the body; status remains `active`. A renderer or publication failure preserves
-the last valid body and records the producer error rather than inventing
-progress. A second `start` fails closed because one card/watch is allowed per
-agent.
+the body; status remains `active` until the last allowed refresh is consumed,
+when the successful final attempt is exhausted and becomes `inactive`. A
+non-exhausting renderer or publication failure preserves the last valid body
+and records the producer error rather than inventing progress; the exhausted
+final attempt follows the limit path. A second `start` fails closed because one
+card/watch is allowed per agent.
 
 ## Pause, terminal cleanup, and restart
 

--- a/src/lingtai/tools/task_card/manual/reference/lifecycle.md
+++ b/src/lingtai/tools/task_card/manual/reference/lifecycle.md
@@ -1,0 +1,89 @@
+---
+name: task_card-manual-lifecycle
+description: >
+  Focused Task Card lifecycle reference for renderer gates, truthful progress,
+  artifact ordering, restart resume, and stop/remove distinction.
+version: 0.1.0
+last_changed_at: "2026-09-06T00:00:00Z"
+tags: [lingtai, task-card, renderer, lifecycle, progress, restart]
+related_files:
+- src/lingtai/tools/task_card/manual/SKILL.md
+- src/lingtai/tools/task_card/__init__.py
+- src/lingtai/tools/task_card/ANATOMY.md
+- src/lingtai/tools/task_card/CONTRACT.md
+maintenance: |
+  Tracks the Task Card renderer and lifecycle procedure; update with the owner
+  manual and contract when artifact ordering, path gates, or watch recovery changes.
+---
+
+# Task Card lifecycle and truthful producer use
+
+## When to use it
+
+Start a watch proactively when a human is following meaningful long-running,
+multi-step, or parallel work and a durable progress view materially helps:
+multi-daemon fleets, multi-PR batches, and long review→merge flows are typical
+cases, especially work running past roughly ten minutes. Skip quick single-step
+work or ritual updates. Keep a watch only while its renderer output is truthful
+and current; a stale card misleads more than no card. When `max_refreshes`
+expires a watch, restart a new watch when work continues mid-task rather
+than letting the card go dark.
+
+## Producer-owned artifacts
+
+The producer writes `taskcard/taskcard.md` as the full rendered body and
+`taskcard/status` as exact `active` or `inactive`. An active watch also keeps
+`taskcard/watch.json` with its renderer, cadence, watch ID, and carried refresh
+budget so refresh/molt/agent-stop can resume it. `taskcard/taskcard.json` is the
+agent-wide policy document; normal reads are read-only and its one-way legacy
+migration is documented in [settings](settings.md). The producer does not own
+Telegram/Feishu chat IDs, portal layout, transport retries, or consumer state.
+
+## Renderer gate and publication order
+
+`renderer_path` must name an existing regular Python file that resolves inside
+the agent working directory after symlink resolution. It runs as
+`sys.executable <renderer>` with that directory as cwd. It must exit `0` and
+print a non-empty complete body to stdout; stderr is not the card body. The
+configured body limit is a refusal, never truncation; see [settings](settings.md).
+
+`start` runs the renderer first, atomically writes the complete body, then
+atomically writes exact `active`, and only then starts the updater and persists
+its descriptor. `retry` reruns the same renderer and atomically replaces only
+the body; status remains `active`. A renderer or publication failure preserves
+the last valid body and records the producer error rather than inventing
+progress. A second `start` fails closed because one card/watch is allowed per
+agent.
+
+## Pause, terminal cleanup, and restart
+
+- `inspect` reports the one current watch, exact artifact paths, status, and the
+  last valid body; it does not create another watch.
+- `stop` writes `inactive` before asking the updater to stop, joins it, clears
+  the descriptor, and preserves the last body for later `retry` or inspection.
+  It is a pause, not cleanup. If the updater does not quiesce, report the
+  retryable failure and leave the watch/body retryable.
+- `remove` takes no `watch_id`: it retires the one watch exactly as `stop` does,
+  waits for quiescence, then deletes `taskcard/taskcard.md`. It leaves status
+  exactly `inactive`, clears restart state, blocks rather than deleting while a
+  watch may still run, and is idempotent when no body exists. Agents must not
+  reach around it with Shell or File deletion.
+- Agent shutdown writes `inactive`, stops the thread, and persists the carried
+  descriptor unless the watch was deliberately stopped, removed, or exhausted.
+  On the next setup the same watch ID, renderer, cadence, ceiling, and remaining
+  refresh budget are rehydrated. Corrupt, missing, escaped, gone, or exhausted
+  descriptors are cleared and left `inactive`; a transient resume failure keeps
+  the last body and lets the live watch retry.
+
+A refresh-limit exhaustion retires the watch, writes `inactive`, clears the
+descriptor, and emits one typed limit event. If the underlying work continues,
+start a new watch rather than letting the card go dark. Use `stop` while work is
+paused and `remove` once it is completed, cancelled, or abandoned.
+
+## Truthful progress
+
+The renderer is the real producer of progress. Read the underlying work state,
+include only evidence available to the producer, and update the body when that
+state materially changes. Do not promise that a consumer transport edited,
+sent, retried, or delivered a card; those consumers only read the producer's
+artifact and apply their own rules.

--- a/src/lingtai/tools/task_card/manual/reference/notifications.md
+++ b/src/lingtai/tools/task_card/manual/reference/notifications.md
@@ -1,0 +1,73 @@
+---
+name: task_card-manual-notifications
+description: >
+  Focused Task Card reference for typed producer notifications, reminders,
+  change-gated resident projection, and limits on consumer guarantees.
+version: 0.1.0
+last_changed_at: "2026-09-06T00:00:00Z"
+tags: [lingtai, task-card, notifications, projection, reminders]
+related_files:
+- src/lingtai/tools/task_card/manual/SKILL.md
+- src/lingtai/tools/task_card/__init__.py
+- src/lingtai/tools/task_card/CONTRACT.md
+- src/lingtai/adapters/tool_plugin_host.py
+maintenance: |
+  Tracks Task Card's typed notification and consumer-projection boundary;
+  update with the owner manual and contract when event forms, reminder seams,
+  or projection guarantees change.
+---
+
+# Task Card notifications and projection
+
+## Typed producer boundary
+
+The producer emits only `TaskCardErrorNotification`,
+`TaskCardRecoveredNotification`, and `TaskCardLimitNotification` through its
+family adapter. The granted native port exposes only
+`publish_error`, `publish_recovered`, `publish_limit`, `submit_reminder(turns)`,
+and `clear_reminder()`. A generic publisher, arbitrary keyword fields, foreign
+source/channel, or caller-supplied priority/extra metadata is refused.
+
+The host adapter pins the established wire policy: error and recovered states
+use `task_card.error`, refresh exhaustion uses `task_card.limit`, and events go
+to the system channel with bounded extras, idempotency, and priority. The
+producer owns event content and deduplication identity; it does not select a
+transport or another channel.
+
+Renderer failures after a valid watch preserve the last body and emit a deduped
+error state; a later successful publication emits recovery. Refresh exhaustion
+emits one limit event whose guidance says to start a new watch if work remains.
+Notification failure must not turn a truthful producer state into a false one.
+
+## Absent/stale reminders
+
+After the configured `reminder_turns` completed text turns (default `10`), the
+producer asks the agent to check whether the card is absent or stale and update
+or retire it only if useful. The counter resets after a successful publication
+(`start`, refresh, or resume), so a watch that keeps publishing does not reach
+the absent/stale reminder threshold. The reminder resurfaces the decision; it
+does not re-inject an unchanged body.
+
+## Resident projection
+
+The card is resident in `_meta.agent_meta.taskcard` for the agent's own view and
+may be read by human-facing consumers. Projection is change-gated: unchanged
+body/status bytes are not repeatedly re-injected, while a first appearance or
+material change can attach a fresh payload. If no card is present, the resident
+hint is generic and routes the agent to the `task_card` manual.
+
+The body cap is a producer guard: oversized renderer output is refused rather
+than truncated. Keep the card focused on the current goal, status, and next
+step; put complex progress in reports, logs, or checklists referenced by the
+card. A consumer may compare bytes and apply its own edit/send rate limits, but
+those are not promises made by this capability. A real changed body remains a
+real producer update even when a consumer chooses when or how to display it.
+
+## No hidden external projection promise
+
+Task Card owns the producer artifact and the typed events, not Telegram, Feishu,
+portal, chat IDs, message edits, retries, or delivery guarantees. Consumers
+independently read `taskcard/status` and `taskcard/taskcard.md` and interpret
+missing, invalid, or inactive state. Do not report a consumer-side projection
+as producer progress; the renderer must report only evidence from the underlying
+work.

--- a/src/lingtai/tools/task_card/manual/reference/notifications.md
+++ b/src/lingtai/tools/task_card/manual/reference/notifications.md
@@ -34,10 +34,12 @@ to the system channel with bounded extras, idempotency, and priority. The
 producer owns event content and deduplication identity; it does not select a
 transport or another channel.
 
-Renderer failures after a valid watch preserve the last body and emit a deduped
-error state; a later successful publication emits recovery. Refresh exhaustion
-emits one limit event whose guidance says to start a new watch if work remains.
-Notification failure must not turn a truthful producer state into a false one.
+A non-exhausting renderer failure after a valid watch preserves the last body
+and emits a deduped error state; a later successful publication emits recovery.
+An exhausted final failure suppresses that error and, like a successful final
+refresh, emits one limit event whose guidance says to start a new watch if work
+remains. Notification failure must not turn a truthful producer state into a
+false one.
 
 ## Absent/stale reminders
 

--- a/src/lingtai/tools/task_card/manual/reference/settings.md
+++ b/src/lingtai/tools/task_card/manual/reference/settings.md
@@ -1,0 +1,93 @@
+---
+name: task_card-manual-settings
+description: >
+  Focused Task Card settings reference for the read-only SHOW inventory,
+  owner-document validation, cadence, safety ceilings, migration, and body cap.
+version: 0.1.0
+last_changed_at: "2026-09-06T00:00:00Z"
+tags: [lingtai, task-card, settings, cadence, ceilings, migration]
+related_files:
+- src/lingtai/tools/task_card/manual/SKILL.md
+- src/lingtai/tools/task_card/__init__.py
+- src/lingtai/tools/task_card/CONTRACT.md
+maintenance: |
+  Tracks the five Task Card owner policies and their SHOW/change procedure;
+  update with the owner manual and contract when defaults, validation, or seams change.
+---
+
+# Task Card settings and cadence
+
+## SHOW and owner document
+
+Call `task_card(action="settings", input={})` with exact empty input. The
+provider returns exactly five rows, in owner order: `interval_s`, `timeout_s`,
+`max_refreshes`, `reminder_turns`, and `max_body_chars`. Each row has only
+`key`, `current`, `default`, `configurable`, and `comment`; comments point to the
+stable anchors in the parent `task_card-manual`.
+
+SHOW reads fresh effective values without creating or changing
+`taskcard/taskcard.json` and without running its one-time legacy migration. A
+`configurable: true` row means an authorized owner may create or edit that JSON
+object outside SHOW, preserving sibling fields; it does not make SHOW a writer.
+After an authorized edit, call SHOW again. Invalid or missing fields fall back
+independently to their own built-in defaults. If effective truth is unavailable,
+the whole bounded inventory fails with no partial rows or raw exception detail.
+Renderer paths, body/status/watch contents, notification state, and unknown
+owner fields are never projected.
+
+## interval-s
+
+`interval_s` is the polling cadence in seconds for a newly started or resumed
+watch. The valid owner value is finite and at least `1`; otherwise the default
+is `5`. An explicit `start.interval_s` also obeys only that one-second floor and
+has no ceiling: a slower cadence is honored. The value is read at each `start`
+or persisted-watch resume; a running watch keeps its captured cadence.
+
+## timeout-s
+
+`timeout_s` is the ceiling, in seconds, for one renderer execution, not the
+watch's lifetime. The valid owner value is finite and at least `0.1`; otherwise
+the default is `10`. An omitted `start.timeout_s` uses the configured ceiling;
+an explicit value may lower it but is silently capped at that ceiling if larger.
+A running watch keeps its captured ceiling.
+
+## max-refreshes
+
+`max_refreshes` is the refresh ceiling for a newly started or resumed watch. A
+valid owner value is a positive integer; otherwise the default is `2000`. An
+explicit `start.max_refreshes` may lower but never exceed the configured ceiling.
+Before `taskcard/taskcard.json` exists, SHOW may preview a genuinely customized
+positive legacy Telegram ceiling; the legacy untouched default `1000` is
+ignored. Preview does not write the new document.
+
+## reminder-turns
+
+`reminder_turns` is the number of completed text turns between absent-or-stale
+Task Card reminders. A valid owner value is a positive integer; otherwise the
+default is `10`. It is read on each completed text turn, so changing the owner
+document applies at that seam rather than changing an already-running watch's
+captured cadence.
+
+## max-body-chars
+
+`max_body_chars` is the maximum rendered body accepted by the producer. A valid
+owner value is an integer at least `100`; otherwise the default is `2000`. It is
+read on each publication. An oversized body is refused, never truncated, and
+the last valid body remains visible.
+
+## Resolution, floors, and the one-way migration
+
+The five fields resolve independently from `taskcard/taskcard.json`; malformed
+siblings do not discard valid values. `start` resolves the first three fresh;
+`reminder_turns` and `max_body_chars` are read at their application seams. The
+first resolution made when the intrinsic JSON document does not exist may read
+`telegram/taskcard.json` only to carry forward a valid customized positive
+`max_refreshes` different from that retired design's untouched `1000` default.
+It then writes the intrinsic document whether the result was migrated or built
+in, and later changes to the legacy file are never consulted. If the intrinsic
+document already exists but is malformed, it remains the sole owner and fields
+fall back to built-ins.
+
+Thus the safety contract is monotonic: `interval_s` cannot go below `1`,
+`timeout_s` cannot go below `0.1`, refresh/reminder counts stay positive, and
+explicit timeout/refresh requests cannot exceed their configured ceilings.

--- a/tests/test_task_card_controller.py
+++ b/tests/test_task_card_controller.py
@@ -186,7 +186,6 @@ def test_manual_routes_focused_references_and_keeps_first_call_guard():
         assert fragment in description, fragment
     start_input = get_schema()["properties"]["input"]["anyOf"][0]
     assert "renderer_path" in start_input["required"]
-    assert len(manual) < 6000
 
 
 def test_start_writes_body_before_active_and_reports_exact_paths(agent, manager, monkeypatch):

--- a/tests/test_task_card_controller.py
+++ b/tests/test_task_card_controller.py
@@ -135,26 +135,58 @@ def test_description_routes_to_manual_and_file_contract():
 
 
 def test_description_manual_and_contract_encourage_proactive_use():
-    """The schema, manual, and Contract Behavior all teach when to (not) use it."""
+    """The schema, short router, and Contract Behavior all teach when to (not) use it."""
     use_fragments = ["long-running", "multi-step", "parallel"]
-    skip_fragments = ["single-step", "ritual", "truthful"]
+    schema_safety_fragments = ["ritual", "truthful"]
+    manual_safety_fragments = ["single-step", "ritual", "truthful"]
 
     desc = get_description()
-    for fragment in use_fragments + skip_fragments:
+    for fragment in use_fragments + schema_safety_fragments:
         assert fragment in desc, f"{fragment!r} missing from get_description()"
 
     root = Path(__file__).resolve().parents[1]
     manual_body = (root / "src/lingtai/tools/task_card/manual/SKILL.md").read_text(
         encoding="utf-8"
     )
-    for fragment in use_fragments + skip_fragments:
+    for fragment in use_fragments + manual_safety_fragments:
         assert fragment in manual_body, f"{fragment!r} missing from manual/SKILL.md"
 
     contract_body = (root / "src/lingtai/tools/task_card/CONTRACT.md").read_text(
         encoding="utf-8"
     )
-    for fragment in use_fragments + skip_fragments:
+    for fragment in use_fragments + manual_safety_fragments:
         assert fragment in contract_body, f"{fragment!r} missing from CONTRACT.md"
+
+
+def test_manual_routes_focused_references_and_keeps_first_call_guard():
+    root = Path(__file__).resolve().parents[1]
+    manual_path = root / "src/lingtai/tools/task_card/manual/SKILL.md"
+    manual = manual_path.read_text(encoding="utf-8")
+    for relative in (
+        "reference/lifecycle.md",
+        "reference/settings.md",
+        "reference/notifications.md",
+    ):
+        reference = manual_path.parent / relative
+        assert reference.is_file(), relative
+        assert f"]({relative})" in manual, f"manual does not route to {relative}"
+        assert reference.read_text(encoding="utf-8").startswith("---")
+
+    description = get_description().lower()
+    for fragment in (
+        "renderer",
+        "working directory",
+        "non-empty stdout",
+        "taskcard/taskcard.md",
+        "taskcard/status",
+        "one watch",
+        "stop",
+        "remove",
+    ):
+        assert fragment in description, fragment
+    start_input = get_schema()["properties"]["input"]["anyOf"][0]
+    assert "renderer_path" in start_input["required"]
+    assert len(manual) < 6000
 
 
 def test_start_writes_body_before_active_and_reports_exact_paths(agent, manager, monkeypatch):

--- a/tests/test_task_card_proactivity.py
+++ b/tests/test_task_card_proactivity.py
@@ -25,6 +25,7 @@ from tests.test_task_card_controller import _FakeAgent, _OK_BODY, _manager, _wri
 ROOT = Path(__file__).resolve().parents[1]
 PROCEDURES = ROOT / "src/lingtai/prompts/procedures/procedures.md"
 TASK_CARD_MANUAL = ROOT / "src/lingtai/tools/task_card/manual/SKILL.md"
+TASK_CARD_LIFECYCLE = ROOT / "src/lingtai/tools/task_card/manual/reference/lifecycle.md"
 
 
 class _StubCard:
@@ -198,7 +199,7 @@ def test_exhausted_watch_reports_itself_inactive(tmp_path):
 
 
 def test_tool_description_asks_for_a_restart_after_expiry():
-    assert "Restart a new watch when one expires mid-task." in get_description()
+    assert "Restart after expiry" in get_description()
 
 
 def test_resident_procedures_routes_to_task_card_manual():
@@ -209,8 +210,8 @@ def test_resident_procedures_routes_to_task_card_manual():
     assert "`daemon`, `avatar`, `shell`, or `task_card` manual" in text
 
 
-def test_task_card_manual_names_the_card_worthy_triggers():
-    text = TASK_CARD_MANUAL.read_text(encoding="utf-8")
+def test_task_card_lifecycle_reference_names_the_card_worthy_triggers():
+    text = TASK_CARD_LIFECYCLE.read_text(encoding="utf-8")
     section = text.split("## When to use it", 1)[1].split("\n## ", 1)[0]
     for fragment in (
         "multi-daemon fleets",


### PR DESCRIPTION
## Summary

- Keep the Task Card family safe for a first call while routing lifecycle, settings, and notification depth into focused references.
- Preserve exact action/schema/controller behavior and the channel-neutral producer/consumer boundary.
- Package the router and all three references as one intrinsic manual tree.

## Review repairs

- Restored the resident guards: remove only after completion/cancellation/abandonment; after expiry, start a new watch when work continues.
- Connected all three new references to both Task Card Anatomy and Contract ownership graphs.
- Corrected final-refresh semantics: the last successful attempt becomes inactive, and an exhausted final failure emits the limit state rather than a renderer-error state.
- Restored the top-manual nonempty-output guard required by the existing intrinsic-manual contract.
- Removed the arbitrary manual-length assertion while retaining route, file, frontmatter, resident-safety, and strict-start coverage. No standalone progressive-disclosure test was added.

## Validation

- Parent repaired-head tests: 103 controller/proactivity/Telegram-family; 70 notification/settings/declaration/Telegram/Feishu; 5 architecture; and 86 docs/manual/action tests passed.
- Independent `gpt-5.6-luna` review also ran a broader 508-test Task Card/controller/consumer/schema/settings set on the reviewed head; its architecture finding was repaired and rerun green by the parent.
- Task Card Anatomy drift, `git diff --check`, non-string AST parity, schema/wire checks, and all manual paths/anchors passed.
- Actual no-isolation wheel and sdist each contain byte-identical router and three references; all 11 relative paths/anchors resolve in each archive.

## Scope and limits

- Final delta: 9 existing files, +375/-245; 2 existing test files, no new test file.
- A pre-existing stale-resume status edge remains outside this documentation-only change; no runtime behavior was altered for it.
- No full-suite claim, runtime refresh, release, rebase, or force-push.
