### PR TITLE
Progressive disclosure for the Email capability

### DIFF
--- a/src/lingtai/tools/email/ANATOMY.md
+++ b/src/lingtai/tools/email/ANATOMY.md
@@ -22,6 +22,10 @@ related_files:
   - src/lingtai/tools/email/glossary-zh.md
   - src/lingtai/tools/email/glossary-wen.md
   - src/lingtai/tools/email/manual/SKILL.md
+  - src/lingtai/tools/email/manual/reference/actions-and-storage/SKILL.md
+  - src/lingtai/tools/email/manual/reference/addressing-and-replies/SKILL.md
+  - src/lingtai/tools/email/manual/reference/notifications-and-delivery/SKILL.md
+  - src/lingtai/tools/email/manual/reference/settings-reference/SKILL.md
 maintenance: |
   Keep related_files as repo-relative paths to real files. Include neighboring
   ANATOMY.md files so the anatomy graph stays connected rather than isolated;

--- a/src/lingtai/tools/email/CONTRACT.md
+++ b/src/lingtai/tools/email/CONTRACT.md
@@ -15,6 +15,10 @@ related_files:
   - src/lingtai/tools/email/ANATOMY.md
   - src/lingtai/tools/email/BEHAVIORS.md
   - src/lingtai/tools/email/manual/SKILL.md
+  - src/lingtai/tools/email/manual/reference/actions-and-storage/SKILL.md
+  - src/lingtai/tools/email/manual/reference/addressing-and-replies/SKILL.md
+  - src/lingtai/tools/email/manual/reference/notifications-and-delivery/SKILL.md
+  - src/lingtai/tools/email/manual/reference/settings-reference/SKILL.md
   - src/lingtai/kernel/tool_plugin/CONTRACT.md
   - src/lingtai/tools/CONTRACT.md
   - src/lingtai/tools/tool_family/CONTRACT.md

--- a/src/lingtai/tools/email/_family_schema.py
+++ b/src/lingtai/tools/email/_family_schema.py
@@ -17,13 +17,12 @@ per-action data here means the model-facing composition and the legacy flat
 shape have one owner each, and the ledger in the migration report can name
 exactly what each file is for.
 
-Field descriptions are reused verbatim from ``schema.py``'s flat properties
-wherever the field is the same field, so the migration changes the envelope
-and not the prose the model reads. ``ACTION_ORDER`` owns the operational/manual
-order and child registration order in ``__init__.py``. The generic declaration
-opt-in inserts ``settings`` immediately before ``manual`` and consequently
-composes the public ``input.anyOf``/``allOf`` order without adding a
-hand-authored schema here.
+Field descriptions retain the first-call semantics of ``schema.py``'s flat
+properties while moving rationale, catalogs, and examples to ``email-manual``
+references. ``ACTION_ORDER`` owns the operational/manual order and child
+registration order in ``__init__.py``. The generic declaration opt-in inserts
+``settings`` immediately before ``manual`` and consequently composes the public
+``input.anyOf``/``allOf`` order without adding a hand-authored schema here.
 
 Optional fields are declared in the provider-compatible nullable
 representation (``"type": [..., "null"]`` plus membership in ``required``) per
@@ -53,97 +52,66 @@ ACTION_ORDER: tuple[str, ...] = (
 
 # --- Shared field descriptions, verbatim from the pre-migration flat schema ---
 
-_ADDRESS_DESCRIPTION = "Target address(es) for send"
-_CC_DESCRIPTION = "CC addresses — visible to all recipients"
-_BCC_DESCRIPTION = "BCC addresses — hidden from other recipients"
-_ATTACHMENTS_DESCRIPTION = "File paths to attach (for send)"
-_SUBJECT_DESCRIPTION = "Email subject line"
-_MESSAGE_DESCRIPTION = (
-    "Email body (max 50,000 chars; longer internal emails are rejected "
-    "because unread bodies are injected in full into persistent "
-    "notifications)."
-)
-_EMAIL_ID_DESCRIPTION = (
-    "List of email IDs for read. For reply/reply_all, pass a single-element "
-    "list."
-)
-_N_DESCRIPTION = "Max recent emails to show (for check, default 10)"
-_QUERY_DESCRIPTION = "Regex pattern for search (matches from, subject, message)"
-_FOLDER_DESCRIPTION = (
-    "Folder for check/search/read/delete. Default: inbox for check, both for "
-    "search. Note: 'sent' is read-only — delete only works on inbox or "
-    "archive."
-)
-_DELAY_DESCRIPTION = (
-    "Delay in seconds before delivery (default: 0). Use for scheduled or "
-    "deferred sends."
-)
-_TYPE_DESCRIPTION = "Email type (for send). Defaults to 'normal'."
-_NAME_DESCRIPTION = (
-    "Contact's human-readable name (for add_contact, edit_contact)"
-)
-_NOTE_DESCRIPTION = (
-    "Free-text note about the contact (for add_contact, edit_contact)"
-)
+_ADDRESS_DESCRIPTION = "Bare name/path for send; string or list."
+_CC_DESCRIPTION = "Visible CC addresses."
+_BCC_DESCRIPTION = "Hidden BCC addresses."
+_ATTACHMENTS_DESCRIPTION = "Attachment paths for send."
+_SUBJECT_DESCRIPTION = "Subject."
+_MESSAGE_DESCRIPTION = "Body; max 50,000 characters."
+_EMAIL_ID_DESCRIPTION = "Own mailbox ID list; replies use one ID."
+_N_DESCRIPTION = "Max messages for check; default 10."
+_QUERY_DESCRIPTION = "Regex query over sender, subject, and body."
+_FOLDER_DESCRIPTION = "Folder; check inbox/search both; sent is read-only."
+_DELAY_DESCRIPTION = "Delivery delay in seconds; default 0."
+_TYPE_DESCRIPTION = "Send type; default normal."
+_NAME_DESCRIPTION = "Contact name."
+_NOTE_DESCRIPTION = "Contact note."
 
-# The ``filter`` object for ``check``, verbatim from the flat schema's own
-# nested ``filter`` property (same properties, same descriptions, same
-# ``truncate`` default). ``additionalProperties: False`` is added because a
+# The ``filter`` object for ``check`` keeps the flat schema's property set,
+# defaults, and first-call matching semantics; its long catalog and examples
+# live in the Email manual. ``additionalProperties: False`` is added because a
 # migrated family's ``input`` branches are closed all the way down
 # (``tools/CONTRACT.md`` "Envelope": "Action branches are closed").
 _FILTER_SCHEMA: dict[str, Any] = {
     "type": ["object", "null"],
-    "description": (
-        "Optional filter object for check. Pass filter={sort, from, subject, "
-        "contains, after, before, unread_only, has_attachments, truncate} to "
-        "narrow and control results."
-    ),
+    "description": "Optional check filters; see email-manual for fields and defaults.",
     "properties": {
         "sort": {
             "type": ["string", "null"],
             "enum": ["newest", "oldest", None],
-            "description": "'newest' (default) or 'oldest'.",
+            "description": "Sort newest (default) or oldest.",
         },
         "from": {
             "type": ["string", "null"],
-            "description": "Filter by sender (case-insensitive substring match).",
+            "description": "Case-insensitive sender substring.",
         },
         "subject": {
             "type": ["string", "null"],
-            "description": "Filter by subject (case-insensitive substring match).",
+            "description": "Case-insensitive subject substring.",
         },
         "contains": {
             "type": ["string", "null"],
-            "description": (
-                "Filter by message body content (case-insensitive substring "
-                "match)."
-            ),
+            "description": "Case-insensitive body substring.",
         },
         "after": {
             "type": ["string", "null"],
-            "description": (
-                "Only show emails after this ISO 8601 timestamp (e.g. "
-                "2026-04-01T00:00:00Z)."
-            ),
+            "description": "Only messages after an ISO 8601 timestamp.",
         },
         "before": {
             "type": ["string", "null"],
-            "description": "Only show emails before this ISO 8601 timestamp.",
+            "description": "Only messages before an ISO 8601 timestamp.",
         },
         "unread_only": {
             "type": ["boolean", "null"],
-            "description": "Only show unread emails.",
+            "description": "Only unread messages.",
         },
         "has_attachments": {
             "type": ["boolean", "null"],
-            "description": "Only show emails that have attachments.",
+            "description": "Only messages with attachments.",
         },
         "truncate": {
             "type": ["integer", "null"],
-            "description": (
-                "Max characters for message preview (default 500). Set to 0 "
-                "for full message body."
-            ),
+            "description": "Preview characters; default 500, 0 means full body.",
         },
     },
     "required": [
@@ -408,26 +376,15 @@ INPUT_SCHEMAS: dict[str, dict[str, Any]] = {
     "manual": MANUAL_INPUT_SCHEMA,
 }
 
-# The canonical ``action`` enum prose. Reuses the pre-migration flat schema's
-# own action description verbatim, with the envelope's ``input=`` call form
-# substituted for the old flat keyword form, and the ``manual`` sentence
-# extended with the family's ``summarize`` guidance profile
-# (``tools/CONTRACT.md`` "Dispatch and actions").
+# The canonical concise ``action`` enum router. It retains first-call action
+# choice and critical safety guidance; action procedures and examples live in
+# the Email manual references (``tools/CONTRACT.md`` "Dispatch and actions").
 ACTION_ENUM_DESCRIPTION = (
-    "send: send with optional cc/bcc (requires address, message; message body "
-    "max 50,000 chars because unread bodies are injected in full into "
-    "persistent notifications). check: list mailbox with preview of each email "
-    "(up to 500 chars). read: fetch inbox emails by ID list "
-    "(input={'email_id': [id1, id2, ...], ...}) AND marks each as read; "
-    "ordinary unread content is already injected in "
-    "notification_persistent.email, so prefer dismiss when you only need to "
-    "clear handled mail. dismiss: same read-state effect as read but returns "
-    "no bodies — preferred after handling content visible in persistent "
-    "notification. reply: reply to email (requires email_id, message). "
-    "reply_all: reply to all recipients. search: regex search mailbox. "
-    "archive/delete: move/remove from inbox or archive. "
-    "contacts/add_contact/remove_contact/edit_contact manage contacts. "
-    "settings shows read-only Email policy/source truth. manual "
-    "returns the installed email-manual skill without reading or changing "
-    "mailbox state."
+    "Choose one action; put only that action's fields in input. send: new internal "
+    "message (address and message required; body max 50,000 characters). check: "
+    "list/filter mail. read: fetch mailbox IDs and mark them read; dismiss: mark "
+    "handled IDs read without returning bodies. reply/reply_all: reply in-thread "
+    "on the arrival channel. search: regex lookup. archive/delete: move or remove "
+    "inbox/archive mail. contacts actions manage the address book. settings is "
+    "read-only. manual returns this manual without mailbox I/O."
 )

--- a/src/lingtai/tools/email/_family_schema.py
+++ b/src/lingtai/tools/email/_family_schema.py
@@ -383,8 +383,10 @@ ACTION_ENUM_DESCRIPTION = (
     "Choose one action; put only that action's fields in input. send: new internal "
     "message (address and message required; body max 50,000 characters). check: "
     "list/filter mail. read: fetch mailbox IDs and mark them read; dismiss: mark "
-    "handled IDs read without returning bodies. reply/reply_all: reply in-thread "
-    "on the arrival channel. search: regex lookup. archive/delete: move or remove "
+    "handled IDs read without returning bodies. Unread bodies are injected in full "
+    "into persistent Email notifications: prefer dismiss after handling; use read "
+    "for source records or attachments. reply/reply_all: answer existing mail on "
+    "the arrival channel. search: regex lookup. archive/delete: move or remove "
     "inbox/archive mail. contacts actions manage the address book. settings is "
     "read-only. manual returns this manual without mailbox I/O."
 )

--- a/src/lingtai/tools/email/manual/SKILL.md
+++ b/src/lingtai/tools/email/manual/SKILL.md
@@ -56,11 +56,11 @@ Leave it false for receipts, contacts, settings, and `manual`.
 
 | Action | Use | Required input / critical note |
 |---|---|---|
-| `send` | Start a new internal thread | `address`, `message`; body max 50,000 characters |
+| `send` | Start new internal mail | `address`, `message`; body max 50,000 characters |
 | `check` | List mail | Optional `folder`, `n`, and structured `filter` |
 | `read` | Fetch source-of-truth mail | `email_id` list; marks inbox IDs read |
 | `dismiss` | Clear handled mail without fetching bodies | `email_id` list; marks inbox IDs read |
-| `reply` / `reply_all` | Continue a thread | `email_id` list (one ID) and `message`; use the arrival channel |
+| `reply` / `reply_all` | Answer existing mail | `email_id` list (one ID) and `message`; use the arrival channel |
 | `search` | Regex search | `query`; optional `folder` |
 | `archive` | Move inbox mail out of the inbox | `email_id` list |
 | `delete` | Permanently remove mail | `email_id` list; inbox/archive only, never `sent` |

--- a/src/lingtai/tools/email/manual/SKILL.md
+++ b/src/lingtai/tools/email/manual/SKILL.md
@@ -5,11 +5,10 @@ description: >
   delayed self-send time capsules, and the full-body persistent notification
   contract. Not internet email (see `mcp-manual`) or recurring schedules
   (see `shell-manual`).
-version: 1.2.2
+version: 1.3.0
 tags: [capabilities, email, communication]
-last_changed_at: "2026-09-04T00:00:00Z"
+last_changed_at: "2026-09-06T00:00:00Z"
 related_files:
-- src/lingtai/tools/skills/manual/reference/cleanup-footprint-contract.md
 - src/lingtai/tools/email/__init__.py
 - src/lingtai/tools/email/_family_schema.py
 - src/lingtai/tools/email/manager.py
@@ -18,404 +17,162 @@ related_files:
 - src/lingtai/adapters/posix/mail.py
 - src/lingtai/tools/email/ANATOMY.md
 - src/lingtai/tools/email/CONTRACT.md
+- src/lingtai/tools/email/manual/reference/addressing-and-replies/SKILL.md
+- src/lingtai/tools/email/manual/reference/actions-and-storage/SKILL.md
+- src/lingtai/tools/email/manual/reference/notifications-and-delivery/SKILL.md
+- src/lingtai/tools/email/manual/reference/settings-reference/SKILL.md
 maintenance: |
   Tracks the routed source/resources it summarizes; update when the underlying capability or its sub-references change.
 ---
 
 # Email Manual — the internal `email` tool
 
-> LingTai email protocol between agents in your `.lingtai/` network. Not the internet. No IMAP, no SMTP, no DNS. Messages are JSON files written under `mailbox/inbox/` of the recipient agent and `mailbox/sent/` of the sender.
+> Internal LingTai mail only. It moves JSON files inside a shared `.lingtai/`
+> network; it is not Gmail, Outlook, IMAP, SMTP, DNS, or any other internet mail.
 
-## 0. How to call it — the envelope
+## 0. Call envelope
 
-Every call takes `action` + `input` + `reasoning`, where `input` is the strict
-argument object **for the selected action only**:
+Every call has `action`, `input`, and `reasoning`; `input` contains only the
+fields for the selected action. `reasoning` is required and `summarize` is an
+optional root result control, never an input field.
 
 ```python
 email(action="check", input={}, reasoning="check for new mail")
 email(action="read", input={"email_id": ["<id>"]}, reasoning="read the request")
-email(action="send", input={"address": "human", "message": "done"},
+email(action="send", input={"address": "peer", "message": "done"},
       reasoning="report completion")
 ```
 
-Two rules follow from that, and they are enforced at dispatch, not just in the
-schema:
+The family rejects unknown root fields and cross-action input keys before
+mailbox I/O, delivery, or read-state mutation. Call
+`email(action="manual", input={}, reasoning="learn Email")` to return this
+installed router and its host-local path.
 
-- **Each argument belongs to one action.** `query` only exists on `search`,
-  `filter`/`n` only on `check`, `attachments`/`delay`/`mode` only on `send`. A
-  key from another action's branch is refused *before* anything is read, sent,
-  or marked read — you get `unsupported email input field`, not a silent
-  ignore.
-- **`reasoning` and `summarize` are root fields, never inside `input`.**
-  `reasoning` is required and is recorded in your diary; `summarize` is the
-  optional result post-processing control.
+`check`, `read`, and `search` can return bulky listings or bodies: use
+`summarize=true` only when exact IDs, addresses, or body text are not needed.
+Leave it false for receipts, contacts, settings, and `manual`.
 
-**`summarize` guidance for this family.** `check`, `read`, and `search` are
-**bulky-result** actions — mailbox listings and full bodies can be long, so
-`summarize=true` is reasonable when you only need the gist. Leave it false
-when you need exact IDs, addresses, or verbatim body text, because you will
-act on those literally. Every other action (`send`, `dismiss`, `reply`,
-`reply_all`, `archive`, `delete`, the four contact verbs, `settings`) is
-**short-result**: its receipt is small and meant to be read exactly, so leave
-`summarize` false. Call `manual` itself with `summarize=false` so procedure
-and constraints are not summarized away.
+## 1. Choose an action
 
-**Settings:** `email(action="settings", input={}, reasoning="inventory Email policy")`
-is SHOW-only and returns exactly five fields per row: `key`, `current`,
-`default`, `configurable`, and an exact section pointer in `comment`. It has no
-set/reset or other mutation input. Read the [settings reference](#settings-reference)
-below for source, precedence, accepted values, timing, sensitivity, and the
-actual owner procedure. A second SHOW verifies the effective snapshot after an
-authorized external change and full relaunch.
+| Action | Use | Required input / critical note |
+|---|---|---|
+| `send` | Start a new internal thread | `address`, `message`; body max 50,000 characters |
+| `check` | List mail | Optional `folder`, `n`, and structured `filter` |
+| `read` | Fetch source-of-truth mail | `email_id` list; marks inbox IDs read |
+| `dismiss` | Clear handled mail without fetching bodies | `email_id` list; marks inbox IDs read |
+| `reply` / `reply_all` | Continue a thread | `email_id` list (one ID) and `message`; use the arrival channel |
+| `search` | Regex search | `query`; optional `folder` |
+| `archive` | Move inbox mail out of the inbox | `email_id` list |
+| `delete` | Permanently remove mail | `email_id` list; inbox/archive only, never `sent` |
+| `contacts` | List the private address book | no input |
+| `add_contact` | Add or update a contact | `address`, `name`; optional `note` |
+| `remove_contact` | Remove a contact | `address` |
+| `edit_contact` | Update contact fields | `address`; optional `name`/`note` |
+| `settings` | Show Email policy/source truth | input must be `{}`; read-only |
+| `manual` | Load this procedure | input must be `{}`; no mailbox I/O |
 
-## Settings reference
+For action-specific fields, defaults, filters, persistence, and examples, read
+[Actions and storage](reference/actions-and-storage/SKILL.md). For address modes,
+reply routing, sender names, and local-ID privacy, read
+[Addressing and replies](reference/addressing-and-replies/SKILL.md).
 
-Email supports no owner settings file or environment peer: there is no
-`settings/email.json`, no `settings/email.<action>.json`, and no
-`LINGTAI_EMAIL_*`. Four installed policy limits are public and
-non-configurable. The pseudo-agent subscription list is the one configurable
-row, owned by the existing launcher manifest path. Mailbox/session paths,
-addresses, identities, contacts, messages, attachments, and read/archive state
-are private runtime or domain data, not settings, and never appear.
+## 2. Non-negotiable routing and privacy
 
-`LINGTAI_AGENT_ALIVE_THRESHOLD_SEC` remains kernel liveness policy and
-`LINGTAI_NOTIFICATION_MAX_CHARS` remains Notification presentation policy;
-Email does not claim either environment variable. Per-call `send`/`check`
-options are action input rather than persisted settings. The legacy
-200-character digest-renderer prose is discarded by the live full-body
-notification publisher, so it is not an effective Email setting.
+- **Reply on the channel where the message arrived.** For Email, use `reply` or
+  `reply_all`, not a new `send`; never answer through text output (that is a
+  private diary). If a dead sender forces a channel change, explain the pivot in
+  the message first.
+- Use the sender's `sender_nickname` when non-empty, otherwise `sender_name`.
+- Addresses are bare names/paths inside `.lingtai/`, not `@` addresses. For
+  internet mail, use the separately owned `imap` MCP addon. `mode="peer"` is
+  normally enough; `mode="abs"` is restricted to explicitly authorized
+  cross-network paths and does not bypass delivery checks.
+- Mailbox IDs are local to this working directory. Pass IDs read from your own
+  notification or listing to Email actions, but never put raw IDs in mail or
+  public prose. See [Addressing and replies](reference/addressing-and-replies/SKILL.md).
+
+Sending writes sender-side state before starting one daemon delivery thread per
+recipient. Even with no delay, `status="sent"` can precede delivery; a target
+must have valid agent metadata and a fresh heartbeat. Delivery failures are
+reported as `email.bounce` system events, not queued for later. Full delivery,
+refresh-window, and recovery semantics are in
+[Notifications and delivery](reference/notifications-and-delivery/SKILL.md).
+
+## 3. Read state and notifications
+
+Unread bodies are injected in full into
+`_meta.agent_meta.notifications.persistent.email`. After handling content already
+shown there, prefer `dismiss`; use `read` for a source-of-truth refresh,
+attachments, or deliberate audit. `read`, `dismiss`, `archive`, and `delete`
+refresh the producer-owned `.notification/email.json` mirror. A handled message
+stays visible until one of those producer verbs changes its read state.
+
+The mirror's attention hook carries IDs while the persistent lane carries full
+entries. If the model-visible block overflows, follow its `overflow` marker to the
+local spill file or use the producer action; do not infer missing content.
+Detailed payload shape, caps, refresh behavior, and the distinction from generic
+notification dismissal are in
+[Notifications and delivery](reference/notifications-and-delivery/SKILL.md).
+
+## 4. Settings anchors
+
+`settings` is SHOW-only: every row has exactly `key`, `current`, `default`,
+`configurable`, and `comment`. It performs no mailbox I/O and never exposes
+paths, identities, addresses, contacts, content, attachments, or read state.
+Comments below are stable anchors used by the settings provider; each short stub
+routes to the full source/precedence/procedure reference.
 
 ### Send body character limit
 
-- Key: `send.body_char_limit`; current and meaningful default: integer `50000`.
-- Meaning: maximum accepted internal-email body length, in Unicode characters;
-  an oversize `send` is refused before delivery.
-- Accepted configuration values: none. The installed integer constant in
-  `email/settings.py` is consumed directly by send and unread-notification code.
-- Source and precedence: installed code only. Canonical environment variable
-  and config key: none. It is public, not sensitive.
-- Application timing and authorized change procedure: `configurable` is false.
-  Only a reviewed product-code/package change followed by a full agent relaunch
-  can change it; SHOW never writes. Re-run SHOW after relaunch.
+`send.body_char_limit` is the installed 50,000-character send/reply cap; see
+[the settings reference](reference/settings-reference/SKILL.md#send-body-character-limit).
 
 ### Duplicate send loop guard
 
-- Key: `send.duplicate_free_passes`; current and meaningful default: integer
-  `2`.
-- Meaning: number of consecutive identical sends allowed per recipient before
-  Email blocks the next duplicate as a loop.
-- Accepted configuration values: none. The installed constant in
-  `email/settings.py` initializes each `EmailManager`.
-- Source and precedence: installed code only. Canonical environment variable
-  and config key: none. It is public, not sensitive.
-- Application timing and authorized change procedure: `configurable` is false.
-  Only a reviewed code/package change plus full relaunch changes it; verify with
-  a second SHOW.
+`send.duplicate_free_passes` is the installed consecutive-duplicate guard; see
+[the settings reference](reference/settings-reference/SKILL.md#duplicate-send-loop-guard).
 
 ### Check result token limit
 
-- Key: `check.result_token_limit`; current and meaningful default: integer
-  `10000`.
-- Meaning: token budget for one `check` result; Email removes summaries until
-  the serialized response fits.
-- Accepted configuration values: none. The installed constant in
-  `email/settings.py` is consumed directly by `EmailManager._check`.
-- Source and precedence: installed code only. Canonical environment variable
-  and config key: none. It is public, not sensitive.
-- Application timing and authorized change procedure: `configurable` is false.
-  Only a reviewed code/package change plus full relaunch changes it; verify with
-  a second SHOW.
+`check.result_token_limit` is the installed `check` result budget; see
+[the settings reference](reference/settings-reference/SKILL.md#check-result-token-limit).
 
 ### Unread notification entry limit
 
-- Key: `unread.max_entries`; current and meaningful default: integer `10`.
-- Meaning: maximum number of newest unread message entries projected into one
-  Email notification mirror; the total unread count remains exact.
-- Accepted configuration values: none. The installed constant in
-  `email/settings.py` supplies the unread-renderer defaults.
-- Source and precedence: installed code only. Canonical environment variable
-  and config key: none. It is public, not sensitive.
-- Application timing and authorized change procedure: `configurable` is false.
-  Only a reviewed code/package change plus full relaunch changes it; verify with
-  a second SHOW.
+`unread.max_entries` limits projected unread entries while preserving total count;
+see [the settings reference](reference/settings-reference/SKILL.md#unread-notification-entry-limit).
 
 ### Pseudo-agent subscriptions
 
-- Key: `manifest.pseudo_agent_subscriptions`; current and default are always
-  `<redacted>`. Both are path lists and are fully redacted by construction.
-- Meaning: pseudo-agent directories whose outboxes the POSIX mail adapter polls
-  in addition to its own inbox. SHOW reads the adapter's effective list after
-  those paths were resolved once against the agent workdir at construction.
-- Accepted values: a JSON list of path strings. An empty list disables these
-  subscriptions. The launcher's meaningful default when the field is absent is
-  `["../human"]`. The init schema checks that the outer value is a list; an
-  element that cannot be interpreted as a path fails mail-adapter construction
-  instead of being silently ignored.
-- Source and precedence: only `init.json` key
-  `manifest.pseudo_agent_subscriptions`; there is no environment or owner-file
-  peer. The raw configured/resolved lists are sensitive local routing data and
-  must not be copied from logs or inferred from SHOW.
-- Application timing and authorized change procedure: `configurable` is true.
-  After explicit owner/human authorization, edit that exact `init.json` field
-  with the existing File or Shell capability, then perform a full agent
-  relaunch. Ordinary refresh does not reconstruct the mail adapter and cannot
-  apply this field. Call SHOW again after relaunch; it confirms availability
-  and redaction, never the raw paths.
-
-## 1. What is internal email
-
-The `email` tool moves messages as files between agents that share a `.lingtai/` directory tree:
-
-- `email(action="send")` records sender-side outbox/sent state, then starts one `_mailman` daemon thread per recipient. Even when `delay=0`, the tool may return `status: "sent"` before that background delivery attempt finishes.
-- Delivery to a normal agent accepts only a target with `.agent.json` and a fresh `.agent.heartbeat` (normally younger than two seconds); human recipients (`admin: null`) skip the heartbeat check. If the target is refreshing/relaunching and its heartbeat is not fresh yet, delivery is refused as `not running`; no recipient inbox entry is queued for later. The eventual failure is surfaced to the sender as an `email.bounce` event in `.notification/system.json`.
-- Read state lives in the recipient's `mailbox/read.json` (a set of message IDs).
-- The kernel mirrors current unread mail into `.notification/email.json`, which surfaces as a notification block read via `notification(action="check")` — that's how you find out new mail arrived.
-
-> **Refresh/relaunch window.** A target `lingtai run` process can already be visible in `ps` before it publishes a fresh heartbeat. In that interval, internal email may bounce for liveness while a CPR attempt's child launch exits because the CLI duplicate-process guard finds the existing same-workdir PID. Those results are compatible: do not stack CPR attempts. Wait for the target heartbeat to become fresh, then retry the email once. Use CPR only if the existing startup exits or fails to become live.
-
-**If a request involves `@gmail.com`, `@outlook.com`, IMAP folders, or anything that needs to leave the machine, the right tool is the `imap` MCP addon — see the `mcp-manual` skill, not this one.**
-
-| Feature         | Internal Email (this skill)                            | IMAP (see `mcp-manual`)                          |
-|-----------------|--------------------------------------------------------|--------------------------------------------------|
-| What            | LingTai email protocol within `.lingtai/` network      | Real email via IMAP/SMTP (Gmail, Outlook, etc.)  |
-| Address format  | Bare path (e.g. `human`, `mimo-1`)                     | `@` address (e.g. `alice@gmail.com`)             |
-| Tool            | `email` (intrinsic)                                    | `imap` (MCP server, `imap` addon)                |
-| Reply policy    | Always reply on the same channel                       | Requires confirmation for unknown senders        |
-| Persistence     | Survives molt, lives in working directory              | External mailbox, managed by IMAP server         |
-| Use case        | Agent-to-agent communication, self-send, time capsules | Real-world email integration                     |
-
-## 2. Addressing
-
-Addresses are **bare directory names** inside `.lingtai/`. No `@`, no domains, no slashes.
-
-| Address              | Meaning                                                  |
-|----------------------|----------------------------------------------------------|
-| `human`              | The human's mailbox at `.lingtai/human/`                 |
-| `mimo-1`             | An agent whose working directory is `.lingtai/mimo-1/`   |
-| `<your-own-name>`    | Self — creates an inbox entry that survives molt (§6)    |
-
-Multiple recipients: pass `address` as a string or a list, plus optional `cc` / `bcc`.
-
-```python
-email(action="send",
-      input={"address": ["mimo-1", "scribe"], "cc": ["human"],
-             "subject": "status", "message": "ready"},
-      reasoning="report status to the team")
-```
-
-To discover who exists: glob `.lingtai/*/.agent.json` from a shell. Use the `agent_name` field of each as the address. Do not invent addresses — a refused dispatch produces an `email.bounce` event and queues no recipient inbox entry.
-
-### `mode` — peer vs abs address resolution
-
-`mode` is the **address mode for `send`**, not an output-verbosity knob. Almost always leave it unset:
-
-- `peer` (default) — `address` is a bare agent name resolved against your own network folder. Correct for the human, fellow agents, and your own avatars.
-- `abs` — `address` is a literal absolute path to another agent's working directory, e.g. `/Users/alice/projectB/.lingtai/外援`. Use it only to reach an agent in a *different* `.lingtai/` network on the same machine. It embeds a `_return_route` so replies resolve unambiguously, and it does **not** bypass the handshake: the recipient still needs a valid `.agent.json` and a fresh heartbeat.
-
-Any other value is rejected with `invalid mode`.
-
-## 3. Reply discipline — the one rule you cannot break
-
-> **Reply on the channel the message arrived on.**
-
-If a message arrived via `email`, reply with `email(action="reply", ...)`. Do not pivot to `pigeon`, IM, or a fresh `send`. If you must change channels (e.g. the original sender is dead), explain that pivot in the reply body before sending it elsewhere.
-
-**Prefer `reply` and `reply_all` over `send`** even when you know the addresses:
-
-- `reply` preserves the thread linkage (the original `id` lands in the new message's `in_reply_to`), so a future `search` or `check` shows the conversation as related.
-- `reply_all` mirrors the original recipient set automatically, so you don't drop someone who was `cc`'d.
-- `send` is for **new** conversations.
-
-Doing it the other way scatters conversations across orphaned threads and is the single most common confusion source in human-facing audits.
-
-## 4. Sender display name resolution
-
-Inbound mail carries an `identity` block:
-
-```json
-"identity": {
-  "sender_name":     "mimo-1",
-  "sender_nickname": "MiMo",
-  "via":             "lingtai" | "claude-code" | ...
-}
-```
-
-When you mention the sender in a reply body or in a summary you give the human, use `sender_nickname` if it is set and non-empty; otherwise fall back to `sender_name`. The address itself (`from`) is for routing, not for prose.
-
-## 5. Actions — full surface
-
-| Action            | Purpose                                                            | Required args                                      |
-|-------------------|--------------------------------------------------------------------|----------------------------------------------------|
-| `send`            | Start a new thread; body hard-capped at 50,000 characters          | `address`, `subject`, `message`                    |
-| `check`           | List inbox (newest-first), with optional `filter={...}` and `n=N`  | —                                                  |
-| `read`            | Fetch source-of-truth record/attachments and mark read             | `email_id` (list of IDs)                           |
-| `dismiss`         | Mark read **without** re-fetching body — preferred after persistent content is handled | `email_id` (list of IDs)                           |
-| `reply`           | Reply to sender only; preserves thread linkage                     | `email_id`, `message`                              |
-| `reply_all`       | Reply to sender + all original recipients minus self               | `email_id`, `message`                              |
-| `search`          | Search across inbox/sent/archive by `query` + `filter`             | `query` (and/or `filter`)                          |
-| `archive`         | Move from inbox to archive folder (keeps thread, removes from view)| `email_id`                                         |
-| `delete`          | Permanently delete (inbox/archive only; `sent` is read-only)       | `email_id`                                         |
-| `contacts`        | List your address book                                             | —                                                  |
-| `add_contact`     | Add or upsert by `address`                                         | `address`, `name`, optional `note`                 |
-| `remove_contact`  | Remove by `address`                                                | `address`                                          |
-| `edit_contact`    | Update fields                                                      | `address`, plus the fields to change               |
-| `settings`        | SHOW Email policy/source truth; no mutation input exists           | —                                                  |
-| `manual`          | Return this installed Email manual                                 | —                                                  |
-
-### `read` vs `dismiss` — when to use which
-
-Unread email bodies are injected in full into `_meta.agent_meta.notifications.persistent.email` (up to the 50,000-character send-layer cap below). You do **not** need `read` merely to see ordinary message text. When the whole persistent notification envelope exceeds its model-visible cap (see `notification-manual` → "Block size cap" for the exact default/ceiling/floor and `LINGTAI_NOTIFICATION_MAX_CHARS` precedence), the full block is spilled to `<workdir>/logs/notification-overflow-<ts>.json` and the block carries an `overflow` marker with the path; read that file (or the producer tool) for the full bodies. After you have handled the visible content, prefer `dismiss`: same read-state effect, no body returned, and the unread notification clears once count reaches zero.
-
-Use `read` when you need to refresh the source-of-truth mailbox record, inspect attachment/metadata details, or deliberately fetch the producer state before a reply/audit. Use `reply`/`reply_all` when answering. Failing to `dismiss`, `read`, `archive`, or `delete` a handled mail keeps the notification reminding you on every heartbeat.
-
-These are the producer-owned verbs for the `email` notification channel; a generic `notification(action='dismiss_channel', input={'channel': 'email', 'force': null, 'reason': null}, reasoning='...')` would clear only the mirror. See `notification-manual` → `reference/dismissal-safety/SKILL.md`.
-
-### 50,000-character send cap
-
-Internal email bodies are capped at 50,000 characters at **send time**. The reason is architectural: unread bodies are injected in full into the persistent notification stream, so the reading/notification layer should not guess, summarize, or truncate ordinary mail. If a message is too large for that guarantee, `send` refuses it with `limit_chars` and `actual_chars`; shorten the body, attach a file, or put bulky material somewhere else and mail a pointer.
-
-### `check` filter
-
-`check` accepts a structured `filter` for narrowing the inbox without round-tripping:
-
-```python
-email(action="check",
-      input={
-          "n": 20,
-          "filter": {
-              "unread_only":     True,
-              "from":            "mimo-1",
-              "subject":         "status",
-              "contains":        "blocker",
-              "after":           "2026-05-18T00:00:00Z",
-              "has_attachments": False,
-              "sort":            "newest",
-              "truncate":        500,    # body preview length per entry
-          },
-      },
-      reasoning="find unread blockers from mimo-1")
-```
-
-`filter` and `n` belong to `check` alone. Any field you do not need may simply
-be omitted (or sent as `null`, which is treated the same as omitting it).
-
-Use this aggressively. Pulling 100 messages with `check` and then post-filtering in your head is wasteful.
-
-## 6. Self-send — persistent notes that survive molt
-
-Mail sent to **your own address** lands in your own inbox. It is marked self-sent, but otherwise behaves like any other unread message — meaning:
-
-- It survives a molt (because it lives in `mailbox/inbox/`, not in chat history).
-- It surfaces in the persistent unread notification lane until you `dismiss`, `read`, `archive`, or `delete` it.
-- It can be `search`ed by the future you.
-
-Use this for: TODOs you want to remember after a memory rotation, breadcrumbs about decisions, "hand-off to self" notes during a long task. See the recipes in §10.
-
-## 7. Time capsule — delayed self-send
-
-Add `"delay": <seconds>` to `send`'s `input` to defer delivery. The outbox entry is written immediately; the `_mailman` daemon thread sleeps until the deadline, then dispatches. Combined with self-send this gives you cheap one-shot alarms without standing up a cron; the notification is delivered exactly once.
-
-Use delayed self-send as a **future nudge**, not delayed tool execution. The message should tell the future you what to inspect and why, then let that future turn decide with current context whether to run `shell(action="poll")`, `daemon(check)`, a channel read, or nothing at all. It is one of the escape hatches when a repeated-call `_advisory` says you may be polling the same thing: write one concrete reminder, then yield/idle.
-
-**Recurring work is not an email feature.** The internal `email` tool has no recurring scheduling API. For repeating reminders or agent-side scheduled work, use a host scheduler (cron, launchd, systemd, or an event watcher) via `shell-manual` → `reference/scheduled-work/SKILL.md`; for a single lightweight wakeup that does not need mailbox state, `shell-manual` → `reference/notification-reminders/SKILL.md` owns the `.notification/cron.json` pattern.
-
-## 8. Privacy — internal IDs
-
-The mailbox UUID (`email_id`) is **local to your working directory**. Never paste a raw mailbox ID into a message to another agent or to the human — it has no meaning outside your tree and reveals nothing useful. Refer to messages by `subject` + `from` + approximate time.
-
-The exception: when you call `email(action="read"/"dismiss"/"reply", input={"email_id": [...]})`, you pass IDs you read out of *your own* persistent notification or mailbox listing. That's internal plumbing, fine.
-
-## 9. Addon ownership — what this skill does NOT cover
-
-This skill is the manual for the **kernel-intrinsic `email` tool** only. Adjacent surfaces live elsewhere:
-
-| Want to …                                          | Use                                          |
-|----------------------------------------------------|----------------------------------------------|
-| Send/receive real internet email (Gmail, etc.)     | `mcp-manual` → `imap` or `cloud_mail` addon  |
-| Send Telegram / Feishu / WeChat / WhatsApp messages | `mcp-manual` → respective MCP addon          |
-| Send a notification-style ping to another agent    | This skill — it IS the notification channel  |
-| Schedule a one-off wake-up of your own loop        | This skill, `delay` + self-send (§7)         |
-| Run recurring agent-side work                       | Host scheduler / event watcher via `shell-manual` |
-
-Those MCP addons are separate processes with separate auth surfaces and failure modes; each ships its own manual. Do not try to use the `email` tool for an external address: an unknown target is refused without creating a recipient inbox entry and is reported through `email.bounce`.
-
-## 10. Quick reference — common recipes
-
-```python
-# Handle content already injected into notification_persistent.email
-email(action="dismiss", input={"email_id": ["<id-from-persistent-email>"]},
-      reasoning="clear mail already handled from the notification")
-
-# Need source-of-truth refresh / attachments / metadata
-email(action="read", input={"email_id": ["<id-from-persistent-email>"]},
-      reasoning="read the full body and attachments")
-
-# Optional mailbox listing / filters
-email(action="check", input={"n": 20, "filter": {"unread_only": True}},
-      reasoning="list pending unread mail")
-
-# Thread-preserving reply
-email(action="reply", input={"email_id": ["<id>"], "message": "ack, looking now"},
-      reasoning="acknowledge on the channel it arrived on")
-
-# Self-note that survives molt
-email(action="send",
-      input={"address": "<self>", "subject": "resume",
-             "message": "Picked the Helmholtz approach; see paper/drafts/2026-05-18.md"},
-      reasoning="leave a breadcrumb for after the next molt")
-
-# 5-minute timer
-email(action="send",
-      input={"address": "<self>", "delay": 300,
-             "subject": "ding", "message": "check the deploy"},
-      reasoning="set a one-shot nudge to re-check the deploy")
-
-# Reach an agent in another .lingtai/ network on this machine
-email(action="send",
-      input={"mode": "abs", "address": "/Users/alice/projectB/.lingtai/外援",
-             "subject": "cross-network", "message": "ping"},
-      reasoning="contact an agent in another network by absolute path")
-
-# Find related mail
-email(action="search", input={"query": "helmholtz"},
-      reasoning="find prior discussion of this approach")
-
-# Address book
-email(action="add_contact",
-      input={"address": "mimo-1", "name": "MiMo (vision)",
-             "note": "reachable for image-analysis requests"},
-      reasoning="record a durable contact")
-```
-
-Note that `search` takes `query` (and optionally `folder`) — the `filter`
-object belongs to `check`, and passing it to `search` is refused at dispatch.
-
----
-> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.
-
-## Cleanup / Footprint
-
-Internal email persists under the agent mailbox: inbox/archive/sent message
-files, attachments, contacts, and read/archive state. Mail is also memory: do not
-blindly delete it. Prefer `email(archive)` or `email(delete)` verbs over `rm`,
-and never delete mail that is the only copy of a decision, handoff, or
-attachment the human may expect you to retain.
-
-Footprint check: load the [shared inspection recipe](../../skills/manual/reference/cleanup-footprint-contract.md#shared-footprint-check-recipe)
-through `skills-manual` → `reference/cleanup-footprint-contract.md`. Combine
-its definitions with this tool-specific selection in one task-owned script;
-the selection is not a standalone executable. Inspection writes nothing.
-Appending `logs/cleanup.jsonl` is the separate, explicitly selected audit step
-in that recipe; retain this manual's cleanup/approval rules below.
-
-```python
-agent = Path.cwd()  # the relevant agent directory, not a repository root
-roots = [p for p in (agent / "mailbox", agent / "mail", agent / "email") if p.exists()]
-items = [p for root in roots for p in ([root] if root.is_file() else root.iterdir())]
-rows, total = footprint_check(items, tool="email", top_n=20)
-```
-
-Recommended cadence: when large attachments are exchanged, before exporting or
-archiving a project, and quarterly for long-lived agents. Cleanup requires a
-dry-run report plus explicit user consent; after deletion/archive, append an
-`apply` record to `logs/cleanup.jsonl`.
+`manifest.pseudo_agent_subscriptions` is the configurable, fully redacted
+construction snapshot; see [the settings reference](reference/settings-reference/SKILL.md#pseudo-agent-subscriptions).
+
+## 5. Self-send and delay
+
+Mail to your own address is a durable inbox note that survives molt and remains
+in the unread lane until handled. `delay` is seconds before one delivery attempt:
+the outbox record is written immediately and a daemon thread waits. Delayed
+self-send is a one-shot future nudge, not delayed tool execution or recurring
+scheduling. For recurring work, use the host scheduler routed by `shell-manual`.
+See [Actions and storage](reference/actions-and-storage/SKILL.md#self-send-and-time-capsules).
+
+## 6. Cleanup and footprint
+
+Email persists inbox/archive/sent messages, attachments, contacts, and read state.
+Do not blindly delete mail that is the only copy of a decision, handoff, or
+attachment. Prefer the Email `archive`/`delete` actions over filesystem removal.
+For a dry-run footprint inspection and explicit-consent cleanup procedure, load
+the shared [cleanup-footprint contract](../../skills/manual/reference/cleanup-footprint-contract.md#shared-footprint-check-recipe).
+
+## Reference map
+
+- [Addressing and replies](reference/addressing-and-replies/SKILL.md) — bare-path
+  addresses, `peer`/`abs`, same-channel replies, identity, and ID privacy.
+- [Actions and storage](reference/actions-and-storage/SKILL.md) — action details,
+  filters, folders, self-send, time capsules, and durable layout.
+- [Notifications and delivery](reference/notifications-and-delivery/SKILL.md) —
+  liveness, bounce/recovery, unread payloads, overflow, and read-state refresh.
+- [Settings reference](reference/settings-reference/SKILL.md) — five rows,
+  effective sources, redaction, timing, and SHOW-only behavior.
+
+> Found a bug? Load the `lingtai-issue-report` skill and follow its procedure.

--- a/src/lingtai/tools/email/manual/reference/actions-and-storage/SKILL.md
+++ b/src/lingtai/tools/email/manual/reference/actions-and-storage/SKILL.md
@@ -44,9 +44,9 @@ A send writes sender-side outbox/sent state synchronously, then starts one daemo
 mailman thread per recipient. A successful `{status: "sent"}` receipt means the
 attempt was scheduled, not necessarily delivered. `delay` is a non-negative
 number of seconds before the one delivery attempt; the outbox record exists while
-the thread waits. See [Notifications and delivery](notifications-and-delivery/SKILL.md)
+the thread waits. See [Notifications and delivery](../notifications-and-delivery/SKILL.md)
 for liveness and bounce behavior. Identical consecutive sends are guarded as a
-loop; the installed pass count is in [Settings reference](settings-reference/SKILL.md).
+loop; the installed pass count is in [Settings reference](../settings-reference/SKILL.md).
 
 ## Listing and filtering
 

--- a/src/lingtai/tools/email/manual/reference/actions-and-storage/SKILL.md
+++ b/src/lingtai/tools/email/manual/reference/actions-and-storage/SKILL.md
@@ -36,7 +36,14 @@ email(action="send", input={
 
 `address` is a bare peer name (or an authorized absolute path in `abs` mode).
 `cc` is visible to recipients; `bcc` is stored in the sender's copy but hidden
-from recipients. `attachments` contains file paths. `message` is capped at
+from recipients. `attachments` contains source file paths. Each recipient
+adapter validates every path before creating that recipient's inbox entry; a
+missing or non-file path leaves no partial recipient inbox entry. Accepted files
+are copied into the message's recipient-local `attachments/` directory before
+atomic publication, and `message.json` records those snapshot paths. Duplicate
+basenames receive `-1`, `-2`, ... suffixes before the extension. Email enforces
+no attachment-size or source-root-containment limit, so callers must select only
+explicitly authorized files. This is separate from `message`, which is capped at
 50,000 Unicode characters at send time; oversize bodies are rejected with the
 limit and actual size rather than truncated.
 
@@ -85,9 +92,10 @@ sender, subject, and body and rejects invalid regexes. It does not accept
 - `dismiss` takes a list of IDs and marks handled inbox mail read without
   returning bodies. Prefer it after handling a body already in persistent
   notification context.
-- `reply` takes one ID and a message, preserves thread linkage, and addresses
-  the sender. `reply_all` keeps the original recipients except self. Both obey
-  the root manual's same-channel rule.
+- `reply` and `reply_all` take one ID and a message and route from the original
+  mail. Recipient selection, subject derivation, and the absence of persistent
+  thread metadata are owned by [Addressing and replies](../addressing-and-replies/SKILL.md#same-channel-reply-discipline).
+  Both obey the root manual's same-channel rule.
 - `archive` moves inbox IDs to `mailbox/archive`; it removes them from the read
   set as part of the move. `delete` permanently removes IDs from inbox or
   archive and refuses `sent`.

--- a/src/lingtai/tools/email/manual/reference/actions-and-storage/SKILL.md
+++ b/src/lingtai/tools/email/manual/reference/actions-and-storage/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: email-manual-actions-and-storage
+description: >
+  Focused Email reference for action inputs, folders, check filters, delivery
+  side effects, self-send/time capsules, contacts, and mailbox persistence.
+  Read after email-manual when an operation needs more than the first-call map.
+version: 1.0.0
+tags: [lingtai, email, actions, mailbox, storage]
+last_changed_at: "2026-09-06T00:00:00Z"
+related_files:
+- src/lingtai/tools/email/manual/SKILL.md
+- src/lingtai/tools/email/_family_schema.py
+- src/lingtai/tools/email/manager.py
+- src/lingtai/tools/email/primitives.py
+- src/lingtai/tools/email/settings.py
+- src/lingtai/tools/email/CONTRACT.md
+maintenance: |
+  Tracks Email action behavior, input details, mailbox layout, and persistence guidance; update when action contracts or storage ownership changes.
+---
+
+# Email actions and storage
+
+The root manual is the first-call router. This page supplies action-level detail;
+input keys remain closed to the action that owns them. Omitted optional values
+use the action defaults. An explicit `null` is treated as omitted at the family
+boundary.
+
+## Sending
+
+```python
+email(action="send", input={
+    "address": "peer", "subject": "status", "message": "ready",
+    "cc": ["human"], "bcc": [], "attachments": [], "delay": 0,
+}, reasoning="report status")
+```
+
+`address` is a bare peer name (or an authorized absolute path in `abs` mode).
+`cc` is visible to recipients; `bcc` is stored in the sender's copy but hidden
+from recipients. `attachments` contains file paths. `message` is capped at
+50,000 Unicode characters at send time; oversize bodies are rejected with the
+limit and actual size rather than truncated.
+
+A send writes sender-side outbox/sent state synchronously, then starts one daemon
+mailman thread per recipient. A successful `{status: "sent"}` receipt means the
+attempt was scheduled, not necessarily delivered. `delay` is a non-negative
+number of seconds before the one delivery attempt; the outbox record exists while
+the thread waits. See [Notifications and delivery](notifications-and-delivery/SKILL.md)
+for liveness and bounce behavior. Identical consecutive sends are guarded as a
+loop; the installed pass count is in [Settings reference](settings-reference/SKILL.md).
+
+## Listing and filtering
+
+`check` lists newest-first by default from `inbox`; `folder` can be `inbox`,
+`sent`, or `archive`, and `n` defaults to 10. Its optional `filter` is owned by
+`check` alone:
+
+```python
+email(action="check", input={
+    "folder": "inbox", "n": 20,
+    "filter": {
+        "sort": "newest", "from": "peer", "subject": "status",
+        "contains": "blocker", "after": "2026-04-01T00:00:00Z",
+        "before": "2026-05-01T00:00:00Z", "unread_only": True,
+        "has_attachments": False, "truncate": 500,
+    },
+}, reasoning="find unread status mail")
+```
+
+`sort` is `newest` (default) or `oldest`; `from`, `subject`, and `contains`
+are case-insensitive substring filters; `after`/`before` accept ISO 8601
+timestamps; the two boolean filters select unread or attachment-bearing mail.
+`truncate` controls preview characters (default 500); `0` requests the full
+body. A check result can be trimmed by Email's token budget and reports that
+fact. Prefer filtering in the call rather than retrieving a large mailbox and
+post-filtering mentally.
+
+`search` takes a regular-expression `query` and optional `folder`; it searches
+sender, subject, and body and rejects invalid regexes. It does not accept
+`filter` or `n`.
+
+## Reading, mutating, and contacts
+
+- `read` takes a list of mailbox IDs, returns source records (including
+  attachments), and marks inbox IDs read.
+- `dismiss` takes a list of IDs and marks handled inbox mail read without
+  returning bodies. Prefer it after handling a body already in persistent
+  notification context.
+- `reply` takes one ID and a message, preserves thread linkage, and addresses
+  the sender. `reply_all` keeps the original recipients except self. Both obey
+  the root manual's same-channel rule.
+- `archive` moves inbox IDs to `mailbox/archive`; it removes them from the read
+  set as part of the move. `delete` permanently removes IDs from inbox or
+  archive and refuses `sent`.
+- `contacts` lists the private address book. `add_contact` upserts by address;
+  `remove_contact` deletes by address; `edit_contact` changes supplied name or
+  note fields. Contact writes use a temporary file and atomic replacement.
+
+All IDs must come from the current agent's own notification or mailbox result.
+Stale IDs produce a not-found hint; an ID from another working directory has no
+meaning here.
+
+## Self-send and time capsules
+
+Sending to your own bare address creates an ordinary unread inbox message that
+survives molt, can be searched later, and remains in the unread lane until
+`dismiss`, `read`, `archive`, or `delete`. Add `delay` to make a one-shot time
+capsule: the outbox is written immediately, and the daemon mailman thread waits
+until the deadline. A delayed self-send is a future nudge, not delayed tool
+execution. Recurring sends are not supported; use a host scheduler through
+`shell-manual` for recurring work.
+
+## Mailbox layout
+
+Paths are relative to the agent working directory:
+
+```text
+mailbox/inbox/<id>/message.json       received mail
+mailbox/sent/<id>/message.json        sent copy (one record per send call)
+mailbox/archive/<id>/message.json     archived inbox mail
+mailbox/outbox/<id>/message.json      pending/delayed send
+mailbox/read.json                     read-ID set
+mailbox/contacts.json                 private contact book
+.notification/email.json              producer-owned unread mirror
+```
+
+Message JSON uses UTF-8. Mailbox message files are direct writes; contact writes
+are the atomic exception. BCC data is not exposed to recipients. The unread
+mirror is refreshed by every read-state mutation; its payload and delivery
+semantics are in the notifications reference.

--- a/src/lingtai/tools/email/manual/reference/addressing-and-replies/SKILL.md
+++ b/src/lingtai/tools/email/manual/reference/addressing-and-replies/SKILL.md
@@ -56,12 +56,15 @@ output. Text output is a private diary, not a communication channel. If the
 original sender is unavailable and a channel pivot is unavoidable, explain that
 pivot in the message before sending elsewhere.
 
-`reply` preserves `in_reply_to` and addresses the sender. `reply_all` retains the
-original recipient set (excluding self) so CC participants are not silently
-dropped. The manager resolves a reply target in this order: embedded
-`_return_route`, an absolute `from`, then a bare peer `from`. It refuses an
-ambiguous peer route that would resolve to the responder's own workdir while the
-original identity names a different agent.
+`reply` addresses the resolved sender. `reply_all` also carries the original
+`to` and `cc` recipients except self and the primary reply target, so CC
+participants are not silently dropped. Unless explicitly overridden, both derive
+a `Re: ` subject from the original subject (or its first body line when absent).
+They do not persist an `in_reply_to` field or thread ID; continuity comes from
+recipient selection and the derived subject. The manager resolves a reply target
+in this order: embedded `_return_route`, an absolute `from`, then a bare peer
+`from`. It refuses an ambiguous peer route that would resolve to the responder's
+own workdir while the original identity names a different agent.
 
 ## Sender display and local IDs
 

--- a/src/lingtai/tools/email/manual/reference/addressing-and-replies/SKILL.md
+++ b/src/lingtai/tools/email/manual/reference/addressing-and-replies/SKILL.md
@@ -27,10 +27,9 @@ Internal Email addresses are names of directories inside `.lingtai/`, with no
 - `mimo-1` addresses an agent directory;
 - your own agent name addresses a durable self-inbox.
 
-`address` accepts one string or a list. Discover real agents from local
-`.agent.json` metadata and use each file's `agent_name`; do not invent an
-address. A refused target creates no recipient inbox entry and is reported as an
-`email.bounce` system event.
+`address` accepts one string or a list. Discover real agents by globbing `.lingtai/*/.agent.json` and use each file's
+`agent_name`; do not invent an address. A refused target creates no recipient
+inbox entry and is reported as an `email.bounce` system event.
 
 ## `peer` and `abs`
 
@@ -72,5 +71,14 @@ routing address, not a display name.
 
 A mailbox UUID (`email_id`) is local to one working directory. Pass IDs copied
 from your own persistent notification or `check` result to `read`, `dismiss`,
-`reply`, or `reply_all`; never paste a raw ID into mail or public prose. When
-referring to mail to another agent, use subject, sender, and approximate time.
+`reply`, or `reply_all`; never paste a raw ID into mail or public prose. When referring to mail to another agent, use subject, sender, and approximate
+time.
+
+## Adjacent surfaces
+
+This manual owns only the kernel-intrinsic `email` tool. Real internet mail
+(Gmail, Outlook, IMAP/SMTP) belongs to the `imap` or `cloud_mail` MCP addon;
+Telegram, Feishu, WeChat, and WhatsApp belong to their respective MCP addons.
+Recurring agent-side work belongs to a host scheduler through `shell-manual`.
+Do not use Email for an external address: an unknown target is refused without a
+recipient inbox entry and is reported as a bounce.

--- a/src/lingtai/tools/email/manual/reference/addressing-and-replies/SKILL.md
+++ b/src/lingtai/tools/email/manual/reference/addressing-and-replies/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: email-manual-addressing-and-replies
+description: >
+  Focused Email reference for bare-path addressing, peer/abs resolution, safe
+  same-channel replies, sender identity display, and local mailbox-ID privacy.
+  Read after email-manual when routing or answering internal mail.
+version: 1.0.0
+tags: [lingtai, email, routing, replies, privacy]
+last_changed_at: "2026-09-06T00:00:00Z"
+related_files:
+- src/lingtai/tools/email/manual/SKILL.md
+- src/lingtai/tools/email/primitives.py
+- src/lingtai/tools/email/manager.py
+- src/lingtai/tools/email/CONTRACT.md
+maintenance: |
+  Tracks Email addressing, reply routing, identity display, and local-ID privacy; update when the manager or routing contract changes.
+---
+
+# Email addressing and replies
+
+## Bare-path addresses
+
+Internal Email addresses are names of directories inside `.lingtai/`, with no
+`@`, domain, or slash in ordinary peer mode:
+
+- `human` addresses the operator mailbox;
+- `mimo-1` addresses an agent directory;
+- your own agent name addresses a durable self-inbox.
+
+`address` accepts one string or a list. Discover real agents from local
+`.agent.json` metadata and use each file's `agent_name`; do not invent an
+address. A refused target creates no recipient inbox entry and is reported as an
+`email.bounce` system event.
+
+## `peer` and `abs`
+
+`mode` belongs to `send` and is normally omitted:
+
+- `peer` (default) resolves a bare agent name against the parent of your own
+  working directory. It is the normal mode for the human, fellow agents, and
+  self-send.
+- `abs` treats `address` as a literal absolute working-directory path in a
+  different, explicitly authorized `.lingtai/` network on the same machine.
+  It is for cross-network/project messaging only.
+
+Both modes require the target's valid `.agent.json` and fresh heartbeat. `abs`
+does not bypass the handshake or liveness check. Absolute sends embed a
+`_return_route` containing the sender workdir and agent identity; this protects
+replies when separate `.lingtai/` networks contain agents with the same short
+name. Older messages without that field still use the absolute-`from` fallback.
+
+## Same-channel reply discipline
+
+**Reply on the channel where the message arrived.** An Email message must be
+answered with `reply` or `reply_all`, not a new `send`, Telegram, IM, or text
+output. Text output is a private diary, not a communication channel. If the
+original sender is unavailable and a channel pivot is unavoidable, explain that
+pivot in the message before sending elsewhere.
+
+`reply` preserves `in_reply_to` and addresses the sender. `reply_all` retains the
+original recipient set (excluding self) so CC participants are not silently
+dropped. The manager resolves a reply target in this order: embedded
+`_return_route`, an absolute `from`, then a bare peer `from`. It refuses an
+ambiguous peer route that would resolve to the responder's own workdir while the
+original identity names a different agent.
+
+## Sender display and local IDs
+
+Inbound messages carry an `identity` block. In prose, call the sender by its
+non-empty `sender_nickname`; otherwise use `sender_name`. The `from` value is a
+routing address, not a display name.
+
+A mailbox UUID (`email_id`) is local to one working directory. Pass IDs copied
+from your own persistent notification or `check` result to `read`, `dismiss`,
+`reply`, or `reply_all`; never paste a raw ID into mail or public prose. When
+referring to mail to another agent, use subject, sender, and approximate time.

--- a/src/lingtai/tools/email/manual/reference/notifications-and-delivery/SKILL.md
+++ b/src/lingtai/tools/email/manual/reference/notifications-and-delivery/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: email-manual-notifications-and-delivery
+description: >
+  Focused Email reference for daemon delivery, heartbeat/liveness, bounce
+  recovery, unread notification payloads, persistent bodies, overflow, and
+  read-state mirror refresh. Read after email-manual when delivery or notices
+  need diagnosis.
+version: 1.0.0
+tags: [lingtai, email, notifications, delivery, recovery]
+last_changed_at: "2026-09-06T00:00:00Z"
+related_files:
+- src/lingtai/tools/email/manual/SKILL.md
+- src/lingtai/tools/email/manual/reference/actions-and-storage/SKILL.md
+- src/lingtai/tools/email/manager.py
+- src/lingtai/tools/email/primitives.py
+- src/lingtai/adapters/posix/mail.py
+- src/lingtai/tools/email/CONTRACT.md
+maintenance: |
+  Tracks Email delivery, unread notification projection, bounce recovery, and read-state mirror semantics; update when producer or mail-adapter behavior changes.
+---
+
+# Email notifications and delivery
+
+## Delivery and liveness
+
+`send` writes the sender's outbox/sent record before creating one daemon
+`_mailman` thread per recipient. `delay=0` still permits a sent receipt before
+the delivery attempt finishes. A normal agent target must have valid
+`.agent.json` metadata and a fresh `.agent.heartbeat` (normally under two
+seconds); a human target (`admin: null`) does not need a heartbeat. A refreshing
+or relaunching target can therefore bounce as `not running`; Email does not
+queue the attempt for later. The sender receives the eventual failure as an
+`email.bounce` event in `.notification/system.json`.
+
+A process can appear in `ps` before publishing a fresh heartbeat. If a CPR
+(child-process restart) attempt also exits because the duplicate-process guard
+finds the existing same-workdir process, these observations are compatible:
+do not stack CPR attempts. Wait for a fresh heartbeat and retry Email once. Use
+CPR only if the existing startup exits or never becomes live.
+
+For an explicitly authorized `abs` target, the same metadata/heartbeat handshake
+applies. An absolute address is not a liveness or authorization bypass.
+
+## Unread producer mirror
+
+Mail arrival and every read-state mutation render the current unread set to
+`.notification/email.json`. The kernel's next heartbeat sync exposes that data
+through `notification(action="check")`. A typical producer envelope is:
+
+```json
+{
+  "header": "3 unread emails",
+  "icon": "📧",
+  "priority": "normal",
+  "published_at": "<timestamp>",
+  "instructions": "Handle the mail, then prefer email.dismiss or use email.read/reply.",
+  "data": {
+    "count": 3,
+    "newest_received_at": "<timestamp>",
+    "email_ids": ["<local-id>"],
+    "emails": [{
+      "id": "<local-id>", "from": "peer", "subject": "...",
+      "message": "full body", "message_chars": 10,
+      "message_truncated": false
+    }]
+  }
+}
+```
+
+`instructions` is producer-owned guidance: Email knows whether a message is a
+full-body context entry and which producer verb clears its source state. The
+attention lane is a high-attention hook carrying IDs; full structured entries
+live in `_meta.agent_meta.notifications.persistent.email`. There is no separate
+per-mail notification pair.
+
+Ordinary new messages are rendered without truncating their bodies. The send
+layer rejects bodies over 50,000 characters; only legacy over-limit records may
+carry `message_truncated=true` defensively. The unread projection limits the
+number of newest entries but keeps total unread count exact.
+
+## Handling persistent mail and overflow
+
+The persistent lane can make `read` unnecessary merely to see ordinary text.
+After handling a visible entry, call `email(action="dismiss", input={"email_id":
+[...]}, ...)` to mark it read without returning another body. Use `read` when
+source-of-truth metadata, attachments, or a deliberate refresh is required.
+`reply` and `reply_all` both mark the source inbox ID read as part of handling.
+`archive` and `delete` also update read state. All four mutation paths rerender
+the Email mirror, which disappears when no unread mail remains.
+
+If the full persistent notification exceeds its model-visible block cap, the
+kernel spills it to a local `logs/notification-overflow-<timestamp>.json` and
+adds an `overflow` marker. Follow that marker or call the producer action for
+full content; do not assume a truncated body is complete. The exact block cap
+and environment ownership belong to `notification-manual`.
+
+A generic
+`notification(action="dismiss_channel", input={"channel": "email", ...}, ...)`
+only clears the mirror. It does not mark source messages read and is not a
+substitute for Email's `dismiss`, `read`, `reply`, `archive`, or `delete`.
+
+## Bounce and retry interpretation
+
+A bounce means no recipient inbox record was queued for that attempt. Inspect the
+bounce event and target metadata/heartbeat. For a target in a refresh window,
+wait for its heartbeat and retry once; do not assume that a successful `sent`
+receipt proves delivery. For an unknown or invalid address, correct the address
+from local metadata rather than guessing.

--- a/src/lingtai/tools/email/manual/reference/settings-reference/SKILL.md
+++ b/src/lingtai/tools/email/manual/reference/settings-reference/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: email-manual-settings-reference
+description: >
+  Focused Email settings reference for the five SHOW rows, installed limits,
+  manifest subscription source, redaction, precedence, timing, and the
+  read-only boundary. Read after email-manual when interpreting settings rows.
+version: 1.0.0
+tags: [lingtai, email, settings, privacy, configuration]
+last_changed_at: "2026-09-06T00:00:00Z"
+related_files:
+- src/lingtai/tools/email/manual/SKILL.md
+- src/lingtai/tools/email/settings.py
+- src/lingtai/tools/email/manager.py
+- src/lingtai/tools/email/primitives.py
+- src/lingtai/adapters/posix/mail.py
+- src/lingtai/tools/email/CONTRACT.md
+maintenance: |
+  Tracks Email's SHOW-only settings rows, source truth, privacy redaction, and authorized configuration timing; update when settings ownership or constants change.
+---
+
+# Email settings reference
+
+Call `email(action="settings", input={}, reasoning="inventory Email policy")` to
+show the effective Email inventory. It is SHOW-only: no set/reset/writer exists,
+non-empty input is refused, and mailbox I/O is not performed. A successful
+response is `{"settings": [...]}` with exactly `key`, `current`, `default`,
+`configurable`, and `comment` in every row. The complete response is bounded at
+65,536 UTF-8 bytes. If applied truth or a provider row is unavailable, the whole
+action fails with fixed `SETTINGS_UNAVAILABLE`; it never returns partial rows or
+exception detail.
+
+The five rows are ordered as follows:
+
+| Key | Current | Default | Configurable | Comment anchor |
+|---|---:|---:|---|---|
+| `send.body_char_limit` | `50000` | `50000` | `false` | `email-manual#send-body-character-limit` |
+| `send.duplicate_free_passes` | `2` | `2` | `false` | `email-manual#duplicate-send-loop-guard` |
+| `check.result_token_limit` | `10000` | `10000` | `false` | `email-manual#check-result-token-limit` |
+| `unread.max_entries` | `10` | `10` | `false` | `email-manual#unread-notification-entry-limit` |
+| `manifest.pseudo_agent_subscriptions` | `<redacted>` | `<redacted>` | `true` | `email-manual#pseudo-agent-subscriptions` |
+
+## Send body character limit
+
+- **Key:** `send.body_char_limit`; installed integer `50000`.
+- **Meaning:** maximum accepted internal-email body length in Unicode
+  characters. Oversize `send` and `reply` bodies are refused before delivery.
+- **Source/configuration:** installed code; no environment variable or owner
+  settings file. `configurable` is false.
+- **Timing:** only a reviewed product-code/package change plus full agent
+  relaunch changes it; SHOW never writes. Verify with SHOW after relaunch.
+
+## Duplicate send loop guard
+
+- **Key:** `send.duplicate_free_passes`; installed integer `2`.
+- **Meaning:** consecutive identical sends allowed per recipient before Email
+  blocks the next duplicate as a loop.
+- **Source/configuration:** installed `email/settings.py` constant; no
+  environment variable or owner settings file. `configurable` is false.
+- **Timing:** only reviewed code/package change plus full relaunch changes it;
+  verify with a second SHOW.
+
+## Check result token limit
+
+- **Key:** `check.result_token_limit`; installed integer `10000`.
+- **Meaning:** one `check` result's token budget; summaries are removed until
+  the serialized response fits.
+- **Source/configuration:** installed `email/settings.py` constant; no
+  environment variable or owner settings file. `configurable` is false.
+- **Timing:** only reviewed code/package change plus full relaunch changes it;
+  verify with a second SHOW.
+
+## Unread notification entry limit
+
+- **Key:** `unread.max_entries`; installed integer `10`.
+- **Meaning:** maximum newest unread entries projected into one Email
+  notification mirror; total unread count remains exact.
+- **Source/configuration:** installed `email/settings.py` constant; no
+  environment variable or owner settings file. `configurable` is false.
+- **Timing:** only reviewed code/package change plus full relaunch changes it;
+  verify with a second SHOW.
+
+## Pseudo-agent subscriptions
+
+- **Key:** `manifest.pseudo_agent_subscriptions`; current and default always
+  `<redacted>`. The raw values are path lists and never appear in SHOW output.
+- **Meaning:** pseudo-agent directories whose outboxes the POSIX mail adapter
+  polls in addition to this agent's inbox.
+- **Accepted values:** JSON list of path strings; `[]` disables subscriptions.
+  If absent, the launcher's meaningful default is `["../human"]`. The init
+  schema requires a list, and an element that cannot be interpreted as a path
+  fails adapter construction rather than being silently ignored.
+- **Source/precedence:** exactly the `manifest.pseudo_agent_subscriptions`
+  field in `init.json`; no Email environment variable or owner-file peer. The
+  resolved list is sensitive local routing data and must not be inferred from
+  SHOW or copied from logs.
+- **Timing/change procedure:** after explicit owner/human authorization, edit
+  that exact manifest field with the existing File or Shell capability, then
+  perform a full agent relaunch. Ordinary refresh does not reconstruct the mail
+  adapter. Call SHOW again after relaunch; it proves availability and redaction,
+  never the paths.
+
+## Privacy and ownership boundaries
+
+Mailbox/session paths, addresses, identities, contacts, messages, attachments,
+and read/archive state are runtime/domain data, not settings. They are excluded,
+not merely redacted. `LINGTAI_AGENT_ALIVE_THRESHOLD_SEC` remains kernel liveness
+policy and `LINGTAI_NOTIFICATION_MAX_CHARS` remains Notification presentation
+policy; Email does not claim either variable. The legacy 200-character digest
+renderer wording is not an effective Email setting because live unread publishing
+uses full-body entries.

--- a/src/lingtai/tools/email/primitives.py
+++ b/src/lingtai/tools/email/primitives.py
@@ -27,7 +27,7 @@ def mode_field(lang: str = "en") -> dict:
     return {
         "type": "string",
         "enum": ["peer", "abs"],
-        "description": "Address mode for send. Almost always leave this unset — the default 'peer' is correct for every agent in your own .lingtai/ network. peer (default): treat 'address' as a bare agent name (working-directory basename) of someone in your network — the human, fellow agents, your own avatars, anyone listed in your brief or who has mailed you; the system resolves the name against your network folder (the parent of your own working directory). abs: treat 'address' as a literal absolute filesystem path to another agent's working directory in a different, explicitly authorized .lingtai/ network on the same machine (cross-project messaging, bridge agents), e.g. /Users/alice/projectB/.lingtai/外援. Both modes require the same fresh-heartbeat/valid-.agent.json handshake — abs does not bypass it. See email-manual.",
+        "description": "Address mode for send; usually omit it. peer (default) resolves a bare name in your own .lingtai/ network. abs accepts a literal absolute workdir only for an explicitly authorized cross-network recipient. Both require valid .agent.json and a fresh heartbeat; abs does not bypass delivery checks. See email-manual.",
     }
 
 

--- a/src/lingtai/tools/email/schema.py
+++ b/src/lingtai/tools/email/schema.py
@@ -17,7 +17,12 @@ from .primitives import mode_field
 
 
 def get_description(lang: str = "en") -> str:
-    return "LingTai email protocol within your .lingtai/ network — NOT real internet email (for Gmail/Outlook use the imap tool). Addresses are bare paths under .lingtai/ with no @ signs (e.g. human for the operator). Every call takes action + input + reasoning; input is the strict argument object for the selected action, so each action's own fields live there (email_id for read/dismiss/reply, query for search, filter/n for check, address/message for send) and a field from another action is refused at dispatch. Reply discipline: always reply on the channel the message arrived on; prefer reply over send. Never reply via text output — that is your private diary, not a comms channel. Always address people by sender_nickname if set, else sender_name. Call email(action='manual', input={}) to return the installed email-manual skill."
+    return ("Internal .lingtai mailbox only — not internet email (use the imap tool for Gmail/Outlook). "
+            "Use bare agent/path addresses; the closed envelope is action + input + reasoning, "
+            "with only the selected action's fields in input. Cross-action fields are rejected "
+            "before mailbox I/O. Reply on the channel the message arrived on (prefer reply or "
+            "reply_all); never reply in text output. Address senders by sender_nickname, else "
+            "sender_name. Call email(action='manual', input={}) for the email-manual router.")
 
 
 def get_schema(lang: str = "en") -> dict:
@@ -32,109 +37,115 @@ def get_schema(lang: str = "en") -> dict:
                     "contacts", "add_contact", "remove_contact", "edit_contact",
                     "manual",
                 ],
-                "description": 'send: send with optional cc/bcc (requires address, message; message body max 50,000 chars because unread bodies are injected in full into persistent notifications). check: list mailbox with preview of each email (up to 500 chars). read: fetch inbox emails by ID list (email_id=[id1, id2, ...]) AND marks each as read; ordinary unread content is already injected in notification_persistent.email, so prefer dismiss when you only need to clear handled mail. dismiss: same read-state effect as read but returns no bodies — preferred after handling content visible in persistent notification. reply: reply to email (requires email_id, message). reply_all: reply to all recipients. search: regex search mailbox. archive/delete: move/remove from inbox or archive. contacts/add_contact/remove_contact/edit_contact manage contacts. manual returns the installed email-manual skill without reading or changing mailbox state.',
+                "description": ("Choose one action; put only its fields in input. send: new internal "
+                                "message (address/message required; body max 50,000 characters). "
+                                "check: list/filter mail. read: fetch IDs and mark read; dismiss: "
+                                "mark handled IDs read without returning bodies. reply/reply_all: "
+                                "reply in-thread. search: regex lookup. archive/delete: move or "
+                                "remove inbox/archive mail. contacts actions manage the address book. "
+                                "settings is read-only. manual returns this manual without mailbox I/O."),
             },
             "address": {
                 "oneOf": [
                     {"type": "string"},
                     {"type": "array", "items": {"type": "string"}},
                 ],
-                "description": 'Target address(es) for send',
+                "description": 'Bare name/path for send; string or list.',
             },
             "cc": {
                 "type": "array",
                 "items": {"type": "string"},
-                "description": 'CC addresses — visible to all recipients',
+                "description": 'Visible CC addresses.',
             },
             "bcc": {
                 "type": "array",
                 "items": {"type": "string"},
-                "description": 'BCC addresses — hidden from other recipients',
+                "description": 'Hidden BCC addresses.',
             },
             "attachments": {
                 "type": "array",
                 "items": {"type": "string"},
-                "description": 'File paths to attach (for send)',
+                "description": 'Attachment paths for send.',
             },
-            "subject": {"type": "string", "description": 'Email subject line'},
-            "message": {"type": "string", "description": 'Email body (max 50,000 chars; longer internal emails are rejected because unread bodies are injected in full into persistent notifications).'},
+            "subject": {"type": "string", "description": 'Subject.'},
+            "message": {"type": "string", "description": 'Body; max 50,000 characters.'},
             "email_id": {
                 "type": "array",
                 "items": {"type": "string"},
-                "description": 'List of email IDs for read. For reply/reply_all, pass a single-element list.',
+                "description": 'Own mailbox ID list; replies use one ID.',
             },
             "n": {
                 "type": "integer",
-                "description": 'Max recent emails to show (for check, default 10)',
+                "description": 'Max messages for check; default 10.',
                 "default": 10,
             },
             "query": {
                 "type": "string",
-                "description": 'Regex pattern for search (matches from, subject, message)',
+                "description": 'Regex query over sender, subject, and body.',
             },
             "folder": {
                 "type": "string",
                 "enum": ["inbox", "sent", "archive"],
-                "description": "Folder for check/search/read/delete. Default: inbox for check, both for search. Note: 'sent' is read-only — delete only works on inbox or archive.",
+                "description": "Folder; check inbox/search both; sent is read-only.",
             },
             "delay": {
                 "type": "integer",
-                "description": 'Delay in seconds before delivery (default: 0). Use for scheduled or deferred sends.',
+                "description": 'Delivery delay in seconds; default 0.',
             },
             "mode": mode_field(lang),
             "type": {
                 "type": "string",
                 "enum": ["normal"],
-                "description": "Email type (for send). Defaults to 'normal'.",
+                "description": 'Send type; default normal.',
             },
             "name": {
                 "type": "string",
-                "description": "Contact's human-readable name (for add_contact, edit_contact)",
+                "description": "Contact name.",
             },
             "note": {
                 "type": "string",
-                "description": 'Free-text note about the contact (for add_contact, edit_contact)',
+                "description": "Contact note.",
             },
             "filter": {
                 "type": "object",
-                "description": 'Optional filter object for check. Pass filter={sort, from, subject, contains, after, before, unread_only, has_attachments, truncate} to narrow and control results.',
+                "description": "Optional check filters; see email-manual for fields and defaults.",
                 "properties": {
                     "sort": {
                         "type": "string",
                         "enum": ["newest", "oldest"],
-                        "description": "'newest' (default) or 'oldest'.",
+                        "description": "Sort newest (default) or oldest.",
                     },
                     "from": {
                         "type": "string",
-                        "description": 'Filter by sender (case-insensitive substring match).',
+                        "description": "Case-insensitive sender substring.",
                     },
                     "subject": {
                         "type": "string",
-                        "description": 'Filter by subject (case-insensitive substring match).',
+                        "description": "Case-insensitive subject substring.",
                     },
                     "contains": {
                         "type": "string",
-                        "description": 'Filter by message body content (case-insensitive substring match).',
+                        "description": "Case-insensitive body substring.",
                     },
                     "after": {
                         "type": "string",
-                        "description": 'Only show emails after this ISO 8601 timestamp (e.g. 2026-04-01T00:00:00Z).',
+                        "description": "Only messages after an ISO 8601 timestamp.",
                     },
                     "before": {
                         "type": "string",
-                        "description": 'Only show emails before this ISO 8601 timestamp.',
+                        "description": "Only messages before an ISO 8601 timestamp.",
                     },
                     "unread_only": {
                         "type": "boolean",
-                        "description": 'Only show unread emails.',
+                        "description": "Only unread messages.",
                     },
                     "has_attachments": {
                         "type": "boolean",
-                        "description": 'Only show emails that have attachments.',
+                        "description": "Only messages with attachments.",
                     },
                     "truncate": {
                         "type": "integer",
-                        "description": 'Max characters for message preview (default 500). Set to 0 for full message body.',
+                        "description": "Preview characters; default 500, 0 means full body.",
                         "default": 500,
                     },
                 },

--- a/src/lingtai/tools/email/schema.py
+++ b/src/lingtai/tools/email/schema.py
@@ -22,7 +22,9 @@ def get_description(lang: str = "en") -> str:
             "with only the selected action's fields in input. Cross-action fields are rejected "
             "before mailbox I/O. Reply on the channel the message arrived on (prefer reply or "
             "reply_all); never reply in text output. Address senders by sender_nickname, else "
-            "sender_name. Call email(action='manual', input={}) for the email-manual router.")
+            "sender_name. Unread bodies are injected in full into persistent Email notifications; "
+            "prefer dismiss after handling and use read for source records or attachments. Call "
+            "email(action='manual', input={}) for the email-manual router.")
 
 
 def get_schema(lang: str = "en") -> dict:
@@ -40,10 +42,13 @@ def get_schema(lang: str = "en") -> dict:
                 "description": ("Choose one action; put only its fields in input. send: new internal "
                                 "message (address/message required; body max 50,000 characters). "
                                 "check: list/filter mail. read: fetch IDs and mark read; dismiss: "
-                                "mark handled IDs read without returning bodies. reply/reply_all: "
-                                "reply in-thread. search: regex lookup. archive/delete: move or "
-                                "remove inbox/archive mail. contacts actions manage the address book. "
-                                "settings is read-only. manual returns this manual without mailbox I/O."),
+                                "mark handled IDs read without returning bodies. Unread bodies are "
+                                "injected in full into persistent Email notifications: prefer dismiss "
+                                "after handling; use read for source records or attachments. "
+                                "reply/reply_all: answer existing mail. search: regex lookup. "
+                                "archive/delete: move or remove inbox/archive mail. contacts actions "
+                                "manage the address book. settings is read-only. manual returns this "
+                                "manual without mailbox I/O."),
             },
             "address": {
                 "oneOf": [

--- a/tests/test_tool_family_email_migration.py
+++ b/tests/test_tool_family_email_migration.py
@@ -118,35 +118,20 @@ def test_settings_is_the_only_added_public_action_and_order_is_pinned():
 
 
 def test_email_schema_keeps_first_call_safety_while_disclosing_depth():
-    """The compact schema retains routing, cap, and channel guards."""
+    """Both resident entry points retain routing, notification, and channel guards."""
     schema = email_tool.get_schema()
     description = email_tool.get_description()
     action_description = schema["properties"]["action"]["description"]
     fields = schema["properties"]["input"]["anyOf"]
-    prose = " ".join((description, action_description))
-    assert "50,000" in prose
-    assert "reply" in prose and "channel" in prose
-    assert "manual" in prose
+    assert "50,000" in action_description
+    for resident in (description, action_description):
+        assert "injected in full" in resident
+        assert "persistent Email notifications" in resident
+        assert "prefer dismiss" in resident
+        assert "use read" in resident
+    assert "reply" in description and "channel" in description
+    assert "manual" in " ".join((description, action_description))
     assert any("email-manual" in str(branch) for branch in fields)
-
-
-def test_email_manual_is_a_short_router_with_focused_references():
-    """Long procedures stay available without inflating the installed router."""
-    root = Path(__file__).resolve().parents[1]
-    manual = root / "src/lingtai/tools/email/manual/SKILL.md"
-    body = manual.read_text(encoding="utf-8")
-    assert len(body) < 12_000
-    assert "## Reference map" in body
-    assert "Reply on the channel where the message arrived." in body
-    for reference in (
-        "addressing-and-replies",
-        "actions-and-storage",
-        "notifications-and-delivery",
-        "settings-reference",
-    ):
-        path = manual.parent / "reference" / reference / "SKILL.md"
-        assert path.is_file(), reference
-        assert f"reference/{reference}/SKILL.md" in body
 
 
 def test_reserved_unread_is_not_a_public_child_or_action():

--- a/tests/test_tool_family_email_migration.py
+++ b/tests/test_tool_family_email_migration.py
@@ -117,6 +117,38 @@ def test_settings_is_the_only_added_public_action_and_order_is_pinned():
     assert list(email_tool.DECLARATION.public_actions) == _PUBLIC_ACTIONS
 
 
+def test_email_schema_keeps_first_call_safety_while_disclosing_depth():
+    """The compact schema retains routing, cap, and channel guards."""
+    schema = email_tool.get_schema()
+    description = email_tool.get_description()
+    action_description = schema["properties"]["action"]["description"]
+    fields = schema["properties"]["input"]["anyOf"]
+    prose = " ".join((description, action_description))
+    assert "50,000" in prose
+    assert "reply" in prose and "channel" in prose
+    assert "manual" in prose
+    assert any("email-manual" in str(branch) for branch in fields)
+
+
+def test_email_manual_is_a_short_router_with_focused_references():
+    """Long procedures stay available without inflating the installed router."""
+    root = Path(__file__).resolve().parents[1]
+    manual = root / "src/lingtai/tools/email/manual/SKILL.md"
+    body = manual.read_text(encoding="utf-8")
+    assert len(body) < 12_000
+    assert "## Reference map" in body
+    assert "Reply on the channel where the message arrived." in body
+    for reference in (
+        "addressing-and-replies",
+        "actions-and-storage",
+        "notifications-and-delivery",
+        "settings-reference",
+    ):
+        path = manual.parent / "reference" / reference / "SKILL.md"
+        assert path.is_file(), reference
+        assert f"reference/{reference}/SKILL.md" in body
+
+
 def test_reserved_unread_is_not_a_public_child_or_action():
     schema = email_tool.get_schema()
     assert "unread" not in schema["properties"]["action"]["enum"]


### PR DESCRIPTION
## Summary

- Keep the Email schema focused on action choice, first-call fields, routing, privacy, and side-effect guards.
- Turn the installed Email manual into a concise router with focused references for addressing, actions/storage, delivery/notifications, and settings.
- Preserve the closed envelope, action order, channel-bound replies, local routing IDs, mailbox side effects, and read-only settings behavior.

## Validation

- Source-built schema measurement: 21,291 to 16,347 characters; non-annotation schema unchanged.
- Manual router measurement: 27,132 to 9,139 characters.
- Canonical focused Email matrix: 194 passed with one upstream deprecation warning.
- Documentation governance, relative links/frontmatter, package-glob checks, and diff hygiene passed.

The PR remains Draft for focused human review.