### PR TITLE
ci(release): notify website mirror after asset publication

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -389,13 +389,13 @@ jobs:
         run: |
           set -euo pipefail
           if [ -z "${GH_TOKEN:-}" ]; then
-            echo "::warning::LINGTAI_WEB_DISPATCH_TOKEN is not set; skipping the lingtai.ai download-mirror dispatch. This is a documented deployment prerequisite (a token with repository_dispatch write access on huangzesen/lingtai-web), not a release failure -- the GitHub release above already succeeded."
+            echo "::warning::LINGTAI_WEB_DISPATCH_TOKEN is not set; skipping the lingtai.ai download-mirror dispatch. This is a documented deployment prerequisite (a token with repository_dispatch write access on Lingtai-AI/lingtai-web), not a release failure -- the GitHub release above already succeeded."
             exit 0
           fi
           version="$(python -c 'import tomllib,sys; print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')"
           tag="${{ github.event.release.tag_name || inputs.release_tag || '' }}"
           tag="${tag:-v${version}}"
-          python3 - "$tag" << 'PY' | gh api repos/huangzesen/lingtai-web/dispatches --method POST --input -
+          python3 - "$tag" << 'PY' | gh api repos/Lingtai-AI/lingtai-web/dispatches --method POST --input -
           import hashlib
           import json
           import sys

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -370,6 +370,78 @@ jobs:
             --skip-gitee \
             $execute_flag
 
+      - name: Notify lingtai-web download mirror
+        # Only after the GitHub upload above actually ran for real -- never on
+        # a dry run, and never before the upload step, so the mirror can only
+        # ever be asked to fetch bytes GitHub has already accepted. This is a
+        # download-acceleration mirror, not an alternate release-publication
+        # path: a missing/failed dispatch never edits or undoes the GitHub
+        # release published above. continue-on-error isolates a dispatch
+        # failure (e.g. an expired/under-scoped LINGTAI_WEB_DISPATCH_TOKEN,
+        # or a transient API error) from this job's overall result, so a
+        # download-acceleration outage can never fail the release-manifest
+        # job or skip the "Upload release manifest artifact" step below --
+        # only the actual manifest/wheel/sdist publish gate stays fail-closed.
+        if: steps.publish_mode.outputs.execute == '1'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.LINGTAI_WEB_DISPATCH_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::warning::LINGTAI_WEB_DISPATCH_TOKEN is not set; skipping the lingtai.ai download-mirror dispatch. This is a documented deployment prerequisite (a token with repository_dispatch write access on huangzesen/lingtai-web), not a release failure -- the GitHub release above already succeeded."
+            exit 0
+          fi
+          version="$(python -c 'import tomllib,sys; print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')"
+          tag="${{ github.event.release.tag_name || inputs.release_tag || '' }}"
+          tag="${tag:-v${version}}"
+          python3 - "$tag" << 'PY' | gh api repos/huangzesen/lingtai-web/dispatches --method POST --input -
+          import hashlib
+          import json
+          import sys
+          from pathlib import Path
+
+          tag = sys.argv[1]
+          assets_dir = Path("release-assets")
+          manifest = json.loads((assets_dir / "lingtai-kernel-release-manifest.json").read_text())
+
+          def sha256_of(path: Path) -> str:
+              digest = hashlib.sha256()
+              with path.open("rb") as handle:
+                  for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                      digest.update(chunk)
+              return digest.hexdigest()
+
+          assets = []
+          # The wheels/sdist already carry a verified sha256 in the manifest
+          # (verify_local_assets() proved it matches on-disk bytes earlier in
+          # this job); the manifest and SHA256SUMS files describe themselves,
+          # so their digests are computed fresh here.
+          for artifact in manifest["artifacts"]:
+              path = assets_dir / artifact["filename"]
+              assets.append({
+                  "name": artifact["filename"],
+                  "sha256": artifact["sha256"],
+                  "size": path.stat().st_size,
+              })
+          for extra_name in ("lingtai-kernel-release-manifest.json", "SHA256SUMS"):
+              path = assets_dir / extra_name
+              assets.append({
+                  "name": extra_name,
+                  "sha256": sha256_of(path),
+                  "size": path.stat().st_size,
+              })
+
+          print(json.dumps({
+              "event_type": "release-asset-published",
+              "client_payload": {
+                  "source_repo": "Lingtai-AI/lingtai-kernel",
+                  "tag": tag,
+                  "assets": assets,
+              },
+          }))
+          PY
+
       - name: Upload release manifest artifact
         uses: actions/upload-artifact@v4
         with:

--- a/ANATOMY.md
+++ b/ANATOMY.md
@@ -217,7 +217,12 @@ disclosure, and fail-loud mismatch reports; do not duplicate that rule here.
   invokes the generator and the publisher (always with `--skip-gitee`;
   no path in that workflow touches Gitee) with `--execute` on a real
   `release.published` event (or an explicit `workflow_dispatch` with
-  `publish: true`) — every other trigger shape stays dry-run.
+  `publish: true`) — every other trigger shape stays dry-run. Only after that
+  publish step actually executes, the job's "Notify lingtai-web download
+  mirror" step dispatches a `repository_dispatch` to `huangzesen/lingtai-web`
+  so it can mirror the same bytes for download acceleration (see
+  `RELEASING.md` "Download-mirror dispatch"); this never runs on a dry run
+  and never touches the GitHub release itself.
 - [`.github/`](.github/) — GitHub Actions, issue templates, and pull request
   templates. `workflows/wheels.yml` is the release build/verify/manifest
   pipeline; `kernel-windows-pr.yml` and `shell-windows-pr.yml` are the native

--- a/ANATOMY.md
+++ b/ANATOMY.md
@@ -219,7 +219,7 @@ disclosure, and fail-loud mismatch reports; do not duplicate that rule here.
   `release.published` event (or an explicit `workflow_dispatch` with
   `publish: true`) — every other trigger shape stays dry-run. Only after that
   publish step actually executes, the job's "Notify lingtai-web download
-  mirror" step dispatches a `repository_dispatch` to `huangzesen/lingtai-web`
+  mirror" step dispatches a `repository_dispatch` to `Lingtai-AI/lingtai-web`
   so it can mirror the same bytes for download acceleration (see
   `RELEASING.md` "Download-mirror dispatch"); this never runs on a dry run
   and never touches the GitHub release itself.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -130,7 +130,7 @@ always triggers a fail-loud error before upload planning completes.
 
 Immediately after the publish step above uploads assets for real (never on a
 dry run), `wheels.yml`'s "Notify lingtai-web download mirror" step sends one
-`repository_dispatch` (`release-asset-published`) to `huangzesen/lingtai-web`
+`repository_dispatch` (`release-asset-published`) to `Lingtai-AI/lingtai-web`
 naming this release's tag and every uploaded asset's filename, sha256, and
 size — artifact digests come from the already-verified manifest; the
 manifest and SHA256SUMS digests are computed from their published local bytes. This exists solely so `lingtai.ai` can
@@ -140,9 +140,9 @@ never edits, retries, or undoes the GitHub release itself.
 
 **Deployment prerequisite:** the `LINGTAI_WEB_DISPATCH_TOKEN` repository
 secret (a token with `repository_dispatch` write access on
-`huangzesen/lingtai-web`) must be configured for this step to do anything;
+`Lingtai-AI/lingtai-web`) must be configured for this step to do anything;
 until then it prints a `::warning::` and exits 0, so its absence cannot fail
-a release. See `huangzesen/lingtai-web`'s `docs/release-mirror/CONTRACT.md` for the
+a release. See `Lingtai-AI/lingtai-web`'s `docs/release-mirror/CONTRACT.md` for the
 receiving side's contract.
 
 ### Manual dry run (safe, no token required)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -126,6 +126,25 @@ asset with different bytes, missing/ambiguous metadata, or a failed download
 always triggers a fail-loud error before upload planning completes.
 **There is no delete-and-replace path.**
 
+### Download-mirror dispatch (lingtai.ai acceleration)
+
+Immediately after the publish step above uploads assets for real (never on a
+dry run), `wheels.yml`'s "Notify lingtai-web download mirror" step sends one
+`repository_dispatch` (`release-asset-published`) to `huangzesen/lingtai-web`
+naming this release's tag and every uploaded asset's filename, sha256, and
+size — artifact digests come from the already-verified manifest; the
+manifest and SHA256SUMS digests are computed from their published local bytes. This exists solely so `lingtai.ai` can
+mirror the exact same bytes for mainland-China download acceleration; GitHub
+remains the sole official release authority, and a missing or failed dispatch
+never edits, retries, or undoes the GitHub release itself.
+
+**Deployment prerequisite:** the `LINGTAI_WEB_DISPATCH_TOKEN` repository
+secret (a token with `repository_dispatch` write access on
+`huangzesen/lingtai-web`) must be configured for this step to do anything;
+until then it prints a `::warning::` and exits 0, so its absence cannot fail
+a release. See `huangzesen/lingtai-web`'s `docs/release-mirror/CONTRACT.md` for the
+receiving side's contract.
+
 ### Manual dry run (safe, no token required)
 
 ```bash


### PR DESCRIPTION
## Summary

- Add one best-effort `repository_dispatch` to `Lingtai-AI/lingtai-web` only after the real release upload in `wheels.yml` succeeds. Dry runs do not dispatch.
- Include the exact tag and each uploaded artifact's filename/SHA256/size; include the release manifest and SHA256SUMS themselves.
- Preserve all existing publish gates. A missing token emits a warning; a dispatch error is visible but isolated by `continue-on-error`, so it cannot skip the subsequent release-manifest artifact step.
- Document the download-only relationship. GitHub remains the sole official release/version authority. No runtime behavior or release format is changed.

Paired website receiver: https://github.com/Lingtai-AI/lingtai-web/pull/80

## Validation

Parent checks:
- New step extracted and run with an empty `GH_TOKEN` — exit 0 with an explicit warning and no outbound call.
- New shell body `bash -n` — exit 0; parsed YAML asserts post-publish placement, real-execute condition, and `continue-on-error: true`.
- `python scripts/check_docs_governance.py --check` using the literal runtime virtualenv interpreter — exit 0, 375 documents validated.
- `git diff HEAD --check` — exit 0.
- Parent `python -m pytest tests/test_architecture_documents.py tests/test_docs_governance.py -q` could **not run**: that interpreter lacks pytest (exit 1). No false pytest PASS.

The implementation worker separately reported 4 architecture tests passing/1 failing and 69 docs tests passing/1 failing, attributing failures to baseline/environment; it also tested payload generation against the cached real 18-asset kernel v1.0.4 fixture. Those worker results are not a green full-suite or live Actions receipt. Source-review failure coupling was fixed and parent-inspected.

## Configuration / remaining gates

Requires the paired website receiver and operator-created `LINGTAI_WEB_DISPATCH_TOKEN` with dispatch access to `Lingtai-AI/lingtai-web`. Missing configuration means **not synchronized**, never mirror success. Website storage/secrets/deployment and live download verification remain separate gates. No secrets changed, no dispatch/upload executed, no merge/release/deploy authorized by opening this PR.

Telegram: @lingtaidev2bot | Nickname: 观一
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai

Publisher dispatch uses GitHub-verified canonical `Lingtai-AI/lingtai-web` (old personal-owner URL redirects).
