### PR TITLE
feat(task-card): show reasoning token counts

### DIFF
--- a/src/lingtai/mcp_servers/task_card/event_projection.py
+++ b/src/lingtai/mcp_servers/task_card/event_projection.py
@@ -459,7 +459,7 @@ class TaskCardEventProjection:
         event: dict[str, Any],
     ) -> tuple[str, dict[str, Any]] | None:
         """Extract per-call LLM usage from a ``notification_block_injected``
-        carrier. Returns ``(call_id, {output, cache_miss, cache_rate,
+        carrier. Returns ``(call_id, {output, thinking, cache_miss, cache_rate,
         context})`` so the tailer can attach it to the matching tool row.
         ``context`` is the session's actual ``context_tokens`` count riding the
         same carrier (never derived from a percentage); absent/invalid values
@@ -484,7 +484,7 @@ class TaskCardEventProjection:
         current = token_usage.get("current_call")
         if not isinstance(current, dict):
             return None
-        supported = ("output", "cache_miss", "cache_rate")
+        supported = ("output", "thinking", "cache_miss", "cache_rate")
         usage = {key: current[key] for key in supported if key in current}
         session = token_usage.get("session")
         if usage and isinstance(session, dict):
@@ -502,9 +502,10 @@ class TaskCardEventProjection:
         Pure-text turns (an assistant reply with no tool call) never carry a
         ``notification_block_injected`` carrier, so their per-call token usage
         has to come from the ``llm_response`` event itself. Returns
-        ``(api_call_id, {output, cache_miss, cache_rate, context})``; estimated
-        token counts are still shown (they are the only signal a pure-text turn
-        has) but missing/zero input degrades to ``None``. ``context`` is the
+        ``(api_call_id, {output, thinking, cache_miss, cache_rate, context})``.
+        Estimated token counts are still shown (they are the only signal a
+        pure-text turn has) but missing/zero input degrades to ``None``.
+        ``context`` is the
         event's ``input_tokens`` — the exact value the kernel records as that
         round's session ``context_tokens`` (``ctx_total_tokens``), an actual
         count, never reconstructed from the cache percentage.
@@ -515,6 +516,7 @@ class TaskCardEventProjection:
         if not isinstance(call_id, str) or not call_id:
             return None
         output = event.get("output_tokens")
+        thinking = event.get("thinking_tokens")
         cached = event.get("cached_tokens")
         total = event.get("input_tokens")
         if (
@@ -529,6 +531,8 @@ class TaskCardEventProjection:
             "cache_miss": max(total - cached, 0),
             "context": total,
         }
+        if type(thinking) is int and thinking >= 0:
+            usage["thinking"] = thinking
         if cached > 0:
             usage["cache_rate"] = min(cached / total, 1.0)
         return (call_id, usage)
@@ -659,24 +663,30 @@ class TaskCardEventProjection:
         api_delay_s: float | None,
         usage: dict[str, Any] | None,
     ) -> str:
-        """Compact divider line: `↻ x s` plus `↓out ↑miss ◌ ctx | cache%`.
+        """Compact divider: `↻ x s ↓out (think) ↑miss ◌ ctx | cache%`.
 
-        The down arrow denotes output tokens, the up arrow denotes cache miss
-        (the two token flows that grow with each call); ``◌`` is the current
-        context length (an actual token count) and the trailing percentage is
-        that call's cache rate, joined as ``◌ <context> | <rate>``. Any piece
-        missing from the event degrades silently — no dangling marker or
-        separator — so old events without usage still render the delay alone.
+        The down arrow denotes output tokens; the immediately following
+        parenthesized count denotes thinking/reasoning tokens; and the up arrow
+        denotes cache miss. ``◌`` is the current context length (an actual token
+        count) and the trailing percentage is that call's cache rate, joined as
+        ``◌ <context> | <rate>``. Any piece missing from the event degrades
+        silently — no dangling marker or separator — so old events without
+        usage still render the delay alone.
         """
         parts: list[str] = []
         if api_delay_s is not None and api_delay_s > 0:
             parts.append(f"↻ {api_delay_s:.1f}s")
         if isinstance(usage, dict) and usage:
             out = usage.get("output")
+            thinking = usage.get("thinking")
             miss = usage.get("cache_miss")
             rate = usage.get("cache_rate")
-            if type(out) is int and out >= 0:
-                parts.append(f"\u2193{cls.format_count(out)}")
+            out_text = cls.format_count(out)
+            if out_text is not None:
+                parts.append(f"\u2193{out_text}")
+                thinking_text = cls.format_count(thinking)
+                if thinking_text is not None:
+                    parts.append(f"({thinking_text})")
             if type(miss) is int and miss >= 0:
                 parts.append(f"\u2191{cls.format_count(miss)}")
             context = cls.format_count(usage.get("context"))

--- a/src/lingtai/mcp_servers/telegram/task_card/ANATOMY.md
+++ b/src/lingtai/mcp_servers/telegram/task_card/ANATOMY.md
@@ -67,7 +67,9 @@ onto its one tracked resident Task Card target per account+chat.
   in-memory copy of the other fields.
 - `../../task_card/event_projection.py` — the channel-neutral pure core for safe
   event allowlisting, redaction, API-call grouping, budgets, metadata, and text
-  rendering. It owns no journal I/O, route, resident, or transport state.
+  rendering, including compact per-call output/thinking/cache metrics from the
+  normalized current-call carrier or `llm_response` fallback. It owns no journal
+  I/O, route, resident, or transport state.
   `DISPLAY_SLOTS`/`DEFAULT_DISPLAY_EXPRESSION`/`validate_display_expression`/
   `compose_display` define and enforce the small declarative display-expression
   grammar: an ordered, allowlisted selection of the fragments

--- a/src/lingtai/mcp_servers/telegram/task_card/BEHAVIORS.md
+++ b/src/lingtai/mcp_servers/telegram/task_card/BEHAVIORS.md
@@ -20,7 +20,8 @@ maintenance: |
 Self-contained agent behavior tasks guarding the observable behavior clauses of
 `src/lingtai/mcp_servers/telegram/task_card/CONTRACT.md` (programmable body
 only when status is exactly active and nonempty; diff-only projection;
-no-op preservation). Pinned pytest commands must run from the repo root with
+no-op preservation; automatic per-call token metrics). Pinned pytest commands
+must run from the repo root with
 the project's Python.
 
 ## Behavior TT001 — the programmable frame is composed only for exact active with a nonempty body, and diff-only updates suppress transport churn
@@ -44,3 +45,25 @@ the project's Python.
 
 ### Pass / Fail
 Pass when the suite passes and the active/diff-only observations hold. Fail on programmable composition for a non-active status, on a transport update for identical bytes, or on `inactive` clearing the resident message or body; record the evidence trail in the task report.
+
+## Behavior TT002 — automatic API-call dividers show reasoning tokens beside output tokens
+
+- **id**: TT002
+- **title**: automatic API-call dividers show reasoning tokens beside output tokens
+- **guards**: `telegram-task-card-projection` § Behavior rule 9
+- **runner**: any LingTai agent with `shell` access to this repository
+- **prerequisites**: a clean checkout of `<repo>`
+- **estimate**: ≈ 2 minutes
+
+### Steps
+1. From `<repo>`, run `python -m pytest tests/test_telegram_task_card_event_tail.py -q` and capture the outcome.
+2. Project one tool-call group whose notification carrier reports `current_call.output`, `current_call.thinking`, cache miss/rate, and session context.
+3. Project one pure-text group whose `llm_response` reports `output_tokens` and `thinking_tokens`, then repeat without a thinking field.
+
+### Expected evidence
+- [ ] Step 1: the automatic event-tail suite passes.
+- [ ] Step 2: the divider contains `↓<output> (<thinking>) ↑<cache-miss>` with compact counts, while `_usage` remains private projection state.
+- [ ] Step 3: the `llm_response` fallback renders the same parenthesized form; an old event without thinking tokens preserves the prior output/cache/context line with no dangling parentheses.
+
+### Pass / Fail
+Pass when both normalized usage paths render the same parenthesized reasoning count immediately after output and legacy missing-field input remains unchanged. Fail if the count is misplaced, reasoning text is exposed, or missing/malformed data leaves a dangling marker.

--- a/src/lingtai/mcp_servers/telegram/task_card/CONTRACT.md
+++ b/src/lingtai/mcp_servers/telegram/task_card/CONTRACT.md
@@ -27,7 +27,7 @@ maintenance: |
 # Telegram Task Card Projection
 
 ## Purpose
-Guarded by: [TT001](BEHAVIORS.md#behavior-tt001)
+Guarded by: [TT001](BEHAVIORS.md#behavior-tt001), [TT002](BEHAVIORS.md#behavior-tt002)
 
 
 Own Telegram's provider adapter and read-only projection of the intrinsic
@@ -87,6 +87,13 @@ semantics live here. The public producer contract lives in
    deriving its siblings, so it can only ever apply its own requested field
    change on top of the freshly observed file — it never writes back a stale
    in-memory copy of an unseen edit's other fields.
+9. The automatic API-call divider renders a valid per-call thinking/reasoning
+   token count as a compact parenthesized value immediately after output tokens:
+   `↓<output> (<thinking>) ↑<cache-miss>`. Both the
+   `token_usage.current_call.thinking` carrier and the `llm_response`
+   `thinking_tokens` fallback produce the same representation. A missing,
+   malformed, or output-less count is omitted without a dangling parenthesis,
+   preserving old-event rendering and never exposing reasoning text.
 
 ## Port
 
@@ -147,7 +154,8 @@ There is no public MCP `task_card` family in this component.
 - `tests/test_telegram_task_card_toggle.py` covers toggle suppression and the
   hidden-finalize clear semantics.
 - `tests/test_telegram_task_card_event_tail.py` continues to cover the automatic
-  channel independently.
+  channel independently, including identical parenthesized reasoning-token
+  rendering from current-call carriers and `llm_response` fallbacks.
 - `tests/test_task_card_event_projection_shared.py` pins shared-core safety and
   byte compatibility with Telegram's established render surface.
 - `tests/test_task_card_resident_shared.py` pins provider-neutral route/slot,

--- a/tests/test_telegram_task_card_event_tail.py
+++ b/tests/test_telegram_task_card_event_tail.py
@@ -532,14 +532,15 @@ def test_second_tool_call_api_delay_is_previous_tool_ts_delta(tmp_path):
 
 def test_divider_renders_compact_per_call_usage_arrows(tmp_path):
     """The group divider carries per-call LLM usage: down arrow = output tokens,
-    up arrow = cache miss, trailing percentage = cache rate. The usage arrives
+    parenthesized count = thinking tokens, up arrow = cache miss, and the
+    trailing percentage = cache rate. The usage arrives
     on the notification_block_injected carrier (real kernel shape), keyed by
     call_id, and is attached to the matching tool row."""
     acct = FakeAccount()
     manager, service = _manager(tmp_path, acct)
     _pre_resident(acct, 555, manager)
 
-    def carrier(call_id, out, miss, rate, context=None):
+    def carrier(call_id, out, miss, rate, context=None, thinking=None):
         token_usage = {
             "current_call": {
                 "output": out,
@@ -547,6 +548,8 @@ def test_divider_renders_compact_per_call_usage_arrows(tmp_path):
                 "cache_rate": rate,
             }
         }
+        if thinking is not None:
+            token_usage["current_call"]["thinking"] = thinking
         if context is not None:
             token_usage["session"] = {"context_tokens": context}
         return json.dumps({
@@ -557,9 +560,9 @@ def test_divider_renders_compact_per_call_usage_arrows(tmp_path):
 
     _write_lines(_events_path(tmp_path), [
         _tool_call_line(call_id="c1", ts=100.0),
-        carrier("c1", 412, 31_000, 0.97716, "junk"),
+        carrier("c1", 412, 31_000, 0.97716, "junk", 0),
         _tool_call_line(call_id="c2", ts=103.4),
-        carrier("c2", 1_234, 512_345, 0.55, 259_800),
+        carrier("c2", 1_234, 512_345, 0.55, 259_800, 56_789),
     ])
 
     manager._poll_event_tail()
@@ -568,8 +571,9 @@ def test_divider_renders_compact_per_call_usage_arrows(tmp_path):
     # The visible tail (last group) carries its own API delay + arrows + rate.
     assert "↻ 3.4s" in rendered
     assert "\u21931.2k" in rendered    # ↓1.2k output tokens
+    assert "(56.8k)" in rendered  # 56.8k thinking/reasoning tokens
     assert "\u2191512.3k" in rendered  # ↑512.3k cache miss
-    assert "↻ 3.4s ↓1.2k ↑512.3k ◌ 259.8k | 55.0%" in rendered
+    assert "↻ 3.4s ↓1.2k (56.8k) ↑512.3k ◌ 259.8k | 55.0%" in rendered
     # Usage is private per-row state: projected for rendering but never
     # leaked into the public window rows.
     assert all("_usage" not in row for row in manager._task_card_event_window())
@@ -607,24 +611,25 @@ def test_pure_text_turn_renders_api_usage_from_llm_response(tmp_path):
             "text": text, "visibility": "public",
         })
 
-    def llm_response(api_call_id, total, cached, out, ts):
+    def llm_response(api_call_id, total, cached, out, thinking, ts):
         return json.dumps({
             "type": "llm_response", "ts": ts, "api_call_id": api_call_id,
             "input_tokens": total, "cached_tokens": cached,
-            "output_tokens": out, "estimated": False,
+            "output_tokens": out, "thinking_tokens": thinking,
+            "estimated": False,
         })
 
     _write_lines(_events_path(tmp_path), [
         diary("first pure text", 100.0, "api_pure_1"),
-        llm_response("api_pure_1", 1_000, 900, 123, 105.0),
+        llm_response("api_pure_1", 1_000, 900, 123, 45, 105.0),
     ])
 
     manager._poll_event_tail()
 
     rendered = [c for c in acct.calls if c[0] == "edit_message"][-1][3]
     assert "first pure text" in rendered
-    # llm_response usage rides the divider: output, cache miss, cache rate.
-    assert "\u2193123" in rendered
+    # llm_response usage rides the divider: output, thinking, cache miss, cache rate.
+    assert "\u2193123 (45)" in rendered
     assert "\u2191100" in rendered   # 1000 - 900 cache miss
     assert "◌ 1.0k | 90.0%" in rendered  # context=input_tokens; rate=900/1000
 
@@ -633,8 +638,8 @@ def test_pure_text_turn_renders_api_usage_from_llm_response(tmp_path):
 def test_divider_context_fallbacks():
     cases = (
         (
-            {"output": 200, "cache_miss": 2_400, "cache_rate": 0.99, "context": "junk"},
-            "↻ 8.5s ↓200 ↑2.4k 99.0%",
+            {"output": 200, "thinking": 0, "cache_miss": 2_400, "cache_rate": 0.99, "context": "junk"},
+            "↻ 8.5s ↓200 (0) ↑2.4k 99.0%",
         ),
         (
             {"output": 200, "cache_miss": 2_400, "context": 259_800},


### PR DESCRIPTION
## Summary

- show the normalized reasoning/thinking token count immediately after output tokens in the automatic Telegram Task Card API divider
- support both per-tool `token_usage.current_call.thinking` carriers and pure-text `llm_response.thinking_tokens` fallbacks
- preserve legacy rendering when the count is missing or malformed, and expose only the numeric count—not reasoning text
- keep the Contract, LABT behavior, and Anatomy ownership documentation synchronized

Before:

```text
↻ 12.1s ↓133 ↑674 ◌ 112.7k | 99.4%
```

After:

```text
↻ 12.1s ↓133 (42) ↑674 ◌ 112.7k | 99.4%
```

## Validation

- `461 passed` across all 23 Task Card test files
- focused Task Card projection + docs: `130 passed`
- exact requested formatter output: PASS
- independent exact-snapshot whole-diff review: **APPROVE — P0/P1/P2 = 0/0/0**
- independent review checks: `94 passed`, adversarial source/edge-case matrix PASS, patch/file hashes exact
- `scripts/check_docs_governance.py --check`: `375 documents` PASS
- `py_compile`: PASS
- `git diff --check`: PASS
- architecture suite: `134 passed, 1 failed`; the same failure reproduces on exact base and concerns two unrelated pre-existing `psyche-manual` orphan files

## Residual risk

- no live Telegram Bot API call was made; the existing fake transport and event projection surface provide the rendering proof
- malformed current-call values are rejected at the strict render boundary rather than eagerly removed during carrier extraction

Telegram: @lingtaidev3bot | Nickname: 澄一

Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
