### PR TITLE
fix(nudge): preserve dismissal across racing upserts

### DIFF
--- a/src/lingtai/kernel/notification_store/CONTRACT.md
+++ b/src/lingtai/kernel/notification_store/CONTRACT.md
@@ -203,9 +203,12 @@ excluded from snapshot, fingerprint, dismissal, and the heartbeat hot path.
   decide from the current payload inside compare-update; daemon event/ref removal
   tombstones only matching event keys, preserves same-run siblings, and never
   rewrites another daemon's file.
-  Force uses
-  `UNCONDITIONAL`, while non-force dismiss uses the delivered fingerprint entry
-  including explicit absence.
+  A channel owner may also consult owner-private read-only state inside that
+  mutator when the read acquires no additional lock, performs no write, and is
+  required to serialize the owner's decision with the channel commit; mutator
+  writes and Store re-entry remain forbidden. Force uses `UNCONDITIONAL`, while
+  non-force dismiss uses the delivered fingerprint entry including explicit
+  absence.
 - `.notification/.store.lock` is compatibility coordination metadata, not
   notification state or authority. POSIX scoped writers acquire it shared for one
   release while legacy writers retain their old exclusive whole-store lock; this

--- a/src/lingtai/kernel/nudge/ANATOMY.md
+++ b/src/lingtai/kernel/nudge/ANATOMY.md
@@ -177,7 +177,13 @@ stamped onto a capped entry as `_dismiss_fingerprint` so `record_dismissal`
 recovers the same identity from the persisted compact shape rather than
 re-deriving it from the rewritten compact `title`/`detail`. An uncapped small
 entry never carries `_dismiss_fingerprint` — the wire shape for the common
-case is unchanged from before the cap existed.
+case is unchanged from before the cap existed. The mute decision is repeated
+inside the Store's `nudge` channel transaction: `upsert`'s pure mutator
+re-reads `.nudge_state.json` (read-only) under the same compare-update that
+`dismiss_channel` uses to clear the channel, so a dismissal recorded after
+`upsert`'s cheap pre-check still wins and the in-flight upsert leaves the
+channel unchanged. Expired-record cleanup (`_clear_dismissal`) stays outside
+the Store mutator, before `_modify`, and never removes a record still in force.
 
 Externalization is fail-loud, not fail-open: an invalid `kind` (bounded
 filesystem-safe pattern, checked before any file naming) or a sidecar write

--- a/src/lingtai/kernel/nudge/__init__.py
+++ b/src/lingtai/kernel/nudge/__init__.py
@@ -374,7 +374,23 @@ def upsert(agent, kind: str, body: dict) -> None:
     _clear_dismissal(agent, fingerprint)
     if legacy_fingerprint != fingerprint:
         _clear_dismissal(agent, legacy_fingerprint)
-    _modify(agent, lambda entries: _replace_kind(entries, kind, entry))
+
+    def _publish_unless_dismissed(entries: list) -> list:
+        # Runs inside the Store's `nudge` channel transaction — the same
+        # compare-update `dismiss_channel` uses to clear the channel — so the
+        # cheap pre-check above is repeated here, serialized with any dismissal
+        # that landed in between. This is a read-only check (the Store mutator
+        # stays pure): a still-future dismissal wins and the entries are
+        # returned unchanged, leaving its record in force.
+        now = time.time()
+        if (
+            _dismissed_until(agent, fingerprint) > now
+            or _dismissed_until(agent, legacy_fingerprint) > now
+        ):
+            return entries
+        return _replace_kind(entries, kind, entry)
+
+    _modify(agent, _publish_unless_dismissed)
 
 
 def remove(agent, kind: str) -> None:
@@ -675,9 +691,7 @@ def _save_policy_state(agent, state: dict[str, Any]) -> None:
     tmp.replace(path)
 
 
-def _dismissed_until(agent, fingerprint: str) -> float:
-    state = _load_policy_state(agent)
-    record = (state.get("dismissed") or {}).get(fingerprint)
+def _record_until(record: object) -> float:
     if not isinstance(record, dict):
         return 0.0
     try:
@@ -686,10 +700,24 @@ def _dismissed_until(agent, fingerprint: str) -> float:
         return 0.0
 
 
+def _dismissed_until(agent, fingerprint: str) -> float:
+    state = _load_policy_state(agent)
+    return _record_until((state.get("dismissed") or {}).get(fingerprint))
+
+
 def _clear_dismissal(agent, fingerprint: str) -> None:
+    """Drop ``fingerprint``'s dismissal record only once it has expired.
+
+    A record still in force can only have been written after ``upsert``'s
+    pre-check passed (otherwise the pre-check would have returned), i.e. by a
+    dismissal that interleaved with this upsert. That dismissal wins, so the
+    record is left untouched for the in-transaction re-check to honour.
+    """
     state = _load_policy_state(agent)
     dismissed = state.get("dismissed")
     if not isinstance(dismissed, dict) or fingerprint not in dismissed:
+        return
+    if _record_until(dismissed.get(fingerprint)) > time.time():
         return
     dismissed.pop(fingerprint, None)
     _save_policy_state(agent, state)

--- a/tests/test_event_journal_count_nudge.py
+++ b/tests/test_event_journal_count_nudge.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+import json
 import os
+import threading
+import time
 from pathlib import Path
 
 import pytest
 
 from lingtai.kernel import nudge as nudge_mod
+from lingtai.kernel.notifications import dismiss_channel
 from lingtai.kernel.nudge import ENTRY_CHANNEL_STORAGE_SIZE
 from lingtai.kernel.nudge import event_journal_count
 from tests._notification_store_helpers import notification_store_for, snapshot_notifications
@@ -177,6 +181,98 @@ def test_unavailable_open_is_quiet_no_finding(monkeypatch, tmp_path: Path) -> No
     event_journal_count.check(agent)
 
     assert _entries(tmp_path) == []
+
+
+def test_dismissal_racing_an_already_authorized_upsert_does_not_republish_same_fingerprint(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Same-fingerprint dismissal/upsert TOCTOU race.
+
+    Nothing about the finding changes: same kind, title, detail, source and
+    ``nudge_channel``; same effective 24h policy; the persisted threshold
+    observation is untouched. A heartbeat evaluation re-upserts that unchanged
+    finding. Its upsert checks ``_dismissed_until`` (no dismissal yet), passes,
+    and is then paused at the Nudge-owned store-update seam. Meanwhile the agent
+    dismisses the visible finding through the real Notification path, which
+    records a *future* dismissal for the exact same fingerprint and clears the
+    channel. When the paused upsert resumes it must not republish the finding
+    the agent just dismissed: the channel stays empty and the future dismissal
+    record stays in force.
+    """
+    kind = "event_journal_line_count"
+    agent = _Agent(tmp_path)
+    _events_path(tmp_path)
+    monkeypatch.setattr(
+        event_journal_count,
+        "_count_newline_records",
+        lambda _: event_journal_count._THRESHOLD_RECORDS,
+    )
+    event_journal_count.check(agent)
+    (displayed,) = _entries(tmp_path)
+    assert displayed["kind"] == kind
+    assert displayed["policy"]["repeat_after_dismiss"] == "24h"
+    fingerprint = nudge_mod._finding_fingerprint(kind, displayed)
+    state_path = tmp_path / ".notification" / ".nudge_state.json"
+
+    reached_store_update = threading.Event()
+    release_store_update = threading.Event()
+    original_modify = nudge_mod._modify
+    worker_ident: list[int] = []
+    armed = [True]
+
+    def paused_modify(agent_, mutate):
+        # One-shot: pause only the worker's first (upsert) store update. Every
+        # other call — including any from the main thread — delegates at once.
+        if armed[0] and worker_ident and threading.get_ident() == worker_ident[0]:
+            armed[0] = False
+            reached_store_update.set()
+            if not release_store_update.wait(timeout=10):
+                raise RuntimeError("worker upsert was never released")
+        return original_modify(agent_, mutate)
+
+    monkeypatch.setattr(nudge_mod, "_modify", paused_modify)
+
+    worker_errors: list[BaseException] = []
+
+    def run_evaluation() -> None:
+        worker_ident.append(threading.get_ident())
+        try:
+            event_journal_count.evaluate(agent)
+        except BaseException as exc:  # propagated to the test thread below
+            worker_errors.append(exc)
+
+    worker = threading.Thread(target=run_evaluation, name="race-upsert")
+    worker.start()
+    try:
+        assert reached_store_update.wait(timeout=10), "worker upsert never reached the store seam"
+
+        # Worker has already passed its dismissal check; now the agent dismisses.
+        result = dismiss_channel(agent, "nudge", invoked_by="notification", force=True)
+        assert result["status"] == "ok"
+        assert result["cleared"] is True
+        assert _entries(tmp_path) == []
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        record = state["dismissed"][fingerprint]
+        assert record["kind"] == kind
+        assert record["until"] > time.time()
+    finally:
+        release_store_update.set()
+        worker.join(timeout=10)
+    assert not worker.is_alive()
+    if worker_errors:
+        raise worker_errors[0]
+
+    state_after = json.loads(state_path.read_text(encoding="utf-8"))
+    assert state_after["dismissed"][fingerprint]["until"] > time.time()
+    reappeared = [
+        nudge_mod._finding_fingerprint(str(entry.get("kind") or ""), entry)
+        for entry in _entries(tmp_path)
+    ]
+    assert reappeared == [], (
+        "an already-authorized upsert republished the same fingerprint "
+        f"{fingerprint} right after the agent dismissed it with a future "
+        "repeat expiry still in force"
+    )
 
 
 def test_counter_uses_physical_newlines_without_json_interpretation(tmp_path: Path) -> None:

--- a/tests/test_nudge_policy.py
+++ b/tests/test_nudge_policy.py
@@ -48,6 +48,37 @@ def test_global_policy_defaults_and_invalid_values(monkeypatch):
     assert len(policy.invalid_values) == 2
 
 
+def test_clear_dismissal_preserves_future_and_removes_only_expired(monkeypatch, tmp_path):
+    from lingtai.kernel import nudge as nudge_module
+
+    agent = _Agent(tmp_path)
+    clock = [1_000.0]
+    monkeypatch.setattr("lingtai.kernel.nudge.time.time", lambda: clock[0])
+    state_path = tmp_path / ".notification" / ".nudge_state.json"
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(
+        json.dumps(
+            {
+                "dismissed": {
+                    "future": {"kind": "example", "until": 1_001.0},
+                    "expired": {"kind": "example", "until": 999.0},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    nudge_module._clear_dismissal(agent, "future")
+    after_future = json.loads(state_path.read_text(encoding="utf-8"))
+    assert set(after_future["dismissed"]) == {"future", "expired"}
+
+    nudge_module._clear_dismissal(agent, "expired")
+    after_expired = json.loads(state_path.read_text(encoding="utf-8"))
+    assert after_expired["dismissed"] == {
+        "future": {"kind": "example", "until": 1_001.0}
+    }
+
+
 def test_emitted_finding_describes_effective_global_policy(monkeypatch, tmp_path):
     agent = _Agent(tmp_path)
     monkeypatch.setenv("LINGTAI_NUDGE_ENABLED", "on")


### PR DESCRIPTION
## Summary

- re-check current and legacy Nudge dismissal fingerprints inside the same `nudge` channel transaction that publishes an upsert
- preserve still-future dismissal records and clear only expired records before publication
- add a deterministic real-store / real-dismiss regression for the already-authorized-upsert race, plus the owning Anatomy update

## Root cause

`upsert` previously checked `.nudge_state.json` before entering the Notification Store channel transaction. A dismissal could then record the same fingerprint with a future 24-hour expiry and clear the channel, while that already-authorized upsert subsequently republished the identical finding.

The old `_clear_dismissal` also removed a record unconditionally, so the same interleaving could erase the newly written future record.

## Behavior after this change

- if dismissal wins first, the in-transaction re-check leaves the channel unchanged
- if upsert wins first, the normal dismissal transaction clears it afterward
- changed/new fingerprints still publish
- truly expired records are cleared and may publish again
- current and legacy fingerprint suppression remain compatible

## Scope

This does not change the visible 24-hour repeat policy, finding wire shape, Store API, notification schema, or introduce a new lock. The earlier unrelated 24h→12h idea is absent.

A narrow pre-existing lost-update window remains in the separately persisted Nudge policy state because that file has no writer lock; closing it is a larger ownership/contract change and is not required for this channel-transaction race.

## Verification

- untouched-base failing-first: same exact fingerprint reappeared after a real dismissal with future expiry
- fixed exact race: 5/5 repeated passes
- touched Nudge surface: `97 passed, 2 deselected` (both deselections are reproduced base init-reader failures outside this diff)
- broader Notification Store/tool/system/sync surface: `232 passed`
- `py_compile`, `ruff check`, and `git diff --check`: pass
- fresh non-persistent final independent review of patch `6af90e57636b…`: `PASS`, no blockers

Telegram: @lingtaidev1bot | Nickname: 知微

Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
