### PR TITLE
docs(wechat): split curated addon manual

### DIFF
--- a/src/lingtai/mcp_servers/ANATOMY.md
+++ b/src/lingtai/mcp_servers/ANATOMY.md
@@ -131,6 +131,9 @@ related_files:
   - src/lingtai/mcp_servers/telegram/notification_header.md
   - src/lingtai/mcp_servers/telegram/updates.py
   - src/lingtai/mcp_servers/wechat/SKILL.md
+  - src/lingtai/mcp_servers/wechat/reference/operations.md
+  - src/lingtai/mcp_servers/wechat/reference/media.md
+  - src/lingtai/mcp_servers/wechat/reference/setup.md
   - src/lingtai/mcp_servers/wechat/__init__.py
   - src/lingtai/mcp_servers/wechat/__main__.py
   - src/lingtai/mcp_servers/wechat/api.py

--- a/src/lingtai/mcp_servers/wechat/SKILL.md
+++ b/src/lingtai/mcp_servers/wechat/SKILL.md
@@ -2,236 +2,124 @@
 name: wechat-mcp-manual
 description: |
   Progressive-disclosure usage manual for the WeChat MCP tool. Read this when you
-  need detail beyond the one-line action descriptions: user_id targeting, send vs
-  reply, check/read/search, media_path attachments (image/video/voice/file),
-  contacts/accounts basics, read-only settings inventory and owner procedures,
-  and external-delivery side-effect caveats. Pulled on demand via action='manual';
-  you do not need to call it before every send.
-version: 1.4.1
-last_changed_at: "2026-08-31T00:00:00-07:00"
+  need detail beyond the resident action catalog: safe send/reply operations,
+  inbound and outbound media, QR login, settings, account ownership, or poller
+  recovery. Pulled on demand via action='manual'; it is not required before every
+  send.
+version: 2.0.0
+last_changed_at: "2026-09-07T00:00:00Z"
 related_files:
+- src/lingtai/mcp_servers/ANATOMY.md
 - src/lingtai/mcp_servers/wechat/manager.py
 - src/lingtai/mcp_servers/wechat/server.py
 - src/lingtai/mcp_servers/wechat/_family.py
 - src/lingtai/mcp_servers/wechat/plugin.py
 - src/lingtai/mcp_servers/wechat/settings.py
 - src/lingtai/mcp_servers/wechat/api.py
-- ENVIRONMENT_VARIABLES.md
+- src/lingtai/mcp_servers/wechat/media.py
+- src/lingtai/mcp_servers/wechat/login.py
+- src/lingtai/mcp_servers/wechat/lockfile.py
+- src/lingtai/mcp_servers/wechat/reference/operations.md
+- src/lingtai/mcp_servers/wechat/reference/media.md
+- src/lingtai/mcp_servers/wechat/reference/setup.md
+- tests/test_wechat_toolfamily_ltpv2.py
+- tests/test_wechat_media_validation.py
+- tests/test_wechat_login.py
 - tests/test_wechat_settings.py
+- tests/test_wechat_config_resolution.py
+- ENVIRONMENT_VARIABLES.md
 maintenance: |
-  Tracks the MCP server's manager/config behavior; update when the server's setup or API surface changes.
+  Tracks the WeChat MCP action catalog and its progressive-disclosure safety,
+  media, and setup routes; update this router and the owning references when the
+  provider behavior, setup boundary, settings projection, or public actions change.
 ---
 
 # WeChat MCP — usage manual (progressive disclosure)
 
-## PUBLIC TOOL FAMILY: strict LTP-v2
+The `wechat` MCP exposes one strict LTP-v2 tool. The `manual` action returns this
+file on demand; the resident description and action catalog are intentionally
+short so ordinary tool calls do not load operational detail.
 
-Raw MCP discovery exposes exactly one public tool, `wechat`. It is an
-independent strict LTP-v2 family with the closed root
-`{action, input, reasoning, summarize?}` (`action`, `input`, and `reasoning`
-required). `action` selects one of the 11 actions below; `input` is a closed,
-action-owned object — only that action's own fields are accepted, and a field
-from another action (or any top-level/host-only key) is rejected before any
-WeChat I/O runs. `wechat` actions are exactly `send`, `check`, `read`,
-`reply`, `search`, `contacts`, `add_contact`, `remove_contact`, `accounts`,
-`settings`, and `manual`. `settings` is inserted immediately before `manual`;
-the `manual` action is the discovery path for this document. Do
-not use the retired flat/legacy shape (arguments at the top level alongside
-`action`), `_reasoning`, aliases, or a generic dispatcher.
+## Public family and first-call boundaries
 
-Example call:
+The root envelope is closed `{action, input, reasoning, summarize?}`. `action`,
+`input`, and `reasoning` are required. `input` is a closed object owned by the
+selected action; host-only fields, aliases, and legacy flat arguments are not
+accepted. The exact public actions are listed below; `settings` is immediately
+before `manual`.
 
-```json
-{
-  "action": "send",
-  "input": {"user_id": "wxid_abc123@im.wechat", "text": "hi"},
-  "reasoning": "acknowledging the user's question"
-}
-```
+- `send` and `reply` cause real external side effects. Verify the recipient and
+  content first. A provider-accepted request is not proof of delivery and must
+  not be automatically replayed.
+- Use a `user_id` returned by `check`, `read`, or `contacts`; do not invent a
+  recipient. `reply` needs the `message_id` of an inbound message from `read`.
+- `media_path` is an outbound file operation. Keep the file in the agent's
+  allowed working area; text and media can produce a partial outcome.
+- Login and configuration are owner/setup procedures, not messaging actions.
+  Never print, paste, or share the admin login QR, bot token, or credentials.
+- iLink `getUpdates` has one consumer per bot account. The MCP holds a per-account
+  poller lock and refuses a second poller; after a refresh or recovery, reconcile
+  with `read` before replying so a replay cannot cause a duplicate response.
+- `settings` is SHOW-only and `manual` is the route to this guide. Read the
+  focused reference only when its topic is needed.
 
-`send`'s `text` and `media_path` are independent, combinable fields (at least
-one is required, and both may be given together in one call — see MEDIA /
-ATTACHMENTS below), not a mutually exclusive choice.
+## Settings anchors
 
-## SETTINGS: READ-ONLY INVENTORY
-
-Call `settings` with an empty input to inspect the active manager's startup
-snapshot:
-
-```json
-{
-  "action": "settings",
-  "input": {},
-  "reasoning": "checking active WeChat configuration"
-}
-```
-
-Success is only `{"settings":[...]}`. Every row has exactly `key`, `current`,
-`default`, `configurable`, and `comment`; `comment` points to one exact section
-below. SHOW has no set, reset, or other mutation input, and it does not reread
-the environment, `config.json`, or `credentials.json`. A missing manager,
-malformed row, non-JSON value, provider failure, or partial failure returns one
-bounded no-row failure. Sensitive rows keep all five fields but render both
-`current` and `default` as `<redacted>`.
-
-`configurable: true` means the external owner procedure in the named section
-can change the next manager construction; it never means SHOW can write. Apply
-the documented restart, then call SHOW again to verify the new active snapshot.
-Launcher-injected `LINGTAI_AGENT_DIR` and `LINGTAI_MCP_NAME` are composition,
-not WeChat preference rows.
+The settings provider's `comment` values point to these stable anchors. The
+setup reference owns the detail; SHOW remains read-only.
 
 ## setting-config-path
 
-`config_path` is the sensitive exact `config.json` path successfully resolved
-and loaded for this manager. It has no meaningful default. The canonical source
-is the non-empty `LINGTAI_WECHAT_CONFIG` launcher value: `~` expands, absolute
-paths are used directly, and relative paths prefer `LINGTAI_AGENT_DIR`, then
-the legacy project root; when the agent directory is absent, relative paths use
-the process cwd. The required sibling `credentials.json` is loaded from that
-resolved directory. Missing or unreadable paths fail manager startup. To change
-the path, update the existing WeChat MCP launch environment, restart the MCP,
-and verify the redacted row with SHOW. The path is redacted because it reveals
-private filesystem layout.
+See [`reference/setup.md#setting-config-path`](reference/setup.md#setting-config-path).
 
 ## setting-base-url
 
-`base_url` is the sensitive endpoint captured by the active manager. A truthy
-`credentials.json.base_url` wins; otherwise a present `config.json.base_url`
-is used, with `https://ilinkai.weixin.qq.com` only when the config key is
-absent. The startup loader does not add endpoint type or non-empty validation,
-so an unusable authored value fails through ordinary downstream API behavior.
-To change it, update `config.json.base_url`, rerun
-`lingtai-wechat-bootstrap <config-directory>` when the credentials value must
-also change, restart the MCP, and verify only the redacted row. Never paste a
-private endpoint into chat, logs, issues, or PRs.
+See [`reference/setup.md#setting-base-url`](reference/setup.md#setting-base-url).
 
 ## setting-poll-interval
 
-`poll_interval` is the public `float(...)` snapshot used between completed
-listener polls. `config.json.poll_interval` is the only authored source and
-the fallback is `1.0`. Startup accepts exactly what Python `float()` accepts;
-non-numeric input fails startup, while zero, negative, and non-finite values are
-not rejected by the current loader. Zero or negative values collapse the
-intended pause. A non-finite active value cannot be encoded by strict SHOW JSON,
-so the complete inventory is unavailable rather than emitting invalid JSON.
-Author a positive finite value, restart the MCP, and verify with SHOW.
+See [`reference/setup.md#setting-poll-interval`](reference/setup.md#setting-poll-interval).
 
 ## setting-allowed-users
 
-`allowed_users` is the sensitive effective inbound authorization set. Missing,
-`null`, `[]`, or another falsy `config.json.allowed_users` value becomes
-unrestricted access and has the meaningful default `null`. A truthy value is
-passed to `set()` without additional schema validation, so operators should
-author a JSON list of WeChat user-ID strings; malformed values may fail startup
-or normalize unexpectedly. Edit the selected `config.json`, restart the MCP,
-and verify only the redacted row. Keep identifiers private and review an
-unrestricted value deliberately.
+See [`reference/setup.md#setting-allowed-users`](reference/setup.md#setting-allowed-users).
 
 ## setting-bot-token
 
-`bot_token` is the required truthy bearer-token snapshot loaded from the
-sibling `credentials.json`; it has no default. The existing QR-login procedure
-writes it. To replace it, run `lingtai-wechat-bootstrap <config-directory>` (or
-the documented headless `cli_login` flow), complete authorization, restart the
-MCP, and verify only the redacted row. Never edit, print, paste, log, or commit
-the token.
+See [`reference/setup.md#setting-bot-token`](reference/setup.md#setting-bot-token).
 
 ## setting-user-id
 
-`user_id` is the required truthy account-identity snapshot from the sibling
-`credentials.json`; it has no default. To change the authorized account, rerun
-`lingtai-wechat-bootstrap <config-directory>` (or the documented headless
-`cli_login` flow), complete authorization for the intended account, restart
-the MCP, and verify only the redacted row. This identity is distinct from
-recipient IDs passed to messaging actions.
+See [`reference/setup.md#setting-user-id`](reference/setup.md#setting-user-id).
 
-## RECIPIENTS: user_id
+## Resident action catalog
 
-- Messages target a WeChat user by `user_id` (e.g. `wxid_abc123@im.wechat`).
-  `user_id` is the routing truth; aliases are convenience labels only. Use the
-  `user_id` returned by `check`/`read`/`contacts` and do not invent one — when
-  in doubt, especially for replies, take it from `read`/`check`.
+| Action | Input and purpose |
+|---|---|
+| `send` | `user_id` plus `text` and/or `media_path`; deliver a new message |
+| `check` | `{}`; list conversations and unread counts |
+| `read` | `user_id`, optional `limit`; read merged inbox/sent history |
+| `reply` | `message_id` plus `text`; respond to a specific inbound message |
+| `search` | `query`, optional `user_id`; regex-search inbox messages |
+| `contacts` | `{}`; list saved contacts |
+| `add_contact` | `user_id` plus `alias`; save a local contact alias |
+| `remove_contact` | `alias` or `user_id`; remove a saved contact |
+| `accounts` | `{}`; list configured account details |
+| `settings` | `{}`; show the read-only startup configuration inventory |
+| `manual` | `{}`; return this progressive-disclosure guide |
 
-## SEND vs REPLY
+All calls still require the root `reasoning` string. Exact schemas, required
+fields, nullability, and validation remain owned by the advertised tool schema.
 
-- `reply` (`message_id` from read results, `text`) threads your response to a
-  specific incoming message; prefer it when answering a particular message.
-- `send` (`user_id`, `text`) starts a fresh message; use it for unsolicited or
-  standalone messages.
+## Focused references
 
-## MEDIA / ATTACHMENTS
+| Need | Read |
+|---|---|
+| Send/reply, reading, contacts, account results, errors, and replay-safe operations | [`reference/operations.md`](reference/operations.md) |
+| Outbound attachments, inbound files, magic-byte checks, and partial media delivery | [`reference/media.md`](reference/media.md) |
+| QR login, config/credentials, poller startup, settings SHOW, and recovery | [`reference/setup.md`](reference/setup.md) |
 
-- `send` with `media_path` attaches a file (absolute or relative to the agent
-  working directory; paths outside it are rejected). Type is detected from
-  the extension: `.jpg`/`.png` → image, `.mp4` → video, `.wav`/`.mp3` → voice,
-  anything else → file.
-- For charts, reports, and other artifacts the user should open intact, send them
-  as a file/document rather than pasting a local path into the message text.
-- `text` and `media_path` may be given together in one `send` call. They are
-  delivered as **two separate WeChat messages** — the text first, then the
-  media — not as a single captioned attachment. A missing `media_path` file
-  is rejected before any text is sent, but a later upload/transport failure
-  can still leave the text delivered without the media.
-
-## INBOUND MEDIA / FILES
-
-- Inbound media is rendered into message text as tags such as `[Image: path]`,
-  `[Voice: "transcript" (audio: path)]`, `[File: name (path)]`, and
-  `[Video: path]`. Use those paths as local artifacts, not as messages to paste
-  back to the user.
-- WeChat document downloads may be encrypted/cache placeholders rather than the
-  real PDF/ZIP/etc. Before parsing a received file, validate its magic bytes
-  (for example `%PDF-` for PDFs, `PK` for ZIP/DOCX). If the bytes do not match
-  the claimed file type, ask the user to re-export with WeChat "Save As" or send
-  a cloud/download link. This is an agent-side validation practice, not a
-  guarantee from the MCP transport.
-- Images and transcribed voice messages are usually more directly usable, but
-  still verify file existence/readability before analysis.
-
-## READING: check / read / search
-
-- `check`: list recent conversations with unread counts; treat previews as
-  hints, not complete context.
-- `read`: read messages from one user (`user_id`; optional `limit`). The read
-  view merges inbox and sent messages, which helps confirm whether you already
-  replied.
-- `search`: regex search over inbox messages (`query`; optional `user_id`). It is
-  for locating inbound content, not proving that no sent reply exists.
-
-## WAKE / REPLAY / DUPLICATE-REPLY DISCIPLINE
-
-- Reply once per inbound `message_id`. Before sending after a refresh, molt, or
-  worker-hang recovery, use `read` to reconcile the merged inbox+sent view and
-  avoid duplicate replies.
-- If a wake notification is based on a preview and an immediate `read`/`check`
-  seems blocked by idle/sleep recovery, acknowledge from the preview if safe,
-  then retry the producer read once the agent is active. Avoid tight polling
-  loops.
-- Some runtimes deduplicate upstream inbound replay by provider `message_id` and
-  cursor checkpoints; if investigating inflated unread counts, confirm the
-  runtime version/state before assuming the MCP lost messages.
-
-## CONTACTS / ACCOUNTS
-
-- `contacts`: list saved contacts.
-- `add_contact`: save a contact alias (`user_id`, `alias`).
-- `remove_contact`: remove a contact (`alias` or `user_id`).
-- `accounts`: list configured WeChat accounts.
-
-## SIDE EFFECTS & ERROR SURFACING
-
-- `send` and `reply` deliver to real users — external side effects. Confirm
-  recipient and content before sending unsolicited messages.
-- A provider response is accepted when `ret` is missing/null or an explicit
-  integer zero, provided `errcode` is absent or an integer zero. Explicit
-  nonzero/noninteger `ret` or `errcode` remains a failure. An accepted result
-  says `delivery_status: provider_accepted` and `delivery_confirmed: false`:
-  iLink accepted the request, but recipient delivery is not proven. Do not
-  automatically replay an accepted request.
-- For text-plus-media partial outcomes, legacy `partial_delivery: true` is only a
-  replay-compatibility flag that a recipient-visible side effect may have occurred;
-  `partial_provider_acceptance` and `delivery_confirmed: false` carry the precise
-  meaning.
-- Actions return a result dict on success or `{'error': <message>}` on failure
-  (e.g. missing `user_id`, unreadable `media_path`). Check for the `'error'` key
-  and surface or act on it rather than assuming delivery.
+These sidecars ship with the package but are not embedded in the `manual` result.
+Use the relative links above; do not infer setup fields or provider behavior from
+memory. Human-facing addon registration and activation remain the host's
+`mcp-manual` procedure, not this provider manual.

--- a/src/lingtai/mcp_servers/wechat/_family.py
+++ b/src/lingtai/mcp_servers/wechat/_family.py
@@ -166,19 +166,16 @@ def wechat_schema() -> dict[str, Any]:
     if "oneOf" in inputs:
         inputs["anyOf"] = inputs.pop("oneOf")
     schema["properties"]["action"]["description"] = (
-        "send: send a message to a WeChat user "
-        "(user_id, text; optional media_path for file/image/voice/video). "
-        "check: list recent conversations with unread counts. "
-        "read: read messages from a user (user_id; optional limit). "
-        "reply: reply to a specific message "
-        "(message_id from read results, text). "
-        "search: search inbox messages by regex "
-        "(query; optional user_id). "
+        "send: deliver text and/or media_path to user_id. "
+        "check: list conversations and unread counts. "
+        "read: read merged inbox/sent history (user_id; optional limit). "
+        "reply: send text for a read message_id. "
+        "search: regex-search inbox messages (query; optional user_id). "
         "contacts: list saved contacts. "
         "add_contact: save a contact (user_id, alias). "
-        "remove_contact: remove a contact (alias or user_id). "
-        "accounts: list configured WeChat accounts. "
-        "settings: show the active read-only WeChat configuration inventory. "
+        "remove_contact: remove by alias or user_id. "
+        "accounts: list configured account details. "
+        "settings: show the read-only startup configuration inventory. "
         + WECHAT_PLUGIN.manual_action_description()
     )
     return schema

--- a/src/lingtai/mcp_servers/wechat/manager.py
+++ b/src/lingtai/mcp_servers/wechat/manager.py
@@ -85,20 +85,16 @@ _HISTORY_INDEX_VERSION = 1
 SCHEMA = _family.WECHAT_SCHEMA
 
 DESCRIPTION = (
-    "WeChat client — interact with WeChat users via iLink Bot API. "
-    "MCP OWNERSHIP: this MCP belongs to the orchestrator (admin). If you are "
-    "an avatar (your admin block is empty or all admin privileges are false), "
-    "do not attempt to configure or reconfigure this MCP — your orchestrator "
-    "manages it, and if the network needs this MCP to reach you the wiring "
-    "is propagated to your session automatically. "
-    "Supports text, images, voice, video, and files. "
-    "Use 'send' for outgoing messages (text and/or media_path). "
-    "'check' to see recent conversations with unread counts. "
-    "'read' to read messages from a user. "
-    "'reply' to respond to a message. "
-    "'search' to find messages by keyword or regex. "
-    "'contacts' to manage saved contacts. "
-    "'accounts' to list configured WeChat accounts."
+    "WeChat via the iLink Bot API for text and media messaging plus inbound "
+    "LICC delivery. Actions: send (user_id with text and/or media_path), check "
+    "(conversations and unread counts), read (merged inbox/sent history), "
+    "reply (message_id and text), search (regex), contacts, add_contact, "
+    "remove_contact, accounts, settings (read-only startup snapshot), and "
+    "manual (progressive-disclosure guide). send/reply reach real users: verify "
+    "the user_id and content, and do not replay a provider-accepted request. "
+    "Media can have a partial outcome. Login/configuration belongs to the "
+    "orchestrator's owner setup flow; only one poller may run per bot account. "
+    "Avatar sessions must not reconfigure this MCP."
 )
 
 

--- a/src/lingtai/mcp_servers/wechat/reference/media.md
+++ b/src/lingtai/mcp_servers/wechat/reference/media.md
@@ -1,0 +1,75 @@
+---
+name: wechat-media-reference
+description: |
+  Focused WeChat media reference: contained outbound paths, extension-based
+  message types, text-plus-media ordering and partial outcomes, inbound file
+  validation, and safe recovery from cache or upload failures.
+version: 1.0.0
+last_changed_at: "2026-09-07T00:00:00Z"
+related_files:
+- src/lingtai/mcp_servers/wechat/SKILL.md
+- src/lingtai/mcp_servers/wechat/manager.py
+- src/lingtai/mcp_servers/wechat/media.py
+- src/lingtai/mcp_servers/wechat/api.py
+- src/lingtai/mcp_servers/wechat/types.py
+- tests/test_wechat_media_validation.py
+- tests/test_wechat_media_warning_integration.py
+- tests/test_wechat_media_official_cdn.py
+- tests/test_wechat_media_upload_diagnostics.py
+maintenance: |
+  Tracks WeChat media type detection, validation warnings, upload stages, and
+  partial-delivery guidance; update when provider media fields, containment, or
+  diagnostics change.
+---
+
+# WeChat media
+
+Use this reference for attachments and inbound files. `send` remains an external
+side effect; confirm `user_id` and content before starting an upload.
+
+## OUTBOUND `media_path`
+
+- The public schema advertises `media_path` as a file path. The outbound-file
+  resolver requires a readable file within the agent's allowed working area and
+  rejects paths outside that boundary before any message is sent.
+- The suffix selects the WeChat item type: common image suffixes (`.jpg`,
+  `.jpeg`, `.png`, `.gif`, `.webp`, `.bmp`) are images; video suffixes (`.mp4`,
+  `.avi`, `.mov`, `.mkv`) are video; voice suffixes (`.wav`, `.mp3`, `.ogg`,
+  `.silk`, `.amr`) are voice; other suffixes are sent as files. This is an
+  extension mapping, not content inspection for outbound files.
+- `text` and `media_path` may be supplied together. The manager sends them as two
+  recipient-visible messages, text first and media second. It validates the path
+  before sending text, preventing a missing or disallowed file from causing an
+  avoidable text-only send.
+- A later upload or media-reference failure can still leave the text delivered.
+  The result reports a partial outcome and disables automatic replay; do not
+  resend the entire text-plus-media request without reconciling what happened.
+
+## INBOUND MEDIA AND FILES
+
+Inbound items are saved as local artifacts and represented in message text with
+bounded tags such as `[Image: path]`, `[Voice: "transcript" (audio: path)]`,
+`[File: name (path)]`, and `[Video: path]`. Verify the path exists and is readable
+before analysis; a path in a message is not a request to paste that path back to
+the user.
+
+Some WeChat document downloads can be encrypted or cache placeholders. Before
+parsing a received file, compare its bytes with its claimed type, for example
+`%PDF-` for PDF and `PK` for ZIP/DOCX. The bundled validator checks known magic
+signatures and emits a warning annotation for a mismatch; an unknown or unreadable
+file is not silently treated as valid. Ask for a WeChat “Save As” re-export or a
+trusted download link when the bytes do not match.
+
+Images are checked against recognized image signatures rather than trusting the
+synthetic filename alone. Voice downloads may remain in Silk form when the
+optional decoder is unavailable; use the preserved path and report that limitation
+instead of claiming successful transcription.
+
+## UPLOAD FAILURE HANDLING
+
+The upload path obtains the provider's upload parameters, uploads the encrypted
+payload to the official CDN route, and requires the CDN's final download
+parameter before constructing the outgoing media item. Bounded immediate retries
+belong to the CDN upload stage only; they do not replay the surrounding send or
+its already accepted text. Read the returned stage/error fields and reconcile
+provider state before any human-authorized retry.

--- a/src/lingtai/mcp_servers/wechat/reference/operations.md
+++ b/src/lingtai/mcp_servers/wechat/reference/operations.md
@@ -1,0 +1,92 @@
+---
+name: wechat-operations-reference
+description: |
+  Focused WeChat operation reference: recipient selection, send versus reply,
+  bounded reads and search, contacts/accounts, result errors, and replay-safe
+  handling of provider acceptance. Read from wechat-mcp-manual when operating the
+  tool beyond its first-call safety rules.
+version: 1.0.0
+last_changed_at: "2026-09-07T00:00:00Z"
+related_files:
+- src/lingtai/mcp_servers/wechat/SKILL.md
+- src/lingtai/mcp_servers/wechat/manager.py
+- src/lingtai/mcp_servers/wechat/_family.py
+- src/lingtai/mcp_servers/wechat/api.py
+- tests/test_wechat_toolfamily_ltpv2.py
+- tests/test_wechat_history_index.py
+- tests/test_wechat_reply_read_state.py
+- tests/test_wechat_inbound_replay.py
+maintenance: |
+  Tracks the WeChat manager's action/result semantics and replay-safe operating
+  guidance; update when action dispatch, history views, acknowledgement handling,
+  or local side effects change.
+---
+
+# WeChat operations
+
+This is a focused reference for the `wechat` action family. The public envelope
+and safety boundaries remain in the parent [`SKILL.md`](../SKILL.md); this file
+only adds operational detail.
+
+## SEND versus REPLY
+
+- `send` starts a new message for the supplied `user_id`. It requires `text`,
+  `media_path`, or both; the recipient ID is routing data, not a contact alias.
+- `reply` takes an inbound `message_id` from `read`, resolves its original
+  sender, and sends the supplied `text`. It fails when the message cannot be
+  found or its sender cannot be determined; it does not silently become a new
+  recipient-less send.
+- A successful reply marks its target inbound message read. A failed send does
+  not mark it read.
+- Both actions deliver to real WeChat users. A successful result records
+  provider acceptance, but `delivery_confirmed` remains false because the
+  provider does not prove recipient delivery.
+
+## CHECK, READ, AND SEARCH
+
+- `check` returns recent conversation aggregates with `user_id`, optional saved
+  alias, total count, unread count, latest preview metadata, and date. Unread
+  counts concern inbound messages; outgoing records are included for context but
+  are not unread messages.
+- `read` requires `user_id` and accepts an optional `limit` (default 10). It
+  returns the newest bounded view merged from inbox and sent records, labels
+  outgoing records, and marks returned inbound records read.
+- `search` requires a regular-expression `query`, optionally filtered by
+  `user_id`. It searches inbox message bodies and returns at most 20 matches; an
+  invalid regular expression is an action error.
+- After a worker refresh, molt, or recovery, use `read` to reconcile the merged
+  view before replying. Do not infer that an unread preview is a new message or
+  that the absence of a search match proves no outgoing reply exists.
+
+## CONTACTS AND ACCOUNTS
+
+- `contacts` lists locally saved aliases. `add_contact` persists an alias for a
+  `user_id`; `remove_contact` accepts either an existing alias or a user ID.
+  These are local state changes, not proof that WeChat accepted a contact
+  relationship remotely.
+- `accounts` reports the configured account view. Treat account IDs and paths as
+  potentially sensitive metadata; it never authorizes changing credentials.
+  Login and credential replacement belong to the owner procedure in
+  [`setup.md`](setup.md).
+
+## RESULTS AND ERROR SURFACING
+
+- Successful business actions return a result object. Failures use an `error`
+  field (for example, missing identifiers, an unknown message, invalid regex, or
+  an unreadable outbound file); surface that error instead of assuming success.
+- Send acknowledgement accepts the provider's missing/null `ret` or integer
+  zero only when `errcode` is absent or integer zero. Nonzero or invalid values
+  remain failures. This is provider acceptance, not delivery confirmation.
+- A text-plus-media send can return `status: partial` when text was accepted but
+  the media stage failed. Its result carries `partial_delivery` for compatibility,
+  precise provider-acceptance fields, and `automatic_retry_allowed: false`.
+  Reconcile state before deciding what to do next; never replay the whole request
+  automatically.
+
+## INBOUND REPLAY AND POLLER STATE
+
+The manager persists cursor progress and bounded stable inbound signatures so a
+stale cursor after a worker failure does not normally create a second local
+message. This is a replay guard, not permission to send twice. Reply at most once
+per inbound `message_id`, and reread the merged history after a refresh before
+performing another external side effect.

--- a/src/lingtai/mcp_servers/wechat/reference/setup.md
+++ b/src/lingtai/mcp_servers/wechat/reference/setup.md
@@ -1,0 +1,135 @@
+---
+name: wechat-setup-reference
+description: |
+  Focused WeChat setup and recovery reference: config/credentials resolution,
+  QR or headless login, read-only settings SHOW, per-account poller locking,
+  session expiry, and safe owner procedures. Read before changing setup or
+  diagnosing startup.
+version: 1.0.0
+last_changed_at: "2026-09-07T00:00:00Z"
+related_files:
+- src/lingtai/mcp_servers/wechat/SKILL.md
+- src/lingtai/mcp_servers/wechat/server.py
+- src/lingtai/mcp_servers/wechat/login.py
+- src/lingtai/mcp_servers/wechat/lockfile.py
+- src/lingtai/mcp_servers/wechat/settings.py
+- src/lingtai/mcp_servers/wechat/api.py
+- tests/test_wechat_config_resolution.py
+- tests/test_wechat_login.py
+- tests/test_wechat_settings.py
+- ENVIRONMENT_VARIABLES.md
+maintenance: |
+  Tracks WeChat configuration, login, settings projection, and poller recovery
+  guidance; update when owner procedures, path precedence, redaction, or startup
+  behavior changes.
+---
+
+# WeChat setup and recovery
+
+Registration and activation are host-owned. This reference covers the provider's
+files, login, startup, and read-only settings after the host has selected the
+curated WeChat addon.
+
+## CONFIGURATION FILES
+
+`LINGTAI_WECHAT_CONFIG` points to `config.json`; the required sibling
+`credentials.json` is loaded from the same directory. An absolute config path is
+used as-is. A relative path prefers `LINGTAI_AGENT_DIR`, then the legacy project
+root for compatibility; without an agent directory, the process working directory
+is used. Put new configuration under the agent directory and use the `settings`
+action for redacted active verification; treat host status diagnostics as local
+and do not paste them into public reports.
+
+The authored `config.json` fields are:
+
+## setting-config-path
+
+`config_path` is the sensitive resolved `config.json` path captured at manager
+startup. It is not an authored JSON field; `LINGTAI_WECHAT_CONFIG` is its source.
+
+## setting-base-url
+
+`base_url` is the endpoint fallback: a truthy `credentials.json.base_url` wins,
+then this config value, then the provider default. `cdn_base_url` is retained for
+configuration compatibility and is not a current upload-destination override when
+the provider supplies its upload route.
+
+## setting-poll-interval
+
+`poll_interval` is converted with Python `float`; default `1.0`. Use a positive
+finite value even though the loader does not reject every non-positive value.
+
+## setting-allowed-users
+
+`allowed_users` is an optional inbound sender allow-list. A missing, null, empty,
+or other falsy value means unrestricted compatibility behavior; a truthy value is
+used as the configured sender set.
+
+`credentials.json` contains the login-produced `bot_token`, account `user_id`,
+and optional effective `base_url`. Treat the file as secret material: do not
+print, paste, commit, or include it in diagnostics. The login writer uses an
+atomic replacement and mode `0600`.
+
+## setting-bot-token
+
+`bot_token` is the required secret written by QR login. It has no default and is
+always redacted by SHOW; replace it only through the login/bootstrap procedure.
+
+## setting-user-id
+
+`user_id` is the required account identity written by QR login. It has no default
+and is redacted by SHOW; it is distinct from recipient IDs used by actions.
+
+## QR LOGIN
+
+Use the existing owner bootstrap procedure, not a messaging action:
+
+```text
+lingtai-wechat-bootstrap <config-directory>
+```
+
+For a headless host, the same login core is available through the documented
+`cli_login('<config-directory>')` entry point. It creates a default config when
+needed, displays a QR in the terminal (or uses the browser bootstrap flow), polls
+for confirmation, and writes sibling credentials on success. The QR authorizes
+the backend account; it is an admin login QR, not a contact or group QR. Never
+share it. After credentials are saved, restart or refresh the WeChat MCP through
+the host owner procedure, then use `settings` to verify only the redacted active
+snapshot.
+
+If the session expires, rerun the login/bootstrap flow and restart the MCP. Do
+not hand-edit a token or attempt to repair credentials through `settings`.
+
+## SETTINGS SHOW
+
+Call the strict-empty action:
+
+```json
+{"action":"settings","input":{},"reasoning":"inspect active WeChat settings"}
+```
+
+Success is exactly `{"settings":[...]}`; each row has only `key`, `current`,
+`default`, `configurable`, and `comment`. The six keys are `config_path`, `base_url`,
+`poll_interval`, `allowed_users`, `bot_token`, and `user_id`, in that order.
+Sensitive rows redact both `current` and `default`; SHOW never writes, resets, or
+rereads owner files, and any unavailable/invalid row fails the complete inventory
+rather than returning a partial one. A `configurable` row describes the owner
+procedure for the next manager construction, not a mutation input to this action.
+
+Change the selected owner file or login credentials through the procedure above,
+restart/refresh at the required boundary, and call SHOW again. Do not expose the
+resolved config path, endpoint, allow-list, token, or account identity in chat or
+public diagnostics; the redacted settings result is the safe verification view.
+
+## ONE POLLER PER ACCOUNT
+
+The iLink updates stream is single-consumer. The MCP takes an exclusive per-account
+POSIX lock for the lifetime of the poller and fails startup with a clear error if
+another process already holds it. A normal process exit releases the lock; do not
+delete lockfiles blindly. Stop or reconfigure the other owner process, then
+restart the intended MCP. On a platform without `fcntl`, startup fails rather
+than pretending duplicate-poller safety exists.
+
+When startup fails, inspect the redacted status/startup error and fix the owner
+configuration or lock holder. Do not start a second poller as a workaround, and
+reconcile `read` history before sending after recovery.


### PR DESCRIPTION
## Summary
- keep WeChat's resident manual concise and route operation, media, and setup depth into three packaged references
- preserve its strict action envelope, configuration resolution, account/contact guidance, inbound replay, and media safety contracts
- connect only the three WeChat sidecars in the shared MCP Anatomy graph

## Review scope
- independent review found no material candidate-introduced defect after the documentation migration
- baseline runtime/security concerns remain outside this documentation-only PR and are not silently expanded here

## Validation
- 361 focused WeChat, manual, schema, Anatomy, and docs-governance tests passed on the rebased exact head
- offline wheel and sdist contain all 4 WeChat manual files byte-for-byte; local links resolve
- diff check, one-channel path scope, and candidate public-path scan passed

## Scope
WeChat only. No runtime refresh, install, release/deploy, or cleanup is included.