### PR TITLE
docs(feishu): clarify manual and send defaults

### DIFF
--- a/src/lingtai/mcp_servers/feishu/SKILL.md
+++ b/src/lingtai/mcp_servers/feishu/SKILL.md
@@ -66,7 +66,7 @@ I/O. The complete action inventory is:
 
 | Action | First-call shape and purpose |
 |---|---|
-| `send` | Fresh message: `receive_id`, `receive_id_type`, and exactly one of `text`/`content`; `account` and `placeholder` are optional. |
+| `send` | Fresh message: `receive_id` and exactly one of `text`/`content`; `receive_id_type` (default `open_id`), `account`, and `placeholder` are optional. |
 | `check` | Recent conversations and unread counts; optional `account`. |
 | `read` | Messages from one chat: `chat_id`; optional `account` and `limit`. |
 | `reply` | Reply to an exact compound `message_id` with exactly one of `text`/`content`; optional `reply_in_thread`. |

--- a/src/lingtai/mcp_servers/feishu/server.py
+++ b/src/lingtai/mcp_servers/feishu/server.py
@@ -61,7 +61,8 @@ _SERVER_INSTRUCTIONS = (
     "host agent's inbox via LICC. Use the single strict `feishu` tool with "
     "{action, input, reasoning, summarize?}; its description gives the action "
     "inventory and first-call safety boundaries. Call action='manual' for the "
-    "deep packaged message-semantics guidance. Configure via the "
+    "concise packaged usage manual, then follow its linked message-semantics "
+    "reference when deeper guidance is needed. Configure via the "
     "LINGTAI_FEISHU_CONFIG environment variable; setup and troubleshooting are "
     "available from the server's packaged resources."
 )


### PR DESCRIPTION
## Summary
- clarify that `action="manual"` returns the concise packaged manual and links onward to deep message semantics
- mark `receive_id_type` optional and document its `open_id` default in the first-call table

## Validation
- 41 focused Feishu tests passed
- `git diff --check`
- public-path leak scan clean

No new standalone progressive-disclosure test file was added.