### PR TITLE
docs(whatsapp): clarify no-ID reply targets

### DIFF
--- a/src/lingtai/mcp_servers/whatsapp/SKILL.md
+++ b/src/lingtai/mcp_servers/whatsapp/SKILL.md
@@ -222,8 +222,10 @@ The effective allowlist is checked before storage or notification. When a
 stable bridge message ID exists, it is namespaced by sender and recorded in the
 persistent `inbox_seen.json` replay guard; a redelivery is suppressed. The
 bounded guard retains up to 5000 keys. Messages without a stable upstream ID
-are not deduplicated. File/event components are sanitized, but the message ID
-used for reply/react remains the opaque value supplied by the bridge.
+are not deduplicated; they receive a local archive UUID for storage and
+notification, and that UUID is not a valid reply/react target. File/event
+components are sanitized. When a stable bridge ID exists, reply/react uses that
+opaque bridge-supplied value.
 
 ## SIDE EFFECTS / RISK / ERRORS
 

--- a/src/lingtai/mcp_servers/whatsapp/SKILL.md
+++ b/src/lingtai/mcp_servers/whatsapp/SKILL.md
@@ -171,11 +171,13 @@ relaunch and verify with a second SHOW.
   is likewise an open compatibility object, and both it and `preview_url` are
   retained schema fields not used by the personal bridge; use text or
   bridge-supported media.
-- `reply` requires an opaque `message_id` and text. Pass `to`/`wa_id` when
-  known; otherwise the manager scans up to 500 stored messages for that ID and
-  recovers the conversation. Use IDs returned by inbound notifications,
-  `read`, or `search` exactly; do not invent or rewrite them. A missing local
-  target and recipient fails before the bridge call. The schema retains
+- `reply` requires a provider-stable opaque `message_id` and text. Pass
+  `to`/`wa_id` when known; otherwise the manager scans up to 500 stored
+  messages for that ID and recovers the conversation. Use provider-stable IDs
+  returned by inbound notifications, `read`, or `search` exactly; do not invent
+  or rewrite them. A no-ID message's local archive/notification UUID is not a
+  reply target (see the LICC section below). A missing local target and
+  recipient fails before the bridge call. The schema retains
   media/template compatibility branches, but the implemented reply path is
   text-only.
 - `react` requires the exact `message_id` and a non-empty `emoji`; the bridge


### PR DESCRIPTION
## Summary
- distinguish stable bridge message IDs from locally generated archive UUIDs
- warn that a no-ID notification UUID is not a valid `reply`/`react` target

## Validation
- 61 focused WhatsApp tests passed
- `git diff --check`
- public-path leak scan clean

No new standalone progressive-disclosure test file was added.