### PR TITLE
docs(cloud-mail): align failure and retry guidance

### DIFF
--- a/src/lingtai/mcp_servers/cloud_mail/reference/actions.md
+++ b/src/lingtai/mcp_servers/cloud_mail/reference/actions.md
@@ -59,9 +59,10 @@ new account and role before calling it. Neither action is a dry run.
 
 ## Results and result size
 
-Successful manager actions use `status: "ok"`; provider or validation failures
-use an error result. Inspect status and the error text rather than assuming a
-send or administrative mutation succeeded.
+Successful manager actions use `status: "ok"`; family or settings validation
+failures use `status: "failed"`, while provider or transport failures use an
+error result. Inspect status and the error text rather than assuming a send or
+administrative mutation succeeded.
 
 `check`, `search`, and `read` can return bulky listings or full bodies. Keep
 exact ids, addresses, and verbatim body text whenever later actions depend on

--- a/src/lingtai/mcp_servers/cloud_mail/reference/setup.md
+++ b/src/lingtai/mcp_servers/cloud_mail/reference/setup.md
@@ -72,13 +72,13 @@ from the current implementation, not additional schema aliases.
 List/search/read/poll and `add_user` use an admin-minted public token from
 `POST /public/genToken`; the token is sent as the raw `Authorization` value,
 not as `Bearer ...`. `send` logs in with the configured user credentials via
-`POST /login` and sends with the returned raw user JWT. The client caches each
-token and refreshes it once after an HTTP-status 401/403 response. The Cloud
-Mail envelope must carry `code: 200`; non-JSON responses and non-200 envelope
-codes become `CloudMailError` results without entering that HTTP-status retry
-path. Transport exceptions are surfaced as bounded manager error results with
-their native `error_type`; neither path should log credentials or full auth
-headers.
+`POST /login` and sends with the returned raw user JWT. For authenticated
+requests, the client checks HTTP status before parsing the response body and
+refreshes the cached token once after HTTP 401/403. After that retry opportunity,
+a non-JSON response or a decoded envelope whose `code` is not 200 becomes a
+`CloudMailError`; a non-200 envelope code alone does not trigger token refresh.
+Transport exceptions are surfaced as bounded manager error results with their
+native `error_type`; neither path should log credentials or full auth headers.
 
 User credentials are optional: public read/search/check/poll actions can work
 without them, while `send` returns a clear error. Admin credentials remain

--- a/src/lingtai/mcp_servers/cloud_mail/reference/setup.md
+++ b/src/lingtai/mcp_servers/cloud_mail/reference/setup.md
@@ -73,11 +73,12 @@ List/search/read/poll and `add_user` use an admin-minted public token from
 `POST /public/genToken`; the token is sent as the raw `Authorization` value,
 not as `Bearer ...`. `send` logs in with the configured user credentials via
 `POST /login` and sends with the returned raw user JWT. The client caches each
-token and refreshes it once after a 401/403 response. The Cloud Mail envelope
-must carry `code: 200`; non-JSON responses and non-200 codes become
-`CloudMailError` results. Transport exceptions are surfaced as bounded manager
-error results with their native `error_type`; neither path should log
-credentials or full auth headers.
+token and refreshes it once after an HTTP-status 401/403 response. The Cloud
+Mail envelope must carry `code: 200`; non-JSON responses and non-200 envelope
+codes become `CloudMailError` results without entering that HTTP-status retry
+path. Transport exceptions are surfaced as bounded manager error results with
+their native `error_type`; neither path should log credentials or full auth
+headers.
 
 User credentials are optional: public read/search/check/poll actions can work
 without them, while `send` returns a clear error. Admin credentials remain


### PR DESCRIPTION
## Summary
- distinguish strict-family/settings `status="failed"` validation results from provider/transport errors
- scope token refresh/retry to HTTP-status 401/403 and distinguish non-200 provider envelope codes

## Validation
- 59 focused Cloud Mail tests passed
- `git diff --check`
- public-path leak scan clean

No new standalone progressive-disclosure test file was added.