### PR TITLE
Telegram Task Card: show a-priori summary time and tokens

### DIFF
--- a/src/lingtai/mcp_servers/task_card/event_projection.py
+++ b/src/lingtai/mcp_servers/task_card/event_projection.py
@@ -404,6 +404,8 @@ class TaskCardEventProjection:
                     row.pop("_ts", None)
                     row.pop("_usage", None)
                     row.pop("_api_call_id", None)
+                    row.pop("_result_ts", None)
+                    row.pop("_apriori_summary", None)
                 if row.get("kind") == "tool":
                     row.pop("kind", None)
                 rows.append(row)
@@ -590,8 +592,109 @@ class TaskCardEventProjection:
                     # Keep the raw ms so sub-second durations render exactly
                     # (e.g. ``412ms``) instead of rounding to ``0s``.
                     row["elapsed_ms"] = elapsed_ms
+                raw_ts = result.get("ts")
+                if type(raw_ts) in (int, float) and not isinstance(raw_ts, bool):
+                    result_ts = float(raw_ts)
+                    if math.isfinite(result_ts):
+                        row["_result_ts"] = result_ts
                 changed = True
         return changed
+
+    @staticmethod
+    def project_apriori_summary_event(
+        event: dict[str, Any],
+    ) -> tuple[str, float] | None:
+        """Project only correlation and completion time from a generated summary.
+
+        Generated summary text, provider fields, and arbitrary event payload stay
+        outside the Task Card projection.
+        """
+        if event.get("type") != "apriori_summary_generated":
+            return None
+        call_id = event.get("tool_call_id")
+        raw_ts = event.get("ts")
+        if (
+            not isinstance(call_id, str)
+            or not call_id
+            or type(raw_ts) not in (int, float)
+            or isinstance(raw_ts, bool)
+        ):
+            return None
+        summary_ts = float(raw_ts)
+        if not math.isfinite(summary_ts):
+            return None
+        return call_id, summary_ts
+
+    @classmethod
+    def apply_apriori_summary_metrics(
+        cls,
+        groups: list[dict[str, Any]],
+        summary_times: dict[str, float],
+        summary_usages: dict[str, dict[str, int]],
+    ) -> bool:
+        """Attach safe existing summary timing/token facts to successful tools."""
+        changed = False
+        for group in groups:
+            for row in group.get("events", []):
+                if row.get("status") != "success":
+                    continue
+                call_id = row.get("_tool_call_id")
+                summary_ts = summary_times.get(call_id)
+                usage = summary_usages.get(call_id)
+                result_ts = row.get("_result_ts")
+                if (
+                    type(summary_ts) not in (int, float)
+                    or isinstance(summary_ts, bool)
+                    or type(result_ts) not in (int, float)
+                    or isinstance(result_ts, bool)
+                    or not isinstance(usage, dict)
+                ):
+                    continue
+                delta_ms = (float(summary_ts) - float(result_ts)) * 1000
+                if (
+                    not math.isfinite(delta_ms)
+                    or delta_ms < 0
+                    or delta_ms > cls.MAX_ELAPSED_MS
+                ):
+                    continue
+                input_tokens = usage.get("input")
+                output_tokens = usage.get("output")
+                if (
+                    type(input_tokens) is not int
+                    or input_tokens < 0
+                    or type(output_tokens) is not int
+                    or output_tokens < 0
+                ):
+                    continue
+                metrics = {
+                    "elapsed_ms": int(round(delta_ms)),
+                    "input": input_tokens,
+                    "output": output_tokens,
+                }
+                if row.get("_apriori_summary") == metrics:
+                    continue
+                row["_apriori_summary"] = metrics
+                changed = True
+        return changed
+
+    @classmethod
+    def format_apriori_summary_metrics(cls, value: object) -> str | None:
+        """Format the requested summary time/input/output line."""
+        if not isinstance(value, dict):
+            return None
+        elapsed_ms = value.get("elapsed_ms")
+        input_text = cls.format_count(value.get("input"))
+        output_text = cls.format_count(value.get("output"))
+        if (
+            type(elapsed_ms) is not int
+            or elapsed_ms < 0
+            or elapsed_ms > cls.MAX_ELAPSED_MS
+            or input_text is None
+            or output_text is None
+        ):
+            return None
+        elapsed = cls.format_elapsed_ms(elapsed_ms)
+        return f"(summary, {elapsed}, {input_text} in, {output_text} out)"
 
     @classmethod
     def render_event_groups(
@@ -1117,7 +1220,7 @@ class TaskCardEventProjection:
         display_expression: tuple[str, ...] | None = None,
     ) -> str:
         footer = cls.footer(normal_rows, locale)
-        tool_prepared: list[tuple[int, str, str, str, bool, str | None]] = []
+        tool_prepared: list[tuple[int, str, str, str, bool, str | None, str | None]] = []
         text_prepared: list[tuple[int, str]] = []
         api_prepared: list[tuple[int, str]] = []
         for idx, row in enumerate(rows):
@@ -1165,7 +1268,14 @@ class TaskCardEventProjection:
             else:
                 status_suffix = f", {status}" if status else ""
                 suffix = f" ({elapsed}{status_suffix})"
-            tool_prepared.append((idx, label, redacted, suffix, done, status))
+            summary_metrics = (
+                cls.format_apriori_summary_metrics(row.get("_apriori_summary"))
+                if status == "success"
+                else None
+            )
+            tool_prepared.append(
+                (idx, label, redacted, suffix, done, status, summary_metrics)
+            )
 
         metadata_lines = cls.format_metadata(metadata, locale)
         time_line = f"{cls.time_prefix(locale)}{cls.render_time(now)}"
@@ -1193,10 +1303,13 @@ class TaskCardEventProjection:
             suffix,
             done,
             status,
+            summary_metrics,
         ) in tool_prepared:
             marker = "✓ " if done or status == "success" else "• "
             prefix = f"{marker}{label}: " if label else marker
             tool_scaffold += len(prefix) + len(suffix) + 2
+            if summary_metrics:
+                tool_scaffold += len(summary_metrics) + 2
         fixed = (
             len(cls.header(locale))
             + 1
@@ -1218,7 +1331,7 @@ class TaskCardEventProjection:
         per_row_cap = max(0, min(cls.REASONING_CAP, budget // divisor))
 
         by_idx: dict[int, str] = {}
-        for idx, label, redacted, suffix, done, status in tool_prepared:
+        for idx, label, redacted, suffix, done, status, summary_metrics in tool_prepared:
             excerpt = (
                 redacted[:per_row_cap] + "…"
                 if len(redacted) > per_row_cap
@@ -1226,7 +1339,10 @@ class TaskCardEventProjection:
             )
             marker = "✓ " if done or status == "success" else "• "
             prefix = f"{marker}{label}: " if label else marker
-            by_idx[idx] = f"{prefix}{excerpt}{suffix}"
+            line = f"{prefix}{excerpt}{suffix}"
+            if summary_metrics:
+                line += f"\n {summary_metrics}"
+            by_idx[idx] = line
         for idx, text in text_prepared:
             excerpt = text[:per_row_cap] + "…" if len(text) > per_row_cap else text
             by_idx[idx] = f"• {excerpt}"

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -2657,9 +2657,65 @@ class TelegramManager:
     _TASK_CARD_MAX_EVENTS_PER_CALL = TaskCardEventProjection.MAX_EVENTS_PER_CALL
     # The same quiet horizontal rule used by the TUI between provider calls.
     _TASK_CARD_API_CALL_DIVIDER = TaskCardEventProjection.API_CALL_DIVIDER
+    # Summary accounting is already durable in the main token ledger. Read only
+    # its newest bounded bytes when a matching generated-summary event appears.
+    _TASK_CARD_TOKEN_LEDGER_TAIL_BYTES = 65536
 
     def _task_card_events_path(self) -> Path:
         return self._working_dir / "logs" / "events.jsonl"
+
+    def _task_card_token_ledger_path(self) -> Path:
+        return self._working_dir / "logs" / "token_ledger.jsonl"
+
+    def _read_apriori_summary_usages(
+        self, tool_call_ids: set[str],
+    ) -> dict[str, dict[str, int]]:
+        """Read safe a-priori input/output counts from a bounded ledger tail."""
+        wanted = {
+            value for value in tool_call_ids
+            if isinstance(value, str) and value
+        }
+        if not wanted:
+            return {}
+        path = self._task_card_token_ledger_path()
+        try:
+            size = path.stat().st_size
+            start = max(0, size - self._TASK_CARD_TOKEN_LEDGER_TAIL_BYTES)
+            with open(path, "rb") as handle:
+                handle.seek(start)
+                data = handle.read(self._TASK_CARD_TOKEN_LEDGER_TAIL_BYTES)
+        except OSError:
+            return {}
+        if start:
+            first_newline = data.find(b"\n")
+            if first_newline < 0:
+                return {}
+            data = data[first_newline + 1 :]
+        last_newline = data.rfind(b"\n")
+        if last_newline < 0:
+            return {}
+        usages: dict[str, dict[str, int]] = {}
+        for raw in data[: last_newline + 1].split(b"\n"):
+            row = self._decode_event_line(raw)
+            if not isinstance(row, dict):
+                continue
+            call_id = row.get("tool_call_id")
+            input_tokens = row.get("input")
+            output_tokens = row.get("output")
+            if (
+                row.get("source") != "summarize_apriori"
+                or row.get("apriori_tool_result_summary") is not True
+                or not isinstance(call_id, str)
+                or call_id not in wanted
+                or type(input_tokens) is not int
+                or input_tokens < 0
+                or type(output_tokens) is not int
+                or output_tokens < 0
+            ):
+                continue
+            # Ledger order is authoritative; a later valid correlated row wins.
+            usages[call_id] = {"input": input_tokens, "output": output_tokens}
+        return usages
 
     def _event_tail_offset(self) -> int:
         with self._task_card_event_lock:
@@ -3120,7 +3176,7 @@ class TelegramManager:
 
     def _reverse_tail_latest_rows(
         self, path: Path, size: int,
-    ) -> tuple[list[dict], int, dict | None] | None:
+    ) -> tuple[list[dict], int, dict | None, dict[str, dict]] | None:
         """Reverse-scan bounded chunks from EOF to collect the latest-N matches.
 
         Reads growing chunks backward from the end of the file until either
@@ -3129,7 +3185,7 @@ class TelegramManager:
         The tail chunk may start mid-line; the leading partial fragment is
         discarded (its predecessor chunk will complete it on the next round).
 
-        Returns ``(rows, offset, metadata)`` where ``offset`` is the forward
+        Returns ``(rows, offset, metadata, usages)`` where ``offset`` is the forward
         byte offset the poller should resume from and ``metadata`` is the latest
         final-carrier session projection (or ``None`` when no carrier exists)
         — ``size`` unless the file's final line
@@ -3143,6 +3199,8 @@ class TelegramManager:
         projected_events: list[tuple[dict, dict]] = []
         latest_metadata: dict | None = None
         per_call_usages: dict[str, dict] = {}
+        tool_results: dict[str, dict] = {}
+        summary_times: dict[str, float] = {}
         tail_offset = size
         try:
             with open(path, "rb") as f:
@@ -3185,6 +3243,17 @@ class TelegramManager:
                         event = self._decode_event_line(raw)
                         if event is None:
                             continue
+                        call_id = event.get("tool_call_id")
+                        if (
+                            event.get("type") == "tool_result"
+                            and isinstance(call_id, str)
+                            and call_id
+                        ):
+                            tool_results[call_id] = event
+                        summary = TaskCardEventProjection.project_apriori_summary_event(event)
+                        if summary is not None:
+                            summary_call_id, summary_ts = summary
+                            summary_times[summary_call_id] = summary_ts
                         row = self._project_task_card_event(event)
                         if row is not None:
                             round_projected.append((event, row))
@@ -3210,7 +3279,12 @@ class TelegramManager:
         # Chunks were prepended above, so projected events are already in
         # journal order before grouping; one API call receives one divider.
         groups = self._group_task_card_events(projected_events)
+        TaskCardEventProjection.apply_tool_results(groups, tool_results)
         TaskCardEventProjection.apply_tool_usages(groups, per_call_usages)
+        summary_usages = self._read_apriori_summary_usages(set(summary_times))
+        TaskCardEventProjection.apply_apriori_summary_metrics(
+            groups, summary_times, summary_usages,
+        )
         return self._flatten_task_card_groups(
             groups, include_group_id=True,
         ), tail_offset, latest_metadata, per_call_usages
@@ -3313,6 +3387,7 @@ class TelegramManager:
         latest_metadata: dict | None = None
         tool_results: dict[str, dict] = {}
         per_call_usages: dict[str, dict] = {}
+        summary_times: dict[str, float] = {}
         for raw in complete.split(b"\n"):
             event = self._decode_event_line(raw)
             if event is None:
@@ -3320,6 +3395,10 @@ class TelegramManager:
             call_id = event.get("tool_call_id")
             if event.get("type") == "tool_result" and isinstance(call_id, str) and call_id:
                 tool_results[call_id] = event
+            summary = TaskCardEventProjection.project_apriori_summary_event(event)
+            if summary is not None:
+                summary_call_id, summary_ts = summary
+                summary_times[summary_call_id] = summary_ts
             carrier = TaskCardEventProjection.project_current_call_usage(event)
             if carrier is not None:
                 carrier_call_id, usage = carrier
@@ -3337,6 +3416,7 @@ class TelegramManager:
                 # candidate is the only current snapshot.
                 latest_metadata = candidate
 
+        summary_usages = self._read_apriori_summary_usages(set(summary_times))
         with self._task_card_event_lock:
             metadata_changed = (
                 latest_metadata is not None
@@ -3363,7 +3443,16 @@ class TelegramManager:
                 self._task_card_event_groups,
                 per_call_usages,
             )
-        return bool(projected_events) or metadata_changed or result_changed or usage_changed
+            summary_changed = TaskCardEventProjection.apply_apriori_summary_metrics(
+                self._task_card_event_groups, summary_times, summary_usages,
+            )
+        return (
+            bool(projected_events)
+            or metadata_changed
+            or result_changed
+            or usage_changed
+            or summary_changed
+        )
 
     def _resident_task_card_targets(self) -> list[tuple[str, int]]:
         """Enumerate every ``(account, chat_id)`` with a resident Task Card.

--- a/src/lingtai/mcp_servers/telegram/task_card/ANATOMY.md
+++ b/src/lingtai/mcp_servers/telegram/task_card/ANATOMY.md
@@ -44,10 +44,12 @@ onto its one tracked resident Task Card target per account+chat.
 - `../../task_card/resident.py` — provider-neutral route, dual-slot composition,
   route locks, commit-after-success, edit/rotation/delete/send/persist state
   machine, and explicit partial/indeterminate outcomes.
-- `manager.py` — the Telegram adapter that tails `events.jsonl`, supplies safe
-  events to the shared projection core, and implements compound-ID binding,
-  high-water supersession, Telegram API classification, real transport,
-  resident persistence, and programmable file projection callbacks.
+- `manager.py` — the Telegram adapter that tails `events.jsonl`, reads only a bounded
+  recent tail of the existing main `token_ledger.jsonl` when a generated-summary
+  event needs token correlation, and supplies safe facts to the shared projection
+  core. It also implements compound-ID binding, high-water supersession, Telegram
+  API classification, real transport, resident persistence, and programmable
+  file projection callbacks.
   `_taskcard_display_expression()` reads the durable declarative display
   expression from `TelegramService` at each automatic projection tick
   (`_broadcast_task_card_event_window`, `_ensure_task_card_resident`) and
@@ -68,8 +70,9 @@ onto its one tracked resident Task Card target per account+chat.
 - `../../task_card/event_projection.py` — the channel-neutral pure core for safe
   event allowlisting, redaction, API-call grouping, budgets, metadata, and text
   rendering, including compact per-call output/thinking/cache metrics from the
-  normalized current-call carrier or `llm_response` fallback. It owns no journal
-  I/O, route, resident, or transport state.
+  normalized current-call carrier or `llm_response` fallback and the safe
+  `(summary, time, input in, output out)` line correlated from already-recorded
+  event/ledger facts. It owns no journal I/O, route, resident, or transport state.
   `DISPLAY_SLOTS`/`DEFAULT_DISPLAY_EXPRESSION`/`validate_display_expression`/
   `compose_display` define and enforce the small declarative display-expression
   grammar: an ordered, allowlisted selection of the fragments
@@ -87,8 +90,11 @@ onto its one tracked resident Task Card target per account+chat.
 
 - The intrinsic producer writes `<workdir>/taskcard/status` and
   `<workdir>/taskcard/taskcard.md`.
-- `TelegramManager` alone tails `<workdir>/logs/events.jsonl`; it delegates only
-  pure event projection/grouping/rendering to `TaskCardEventProjection` and
+- `TelegramManager` alone tails `<workdir>/logs/events.jsonl`; when an existing
+  `apriori_summary_generated` event appears, it additionally reads at most 64 KiB
+  from the end of `<workdir>/logs/token_ledger.jsonl` to find the existing
+  correlated summary accounting row. It delegates only pure safe-field
+  correlation/projection/grouping/rendering to `TaskCardEventProjection` and
   keeps the existing private helpers as compatibility wrappers.
 - `TelegramManager` constructs `TaskCardResidentTransport` with dynamic provider
   callbacks. The shared core never imports Telegram, reads its state file, or

--- a/src/lingtai/mcp_servers/telegram/task_card/BEHAVIORS.md
+++ b/src/lingtai/mcp_servers/telegram/task_card/BEHAVIORS.md
@@ -1,6 +1,6 @@
 ---
 name: telegram-task-card-behavior-tests
-behavior_version: 1
+behavior_version: 2
 labt_version: 2
 contract: CONTRACT.md
 anatomy: ANATOMY.md
@@ -67,3 +67,25 @@ Pass when the suite passes and the active/diff-only observations hold. Fail on p
 
 ### Pass / Fail
 Pass when both normalized usage paths render the same parenthesized reasoning count immediately after output and legacy missing-field input remains unchanged. Fail if the count is misplaced, reasoning text is exposed, or missing/malformed data leaves a dangling marker.
+
+## Behavior TT003 — generated a-priori summaries add an existing-data-only cost line after the successful tool row
+
+- **id**: TT003
+- **title**: generated a-priori summaries add an existing-data-only cost line after the successful tool row
+- **guards**: `telegram-task-card-projection` § Behavior rule 10 and Contract rule 11
+- **runner**: any LingTai agent with `shell` access to this repository
+- **prerequisites**: a clean checkout of `<repo>`
+- **estimate**: ≈ 2 minutes
+
+### Steps
+1. From `<repo>`, run `python -m pytest tests/test_telegram_task_card_event_tail.py -q` and capture the outcome.
+2. Project an existing successful `tool_result` followed by `apriori_summary_generated`, plus its already-recorded `source=summarize_apriori` token-ledger row, all sharing one `tool_call_id`.
+3. Repeat with missing, malformed, mismatched, and unsuccessful inputs, and restart-rehydrate the valid case.
+
+### Expected evidence
+- [ ] Step 1: the automatic event-tail suite passes.
+- [ ] Step 2: exactly one `(summary, <elapsed>, <input> in, <output> out)` line follows the completed tool row; elapsed derives from event timestamps and tokens from the bounded ledger tail.
+- [ ] Step 3: valid data survives restart rehydration; all invalid/legacy cases preserve old output, while generated summary text, tool-result bodies, and provider metadata never render.
+
+### Pass / Fail
+Pass when only fully correlated existing data produces the second line in the required order and all unsafe/malformed cases omit it. Fail if a new producer event is required, more than the bounded ledger tail is read, an unsuccessful tool receives a summary line, or private payload fields render.

--- a/src/lingtai/mcp_servers/telegram/task_card/CONTRACT.md
+++ b/src/lingtai/mcp_servers/telegram/task_card/CONTRACT.md
@@ -1,9 +1,10 @@
 ---
 name: telegram-task-card-projection
-contract_version: 7
+contract_version: 8
 root_contract: CONTRACT.md
 related_files:
   - src/lingtai/mcp_servers/telegram/task_card/ANATOMY.md
+  - src/lingtai/mcp_servers/telegram/task_card/BEHAVIORS.md
   - src/lingtai/mcp_servers/telegram/task_card/resident.py
   - src/lingtai/mcp_servers/task_card/resident.py
   - src/lingtai/mcp_servers/telegram/task_card/SKILL.md
@@ -27,7 +28,7 @@ maintenance: |
 # Telegram Task Card Projection
 
 ## Purpose
-Guarded by: [TT001](BEHAVIORS.md#behavior-tt001), [TT002](BEHAVIORS.md#behavior-tt002)
+Guarded by: [TT001](BEHAVIORS.md#behavior-tt001), [TT002](BEHAVIORS.md#behavior-tt002), [TT003](BEHAVIORS.md#behavior-tt003)
 
 
 Own Telegram's provider adapter and read-only projection of the intrinsic
@@ -94,6 +95,14 @@ semantics live here. The public producer contract lives in
    `thinking_tokens` fallback produce the same representation. A missing,
    malformed, or output-less count is omitted without a dangling parenthesis,
    preserving old-event rendering and never exposing reasoning text.
+10. When an existing `apriori_summary_generated` event, its preceding successful
+    `tool_result`, and the already-recorded `source=summarize_apriori` main-ledger
+    row correlate by `tool_call_id`, the automatic card appends
+    `(summary, <elapsed>, <input> in, <output> out)` immediately after that tool
+    row. Elapsed time derives only from the two existing event timestamps; token
+    counts come from a bounded recent read of `logs/token_ledger.jsonl`. Missing,
+    malformed, unsuccessful, unmatched, or out-of-bound data preserves the old
+    output. Generated summary text and provider metadata are never projected.
 
 ## Port
 
@@ -144,6 +153,10 @@ There is no public MCP `task_card` family in this component.
     must never rewrite the file from a cache older than the file it is about
     to overwrite; only genuinely concurrent writers overlapping at the same
     instant remain last-writer-wins.
+11. Summary metrics reuse only existing producer data. Telegram must not add or
+    require a new kernel event/accounting path, may read at most
+    `_TASK_CARD_TOKEN_LEDGER_TAIL_BYTES` recent ledger bytes per correlation
+    attempt, and must expose only validated elapsed/input/output integers.
 
 ## Tests
 
@@ -155,7 +168,9 @@ There is no public MCP `task_card` family in this component.
   hidden-finalize clear semantics.
 - `tests/test_telegram_task_card_event_tail.py` continues to cover the automatic
   channel independently, including identical parenthesized reasoning-token
-  rendering from current-call carriers and `llm_response` fallbacks.
+  rendering from current-call carriers and `llm_response` fallbacks, plus
+  correlated a-priori summary time/input/output rendering from existing events
+  and a bounded ledger tail with fail-closed legacy/malformed cases.
 - `tests/test_task_card_event_projection_shared.py` pins shared-core safety and
   byte compatibility with Telegram's established render surface.
 - `tests/test_task_card_resident_shared.py` pins provider-neutral route/slot,

--- a/tests/test_telegram_task_card_event_tail.py
+++ b/tests/test_telegram_task_card_event_tail.py
@@ -1,8 +1,10 @@
 """Automatic Task Card as a broadcast projection of the agent's ``events.jsonl``.
 
 The automatic slot mechanically consumes the agent's authoritative
-``logs/events.jsonl`` in file order, keeps the most recent N provider-call groups
-of canonical ``diary`` text and safe tool fields, and projects
+``logs/events.jsonl`` in file order plus a bounded recent slice of existing
+``logs/token_ledger.jsonl`` for correlated a-priori summary input/output counts,
+keeps the most recent N provider-call groups of canonical ``diary`` text and safe
+tool fields, and projects
 current session telemetry only from the latest final-carrier ``notification_block_injected``,
 and broadcasts the same projection to every resident Task Card for the agent
 (no per-route correlation — this is an agent-behavior broadcast, not per-chat
@@ -11,7 +13,7 @@ visibility).
 These tests exercise ``TelegramManager``'s tailer directly: no durable
 cursor/checkpoint file, no BaseAgent pre-dispatch/result callback dependency,
 no full-file scan on every poll, and restart rehydration from the same
-durable file only.
+durable files only.
 """
 from __future__ import annotations
 
@@ -120,6 +122,12 @@ def _manager(tmp_path, *accounts):
 
 def _events_path(tmp_path: Path) -> Path:
     path = Path(tmp_path) / "logs" / "events.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _ledger_path(tmp_path: Path) -> Path:
+    path = Path(tmp_path) / "logs" / "token_ledger.jsonl"
     path.parent.mkdir(parents=True, exist_ok=True)
     return path
 
@@ -496,6 +504,152 @@ def test_tool_result_updates_status_and_elapsed(tmp_path):
     ])
     manager._poll_event_tail()
     assert "(0.4s, error)" in [c for c in acct.calls if c[0] == "edit_message"][-1][3]
+
+
+def test_apriori_summary_metrics_render_after_completed_tool(tmp_path):
+    acct = FakeAccount()
+    manager, _ = _manager(tmp_path, acct)
+    _pre_resident(acct, 555, manager)
+    _write_lines(_ledger_path(tmp_path), [json.dumps({
+        "source": "summarize_apriori",
+        "apriori_tool_result_summary": True,
+        "tool_call_id": "c1",
+        "input": 12_345,
+        "output": 456,
+        "provider": "PROVIDER_SECRET",
+    })])
+    _write_lines(_events_path(tmp_path), [
+        _tool_call_line(tool_name="file", action="edit", call_id="c1", ts=100.0),
+        json.dumps({
+            "type": "tool_result", "tool_call_id": "c1", "status": "ok",
+            "elapsed_ms": 15, "ts": 102.0, "result": "RESULT_SECRET",
+        }),
+        json.dumps({
+            "type": "apriori_summary_generated", "tool_call_id": "c1",
+            "ts": 103.234, "generated_summary": "SUMMARY_SECRET",
+            "provider": "EVENT_PROVIDER_SECRET",
+        }),
+    ])
+
+    manager._poll_event_tail()
+
+    rendered = [c for c in acct.calls if c[0] == "edit_message"][-1][3]
+    lines = rendered.splitlines()
+    tool_index = next(i for i, line in enumerate(lines) if "file.edit:" in line)
+    assert lines[tool_index].endswith("(15ms, success)")
+    assert lines[tool_index + 1] == " (summary, 1.2s, 12.3k in, 456 out)"
+    assert all(secret not in rendered for secret in (
+        "RESULT_SECRET", "SUMMARY_SECRET", "PROVIDER_SECRET",
+        "EVENT_PROVIDER_SECRET",
+    ))
+    assert all(
+        "_apriori_summary" not in row and "_result_ts" not in row
+        for row in manager._task_card_event_window()
+    )
+
+
+def test_apriori_summary_metrics_rehydrate_from_existing_data(tmp_path):
+    acct = FakeAccount()
+    manager, _ = _manager(tmp_path, acct)
+    _pre_resident(acct, 555, manager)
+    _write_lines(_ledger_path(tmp_path), [json.dumps({
+        "source": "summarize_apriori",
+        "apriori_tool_result_summary": True,
+        "tool_call_id": "c1",
+        "input": 100,
+        "output": 20,
+    })])
+    _write_lines(_events_path(tmp_path), [
+        _tool_call_line(call_id="c1", ts=10.0),
+        json.dumps({
+            "type": "tool_result", "tool_call_id": "c1", "status": "ok",
+            "elapsed_ms": 4, "ts": 11.0,
+        }),
+        json.dumps({
+            "type": "apriori_summary_generated", "tool_call_id": "c1",
+            "ts": 11.031,
+        }),
+    ])
+
+    manager._init_event_tail()
+    manager._broadcast_task_card_event_window()
+
+    rendered = [c for c in acct.calls if c[0] == "edit_message"][-1][3]
+    assert "\n (summary, 31ms, 100 in, 20 out)" in rendered
+
+
+def test_apriori_summary_metrics_fail_closed_on_unmatched_or_unsafe_data(tmp_path):
+    acct = FakeAccount()
+    manager, service = _manager(tmp_path, acct)
+    _pre_resident(acct, 555, manager)
+    service.normal_rows = 2
+    _write_lines(_ledger_path(tmp_path), [
+        json.dumps({
+            "source": "main", "apriori_tool_result_summary": True,
+            "tool_call_id": "c1", "input": 10, "output": 2,
+        }),
+        json.dumps({
+            "source": "summarize_apriori",
+            "apriori_tool_result_summary": True,
+            "tool_call_id": "c2", "input": True, "output": 2,
+        }),
+        json.dumps({
+            "source": "summarize_apriori",
+            "apriori_tool_result_summary": True,
+            "tool_call_id": "other", "input": 10, "output": 2,
+        }),
+    ])
+    _write_lines(_events_path(tmp_path), [
+        _tool_call_line(call_id="c1", ts=1.0),
+        json.dumps({
+            "type": "tool_result", "tool_call_id": "c1", "status": "ok",
+            "elapsed_ms": 4, "ts": 2.0,
+        }),
+        json.dumps({
+            "type": "apriori_summary_generated", "tool_call_id": "c1",
+            "ts": 2.1, "generated_summary": "MUST_NOT_RENDER",
+        }),
+        _tool_call_line(call_id="c2", ts=3.0),
+        json.dumps({
+            "type": "tool_result", "tool_call_id": "c2", "status": "error",
+            "elapsed_ms": 4, "ts": 4.0,
+        }),
+        json.dumps({
+            "type": "apriori_summary_generated", "tool_call_id": "c2",
+            "ts": 4.1,
+        }),
+    ])
+
+    manager._poll_event_tail()
+
+    rendered = [c for c in acct.calls if c[0] == "edit_message"][-1][3]
+    assert "(summary," not in rendered
+    assert "MUST_NOT_RENDER" not in rendered
+
+
+def test_apriori_summary_usage_reader_is_bounded_to_recent_ledger_tail(tmp_path):
+    manager, _ = _manager(tmp_path)
+    manager._TASK_CARD_TOKEN_LEDGER_TAIL_BYTES = 256
+    path = _ledger_path(tmp_path)
+    old = json.dumps({
+        "source": "summarize_apriori",
+        "apriori_tool_result_summary": True,
+        "tool_call_id": "old",
+        "input": 999,
+        "output": 111,
+    })
+    current = json.dumps({
+        "source": "summarize_apriori",
+        "apriori_tool_result_summary": True,
+        "tool_call_id": "current",
+        "input": 42,
+        "output": 7,
+    })
+    _write_lines(path, [old, "x" * 512, current])
+
+    usages = manager._read_apriori_summary_usages({"old", "current"})
+
+    assert usages == {"current": {"input": 42, "output": 7}}
 
 
 def test_second_tool_call_api_delay_is_previous_tool_ts_delta(tmp_path):


### PR DESCRIPTION
## Summary
- reuse the existing `tool_result` / `apriori_summary_generated` timestamps and existing `source=summarize_apriori` main token-ledger row
- append `(summary, <elapsed>, <input> in, <output> out)` immediately after the successful completed tool row
- fail closed for legacy, missing, malformed, unsuccessful, out-of-window, or unmatched data; never project summary text, tool-result bodies, or provider metadata
- add no producer event and change no kernel summary/accounting path

## Validation
- `tests/test_telegram_task_card_event_tail.py`: 55 passed
- adjacent shared projection / Telegram Task Card / architecture selection: 88 passed; the one failure reports two unrelated existing psyche-manual Anatomy orphans outside this diff
- `git diff --check` and Python syntax checks passed

No merge or release is included.