### PR TITLE
docs(context): make handoffs proportional and shorten manuals

### DIFF
--- a/src/lingtai/intrinsic_skills/system-manual/reference/procedures-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/procedures-manual/SKILL.md
@@ -69,7 +69,7 @@ settings without another concrete tool owner. Follow `comment` to the owning
 manual before an authorized change; a SHOW result grants no mutation authority.
 Do not reproduce adjustable numeric defaults in general workflow guidance.
 
-`context-manual` → `reference/summarize-manual/SKILL.md` §3a owns reconstruction
+`context-manual` → `reference/summarize-manual/SKILL.md` (Apply and recover) owns reconstruction
 mechanics and boundaries. Follow the current runtime pressure guidance instead
 of duplicating thresholds here: pending summaries are normal, `refresh` is not
 an apply-summary shortcut, and rebuild/summarize must not become a loop.

--- a/src/lingtai/prompts/procedures/procedures.md
+++ b/src/lingtai/prompts/procedures/procedures.md
@@ -85,7 +85,7 @@ authority. Do not duplicate adjustable numbers here. Load only relevant detail;
 | Before doing this | Read |
 |---|---|
 | Runtime updates, preset/configuration changes, Nudge controls, or lifecycle recovery | `system-manual` and its matching reference |
-| Context summarize/rebuild/molt or a consequential handoff | `context-manual` |
+| Before molt, or for unfamiliar/consequential Context work or context-loss recovery | `context-manual` |
 | Delegation, long-running host work, or progress-watch management | The matching `daemon`, `avatar`, `shell`, or `task_card` manual |
 | Integration setup, debugging, or ownership changes | `mcp-manual` / `plugin-manual`, then that integration's docs |
 | Durable-store or skill authoring | The relevant `psyche` domain manual |

--- a/src/lingtai/tools/context/__init__.py
+++ b/src/lingtai/tools/context/__init__.py
@@ -89,11 +89,11 @@ _MOLT_INPUT_SCHEMA: dict[str, Any] = {
     "properties": {
         "summary": {
             "type": "string",
-            "description": 'Your session retrospective (~10,000 tokens). Write as a record — what happened, what you learned, what remains. The four stores must be tended BEFORE molt. Saved to `system/summaries/molt_<count>_<ts>.md` and replayed to the next you. See context-manual for full writing guidance. This is domain input the molt itself consumes, not the root `summarize` post-processing control.',
+            "description": 'Your shortest sufficient successor briefing: active task/state, verified results, pending authority, next steps, live job/thread IDs, artifact or evidence paths, blockers, and essential lessons. Update only durable stores that changed and write the required session journal BEFORE molt. The briefing is saved to `system/summaries/molt_<count>_<ts>.md` and replayed to the next you. See context-manual for handoff guidance. This is domain input the molt itself consumes, not the root `summarize` result-presentation control.',
         },
         "session_journal_path": {
             "type": "string",
-            "description": 'REQUIRED. The path to the session-journal entry you wrote for the just-finished segment BEFORE molting: knowledge/session-journal/<entry>/KNOWLEDGE.md (a per-segment sub-entry, NOT the parent index). Must be inside your workdir, exist, be non-empty UTF-8, have valid YAML frontmatter with `name` and `description`, and identify itself as session knowledge via `type: session-journal` or `session_journal: true`. The molt is refused before any context is shed if this is missing or invalid. See context-manual §4.',
+            "description": 'REQUIRED. The path to the session-journal entry you wrote for the just-finished segment BEFORE molting: knowledge/session-journal/<entry>/KNOWLEDGE.md (a per-segment sub-entry, NOT the parent index). Must be inside your workdir, exist, be non-empty UTF-8, have valid YAML frontmatter with `name` and `description`, and identify itself as session knowledge via `type: session-journal` or `session_journal: true`. The molt is refused before any context is shed if this is missing or invalid. See context-manual: Shortest useful path.',
         },
         "keep_tool_calls": {
             "type": ["array", "null"],
@@ -159,7 +159,9 @@ _SUMMARIZE_ITEMS_DESCRIPTION = (
     "block) and 'summary' (your agent-authored text). Supports multiple items "
     "per call. The original is NOT deleted — it remains retrievable from "
     "events.jsonl by tool_call_id. Pick targets from "
-    "`_meta.agent_meta.agent_state.current_tool_result_chars.top_results`. "
+    "the newest `_meta.agent_meta.agent_state.current_tool_result_chars.top_results` IDs. "
+    "The item `tool_call_id` is the producer call ID, not the visible `_tool_call_id` "
+    "event reference; preserve any `raw_locator` or spill path for recovery. "
     "This action RECORDS ONLY: the active provider context may still carry "
     "the old raw results until context(action='rebuild') applies them."
 )
@@ -352,8 +354,8 @@ def _build_family(
 _ACTION_ENUM_DESCRIPTION = (
     'Required operation. '
     'molt: shed your conversation context, keep the durable stores. Requires '
-    '`summary` and a valid `session_journal_path` — tend the four stores '
-    'BEFORE molting. See context-manual.\n'
+    '`summary` and a valid `session_journal_path` — write the journal first and '
+    'update only durable stores that changed. See context-manual.\n'
     'summarize: record your own compact replacements for prior tool results in '
     'runtime history. RECORD ONLY — it does not rebuild, so the active '
     'provider context may still carry the old raw results.\n'

--- a/src/lingtai/tools/context/manual/SKILL.md
+++ b/src/lingtai/tools/context/manual/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: context-manual
 description: |
-  Read before summarize/rebuild/molt, session journaling, consequential handoff or context-loss recovery.
-version: 2.1.2
-last_changed_at: "2026-09-04T00:00:00Z"
+  Use for an unfamiliar or consequential context operation, session journaling, handoff, or context-loss recovery; routine calls can follow the schema.
+version: 2.2.0
+last_changed_at: "2026-09-08T00:00:00Z"
 related_files:
 - src/lingtai/tools/context/__init__.py
 - src/lingtai/tools/context/_molt.py
@@ -18,207 +18,28 @@ maintenance: |
 
 # Context Manual
 
-This manual is the router for `context` operations — `molt`, `summarize`, and `rebuild`. Keep routine guidance here; load the supporting asset or reference only when you need the full scaffold or the detailed summarize/rebuild procedure.
+Use the schema for routine calls; open this manual for unfamiliar workflows or recovery risk. Context has four operations:
 
-## Reference catalog
+- `summarize` records compact replacements for selected old tool results; it does not rebuild provider context.
+- `rebuild` recomposes all canonical prompt sources, applies summaries, then requests provider replay. Bare `input={}` is valid; durable file edits do not hot-load.
+- `molt` sheds conversation while retaining durable files and stores. It is an irreversible boundary, not housekeeping.
+- `manual` returns the installed `context-manual` without changing context.
 
-| Reference | When to load |
-|---|---|
-| `reference/summarize-manual/SKILL.md` | Compacting bulky tool results with `context(action='summarize')`, applying them during a full `context(action='rebuild')`, recovery by `tool_call_id`, and summarize-versus-molt tradeoffs |
+## Shortest useful path
 
-## Full context rebuild
+When current `meta_guidance` says a consumed result needs a posteriori compaction, inspect it first, then use `context(action="summarize", input={"items": [...]})`; do not use this as routine cleanup. Use one `context(action="rebuild", input={})` to apply pending summaries or a durable prompt edit now. The [summarize reference](reference/summarize-manual/SKILL.md) owns selection, recovery, and pressure guidance.
 
-`context(action="rebuild", ...)` is the **one active full reconstruction operation**: recompose every canonical prompt source → apply pending summaries → provider replay. The tool description and the `rebuild` schema carry the exact contract, including that bare `{}` is valid.
+Before a deliberate molt:
 
-The fact that is only here: **generic durable mutations do not hot-load.** Write with `file.write`/`file.edit`, then rebuild when the change must apply now — that is the only mutation path for all four durable stores (no per-store append, info, or reload action). Passive refresh and molt invoke the same internal reconstruction contract with their own lifecycle effects. Do not loop rebuild.
+1. Make the task, authority, blockers, live IDs, evidence paths, and next action recoverable. Update only stores that changed.
+2. Write the session-journal child and parent-index pointer. It must be `knowledge/session-journal/<entry>/KNOWLEDGE.md`, nonempty UTF-8, with valid `name`/`description` frontmatter and `type: session-journal` or `session_journal: true`. Use the [journal scaffold](assets/session-journal-entry-template.md) if useful.
+3. Pass its path as `session_journal_path` and write the shortest sufficient handoff: active state, verified results, pending authority, next steps, live IDs, artifact/evidence paths, blockers, and lessons. Use the [optional handoff scaffold](assets/molt-template.md) only when it lowers real risk.
+4. Call `context(action="molt", ...)`. The journal is validated before shedding; invalid input leaves molt count/history untouched. `keep_tool_calls` refuses unknown IDs; `keep_last` preserves a suffix and complete tool-call batches. The schema is authoritative.
 
-## Asset catalog
+Molt preserves durable files and source reconstruction: it archives/snapshots the old conversation, rebuilds the fresh prompt, and publishes a post-molt notification. It does not delete durable stores. Molt for sustained pressure, an explicit human reset, or confusion—not merely task completion. Tending stores need not create gratuitous edits or new skills.
 
-| Asset | When to load | What it contains |
-|---|---|---|
-| `assets/session-journal-entry-template.md` (read from this skill directory) | Whenever you write the molt-history record for a session segment before a molt | Frontmatter + section template for a `knowledge/session-journal/<YYYY-MM-DD>-molt-<molt-count>-<slug>/KNOWLEDGE.md` entry |
-| `assets/molt-template.md` (read from this skill directory) | Consequential molt, long-running task, multiple collaborators, pending human commitments, open worktrees/artifacts, active background jobs, or any successor briefing that would be risky to improvise | 9-section summary scaffold plus pre-molt verification checklist |
+## After a molt
 
-## 1. Molt Overview
+Read the post-molt notification/`summary_path`, current prompt/Pad, journal index, and new producer messages. Treat the briefing as context, not a command to run blindly. Re-check IDs and evidence paths. After reorientation, explicitly choose `continue`, `defer`, or `obsolete` and dismiss the channel with a reason, for example `notification(action="dismiss_channel", input={"channel":"post-molt","force":null,"reason":"continue: ..."}, reasoning="...")`; use the Notification manual/schema for its exact fields. Resume through the originating channel/tool; a saved briefing or provider replay is not proof of delivery.
 
-Molt is yours to perform. The covenant teaches the philosophy (§V); this is the recipe.
-
-Save anything you need to pad, lingtai, knowledge, and skills beforehand, then molt. Molt is not routine housekeeping: do it once context pressure (≥85%), an explicit human request, or conversation confusion actually makes the fresh briefing worth its cost (see `reference/summarize-manual/SKILL.md`) — not merely because the window still has room. Once a molt is actually warranted, tending the stores and molting promptly still saves tokens over a rushed, late one.
-
-**Tend the stores first, every time.** The four stores are the real persistence and the summary is only the briefing on top of them: molt without tending them and the next you wakes with the briefing alone — no character evolution, no pad state, no new knowledge, no new skills.
-
-## 2. Store-Tending Rhythm
-
-For `lingtai` and `knowledge`, tending happens *once* per task, at the end — not mid-task. Hold updates in your head while working, then commit them in a single pass before going idle (or before molting). Mid-task edits create noise and waste tokens. The exception is a long-running task where a crash would genuinely destroy work — checkpoint deliberately in that case.
-
-Pad has a different rhythm — update it whenever the index meaningfully changes. See §5 below.
-
-All four durable stores are taught by manuals loaded through the one `psyche` root (pad + lingtai + knowledge + skills = psyche); generic mutation belongs to `file`. §3 below is the per-store how-to.
-
-## 3. Step 1 — Tend the Four Durable Stores and Session Journal
-
-- **lingtai** — carry forward your complete identity in `system/lingtai.md` using `file.write` (full rewrite) or `file.edit` (exact replacement). Read `psyche(action="lingtai", input={}, reasoning="...")` for forced/self-evolve behavior.
-- **pad** — keep the living index in `system/pad.md` via `file.write`/`file.edit`; edit `system/pad_append.json` the same way for the durable pinned-reference list. See `psyche(action="pad", input={}, reasoning="...")`.
-- **knowledge** — write to `knowledge/<name>/KNOWLEDGE.md` for long-term private context using `file.write`/`file.edit`.
-- **skills** — write `.library/custom/<name>/SKILL.md` (with YAML frontmatter: `name`, `description`, `version`) for any reusable procedure the next you (or a peer) might need, then rebuild to refresh the catalog. Share by sending the skill source/artifact so peers install it into their own `.library/custom/<name>/` and refresh; use `../.library_shared/<name>/` only as an explicit opt-in local-network shared root.
-- **session journal** — append a substantial sub-entry under `knowledge/session-journal/` describing what you did this session. See §4 for the full practice.
-
-All five happen *before* the molt call. They are not optional. Without them, the molt sheds everything.
-
-## 4. Session Journal
-
-The four stores capture *who you are*, *what you're working on*, *verifiable truths*, and *reusable procedures*. None of them captures the *story* of a session. The session journal is that missing layer — it is also your **molt history**: each sub-entry is the record of one session segment that you write *before* you molt, so the chain of entries reconstructs how you got here across many molts.
-
-Write it as a **routing parent with sub-knowledge children** under
-`knowledge/session-journal/` — the routing/index shape from the knowledge manual's
-"Nesting and sub-knowledge" section. Do **not** create each session as its own
-top-level knowledge entry; that floods the catalog. The parent is routing-only;
-the children carry the substance:
-
-```
-knowledge/session-journal/
-├── KNOWLEDGE.md                                            # top-level routing/index ONLY
-├── 2026-05-13-molt-7-nudge-service/KNOWLEDGE.md            # sub-knowledge — one session
-├── 2026-05-13-molt-8-procedures-to-kernel/KNOWLEDGE.md     # sub-knowledge — same day
-└── 2026-05-14-molt-9-wechat-fixes/KNOWLEDGE.md             # sub-knowledge — ...
-```
-
-Because `session-journal/` has its own `KNOWLEDGE.md`, the knowledge scanner
-treats it as a single entry and does **not** descend into the children — they are
-reachable only through the parent index. That is why the parent must list every
-child explicitly. See the knowledge manual's "Nesting and sub-knowledge" section
-(`.library/intrinsic/capabilities/knowledge/SKILL.md`) for the structural rule.
-
-The directory name is `<YYYY-MM-DD>-molt-<molt-count>-<slug>`. Read `<molt-count>` from your resident system prompt's identity section — "You have undergone N molts since birth." Use that N: the entry records the pre-molt segment. Embedding the count keeps chronology stable when you molt more than once on the same date, which the date alone cannot order.
-
-**The parent `knowledge/session-journal/KNOWLEDGE.md` is routing-only** — short,
-scannable, progressive-disclosure. It is a table of contents, not a journal. One
-line per sub-entry: date, slug, one-sentence hook, and the child's *relative* path
-(`2026-05-13-molt-7-nudge-service/KNOWLEDGE.md`), never an absolute local path.
-Never let narrative leak into the parent — if a line grows past its hook, the
-detail belongs in the child.
-
-**The sub-entry `<YYYY-MM-DD>-molt-<molt-count>-<slug>/KNOWLEDGE.md` is the substance** — write it as the molt-history record of the segment, *before* you molt, via `write`/`edit` directly. Read `assets/session-journal-entry-template.md` from this skill directory for the frontmatter (including `molt_count`, the required `type: session-journal` marker, and the YAML block-scalar `description` that keeps a `: ` in the text from breaking the gate) and the section layout. It is a journal, not a transcript. Several thousand tokens is fine when the segment was rich; keep it concise when it was small.
-
-This sub-entry's path is what you pass as `context(action='molt', input={'session_journal_path': ...})`, and the kernel validates it before letting the molt proceed (see §6).
-
-Updating the parent index at each session is part of the practice — append one line referencing the new sub-entry. Then write the successor summary (§6), which points back at this entry's path.
-
-## 5. Tending the Pad
-
-**Pad has its own manual — read `psyche(action="pad", input={}, reasoning="load Pad guidance")` for the full practice.** It owns what belongs in the pad and what does not, the tending rhythm, how the `system/pad_append.json` pinned list works, and how to archive a completed pad.
-
-What matters here is only the molt-relevant fact: pad is one of the four durable stores, it survives the molt and is reloaded into the fresh session's system prompt, so it must be accurate **before** you molt. A stale pad is the fastest way to make the next you lose the thread.
-
-Your 灵台 is likewise taught by a manual — call `psyche(action="lingtai", input={}, reasoning="load identity guidance")` for identity modes and file/rebuild guidance.
-
-## 6. Step 2 — Write the Summary and Molt
-
-```
-context(
-    action="molt",
-    input={
-        "summary": <your charge to the next you>,
-        "session_journal_path": "knowledge/session-journal/<entry>/KNOWLEDGE.md",
-        "keep_tool_calls": null,
-        "keep_last": null,
-    },
-    reasoning="why you are molting now",
-)
-```
-
-Every `context` call uses this one envelope: a single `action`, that action's
-own strict `input` object, and a root `reasoning`. The four actions are `molt`,
-`summarize`, `rebuild`, and `manual`. Leave the root `summarize` **boolean**
-false: `context` results are small (short-result profile), and summarizing a
-`manual` call would drop the exact procedure you called it for.
-
-(The action-`summarize` versus root-`summarize` distinction is stated in the
-resident tool description; no action takes `summarize` as input.)
-
-`context` owns only your context. Your name is `system(action='name_set')` /
-`system(action='name_nickname')`. Your four durable stores share one read-only
-root. `psyche(action="pad"|"lingtai"|"knowledge"|"skills"|"manual", input={},
-reasoning="...")` returns the matching manual;
-`psyche(action="settings", input={}, reasoning="...")` returns the two fully
-redacted Psyche-owned Pad configuration rows. Use `file.write`/`file.edit` for
-durable files, then rebuild explicitly when needed.
-
-**Required pre-molt order (enforced by the kernel):** write the session journal
-sub-entry first (§4) → pass its path as `session_journal_path` → the kernel
-validates it → only then does the molt proceed. `session_journal_path` is a
-**mandatory** structured argument for agent-initiated molt. If it is missing or
-the journal fails validation, the molt is **refused before any context is shed**
-and your `molt_count`/history are untouched — you get an actionable recovery
-message instead. The validator (a signpost, not a grader) checks what the schema
-describes: path inside your workdir resolving to
-`knowledge/session-journal/<entry>/KNOWLEDGE.md` (the per-segment sub-entry, not
-the parent index and not a scratch file), non-empty UTF-8, frontmatter with
-`name` + `description`, and the marker `type: session-journal` or
-`session_journal: true` — see the template in §4.
-
-The accepted path is recorded in the molt result, the persisted summary
-frontmatter (`session_journal_path:`), and the post-molt notification, so later
-recovery and audits can see which journal backed each molt.
-
-The `summary` is the only *conversation-layer* thing the next you will see. Aim for the ~10,000 tokens the schema suggests. The summary is not a recap of conversation. It is your charge to the self that comes after you — anchored in the four stores, which are already waiting in the fresh session.
-
-For a routine molt, include:
-
-- **What you are working on** — current task, current state, the next concrete step
-- **What you have accomplished** — completed pieces, key decisions made
-- **What remains** — pending items, blockers, open questions
-- **Who to contact** — collaborators, who is waiting on what
-- **Which knowledge entries and skills matter** — paths the next you should load
-- **The session journal sub-entry path** — so the next you can read the full narrative
-- **Anything else worth carrying forward** — insights, gotchas
-
-Quick routing:
-
-| Need | Use |
-|---|---|
-| Routine molt | The short bullet list above. |
-| Consequential molt / successor handoff — long-running task, multiple collaborators, pending human commitments, open worktrees/artifacts, or any handoff the next you could not reconstruct quickly | Read `assets/molt-template.md` from this skill directory; use its full scaffold and checklist. Fill every section; write `None` rather than omitting one. |
-| Unsure whether the handoff is complex | Use the asset; extra structure is cheaper than a bad handoff. |
-
-Before you call `context(action="molt", ...)`, verify at minimum:
-
-- The session-journal sub-entry for the just-finished segment exists and was
-  written *before* the summary (§4) — it is the narrative the summary points
-  back to, and its path is the validated `session_journal_path`.
-- Durable stores were tended before the summary was written.
-- The first five minutes after wake are obvious.
-
-`assets/molt-template.md` carries the full pre-molt verification checklist
-(outstanding tasks, collaborators, background work, key paths).
-
-**`keep_tool_calls`** — see the schema description for the exact semantics (refusal on an unknown ID, replay order). Keep the list short: the durable stores are the primary persistence.
-
-**`keep_last`** — see the schema description (default 20, backward expansion to keep a tool-call batch whole, `0` to archive everything, dedupe against `keep_tool_calls`).
-
-## 7. Context Pressure Reminder
-
-Context pressure is agent state, not a dismissible notification. Tool results surface a natural-language reminder under `_meta.agent_meta.agent_state.context.molt` only after context has stayed high for several consecutive fresh provider rounds (the sustained-pressure threshold is 85%). It rides on the current `agent_meta` snapshot (carried on the designated final result of each batch; restamped there while active) so the reminder persists. The field name is historical: the reminder is a context-pressure action, not an early staged molt order or a machine-readable tag block.
-
-When this reminder appears, follow the urgent cadence in `reference/summarize-manual/SKILL.md` (which owns the summarize cadence, rebuild semantics, and recovery target). The molt decision is yours: if a batched summarize/rebuild pass still leaves context above 85%, stop repeating summarize, tend durable stores, and molt deliberately. If context falls below 85% but stays above the recovery target, continue only when the current task still needs the carried context; otherwise molt at a natural task boundary.
-
-### Cache-miss budget
-
-The soft **cache-miss token budget** (default 2,000,000, System-owned via `<agent-workdir>/settings/system.json`, cumulative since your last molt, surfaced as `cache miss budget {N} reached, molt now`) is owned by the resident `meta_guidance` token-efficiency guidance. Two details only documented here:
-
-- It is **overridable at runtime** by `LINGTAI_CACHE_MISS_BUDGET` (positive int, read live at every budget resolution, so `env_file` + refresh applies it without a file edit; an invalid or non-positive value silently falls back to the System file, then the fixed default). Legacy `manifest.cache_miss_budget` in `init.json` is ignored. `_meta.agent_meta.agent_state.context` reports the effective `cache_miss_budget` and the current `cache_miss_tokens`. The `system-manual` owns the file format.
-- The total **survives a refresh/restart** — it is not the since-refresh runtime delta, so refreshing does not reset the remaining budget. If the sustained context-pressure reminder is also active, both warnings are preserved in `context.molt`.
-
-## 8. Post-Wipe Recovery
-
-If you wake up after a *system-performed* molt (triggered by karma, `.clear`, or operator — NOT by context-pressure reminders), the post-molt notification points at a system-authored summary in `system/summaries/`. All canonical prompt sources (including character and Pad) were reconstructed, and recent conversation may be gone except for any entries the system explicitly kept. To reconstruct:
-
-1. Read the `summary_path` from the post-molt notification
-2. `email(check)` — see what arrived while you were down
-3. Check `knowledge/session-journal/KNOWLEDGE.md` — your session history index
-4. Read the `skills` section of your system prompt — it lists every skill you have
-5. `shell({"command": "tail -n 200 logs/events.jsonl | grep ..."})` — surgical reads if needed
-
-Reconstruct your situation from these sources.
-
-If you ever need to retrieve specific prior context, the full activity log is at `logs/events.jsonl` — read tactically (grep/tail/filter), not whole.
+The action `summarize` records Context history; the optional root `summarize` boolean only presents results. They are not the same input. Use `psyche(action="manual", input={}, reasoning="load durable-store routes")` for store ownership; generic writes are through `file`, followed by one rebuild when needed.

--- a/src/lingtai/tools/context/manual/assets/molt-template.md
+++ b/src/lingtai/tools/context/manual/assets/molt-template.md
@@ -3,68 +3,27 @@ related_files:
 - src/lingtai/tools/context/manual/SKILL.md
 - tests/test_skills.py
 maintenance: |
-  Consequential-molt summary scaffold referenced by context-manual/SKILL.md and asserted on by tests/test_skills.py; keep its 9-section structure and heading text synced with both, since the test pins exact section headings verbatim.
+  Optional consequential-molt handoff scaffold referenced by context-manual; keep its recovery fields aligned with the owner manual without making the scaffold mandatory.
 ---
 
-# Consequential Molt Summary Template
+# Consequential Molt Handoff Template
 
-Use this asset when a molt is more than routine: long-running task, multiple collaborators, pending human commitments, open worktrees/artifacts, active background jobs, or any handoff the next you could not reconstruct quickly.
+Use this optional scaffold when a task is unfamiliar, long-running, collaborative, externally committed, or otherwise hard to reconstruct. A routine molt may use a few precise sentences. Write only useful facts; do not fill absent fields with `None`, and do not target a fixed length.
 
-Fill every section. Write `None` rather than omitting a section. This template is for the `input.summary` argument to `context(action="molt", ...)`; tend durable stores before writing it.
+Include whichever of these fields reduce recovery risk:
 
-## Summary scaffold
+- **Active task and state** — the exact objective, current status, and first next action.
+- **Authority and collaborators** — who may decide what, pending approvals/replies, and the originating channel.
+- **Verified work and open work** — completed results, blockers, unresolved questions, and the evidence that supports them.
+- **Live work** — active job/thread/daemon IDs, their owners, and how to check or stop them.
+- **Paths and lessons** — absolute artifact/log/report paths, relevant journal/knowledge/skill paths, and essential gotchas.
+- **Boundaries** — side effects still forbidden, secrets to avoid, and any exact command or recipient constraint.
 
-1. **Who I Am**
-   - Name/address and current role.
-   - Standing constraints, authorizations, and things not to do without explicit confirmation.
-   - Parent/peer relationships or topology that affect the task.
-2. **Accomplishments**
-   - Completed tasks and outputs.
-   - Key decisions made and why.
-   - Who has already been told, on which channel.
-3. **Outstanding Tasks**
-   - Incomplete work, status, blocker, and the next concrete step.
-   - Pending reviews, PRs, human approvals, daemon/avatar work, or external replies.
-4. **Action Checklist**
-   - Priority-ordered actions in the form: `[Immediate|Today|Pending|Optional] Action + recipient/channel + exact content/command`.
-   - Every outstanding task must have a matching action item.
-   - `Immediate` means first five minutes after wake; `Pending` means blocked on someone else and includes when/how to follow up.
-5. **Collaborators**
-   - People/agents involved, addresses/channels, roles/capabilities.
-   - Pending replies, deliverables owed by you, deliverables owed to you.
-6. **Durable Memory and Execution Notes**
-   - Pad sections, knowledge entries, skills/manuals, character changes, session-journal entries, or pinned files the next you should load.
-   - Commands, tests, environment assumptions, active daemons/bash jobs/avatars/schedules, or tool states the next you must know.
-   - Use current durable-store terms; avoid old `codex` wording unless documenting historical material.
-7. **Key Paths and Artifacts**
-   - Absolute paths for repos, worktrees, reports, drafts, logs, local deliverables, and test outputs.
-   - Include PR/issue URLs or branch names when relevant.
-8. **Lessons and Gotchas**
-   - Actionable warnings, failed approaches, verification requirements, and authorization limits.
-   - Prefer precise lessons: “run X before Y” beats “be careful”.
-9. **Context Status**
-   - Why you are molting.
-   - Leftover items not yet stored elsewhere.
-   - Unsent drafts, interrupted tool calls, or recent state that should be re-checked.
+## Before calling molt
 
-## Pre-molt verification checklist
+- Update only durable stores whose content changed.
+- Write the required session-journal child first and add its relative path to the parent index.
+- Pass that child path as `session_journal_path`.
+- Make the next agent's first few minutes obvious, then call `context(action="molt", ...)`.
 
-Before you call `context(action="molt", input={"summary": ..., "session_journal_path": ...}, reasoning=...)`, verify:
-
-- The just-finished session segment is recorded as a session-journal child at
-  `knowledge/session-journal/<YYYY-MM-DD>-molt-<molt-count>-<slug>/KNOWLEDGE.md`,
-  written before the summary — **its path is the required
-  `session_journal_path` argument and the kernel refuses the molt, before
-  shedding any context, if it is missing, mislocated, or unmarked** (see
-  context-manual §4 and §6). The parent index has a new one-line, relative-path
-  hook for it, and the summary points at the child's path.
-- Pad, lingtai/character, knowledge, skills, and session journal were updated where needed before writing the summary.
-- Every outstanding task has an action checklist entry.
-- Every action names who/where and what exact content or command is needed.
-- Every collaborator has a usable address/channel and pending-reply state.
-- Every key path is absolute and still useful.
-- Active background work is listed or explicitly absent.
-- Authorization limits, external-side-effect approvals, and secret/privacy constraints are explicit.
-- Every lesson/gotcha is actionable.
-- Pending human/peer contacts have been acknowledged if the molt will delay them.
-- The first five minutes after wake are obvious.
+The kernel validates the journal before shedding context. Durable files remain recoverable; the handoff is a pointer and decision aid, not a replacement for those sources.

--- a/src/lingtai/tools/context/manual/assets/session-journal-entry-template.md
+++ b/src/lingtai/tools/context/manual/assets/session-journal-entry-template.md
@@ -4,80 +4,34 @@ related_files:
 - src/lingtai/tools/context/_session_journal.py
 - src/lingtai/tools/context/ANATOMY.md
 maintenance: |
-  Session-journal / molt-history entry scaffold whose required frontmatter marker (`type: session-journal`) and path convention are enforced by the molt gate in src/lingtai/tools/context/_session_journal.py; update it in lockstep whenever that validator's required fields or path rule change.
+  Session-journal / molt-history scaffold whose required frontmatter marker and path convention are enforced by the Context molt gate; keep it aligned when that validator changes.
 ---
 
 # Session-Journal / Molt-History Entry Template
 
-Use this when writing the molt-history record for a session segment, *before* a
-deliberate molt. Write it to
+Write one child entry **before every agent-initiated molt** and pass its path as `session_journal_path`:
+
 `knowledge/session-journal/<YYYY-MM-DD>-molt-<molt-count>-<slug>/KNOWLEDGE.md`
-via `write`/`edit` (the kernel `knowledge` mechanic auto-discovers subdirectories
-containing `KNOWLEDGE.md`). Read `<molt-count>` from your resident system
-prompt's identity section — "You have undergone N molts since birth" — and use
-that N: this entry records the pre-molt segment, written *before* you call
-`context(action='molt')`. (The tool result afterward reports the next count,
-N+1, which belongs to the next segment.) Including it keeps chronology stable
-when you molt more than once on the same date: the date alone cannot order two
-same-day entries, but the molt count always can.
 
-It is a **journal, not a transcript**: capture what happened and why, point at
-where the substance lives, and stop. Reference paths/PRs/message IDs — never
-inline secrets or full file contents. After writing it, append one line to the
-parent index at `knowledge/session-journal/KNOWLEDGE.md`.
+The parent `knowledge/session-journal/KNOWLEDGE.md` is routing-only. Add one concise relative-path hook there after writing the child. Use the current pre-molt count from the resident identity section; the entry describes the segment that is ending.
 
-The frontmatter below is the on-disk format; fill every section, writing `None`
-rather than omitting one. The molt validator checks only the frontmatter marker
-and structure, never the body.
-
-> **Required marker (the molt gate):** the frontmatter **must** include
-> `type: session-journal` (or, equivalently, `session_journal: true`). The
-> kernel molt gate rejects the molt unless this marker is present, the file
-> lives at `knowledge/session-journal/<entry>/KNOWLEDGE.md` (a per-segment
-> sub-entry, not the parent index), exists, is non-empty UTF-8, and has valid
-> YAML frontmatter with `name` and `description`. You pass this file's path to
-> `context(action='molt', input={'session_journal_path': ...})`.
-
-> **YAML scalar safety:** keep `description` in the block-scalar form shown
-> below. Plain YAML values break when they contain a colon followed by a space
-> (for example `molt 53: runtime relay`), causing `mapping values are not
-> allowed here` during the molt gate.
+The kernel checks the path inside the workdir, the per-segment `KNOWLEDGE.md` filename, nonempty UTF-8, valid YAML frontmatter with `name` and `description`, and either `type: session-journal` or `session_journal: true`. It performs this check before any context is shed or molt count changes. Keep the body concise and factual; use only the headings that help recovery, such as current task/state, verified results, decisions, artifacts/evidence, open tasks, collaborators, and gotchas. Do not write a transcript or pad missing sections with `None`.
 
 ```markdown
 ---
 name: <YYYY-MM-DD>-molt-<molt-count>-<slug>
 description: >-
-  One-sentence hook — what this session segment did. Use this block style so
-  colons such as "molt 53: runtime relay" remain valid YAML.
+  One-sentence hook — what this session segment did and where it left off.
 date: <YYYY-MM-DD>
-molt_count: <current molt count, before calling context(action='molt')>
+molt_count: <current count before calling context(action='molt')>
 type: session-journal
 ---
 
-**<YYYY-MM-DD HH:MM TZ>** — TL;DR: one or two lines on what this segment did and
-where it left off, so the next you can orient at a glance. *(Soft convention —
-not validated; skip if it does not fit.)*
+## Current task and state
+What mattered, what changed, and the next action.
 
-## What this segment was about
-The original ask and the framing. Why this segment existed.
-
-## Accomplishments
-What you completed or moved forward, and the outputs. Who was told, on which channel.
-
-## Decisions and reasoning
-The choices made and *why* — especially where an alternative was rejected.
-
-## Artifacts and paths
-Files, reports, branches, worktrees, PRs, commits, message IDs that anchor the
-work. Use repository paths / URLs / IDs; do not paste secrets or large blobs.
-
-## Open tasks
-Work noticed or started but not finished, with the next concrete step for each.
-
-## Collaborators
-People/agents involved, their channels, who is waiting on what.
-
-## Gotchas and lessons
-Actionable warnings, failed approaches, verification requirements — "run X
-before Y" beats "be careful".
+## Evidence and open work
+Paths, IDs, decisions, blockers, pending authority, and essential lessons.
 ```
+
+The block-scalar `description` form keeps a colon followed by a space valid YAML. The journal preserves the session story; the molt summary should carry only the shortest handoff needed to resume.

--- a/src/lingtai/tools/context/manual/reference/summarize-manual/SKILL.md
+++ b/src/lingtai/tools/context/manual/reference/summarize-manual/SKILL.md
@@ -1,12 +1,8 @@
 ---
 name: summarize-manual
 description: >-
-  Operational guide for tool-result summarization: the three compression modes
-  (a-priori `summary=true`, a-posteriori `context(action="summarize")`, molt),
-  the urgent and idle cadences, delayed provider reconstruction and the
-  0.85/1.0 rebuild boundaries, recovery by `tool_call_id`, and summarize
-  versus molt.
-last_changed_at: "2026-09-04T00:00:00Z"
+  Operational guide for recording tool-result summaries, applying them with a full rebuild, recovering raw evidence, and choosing summarize versus molt.
+last_changed_at: "2026-09-08T00:00:00Z"
 related_files:
 - src/lingtai/intrinsic_skills/system-manual/SKILL.md
 - src/lingtai/tools/system/summarize.py
@@ -18,329 +14,50 @@ maintenance: |
 
 # Summarize Manual
 
-`context(action="summarize")` is context hygiene for completed tool results. It
-records an agent-authored compact replacement for one or more prior tool-result
-blocks in runtime history. It does **not** delete the original event; the raw
-result remains in logs for fallback, and the active provider continuation may
-still carry the old raw block until delayed reconstruction applies the compacted
-history.
+Use this reference after you have inspected a bulky tool result and know what a future turn must retain, or when current Context guidance asks you to compact consumed results. It is the focused procedure; resident `meta_guidance` remains the source for current pressure timing.
 
-Use this manual when runtime guidance tells you to summarize, when a result is
-ranked large under `_meta.agent_meta.agent_state.current_tool_result_chars.top_results`,
-when tool output has served its immediate purpose, or when you need to explain
-how summarize differs from molt.
+## Choose the operation
 
-## 0 · The three modes (a priori, a posteriori, molt)
+- `context(action="summarize")` is **record-only**. It replaces selected prior tool-result blocks in runtime history with your agent-authored summaries, marks them pending, and preserves the raw event for recovery. The active provider continuation may still carry the raw block.
+- `context(action="rebuild")` is the one active application path. It first re-reads and recomposes **all** canonical prompt sources, then records/applies supplied and pending summaries, then requests provider replay with the new prompt and history. Bare `input={}` is valid, including with no pending summaries.
+- `context(action="molt")` is the whole-session boundary. Choose it when pressure, an explicit human reset request, or conversation confusion makes a fresh briefing worthwhile; do not use it as task-completion housekeeping.
 
-Tool-result summarization is one face of a larger idea: keeping context lean.
-LingTai gives you three deliberate modes, ordered from local to
-whole-conversation. All three preserve the raw original in durable logs and none
-is canonical.
+The root `summarize` boolean is a separate generic result-presentation control. It is not the `context` action, is not an item-list input, and does not apply a recorded summary to provider context. The action/schema descriptions are authoritative for fields and requiredness.
 
-| Mode | Trigger | When the raw is hidden | Authored by |
-|---|---|---|---|
-| **A priori** — reasoning-guided | `summarize=true` (legacy `summary=true` also accepted) on any migrated family — e.g. `file` (covers read/grep/glob-style bulky reads), `shell`, `daemon` | *before* the result ever enters context | the runtime LLM, driven by your `reasoning` |
-| **A posteriori** — agent-guided | `context(action="summarize")` | *after* you have already seen and digested it | you |
-| **Molt** — context-pressure-triggered | `context(action='molt', ...)` | the whole conversation is continued/reset | you (briefing) |
+## A-priori root result summaries
 
-Sections 1–6 below are mostly about the a-posteriori `summarize` action; §1a
-covers the a-priori `summary=true` option and when to prefer it; §6 contrasts
-both with molt.
+Before a call, root `summarize=true` requests a generated, noncanonical, lossy summary; put the retention specification in `reasoning` and preserve its `raw_locator` (and producer ID) for recovery. If generation fails, it is fail-closed: no raw payload is returned, so rerun narrowly or with `summarize=false`. Check `summary_effect.prev_chars`, `after_chars`, and `saved_chars`; weak savings are a lesson to sharpen the retention specification or choose a narrower call.
 
-## 1a · A priori summary: `summarize=true` on migrated tool families
+## Record a summary
 
-Any LingTai Tool Protocol v2-migrated family — `web`, `mcp`, `file` (covering
-read/grep/glob-style bulky reads), `vision`, `avatar`, `soul`, `shell`,
-`notification`, `system`, `daemon`, `email`, `task_card`, `context`, `psyche`,
-`plugin` — accepts an optional boolean root `summarize` (legacy spelling `summary` is
-also honored on any call, for backward compatibility). Default `false`. When
-`true`:
-
-- The tool runs **normally**. The raw result is written to the durable event log
-  and (if oversized) spilled, exactly as with `summary=false` — nothing is lost
-  and the raw is recoverable by `tool_call_id` (see §4).
-- **Before** the result enters your model-visible context, the runtime replaces
-  it with a generated summary. The summary is driven by your `reasoning` field
-  on that call — so when you set `summary=true`, make `reasoning` specific about
-  what to retain (e.g. "I only need the failing test names and their assertion
-  messages", "I only need the list of changed file paths").
-- The replacement is clearly marked **generated and non-canonical** and carries
-  a retrieval hint pointing back at the preserved raw by `tool_call_id`.
-
-Prefer it when you can state the retention spec before the call and the output
-is large — rule of thumb >10k chars; leave it `false` when you need exact
-line/file/diff/stderr text you will quote, diff, patch, or compare.
-
-**A priori is preferred but still lossy.** The runtime discards everything
-outside what your `reasoning` named, with no chance for you to notice what
-mattered — so it is **not** a substitute for a-posteriori
-`context(action="summarize")` on high-information-density results whose
-important facts you cannot name in advance (daemon outputs, code reviews, long
-reports). For those, leave `summary=false`, consume the raw, then summarize a
-posteriori once you know what to keep — or molt when the whole conversation is
-the pressure.
-
-**Hard cap.** If the raw visible payload exceeds **500,000 characters**, the
-runtime does **not** call the summarizer LLM. Instead you receive a small
-summary-layer refusal that says the result exceeded the cap, that the raw is
-preserved, and how to retrieve / narrow / rerun. The oversized raw is **not**
-dumped into your context on this path. Narrow the call (tighter command, path,
-pattern, or `offset`/`limit`) and rerun, or rerun with `summary=false` to take
-the raw (capped/spilled) result directly.
-
-**Untrusted output.** The summarizer treats the tool output strictly as data: it
-will not follow instructions embedded inside the tool result. This is the same
-prompt-injection posture the rest of the runtime uses for external text.
-
-**Fail-closed.** `summary=true` is a request *not* to put the raw into context.
-If the summarizer call fails or returns nothing, you get a summary-layer error
-with the retrieval locator — never the raw payload. Rerun with `summary=false`
-if you actually need the raw.
-
-**Reasoning critique as feedback.** A generated `summary=true` result may end
-with a brief, plain-text critique of whether your `reasoning` (the retention
-spec) was specific enough to guide what to keep. Treat it as feedback: sharpen
-your `reasoning` on later `summary=true` calls so the summary keeps what you
-actually need. If the critique says the reasoning was too poor for the summary
-to be trusted, do not rely on the lossy summary — inspect the preserved raw
-original via the retrieval hint / `raw_locator` (by `tool_call_id`, see §4)
-before acting on it. This critique is ordinary summary prose, not a separate
-field — read it, don't parse it.
-
-**Track the a-priori savings.** Each `summary=true` result also carries
-`summary_kind` and generated-summary `summary_effect` fields (`prev_chars`,
-`after_chars`, `saved_chars`). When the savings are weak or negative, or the
-closing critique says the retention spec was vague, sharpen future
-`reasoning`/tool choice and deposit the lesson into pad, knowledge, skills, or
-lingtai as appropriate.
-
-## 1 · The principle: progressive disclosure
-
-A raw tool result is the first layer: it is useful while you inspect it. After
-you have consumed it and no longer need the raw text visible, the better layer is
-an index that future-you can reason from without carrying the raw bulk. Strongly
-prefer the compact index once summarization is warranted by the §2 gate;
-keep raw output visible while needed for inspection, quotation, or comparison.
-
-A good summary should let future-you decide whether the hidden raw result must
-be reopened. Preserve:
-
-- the conclusion or decision;
-- key evidence, measurements, or error text;
-- paths, URLs, message IDs, tool_call_ids, commit hashes, job IDs, and other
-  anchors;
-- validation status and commands/tests run;
-- risks, caveats, and unresolved questions;
-- next steps.
-
-Do not write casual one-liners for consequential results. The summary is the
-progressive-disclosure entry point.
-
-## 2 · The two summarize cadences
-
-**Summarize cadence.** Strongly prefer a priori `summary=true` on `shell`,
-`file` (read/glob/grep), or `daemon` when you can predict bulky output and
-already know the facts, counts, anchors, or conclusion you need from the call;
-put that retention contract in `reasoning` so raw bulk never spends context.
-Leave it off when exact raw text or unknown high-information details may matter.
-Treat a posteriori `context(action="summarize")` as a last resort, not routine
-cleanup: use it only when context is close to overflowing and a molt is
-unsuitable. Otherwise prefer a priori summary before the call, narrower work,
-or a daemon; at a whole-session boundary, tend durable stores and molt instead.
-
-The urgent and idle patterns below operate within that gate; neither makes
-a-posteriori summarization a routine housekeeping obligation.
-
-### Urgent cadence: summarize the bulky result now
-
-When the §2 execution gate is met, prioritize a long or noisy result — typically
-one that ranks high in
-`_meta.agent_meta.agent_state.current_tool_result_chars.top_results` (above its `threshold`,
-counted in `over_threshold_count`). `agent_meta` is a complete current final-carrier snapshot attached to each eligible final carrier. Its nested `agent_state.current_tool_result_chars` is current on the newest emitted snapshot; older snapshots remain retained historical traces and are not actionable.
-
-1. Read or inspect the result first.
-2. Decide what future-you needs from it.
-3. On a later step, call `context(action="summarize")` on the completed prior
-   result. Do not try to summarize the current result in the same tool batch
-   before it exists.
-4. Batch several already-digested results in one summarize call when convenient.
-
-### Idle cleanup cadence: sweep what is already consumed
-
-When the task quiets down, inspect older results that are already digested,
-obsolete, or useful only as evidence anchors. This is a decision point, not an
-automatic summarize call: apply the §2 execution gate before replacing them
-with summaries. Prefer avoiding raw bulk in the first place; keep only the
-context the continuing task actually needs.
-
-Idle cleanup is also the right time to decide whether a deliberate molt is
-worth its cost. If the current task is complete, necessary reporting/durable
-stores are tended, no human reply is pending, and no concrete next action
-remains, do not molt automatically; molt only when context pressure (≥85%),
-explicit human request, or conversation confusion makes the fresh briefing
-worth its cost. Summarize is a mini molt for a consumed tool result. Once you
-have decided to molt, do not spend a separate summarize call merely to
-prepare; molt is the stronger whole-conversation summarize boundary.
-
-## 3 · How to call summarize
-
-Summarize prior completed tool results only:
+Summarize only a completed result you have read. Pick targets from the newest `_meta.agent_meta.agent_state.current_tool_result_chars.top_results` IDs. In each item, `tool_call_id` is the producer call ID, not the visible `_tool_call_id` event reference; preserve any `raw_locator` or spill path. Preserve the conclusion, evidence or error, paths/URLs/IDs, validation status, risks, and next step—enough to decide whether the raw result must be reopened. Batch several already-digested results when useful:
 
 ```json
 {
   "action": "summarize",
   "input": {
     "items": [
-      {
-        "tool_call_id": "call_abc123",
-        "summary": "What future-you needs: conclusion, evidence, anchors, validation, risks, next steps."
-      }
+      {"tool_call_id": "call_abc123", "summary": "Conclusion, evidence, anchors, risks, and next step."}
     ]
   },
-  "reasoning": "Compact the completed result while preserving its evidence and next steps."
+  "reasoning": "Keep the evidence and recovery anchor needed by the next turn."
 }
 ```
 
-Operational rules:
+Recording is not durable-store authoring and does not rebuild. Do not summarize text that still needs exact inspection, quotation, patching, or comparison. If the result is still ambiguous, reopen it first.
 
-- `tool_call_id` is the producer call ID shown on the original result, not the
-  visible `_tool_call_id` event ref.
-- A successful summarize updates the runtime-history/chat-history copy and
-  persists that compact replacement; it does not mutate the original event log
-  and does not by itself prove the active provider continuation has dropped the
-  old raw block.
-- If a large-result notification points at that result, successful summarize
-  clears the reminder.
-- If the result is still ambiguous, reopen or inspect it before summarizing.
+## Apply and recover
 
-## 3a · Delayed summarization: summary recorded now, provider reconstruction delayed
+Call one `context(action="rebuild", input={})` when making recorded summaries or a durable prompt-source edit active is worth a provider replay. Reconstruction is deliberately delayed for cache efficiency; do not loop summarize/rebuild calls. If composition fails, the Context contract leaves summaries unapplied and reports the reconstruction error.
 
-Summarize has two decoupled effects:
+The rebuild receipt reports the provider round that requested the rebuild; post-rebuild context usage does not exist yet in that receipt. Observe it on the next provider round.
 
-1. **Runtime-history replacement now.** The prior tool-result block in local
-   history is replaced with your agent-authored summary, stamped `status: pending`,
-   and matching large-result reminders may clear.
-2. **Full reconstruction later.** The current provider continuation may still
-   contain the old raw block. A manual `context(action="rebuild")` first re-reads
-   and recomposes every canonical system-prompt source, then applies pending/new
-   summaries (markers flip to `status: done`), then requests provider replay with
-   the new prompt/history. The automatic 1.0 hard forced path uses the
-   same full prompt reconstruction contract before fresh replay.
-
-The rebuild action's own result reports the provider round that requested the rebuild.
-Post-rebuild context usage does not exist yet at that point; it only becomes
-observable on the next provider round. Do not read the requesting round's usage
-number as if it already reflects the rebuilt context.
-
-The dynamic pending totals in the result comment scan only `status: pending`
-markers — already-applied (`done`) markers and legacy markers without a status
-are not counted as pending.
-
-Reconstruction is delayed because runtimes append turns onto a stable
-cache/continuation prefix, and rebuilding that prefix on every summarize would
-discard the cache benefit.
-
-- **Below 1.0 of the context window:** summarize stays pending at the provider
-  layer and the session keeps appending. This delay is normal, not a failure.
-- **At or above 0.85 of the context window:** `_meta.agent_meta.agent_state.context.rebuild`
-  is stamped continuously. It is a decision prompt / permission, not an automatic
-  rebuild — recording summaries never triggers a provider-context rebuild on its
-  own. If making already-recorded summaries active in the provider context earlier
-  is worth the cost, make one proactive tactical
-  `context(action="rebuild", input={})` call. Every call recomposes all canonical
-  prompt sources first. With new items it then records/applies them; with no items
-  it applies the already-pending set, or simply replays the newly composed prompt
-  when none are pending. Bare `{}` is valid. Do not loop rebuild/summarize calls.
-- **At 1.0 of the context window (the full-context HARD boundary):** the runtime
-  **forces** a provider-context rebuild / fresh replay on the next request
-  **regardless of whether pending summaries exist**, but only **once per
-  continuous full-context episode**. The automatic forced rebuild fires a single
-  time when provider-reported usage first reaches `1.0` (inclusive); it does NOT
-  re-force while usage stays at/above `1.0` (including exactly `1.0`), and it
-  re-arms only after a later provider round drops usage strictly below `1.0`, so a
-  future crossing can force exactly once again. Both automatic paths — the
-  pre-request boundary check and the immediate post-`summarize` release — share
-  this one latch, so they cannot double-fire. (Explicit
-  `context(action="rebuild")` is independent and always available.)
-  If pending summaries exist,
-  they are applied and their markers marked done. `summarize` is the only
-  historical tool-result body replacement a rebuild applies; the fresh replay
-  otherwise preserves each historical timely-transient holder and does not
-  strip its agent_meta/guidance or notifications/notification_guidance keys,
-  on every provider, without rewriting recorded history — only the LATEST
-  holder
-  per family represents current state, older holders are historical traces
-  and must not be acted on. Every 1.0 forced rebuild ALWAYS carries a one-shot
-  `_meta.agent_meta.agent_state.events.reconstruction.warning`: it reports the before→after context
-  change, advises that reaching the full boundary means waiting was not ideal (prefer
-  a proactive 0.85 `context(action="rebuild")`), and says that if the rebuilt context is still
-  above the 0.75 recovery target you should tend durable stores and molt. This is
-  one unified warning — it does not branch on whether context dropped low or stayed
-  high.
-- **If the forced rebuild does NOT clear the overflow:** the persistent
-  `Forced Rebuilt Failed` warning activates. Once the forced fresh replay's own
-  first provider response is observed and that post-rebuild provider input is still
-  **strictly above** `1.0` (a failed forced request keeps verification pending
-  until a successful provider-usage result exists), EVERY following result carries
-  a permanent `_meta.agent_meta.agent_state.context.molt` line, verbatim:
-  `100% context Forced Rebuild Failed to Bring Usage Below 100%. Context overflowed!! (xxx %) Molt IMMEDIATELY!!`
-  (`xxx` = the current measured percentage, one decimal). It rides the same
-  permanent current-state channel as the sustained-pressure and cache-miss-budget
-  molt reminders (each preserved on its own line when several coexist). Because the
-  runtime will NOT keep force-rebuilding while you stay overflowed, this line is
-  the signal that the emergency rebuild could not recover the context — molt
-  immediately. At exactly `1.0` after the rebuild there is no repeat rebuild and no
-  overflow warning (the warning is for strictly `> 1.0`).
-
-Waiting for the 1.0 forced boundary is the emergency path — prefer the proactive
-0.85 rebuild. If no summary is pending, the forced rebuild has nothing to apply
-(the replay-preservation rule above still holds), so summarize more or molt
-instead. `refresh` is the emergency path for broken/stale context or explicit
-human direction — never the way to "apply" a summary. If summarize or
-a rebuild still cannot bring context below `0.75 * context_window` (the recovery
-target), tend durable stores and molt deliberately.
-
-## 4 · Recovering the original result
-
-A summarized block should carry a retrieval hint. The usual fallback is to search
-the agent event log by the preserved `tool_call_id`:
+Keep the original `tool_call_id` in any summary. The normal fallback is a narrow JSONL search:
 
 ```bash
-grep 'call_abc123' <workdir>/logs/events.jsonl
+rg 'call_abc123' <workdir>/logs/events.jsonl
 ```
 
-For structured trace work, use the SQLite/log tooling documented in
-`../../../system-manual/reference/sqlite-log-query/SKILL.md`, for example `lingtai-agent log query`, to
-locate the event and inspect nearby context.
+For a spilled result, preserve and reopen its `tmp/tool-results/` path. Use `system(action="manual", input={}, reasoning="load System routes")` for settings, cache-miss budget ownership, and current automatic threshold details; this reference does not duplicate System-owned numbers or configuration procedures.
 
-If the original was a spill result, the log entry or summary should also point to
-the spill path under `tmp/tool-results/`. Preserve that path in the summary.
-
-## 5 · Good and bad uses
-
-Good uses:
-
-- a large test output after you know which tests passed/failed;
-- a long file read after extracting the relevant lines and path;
-- a search sweep after preserving matched files and decisions;
-- a channel read after responding and keeping the message IDs that matter;
-- a resolved error once the recovery path is known.
-
-Bad uses:
-
-- summarizing before you have read or understood the result;
-- hiding evidence that you still need to inspect line by line;
-- replacing a required deliverable with a vague recap;
-- assuming summarize is a durable memory layer.
-
-## 6 · Summarize is not molt
-
-Neither summary mode updates pad, character, knowledge, skills, or the
-session-journal, and neither sheds the conversation — the mini-molt framing and
-the molt boundary are resident. `context-manual` owns the molt procedure and its
-required checklist. Use them together:
-
-1. Summarize bulky consumed tool results so the active context is navigable.
-2. Tend durable stores for facts, procedures, identity changes, and current plan.
-3. Molt deliberately while you still have enough context to write a good
-   briefing, not only when warnings become urgent.
+When the current pressure reminder is active, follow the resident cadence: make at most one useful summarize/rebuild pass, then stop repeating it and molt deliberately if the context remains too high. The pressure reminder is a decision aid, not an automatic molt order. A deliberate molt still requires the Context manual's journal gate and concise successor handoff.

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -289,6 +289,49 @@ def test_skills_setup_hard_copies_intrinsics(tmp_path):
         agent.stop(timeout=1.0)
 
 
+def test_context_manual_installed_artifact_preserves_owner_routes(tmp_path):
+    """Installed Context entry/assets retain the proportional recovery path."""
+    agent, workdir = _mk_agent(tmp_path)
+    try:
+        context_manual_md = (
+            workdir
+            / ".library"
+            / "intrinsic"
+            / "capabilities"
+            / "context-manual"
+            / "SKILL.md"
+        )
+        assert context_manual_md.is_file()
+        context_manual_body = context_manual_md.read_text(encoding="utf-8")
+        assert "name: context-manual" in context_manual_body
+        assert "assets/molt-template.md" in context_manual_body
+        assert "shortest sufficient handoff" in context_manual_body
+        assert "do not use this as routine cleanup" in context_manual_body
+        assert "not a command to run blindly" in context_manual_body
+        assert "do not fill absent fields with `None`" not in context_manual_body
+
+        summarize_reference = context_manual_md.parent / "reference" / "summarize-manual" / "SKILL.md"
+        assert summarize_reference.is_file()
+        summarize_body = summarize_reference.read_text(encoding="utf-8")
+        summarize_content = summarize_body.split("\n---\n", 1)[1]
+        assert "current_tool_result_chars.top_results" in summarize_content
+        assert "summary_effect.prev_chars" in summarize_content
+        assert 'system(action="manual", input={}, reasoning="load System routes")' in summarize_content
+        assert "intrinsic_skills/system-manual" not in summarize_content
+
+        molt_template_asset = context_manual_md.parent / "assets" / "molt-template.md"
+        assert molt_template_asset.is_file()
+        assert (context_manual_md.parent / "assets" / "session-journal-entry-template.md").is_file()
+        molt_template_body = molt_template_asset.read_text(encoding="utf-8")
+        assert "# Consequential Molt Handoff Template" in molt_template_body
+        assert "optional scaffold" in molt_template_body
+        assert "do not fill absent fields with `None`" in molt_template_body
+        assert "## Before calling molt" in molt_template_body
+        assert "session_journal_path" in molt_template_body
+    finally:
+        agent.stop(timeout=1.0)
+
+
 def test_skills_setup_hard_copies_standalone_intrinsic_skills(tmp_path):
     # Standalone always-included skills live in lingtai.intrinsic_skills and are
     # copied next to capability manuals under .library/intrinsic/capabilities/.
@@ -400,22 +443,6 @@ def test_skills_setup_hard_copies_standalone_intrinsic_skills(tmp_path):
         assert "editable/source/dev" in runtime_update_body
         assert "receiving explicit confirmation" in runtime_update_body
 
-        context_manual_md = (
-            workdir
-            / ".library"
-            / "intrinsic"
-            / "capabilities"
-            / "context-manual"
-            / "SKILL.md"
-        )
-        assert context_manual_md.is_file()
-        context_manual_body = context_manual_md.read_text(encoding="utf-8")
-        assert "name: context-manual" in context_manual_body
-        assert "## Asset catalog" in context_manual_body
-        assert "assets/molt-template.md" in context_manual_body
-        assert "9-section summary scaffold" in context_manual_body
-        assert "9. **Context Status**" not in context_manual_body
-
         file_manual_md = (
             workdir
             / ".library"
@@ -438,25 +465,6 @@ def test_skills_setup_hard_copies_standalone_intrinsic_skills(tmp_path):
             / "capabilities"
             / "file"
         ).exists()
-
-        molt_template_asset = context_manual_md.parent / "assets" / "molt-template.md"
-        assert molt_template_asset.is_file()
-        molt_template_body = molt_template_asset.read_text(encoding="utf-8")
-        assert "# Consequential Molt Summary Template" in molt_template_body
-        assert "## Summary scaffold" in molt_template_body
-        for section in (
-            "1. **Who I Am**",
-            "2. **Accomplishments**",
-            "3. **Outstanding Tasks**",
-            "4. **Action Checklist**",
-            "5. **Collaborators**",
-            "6. **Durable Memory and Execution Notes**",
-            "7. **Key Paths and Artifacts**",
-            "8. **Lessons and Gotchas**",
-            "9. **Context Status**",
-        ):
-            assert section in molt_template_body
-        assert "## Pre-molt verification checklist" in molt_template_body
 
         sqlite_log_query_ref = system_manual_md.parent / "reference" / "sqlite-log-query" / "SKILL.md"
         assert sqlite_log_query_ref.is_file()
@@ -1187,13 +1195,15 @@ def test_skills_manual_documents_external_skill_intake_default():
         assert phrase in manual
 
 
-def test_context_manual_routes_skill_sharing_through_custom_by_default():
+def test_context_manual_routes_store_ownership_to_psyche():
     manual = (
         Path(__file__).resolve().parents[1]
         / "src/lingtai/tools/context/manual/SKILL.md"
     ).read_text(encoding="utf-8")
-    assert "peers install it into their own `.library/custom/<name>/`" in manual
-    assert "explicit opt-in local-network shared root" in manual
+    assert 'psyche(action="manual", input={}, reasoning="load durable-store routes")' in manual
+    assert "generic writes are through `file`" in manual
+    assert "intrinsic_skills/psyche-manual" not in manual
+    assert "peers install it into their own `.library/custom/<name>/`" not in manual
 
 
 def test_resident_layers_query_settings_instead_of_copying_adjustable_defaults():


### PR DESCRIPTION
## Summary

- Replace Context's fixed ~10,000-token / mandatory nine-section handoff with a shortest-sufficient briefing and optional assets; keep the required session-journal gate and all runtime/replay semantics unchanged.
- Cut the entry from **16,805 → 3,405 Unicode body characters (−79.7%)** and the four touched Context documents from **42,214 → 10,937 (−74.1%)**, using one delimiter-stripped/newline-preserving count rule. Keep unique summary-ID, lossy a-priori recovery, installed-route and post-molt acknowledgement guidance.
- Narrow only the Context row in resident procedures (routine schema-sufficient use; manual still required before molt), fix two stale Context section references, and isolate Context installed-artifact assertions from unrelated earlier failures.
- Honest surface budget: all public schema-description occurrences, including repeated branches, increase **698 characters**; resident procedures increase **25**, combined **+723**. This is not a total-token or dollar-savings claim.

## Scope and review

Eight files: Context descriptions/manual/reference/assets, one Context row in shared procedures, one stale Context section citation in the System procedure reference, and directly related tests. No input structure/default/validator/handler/runtime logic change. Luna implemented the candidate; 知微 independently reviewed the complete diff and corrected the two final citation pointers. No extra review worker, runtime refresh, release, or cleanup.

## Validation

Literal final owner commands (Python 3.14 interpreter):

```text
python -B -m pytest -q tests/test_context.py tests/test_context_declared_tool_plugin.py tests/test_context_ownership_redesign.py tests/test_tool_family_context_migration.py tests/test_context_pressure_reminder.py tests/test_context_pressure_streak.py tests/test_molt_notification_persistence.py tests/test_molt_task_persistence.py tests/test_post_molt_notification.py tests/test_session_journal_gate.py tests/test_skills.py tests/test_prompt.py tests/test_agent_meta_guidance.py tests/test_prompt_catalog.py tests/test_prompt_section_definitions.py tests/test_tool_prose_section_gate.py tests/test_intrinsic_manual_actions.py tests/test_docs_governance.py tests/test_architecture_documents.py
# Candidate: 465 passed / 6 failed. Clean 5fdf8d12 base: 464 passed / same 6 failed.
# Failed IDs AND normalized error lines match exactly.
python -B scripts/check_docs_governance.py --check
# OK: 401 documents (+ docs.yaml itself) validated.
python -B src/lingtai/intrinsic_skills/lingtai-kernel-anatomy/scripts/check_anatomy_drift.py --check
# 6 existing drift items, byte-identical to the exact base.
git diff --check
# PASS
```

The six existing failures are two broad Shell/File manual assertions, two unchanged prompt-catalog assertions, an installed MCP `ServerRequestContext` import mismatch, and the Psyche orphan-document check. They are not repaired in this PR.

Additional owner proof on final bytes: exact operational AST equality after excluding only four reviewed description locations; public schema equality except description; real `Agent` construction and canonical complete prompt (32,152 characters); one Context mount; byte-equal installed entry/reference/two assets and valid internal installed links. Mock provider and socket-connect prohibition: **not** live-provider or production E2E. Full repository and native Windows suites were not run.

Local-only self-contained HTML explainer is provided to the maintainer; desktop/mobile offline rendering verified. Please review/merge this tool PR independently; no batch merge implied.

Telegram: @lingtaidev1bot | Nickname: 知微
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
