### PR TITLE
docs(system): make refresh checks mode-specific

### DIFF
--- a/src/lingtai/intrinsic_skills/system-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: system-manual
 description: >
-  Short router for runtime, lifecycle, identity, refresh, presets, settings,
-  LLM adapters, and operating procedures; route to the named reference for depth.
-version: 1.22.0
-last_changed_at: "2026-09-08T00:00:00Z"
+  Short router for runtime, lifecycle, identity, refresh transactions, presets,
+  settings, update/mismatch diagnosis, LLM adapters, and operating procedures.
+version: 1.23.0
+last_changed_at: "2026-09-09T00:00:00Z"
 tags: [lingtai, agent, runtime, procedures, substrate, system, lifecycle, alarm, memory, communication, skills, settings, molt, summarize, nudge, updates, refresh, preset, llm, adapters, codex, websocket]
 related_files:
 - src/lingtai/prompts/substrate/substrate.md
@@ -18,6 +18,8 @@ related_files:
 - tests/test_system_declared_plugin.py
 - src/lingtai/kernel/nudge/ANATOMY.md
 - src/lingtai/intrinsic_skills/system-manual/reference/llm-adapters/SKILL.md
+- src/lingtai/intrinsic_skills/system-manual/reference/refresh-precheck/SKILL.md
+- src/lingtai/intrinsic_skills/system-manual/reference/runtime-update-checks/SKILL.md
 - src/lingtai/intrinsic_skills/system-manual/reference/external-attach-diagnostic/SKILL.md
 - src/lingtai/llm/_register.py
 - src/lingtai/llm/openai/adapter.py
@@ -25,7 +27,9 @@ related_files:
 - src/lingtai/intrinsic_skills/system-manual/reference/settings-inventory/SKILL.md
 - tests/test_skills.py
 maintenance: |
-  Tracks the routed source/resources it summarizes; update when the underlying capability or its sub-references change.
+  Tracks the routed source/resources it summarizes; keep refresh-precheck as the
+  single refresh-transaction owner and runtime-update-checks as the update,
+  source, install, nudge, and mismatch owner.
 ---
 
 # System Manual — Task Router
@@ -40,8 +44,8 @@ read one route below for unfamiliar or consequential work.
 |---|---|
 | Runtime/lifecycle, alarms, MCP, memory, presets, or peer recovery | [substrate manual](reference/substrate-manual/SKILL.md) |
 | Action discipline, authorization, collaboration, or deliverables | [procedures manual](reference/procedures-manual/SKILL.md) |
-| Refresh/preset pre-check and exact-target gates | [refresh pre-check](reference/refresh-precheck/SKILL.md) |
-| Install/update, provenance, or `source_drift` | [runtime update checks](reference/runtime-update-checks/SKILL.md) |
+| Any refresh transaction: same-runtime reload, preset swap/revert, source/venv cutover, or failure recovery | [refresh pre-check](reference/refresh-precheck/SKILL.md) |
+| Update/source/install/nudge/mismatch diagnosis and cutover handoff, including `source_drift` | [runtime update checks](reference/runtime-update-checks/SKILL.md) |
 | Settings and SHOW ownership | [settings inventory](reference/settings-inventory/SKILL.md) |
 | Environment variables and runtime controls | [environment variables](reference/environment-variables/SKILL.md) |
 | Provider transport and adapter behavior | [LLM adapters](reference/llm-adapters/SKILL.md) |
@@ -68,11 +72,12 @@ summarize/rebuild/molt and provider replay.
 
 ## Consequential use
 
-- **Refresh/preset:** read `reference/refresh-precheck/SKILL.md` first. Check
-  approved scope, active/pending work, provenance, exact preset output, context
-  fit, and the post-refresh surface. Refresh reloads runtime; it never installs,
-  upgrades, fetches, or repairs code. Verify the actual target; do not silently
-  accept a fallback.
+- **Refresh/preset:** `reference/refresh-precheck/SKILL.md` is the single
+  owner of same-runtime reload, preset swap/revert, source/venv cutover, and
+  failure recovery: one targeted preflight, exactly one refresh, and one
+  targeted receipt. Route update/source/install/nudge/mismatch diagnosis through
+  `reference/runtime-update-checks/SKILL.md` first. Refresh never installs,
+  upgrades, fetches, or repairs code.
 - **Peer recovery:** use the exact target working-directory address within authority and
   diagnose/communicate first. `lull`, `interrupt`, `suspend`, `cpr`, and `clear`
   require `admin.karma=True`; `nirvana` also requires `admin.nirvana=True` and

--- a/src/lingtai/intrinsic_skills/system-manual/reference/refresh-precheck/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/refresh-precheck/SKILL.md
@@ -1,16 +1,12 @@
 ---
 name: refresh-precheck
-description: |
-  Nested system-manual reference: the ordered pre-flight to run BEFORE
-  `system(action="refresh")` (including preset swap/revert), the refresh
-  sequence itself, and the post-refresh verification pass. Covers
-  authorization boundary, allowed-preset catalog, MCP registry/init.json
-  consistency, newly introduced env vars, context-vs-target-context_limit,
-  durable-store and working-tree state, source_drift, and what to check when
-  a refresh fails or comes back with a broken surface.
-version: 1.1.3
-last_changed_at: "2026-09-07T00:00:00Z"
-tags: [lingtai, system, refresh, preset, precheck, checklist, mcp, env, pth, editable-install, verification, lifecycle]
+description: >
+  Nested system-manual reference and single owner for a refresh transaction:
+  select same-runtime reload, source/venv cutover, or failure recovery; run only
+  triggered owner checks; issue exactly one refresh; capture one targeted receipt.
+version: 2.0.0
+last_changed_at: "2026-09-09T00:00:00Z"
+tags: [lingtai, system, refresh, preset, precheck, cutover, recovery, receipt, lifecycle]
 related_files:
 - src/lingtai/intrinsic_skills/system-manual/SKILL.md
 - src/lingtai/intrinsic_skills/system-manual/reference/substrate-manual/SKILL.md
@@ -24,392 +20,136 @@ related_files:
 - src/lingtai/tools/system/settings.py
 - src/lingtai/kernel/presets.py
 maintenance: |
-  Sequencing-only node: every check here cites the owner that holds the fact
-  (preset runtime model → substrate-manual §11; installer/update authority and
-  runtime/version probe → runtime-update-checks; env var catalogue →
-  environment-variables → root ENVIRONMENT_VARIABLES.md; MCP registry health →
-  mcp-manual; molt/rebuild → context-manual). Do not restate an owned fact
-  here — add or reorder a step and keep the citation. Update when
-  `system(action="refresh")` / `system(action="presets")` semantics, the
-  preset `allowed` gate, or the nudge kinds change.
+  Own the three-mode refresh transaction and its budgets, call shapes, receipts,
+  refusal boundaries, and trigger routing. Leave source/install/nudge diagnosis
+  to runtime-update-checks and subsystem facts to their owning manuals. Never
+  turn an unchanged subsystem check into a universal preflight or receipt step.
 ---
 
-# Refresh Pre-check — the ordered pre-flight for `system(action="refresh")`
+# Refresh Transaction
 
-`system(action="refresh")` is the highest-blast-radius routine action an agent
-takes on itself: it rebuilds LLM/config, capabilities, MCP clients, addons,
-prompt sections, and identity projection from `init.json`, optionally swapping
-the active preset.
+The invariant is:
 
-Every fact needed to run one safely is already owned somewhere — `substrate-manual`
-§3/§11 (refresh and preset semantics), `runtime-update-checks` (authorization,
-runtime/version probe, update/nudge lifecycle, and installer ownership),
-`environment-variables` (env var catalogue), `mcp-manual` (registry
-health), `context-manual` (molt/rebuild). What is *not* owned anywhere else is
-the **ordering**: which check runs at the moment before you press the button,
-and what you verify after. That is this node's only job. It adds sequencing,
-not content; each step cites its owner rather than restating it.
+`select one mode -> one targeted preflight -> exactly one refresh -> one targeted receipt`
 
-## The pre-refresh checklist
+Refresh reloads code and configuration already visible to the runtime. It does
+not install, update, switch a checkout, repair a venv, save unfinished work, or
+grant authority. Read this reference immediately before the call.
 
-Ordered. Steps 0–3 are unconditional; 4–8 are conditional and each names its
-trigger. Every step states **check → command → refuse/proceed**.
+## Select exactly one mode
 
-### Step 0 — Authorization boundary (unconditional, blocking)
+| Mode | Select when | Preflight budget | Targeted receipt |
+|---|---|---|---|
+| **A. Same-runtime reload** | Source, venv, and interpreter selectors stay unchanged; a reload or preset swap applies an authorized on-disk change. | One transaction gate for exact target/authority and interruption safety; at most one check owned by the changed input. | Fresh process identity or heartbeat, plus one assertion for the changed surface. |
+| **B. Source/venv cutover** | An update/build owner intentionally changed source, venv, interpreter, version, or their selectors. | Authority/work safety for the exact target; consume the owner's target receipt; compare intended selectors. Do not repeat a general install audit. | One target assertion: runtime-tuple equality, extended with expected MCP health only if MCP interpreter/config changed; then one real originating-channel round trip. |
+| **C. Failure recovery** | The preceding refresh refused, raised, did not relaunch, or produced `logs/refresh_failed_permanent.json`. | Read the exact error/artifact; identify and repair only its owning fault; authorize at most one deliberate retry. | Fresh-process proof plus the assertion for that repaired fault. |
 
-**Check:** does the refresh implement a config/prompt/MCP/preset change that a
-human/config-owner authorized, or is it a self-initiated reload?
+Mode budgets are ceilings, not goals. A has one combined transaction gate plus
+at most one changed-owner check: two before and two after. B uses the combined
+transaction gate, target receipt, and selector equality: three before and two
+after. The first after-check includes changed-MCP health only on that trigger.
+Never inspect an unchanged
+subsystem.
 
-- Any refresh that **applies** an update, migration, or configuration write requires
-  explicit human/config-owner authority *before* the write and *before* the refresh
-  (`runtime-update-checks` steps 8–10). A nudge is a fact, not a command,
-  and never grants authority.
-- A refresh that could **interrupt active work** (running daemons, an in-flight
-  collaboration, a peer waiting on a reply) is gated by work safety and the human's
-  intent even when nothing is being written.
-- A pure self-reload with nothing pending and no active work is the only case that does
-  not need a fresh ask.
+## Universal transaction gate
 
-**If the trigger is a `kernel_version` nudge:** stop. That is the installer's route —
-let Shell run `https://lingtai.ai/install.sh --help` and follow *its* current output.
-Do not read or paste the script source. Refresh is the last step after authorized
-writes are validated, never the first.
+Before A or B, resolve these two facts as one decision, not two tool calls:
 
-### Step 1 — Know what you are actually running (unconditional)
+1. **Target and authority:** name the exact agent/workdir, record its current
+   process incarnation or heartbeat baseline, and name the authorized reload or
+   already-authorized write. A nudge, successful preflight, or tool
+   availability is not consent to install, migrate, edit config, or expand a
+   preset allowlist. A safe pure self-reload needs no invented write authority.
+2. **Work safety:** refuse while the relaunch would interrupt active human work,
+   an in-flight collaboration, or daemon work whose result needs this process.
+   Tend any durable state that actually needs tending; do not run generic Git,
+   notification, or daemon inventories.
 
-```bash
-# POSIX. Uses only the exported runtime interpreter; never guesses a path.
-PYTHON="$LINGTAI_RUNTIME_PYTHON"
-[ -n "$PYTHON" ] || { echo "LINGTAI_RUNTIME_PYTHON is unset — stop; locate the actual launcher/runtime venv via runtime-update-checks instead of guessing one." >&2; return 1 2>/dev/null || exit 1; }
-"$PYTHON" -c 'import sys, lingtai, lingtai.kernel; print(sys.executable); print(lingtai.__file__); print(lingtai.kernel.__file__); print(getattr(lingtai,"__version__","unknown"))'
-```
+Stop if the target or runtime selector is ambiguous. Route source, venv,
+installer, nudge, and mismatch diagnosis to `runtime-update-checks`; do not
+refresh hoping ambiguity will resolve itself.
 
-Refresh reloads the **current on-disk/runtime surface**; it does not fetch code, pull a
-commit, switch an editable checkout, or install a package. If you cannot say which
-interpreter and which module files are authoritative, **stop and ask** — do not refresh
-hoping it resolves the ambiguity.
+## Add only the triggered owner check
 
-### Step 2 — `.pth` / editable-install occupancy (unconditional, blocking on mismatch)
-
-Step 1 says *which* files import. This step says *why* — and it is the check that catches a
-refresh-time landmine before it fires.
-
-```bash
-SP=$("$PYTHON" -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')
-ls -1 "$SP" | grep -Ei '^(__editable__|__editable___)?[._]*lingtai.*\.(pth|dist-info|egg-link)$|^lingtai.*'
-for f in "$SP"/*lingtai*.pth; do echo "== $f"; cat "$f"; done
-cat "$SP"/lingtai-*.dist-info/direct_url.json 2>/dev/null
-```
-
-**Check, in order:**
-
-1. **Exactly one lingtai path marker.** `__editable__.lingtai-*.pth` /
-   `__editable___lingtai*.pth` / `lingtai*.pth` / `lingtai.egg-link`. Two markers, or a
-   `.pth` alongside a real `site-packages/lingtai/` package directory, means pip left both
-   an editable and a non-editable install — imports then resolve by `sys.path` order, not
-   by intent.
-2. **Every path inside each `.pth` exists.** A residual marker from a removed release
-   points at a deleted checkout; the entry is silently skipped, and the *next* candidate on
-   `sys.path` wins. Same for an orphaned `lingtai-*.dist-info` with no matching `.pth`.
-3. **The marker matches the intended install kind.** `~/.lingtai-tui/install.json`
-   declares it (`install_kind`, `kernel_source`, `kernel_source_path`); `direct_url.json`
-   in the dist-info records what pip actually did (`{"dir_info": {"editable": true}}` for
-   an editable). Editable → the `.pth` must point at the source checkout's `src/`.
-   Non-editable → there must be **no** `.pth` and a real package dir instead.
-4. **Cross-check against step 1's `lingtai.__file__`.** If the `.pth` names one source and
-   the import resolves elsewhere, do not refresh — the refresh will load whichever one
-   `sys.path` happens to favour, and you will have no evidence of which. Resolve the
-   provenance first.
-
-Resolve the interpreter from the exported `LINGTAI_RUNTIME_PYTHON` only and read
-module `__file__`, never a PATH `python` and never a guessed venv path — if it
-is unset, stop and locate the actual launcher via `runtime-update-checks`
-rather than assuming a default venv location; that rule is owned by
-`runtime-update-checks`, this step only sequences it.
-
-**Refuse to refresh if:** more than one lingtai path marker is live; any `.pth` entry does
-not exist on disk; or the marker and `lingtai.__file__` disagree. Repairing an install is a
-pip/installer action, not a refresh — it needs the same authority as step 0.
-
-### Step 3 — Config parses and is internally consistent (unconditional if anything was edited)
-
-```bash
-"$PYTHON" -c 'import json,sys; d=json.load(open("init.json")); print("init.json parses ok"); print("addons:", d.get("addons")); print("mcp:", list((d.get("mcp") or {}).keys()))'
-```
-
-Then cross-check against the registry:
-
-```text
-mcp(action="info", input={}, reasoning="pre-refresh registry health and problems")
-```
-
-**Refuse to refresh if:** `init.json` does not parse (a refresh on unparseable config is
-how you get a broken surface with no easy way back); the `mcp` block names an entry with
-no corresponding registry record (stale/duplicate surface); or `mcp(action="info")`
-reports `problems` you have not explained. Fix the config *first*, then refresh once.
-
-Remember the direction of causation: **a config/MCP/capability edit needs
-`refresh` to take effect. A canonical prompt-source edit may instead use
-`context(action="rebuild")`; `context(action="summarize")` only records summaries.**
-
-### Step 4 — Preset target validity (trigger: `preset` or `revert_preset` in the call)
-
-```text
-system(action="presets", input={}, reasoning="confirm exact allowed preset paths before swap")
-```
-
-Use only an exact path from this call's result. See `substrate-manual` §11
-for the allowed-only catalog mechanics, the `preset`/`revert_preset` conflict
-rule, and `revert_preset`'s default-lookup behavior — this step only
-sequences the check before activation, it does not restate those rules.
-
-### Step 5 — Context fits the target's `context_limit` (trigger: preset swap)
-
-**Check:** current context usage (`agent_meta.agent_state.context`) against the target
-preset's `context_limit` as reported by `system(action="presets")`.
-
-If current context exceeds the target's limit, **the swap is refused before activation
-— molt first.** Do not discover this by attempting the swap; a refused swap after you
-have already told a human "switching now" is a self-inflicted incident. Order is:
-tend durable stores → `context(action="molt", …)` → re-check → swap.
-
-The cache-miss total accumulates **since last molt and survives a refresh** —
-refreshing does not reset it, so do not expect this precheck's refresh to clear
-it. Inspect the live value through `system(action="settings", input={})`; see
-`reference/settings-inventory/SKILL.md` → "Cache-miss budget" for its exact
-source precedence and document shape.
-
-### Step 6 — Newly introduced environment variables (trigger: the change adds an env read)
-
-**Check three things, in this order:**
-
-1. **Is the variable documented?** New reads belong in
-   `system-manual → reference/environment-variables/SKILL.md` (purpose, default,
-   accepted values, scope, read point, reload behavior, invalid-value handling).
-2. **Will the running agent actually see it?** `env_file`/`venv_path` are resolved at
-   **boot**; refresh/restart *reuse* that resolution. A variable added to a file the
-   process never loaded will not appear just because you refreshed. Confirm the read
-   point, not the file's existence.
-3. **Is the test suite hermetic against it?** If the ambient environment
-   sets the variable, tests that assume the default will pass or fail depending on the
-   shell they run in. The suite needs an autouse fixture clearing it. This check belongs
-   in the *change*, before the refresh, not after a confusing CI result.
-
-### Step 7 — Durable-store and working-tree state (unconditional, cheap)
-
-Refresh preserves identity and conversation. It is **not** a save operation for anything
-else. Before refreshing:
-
-- Deposit anything that should outlive this runtime surface into pad / knowledge /
-  skills / character — durable stores are written with `file.write` / `file.edit`, and a
-  refresh is not a substitute for having written them.
-- Check for uncommitted work in any checkout you are mid-edit on
-  (`git -C <checkout> status --short --branch`). Refresh does not commit, stash, or
-  protect a dirty tree.
-- Check for in-flight daemon work. Ordinary stop/refresh must not terminate active
-  daemon runs, but a refresh mid-batch changes the parent surface those runs report
-  back into — prefer to let a batch finish, or know exactly why you are not.
-- If context is near the limit, tend durable stores **now**, not after (step 5).
-
-### Step 8 — Known breaking-change nudge (unconditional, read-only)
-
-```bash
-ls -l .notification/nudge.json 2>/dev/null && sed -n '1,240p' .notification/nudge.json
-```
-
-- **`source_drift`** (channel `source_integrity`): the running process differs from code
-  on disk. This is exactly the case where refresh *is* the right action — and also the
-  case where you should know what changed before you load it. It stays local to refresh
-  mechanics and never enters release-migration routing.
-- **`init_config_shape`** (channel `configuration_staleness`): configuration-staleness
-  guidance. Read it before refreshing, not after.
-- **`kernel_version`** (channel `release_version`): **not** a refresh trigger by itself —
-  see step 0.
-
-## The refresh sequence
-
-### Before
-
-1. Complete steps 0–8 above. Anything that says *refuse* is a stop, not a warning.
-2. If near the context limit or swapping to a smaller preset: tend durable stores, then
-   molt, then re-check current context against the target's `context_limit`.
-3. Tell the human what you are about to reload and why, if the refresh was their ask or
-   could interrupt their work.
-
-### During
-
-**Exactly one call.** Do not stack refreshes; do not "refresh again to be sure."
-
-```text
-system(action="refresh",
-       input={"reason": "<what config change this applies>",
-              "preset": null, "revert_preset": null},
-       reasoning="apply the authorized <X> edit")
-```
-
-or, for a swap:
-
-```text
-system(action="refresh",
-       input={"reason": null,
-              "preset": "<exact path from system(action='presets')>",
-              "revert_preset": null},
-       reasoning="swap to <preset> for <task>")
-```
-
-or, to go home:
-
-```text
-system(action="refresh",
-       input={"reason": null, "preset": null, "revert_preset": true},
-       reasoning="return to default preset after experimenting")
-```
-
-The refresh path checks `allowed` membership → checks target context limit → activates
-atomically (writing raw `init.json`) → persists the new default for a named swap →
-best-effort retries failed MCPs → rebuilds LLM/config/capabilities/MCP/prompts,
-preserving conversation history where a live session exists.
-
-Note: refresh requests a **deferred relaunch** and only when the runtime can build a
-valid launch command and has a configured refresh watcher. Without a launch command it
-returns *without relaunching*; without a refresh watcher it raises. **Neither of those
-is success** — diagnose before believing the refresh happened.
-
-### After (verification — this is not optional)
-
-1. **Confirm you are the new process, from the intended source.** Re-run the step-1
-   interpreter/import probe *and* the step-2 `.pth` listing. Same commands, new process;
-   compare. `lingtai.__file__` must resolve to the intended source, and no stale or
-   duplicate lingtai path marker may have appeared.
-2. **Confirm the MCP surface.** `mcp(action="info", input={}, reasoning="post-refresh
-   verification")` — count, `problems` empty, and the specific tools you expected
-   actually present. A config that looked right is exactly the case where the surface
-   still does not match.
-3. **Confirm the preset.** `system(action="presets", input={}, …)` and/or read the
-   derived `system/manifest.resolved.json` — the fully materialized, validated,
-   path-resolved running configuration. It is derived and read-only; never write it.
-4. **Confirm the tool surface.** The tool list and LLM may have changed. Do not assume
-   the tool you were about to call still exists at the same shape.
-5. **Re-check daemon allowed presets before dispatching.** If you are about
-   to dispatch daemon work with an explicit `tasks[].preset`, re-read
-   `system(action="presets")` *after* the refresh and pass an exact path from that list.
-   An unauthorized path refuses the **whole batch** before load, connectivity probing,
-   capability construction, run-dir creation, scheduling, or dispatch.
-6. **Then, and only then**, dismiss the nudge that motivated the refresh —
-   `notification(action="dismiss_channel", input={"channel": "nudge", …})`. Dismissing
-   before verifying loses the evidence.
-
-## Failure handling
-
-| Symptom | First check | Then |
+| Actual change or trigger | One preflight addition | One post-refresh assertion / owner route |
 |---|---|---|
-| Refresh returned but nothing changed | Re-run the interpreter/import probe in the new process | A refresh only loads code already on disk. It cannot pull a commit or repair an incomplete checkout. Check for a still-held old process or a different environment. |
-| `lingtai` imports from the wrong source, or an edit to the checkout has no effect | Step 2 — list `*lingtai*.pth` + `lingtai-*.dist-info` in the runtime venv's site-packages and compare each `.pth` entry against `lingtai.__file__` | Two markers (editable + non-editable) → `sys.path` order decides, not intent. A `.pth` naming a path that no longer exists → the entry is skipped and the next candidate wins. Orphaned `dist-info` with no `.pth` → stale metadata reporting a version nothing imports. Repair the install via pip/installer with step-0 authority; do **not** refresh against a mismatched marker. |
-| Refresh returned without relaunching | Can the runtime build a valid launch command? Is a refresh watcher configured? | Missing launch command → returns silently; missing watcher → raises. Diagnose the launcher, do not retry blindly. |
-| Refresh raised | The raised error text first | Then `init.json` parse, then `allowed` membership, then target `context_limit` — these are the three gates that reject *before* any runtime change (so the old surface is intact). |
-| Preset swap refused | Was the path in `system(action="presets")` output? Does current context fit the target `context_limit`? | Unauthorized path → ask the config owner to add it to `manifest.preset.allowed`, then refresh, then re-verify with `presets`. Context too large → molt first. |
-| Broken/missing MCP surface after refresh | `mcp(action="info")` `problems` list; `init.json` `mcp` block vs. `mcp_registry.jsonl` records | Fix the registry/config, then refresh **once** more. Do not loop refreshes against an unfixed config. |
-| Active preset file missing or malformed | Which one? | Missing → materialization may fall back to a different loadable default (so the running preset may not be the one you think). Malformed **existing active** preset → materialization fails rather than silently substituting. Read `system/manifest.resolved.json` to see what actually loaded. |
-| Wrong preset is live and you want out | — | `system(action="refresh", input={"reason": null, "preset": null, "revert_preset": true})` — the home button to `manifest.preset.default`. Cannot be combined with `preset`. |
-| Terminal relaunch failure | `logs/refresh_failed_permanent.json` and the high-priority `.notification/system.json` event the kernel writes on permanent relaunch failure | This is a human-escalation condition, not a retry condition. |
-| Mixed/contradictory evidence (offline? stale paths? heartbeat vs. status disagree?) | `lingtai-doctor` — read-only, redacts secrets, never edits | Diagnose before repair; repairs belong to the owning manual. |
+| `init.json`, an init-owned value, or capability config | Use the changed owner's parser/validator on that document or value. | Assert only that changed value/surface on the fresh process. |
+| MCP registry, MCP config, or MCP interpreter | Use the MCP owner's registry/config health check. | Check the expected MCP entry and relevant problem state; do not inventory MCP otherwise. |
+| Preset swap | Call `system(action="presets", input={}, reasoning="select exact allowed preset path")` once and pass an exact returned path. | Assert the active preset from the fresh process's resolved runtime state; do not call `presets` again. |
+| Preset revert | No catalog lookup is needed. | Assert the configured default became active. |
+| Environment or a System-owned setting | Read only its environment-catalog entry or relevant `system(action="settings", input={}, reasoning="read changed owner value")` row. | Assert that one effective value, respecting its documented read point. |
+| Canonical prompt source only | Route out before selecting a mode: use `context(action="rebuild", input={})`, not refresh. | Follow `context-manual`; no refresh transaction started. |
+| Source, venv, interpreter, version, or selector | Select B and consume the update/build owner's frozen receipt. | Compare the runtime tuple below; mismatch returns to `runtime-update-checks`. |
+| `source_drift`, `kernel_version`, or other nudge | Read that finding through `runtime-update-checks`; it is not universal preflight. | Dismiss only under notification-owner guidance after the matching fact is resolved. |
+| No changed subsystem (pure reload) | No add-on check. | Fresh-process proof is the receipt; do not manufacture an audit. |
 
-**When to ask the human — bright lines.** Ask, do not improvise, when: (a) the
-interpreter/import path is ambiguous; (b) `manifest.preset.allowed` needs a new entry
-(the agent cannot authorize itself, and a daemon call cannot mutate `allowed`); (c) any
-migration or `init.json` write beyond an explicit preset activation is implied; (d) a
-`kernel_version` nudge suggests an install/update; (e) two refreshes have not produced
-the expected surface — the third attempt is not the answer.
+Preset activation is an additive A case. The runtime itself owns preset/revert
+exclusivity, allowlist authorization, materialization, and context-fit refusal.
+Do not simulate or bypass those gates; if refused, preserve the old surface and
+route the exact error.
 
-## Scope guard — what this node must NOT do
+## Issue exactly one call
 
-1. **It is not the installer or update route.** It never instructs a download, install,
-   `pip install --upgrade`, package switch, or version migration. The single official
-   route is `https://lingtai.ai/install.sh`, and `runtime-update-checks` owns that
-   routing. This node's `source_drift` handling stays local and never enters
-   release-migration routing.
-2. **It performs no automatic migrations and no config writes.** It is a checklist the
-   agent *reads*; it does not ship a script that edits `init.json`,
-   `mcp_registry.jsonl`, `manifest.preset.allowed`, or any durable store.
-3. **It grants no authorization.** Completing every check does not substitute for the
-   human/config-owner authority required by `runtime-update-checks`. A checklist is not
-   consent. Explicitly: "the pre-flight passed" is never a reason to skip asking.
-4. **It does not restate owned facts.** Preset runtime model → `substrate-manual` §11.
-   Runtime/version provenance probe (`LINGTAI_RUNTIME_PYTHON` / module `__file__`, never a
-   PATH `python`) → `runtime-update-checks`; step 2 sequences that rule, it does not restate it.
-   Env var catalogue → `environment-variables`. Update/nudge lifecycle →
-   `runtime-update-checks`. MCP registry mechanics → `mcp-manual`. Molt/rebuild →
-   `context-manual`. Notification dismissal safety → `notification-manual`. Each check
-   *cites*; duplication here means four places to update and three that will go stale.
-5. **It does not replace `context(action="rebuild")`.** Rebuild is the active
-   full-context reconstruction operation. Refresh is a lifecycle operation with broader
-   effects. Do not reach for refresh merely to apply a summary — that boundary is
-   already stated in the resident prompts and must be reinforced, not re-litigated, here.
-6. **It is not a gate in code.** Nothing in the kernel enforces it; this is strong
-   guidance an agent is expected to follow, not a runtime refusal.
-
-## Recipes (copy-paste)
-
-### Recipe A — Pre-refresh health check (run before any config-motivated refresh)
-
-```bash
-# POSIX. Uses only the exported runtime interpreter; never guesses a path.
-PYTHON="$LINGTAI_RUNTIME_PYTHON"
-[ -n "$PYTHON" ] || { echo "LINGTAI_RUNTIME_PYTHON is unset — stop; locate the actual launcher/runtime venv via runtime-update-checks instead of guessing one." >&2; return 1 2>/dev/null || exit 1; }
-"$PYTHON" -c 'import sys, lingtai, lingtai.kernel; print("py=",sys.executable); print("lingtai=",lingtai.__file__); print("kernel=",lingtai.kernel.__file__)'
-SP=$("$PYTHON" -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')
-ls -1d "$SP"/*lingtai* 2>/dev/null; for f in "$SP"/*lingtai*.pth; do echo "== $f"; cat "$f"; done
-"$PYTHON" -c 'import json; d=json.load(open("init.json")); print("init.json OK"); print("addons=",d.get("addons")); print("mcp=",list((d.get("mcp") or {}).keys()))'
-ls -l .notification/nudge.json 2>/dev/null && sed -n '1,120p' .notification/nudge.json
-git -C "$(pwd)" status --short --branch 2>/dev/null || true
-```
+Choose one shape; nulls are explicit because the System input is closed.
 
 ```text
-mcp(action="info", input={}, reasoning="pre-refresh registry health and problems")
+system(action="refresh", input={"reason":"<authorized reload reason>","preset":null,"revert_preset":null}, reasoning="reload <targeted change>")
+system(action="refresh", input={"reason":null,"preset":"<exact allowed path>","revert_preset":null}, reasoning="activate authorized preset")
+system(action="refresh", input={"reason":null,"preset":null,"revert_preset":true}, reasoning="return to configured default preset")
 ```
 
-Proceed only if: interpreter unambiguous, exactly one lingtai path marker whose entries
-exist and agree with `lingtai.__file__`, `init.json` parses, `mcp` block matches the
-registry, `problems` empty or explained, and no `kernel_version` nudge is the real
-trigger.
+Execute exactly one of those lines. Never stack calls or refresh again “to be
+sure.” A successful tool result only accepts or hands off the request; it does
+**not** prove that a replacement process started. Missing launch-command or
+watcher setup, handshake failure, and terminal watcher exhaustion remain
+failures until fresh-process evidence exists.
 
-### Recipe B — Daemon-preset preflight (before dispatching daemon work with an explicit preset)
+## Capture one targeted receipt
+
+Record one compact receipt, not a second checklist:
 
 ```text
-1. system(action="presets", input={}, reasoning="read the allowed-only catalog")
-2. # If the path you want is absent, it is NOT authorized (allowed-catalog
-   #   mechanics: substrate-manual §11). Ask the config owner to add it, then:
-   system(action="refresh",
-          input={"reason": "pick up new allowed preset entry",
-                 "preset": null, "revert_preset": null},
-          reasoning="apply the config owner's allowed-list edit")
-3. system(action="presets", input={}, reasoning="confirm the new path is now listed")
-4. # Pass the EXACT path from step 3 as tasks[].preset — not the pre-authorization
-   #   string, not a library-screen path, not a shorthand.
+mode: A | B | C
+target: <exact agent/workdir>
+authority_and_reason: <who/what authorized this transaction>
+refresh_calls: 1
+fresh_process: <new incarnation or heartbeat advanced beyond the pre-call baseline>
+target_assertion: <one changed surface, runtime tuple, or repaired fault + result>
+originating_channel_round_trip: <required for B; otherwise n/a>
 ```
 
-An unauthorized explicit `tasks[].preset` refuses the **entire batch** before dispatch.
-Omitting `preset` entirely inherits the parent's regular surface and skips this check.
-External CLI backends (`claude-p`, `codex`, `opencode`, …) skip LingTai preset
-resolution entirely — this recipe does not apply to them.
+For B, the update/build owner must freeze before refresh: target, exact
+`runtime_tuple` fields (`sys_executable`, `lingtai_file`,
+`lingtai_kernel_file`, and `version_or_head`), plus intended `selectors`.
+Consume that receipt and compare intended selectors once; do not rerun `.pth`,
+editable-install, package, or general Git audits. On the fresh process, compare
+those four runtime fields directly to the frozen tuple. If MCP interpreter or
+config changed, include the expected
+MCP entry and relevant problem state in that same target assertion. Then complete
+one real request/response round trip on the originating channel. If
+`LINGTAI_RUNTIME_PYTHON` is absent or the tuple differs, stop and diagnose
+through `runtime-update-checks`; never substitute PATH Python or a guessed venv.
 
-### Recipe C — Post-refresh verification (always, immediately after refresh returns)
+## Mode C: recover one fault, once
 
-```bash
-# POSIX. Uses only the exported runtime interpreter; never guesses a path.
-PYTHON="$LINGTAI_RUNTIME_PYTHON"
-[ -n "$PYTHON" ] || { echo "LINGTAI_RUNTIME_PYTHON is unset — stop; locate the actual launcher/runtime venv via runtime-update-checks instead of guessing one." >&2; return 1 2>/dev/null || exit 1; }
-"$PYTHON" -c 'import sys, lingtai, lingtai.kernel; print(sys.executable, lingtai.__file__, lingtai.kernel.__file__)'
-SP=$("$PYTHON" -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])'); ls -1d "$SP"/*lingtai*
-sed -n '1,200p' system/manifest.resolved.json 2>/dev/null
-```
+1. Read the returned error first. If the watcher exhausted its bounded retries,
+   also read `logs/refresh_failed_permanent.json` and the matching high-priority
+   system notification. That artifact is terminal evidence, not permission to
+   launch again.
+2. Route the named fault: preset/refusal semantics to `substrate-manual`; source,
+   venv, selector, or import mismatch to `runtime-update-checks`; MCP fault to
+   `mcp-manual`; context fit/rebuild to `context-manual`; launcher/watcher fault
+   to its owner. Do not rerun the happy-path table.
+3. Repair only that fault with the required human/config-owner authority. If the
+   cause is unknown, the repair is unproved, or a permanent failure has not been
+   escalated to the human/launcher owner, stop.
+4. After a specific repair, permit exactly one deliberate retry and produce the
+   C receipt. A failed retry ends the transaction; do not loop or stack calls.
 
-```text
-mcp(action="info", input={}, reasoning="post-refresh: confirm MCP tools actually loaded")
-system(action="presets", input={}, reasoning="post-refresh: confirm active preset and allowed set")
-```
+## Hard scope boundary
 
-Confirm, in order: new process importing from the intended source with no stale/duplicate
-lingtai `.pth` → MCP count/`problems`/expected tools present → active
-preset is what you asked for → the specific tool you are about to use still exists.
-Only then dismiss the motivating nudge.
+This reference is guidance, not a public command, script, runtime guard, or
+installer. It performs no write, migration, download, package switch, config
+change, allowlist expansion, or automatic retry. Owner checks remain available
+on their triggers; `.pth`, install provenance, MCP, preset, Git, nudge, whole
+tool surface, and daemon checks are never unconditional refresh ceremony.

--- a/src/lingtai/intrinsic_skills/system-manual/reference/runtime-update-checks/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/runtime-update-checks/SKILL.md
@@ -1,14 +1,12 @@
 ---
 name: runtime-update-checks
 description: >
-  Nested system-manual reference for tracing LingTai kernel update nudges:
-  runtime/version/source identity, packaged versus editable/source behavior,
-  heartbeat dispatch, nudge persistence and notification delivery, refresh
-  versus installation, human confirmation, and post-refresh verification. The
-  ordered pre-flight for a refresh is the sibling `refresh-precheck`.
-version: 0.3.0
-tags: [lingtai, runtime, kernel, nudge, updates, refresh, editable, source, diagnostics]
-last_changed_at: "2026-08-07T00:00:00Z"
+  Nested system-manual reference for update, source, install, nudge, and
+  runtime-mismatch diagnosis. Owns interpreter/provenance evidence and the
+  source/venv cutover handoff; routes refresh sequencing to refresh-precheck.
+version: 0.4.0
+tags: [lingtai, runtime, kernel, nudge, updates, install, editable, source, diagnostics]
+last_changed_at: "2026-09-09T00:00:00Z"
 related_files:
 - src/lingtai/intrinsic_skills/system-manual/SKILL.md
 - src/lingtai/intrinsic_skills/system-manual/reference/environment-variables/SKILL.md
@@ -32,248 +30,185 @@ related_files:
 - tests/test_source_drift.py
 - tests/test_runtime_identity.py
 maintenance: |
-  Keep this as the local detailed source for kernel update/nudge read-only
-  diagnosis and refresh mechanics, not release-migration routing. Update it
-  when the nudge producers, heartbeat dispatch, notification sync, runtime
-  identity, refresh boundary, or supported update ownership changes; keep
-  system-manual and notification-manual as routers.
+  Keep this as the detailed owner for kernel update/nudge facts, source and
+  install provenance, mismatch diagnosis, and the frozen cutover handoff.
+  Update it with the producers, heartbeat dispatch, notification sync, runtime
+  identity, or installer ownership; keep refresh transaction order only in the
+  sibling refresh-precheck reference.
 ---
 
 # Runtime Update Checks
 
-Kernel-local read-only diagnosis and refresh mechanics for update nudges. The
-install/update route itself is owned by the official installer — see step 9 and
-**Boundaries** below for the split. This is operational guidance, not permission
-to download, install, change configuration, or relaunch a runtime.
+Use this reference to determine **what is running, what is on disk, and who owns
+a change**. It is read-only guidance, not permission to download, install,
+modify configuration, switch a checkout, or relaunch. Once a target source/venv
+is proven and authorized, `refresh-precheck` owns the complete refresh
+transaction; do not copy its happy-path sequence here.
 
-## The lifecycle and its owners
+## Ownership map
 
-The end-to-end path is:
+| Question | Owner / answer |
+|---|---|
+| Is an official package update available? | `kernel_version.py` plus the release-manifest path described below. |
+| Did source already on disk change under this process? | `source_drift.py`; local source-integrity diagnosis only. |
+| Which interpreter/source/version is authoritative? | Runtime identity plus the exact probe in this reference. |
+| How is a normal user install/update performed? | The current `https://lingtai.ai/install.sh --help` output. |
+| May a download, migration, config write, or disruptive relaunch proceed? | Only explicit human/config-owner authority after the proposed action is shown. |
+| How is the one refresh performed and receipted? | `reference/refresh-precheck/SKILL.md`. |
+| How is a nudge dismissed? | `notification-manual`, after the matching fact is interpreted or resolved. |
 
-1. **Discover runtime facts — `kernel_version.py` and runtime identity.** The
-   kernel reads the already-loaded `lingtai` wrapper from `sys.modules` for the
-   running version, and `importlib.metadata` for the installed distribution
-   version. `runtime_identity.py` separately stamps durable event identity with
-   package/dev mode, source kind, and available git state. No package-index
-   request is needed for the local comparison.
-2. **Check `kernel_version` — `kernel_version.py`.** This is the
-   `release_version` nudge channel. In editable/source/dev runtimes it is
-   silent and clears only its own stale release-version entry. If running and installed
-   versions differ, it emits a local refresh nudge and preserves the existing
-   local-only path. For packaged, non-editable, non-dev runtimes whose versions
-   match, it fetches the exact `lingtai-kernel-release-manifest.json` asset from
-   the latest GitHub and Gitee releases through the bounded producer probe gate.
-   If both manifests are available, version, manifest content, and artifact
-   hashes must agree; a mirror mismatch is reported without choosing a higher
-   version. If one mirror is unavailable, the other may establish the result.
-   A newer manifest version produces a package-availability nudge; network or
-   response errors are recorded diagnostically and do not become an update.
-3. **Check `source_drift` — `source_drift.py`.** This is the
-   `source_integrity` nudge channel. It compares the startup runtime fingerprint
-   (git revision and curated source digest when available) with a fresh on-disk
-   fingerprint. Drift means the running process differs from code currently on
-   disk. Editable/source/dev runtimes still emit this diagnostic; the finding is
-   local read-only source diagnosis and refresh mechanics only, and does not
-   enter the release-migration route.
-4. **Dispatch — `nudge/__init__.py` and `lifecycle.py`.** The heartbeat loop
-   runs the nudge dispatcher once per one-second tick. `kernel_version` and
-   `source_drift` each have their own roughly 60-second in-memory probe gate;
-   `goal` runs on each dispatch while IDLE and applies its configured
-   idle-reminder delay. One failing producer is logged and does not block the
-   others.
-5. **Persist and publish — `nudge/__init__.py` and the Notification Store.**
-   Shared Nudge policy state lives in `.notification/.nudge_state.json` only for
-   dismissal mute expiries. The user-facing mirror is `.notification/nudge.json`;
-   it is not a package state or migration registry. Each entry has a unique
-   `kind`; `upsert` replaces that kind, `remove` deletes it, and clearing the
-   last entry clears the channel file. Updates use the store's atomic
-   compare/update operation.
-6. **Sync and wake — `BaseAgent._sync_notifications`.** The heartbeat polls
-   allowlisted `.notification` files by fingerprint. A changed nudge file is
-   injected as a synthesized `notification(action="check")` pair when IDLE;
-   ACTIVE work defers delivery until an IDLE boundary; ASLEEP is moved to IDLE,
-   then the pair and `MSG_TC_WAKE` are queued. STUCK/SUSPENDED cannot inject.
-   A failed injection leaves the fingerprint uncommitted for retry (with the
-   documented degraded recovery path after healing pending tool calls).
-7. **Interpret — the agent, using the stable installer plus this local reference.**
-   Treat the payload as kernel-synchronized facts, not a human command. Compare
-   `running`, `installed`, `latest`, and `source`; inspect the runtime when
-   ambiguous. For a real update, let Shell execute the installer's concise
-   `--help`, without reading or pasting the script source, and follow whatever
-   it currently instructs; the installer owns
-   release-interval migration navigation and the exact child command shape
-   while this reference owns local diagnosis and refresh mechanics.
-8. **Confirm — the human/config-owner.** After the installer has displayed the
-   applicable release-interval migrations, obtain explicit human/config-owner
-   authorization for every migration/config write and for refresh. Apply only
-   authorized writes, validate
-   the resulting configuration, and refresh last. A release-manifest availability
-   nudge also requires telling the human what was found and receiving explicit confirmation
-   before any download or package update. A nudge or this manual
-   never grants authority; a local refresh remains gated by work safety and the
-   human's intent when it could interrupt active work.
-9. **Install/update — the single official installer.** Normal user-facing
-   installation and updates, including `lingtai-tui`, `lingtai-portal`, the
-   managed kernel runtime, exact-tag migration guidance, mirror comparison, and
-   artifact verification, belong to `https://lingtai.ai/install.sh`. Bare
-   `pip install --upgrade lingtai` is not the normal user instruction; pip/venv
-   commands below are diagnostic or developer verification only.
-10. **Refresh and verify — kernel lifecycle plus the operator.**
-    After authorized writes are validated, `system(action="refresh")` requests a
-    deferred relaunch only when the runtime can build a valid launch command and
-    has a configured refresh watcher. Without a launch command it returns
-    without relaunching; without a refresh watcher it raises. Diagnose either
-    outcome before treating the refresh as successful. Refresh never pulls
-    commits, downloads a release asset, installs a package, or switches an
-    editable checkout. After a confirmed update or refresh, verify the new
-    process's interpreter, `lingtai.__file__`, `lingtai.kernel.__file__`,
-    version, and import path.
+## Nudge lifecycle and meanings
 
-## Packaged, editable, and source/dev runtimes
+1. **Local facts.** `kernel_version.py` reads the already-loaded `lingtai`
+   wrapper for the running version and distribution metadata for the installed
+   version. `runtime_identity.py` stamps package/dev mode, source kind, and
+   available Git identity into durable events.
+2. **Release-version producer.** Packaged, non-editable, non-dev runtimes compare
+   matching local versions with the exact release-manifest asset on GitHub and
+   Gitee through a bounded probe gate. Two available mirrors must agree on
+   version, content, and hashes; one available mirror may establish the result.
+   Network or mirror disagreement is diagnosis, not an update. Editable/source/
+   dev runtimes are release-version-silent and clear only their stale entry.
+3. **Source-integrity producer.** `source_drift.py` compares the startup runtime
+   fingerprint with a fresh on-disk fingerprint. `source_drift` means this
+   process differs from local disk; it never becomes release-migration or
+   package-install authority.
+4. **Dispatch.** Heartbeat runs the nudge dispatcher once per one-second tick.
+   `kernel_version` and `source_drift` each use a roughly 60-second in-memory
+   probe gate. One producer failure is logged and does not block the others.
+5. **Persistence and delivery.** The user-facing aggregate is
+   `.notification/nudge.json`; dismissal mute expiries live in
+   `.notification/.nudge_state.json`. Each producer owns one `kind`. Atomic
+   upsert replaces that kind and resolution removes it. Notification sync
+   injects changed allowlisted files at an IDLE boundary, wakes ASLEEP, defers
+   during ACTIVE, and cannot inject into STUCK/SUSPENDED.
+6. **Interpretation.** A nudge is synchronized kernel evidence, not a human
+   command. Compare its fields and diagnose ambiguity before proposing action.
 
-For a packaged/non-editable install, the distribution metadata and release
-manifest are meaningful. A local `running != installed` mismatch means a
-package landed on disk after this process started: it is a refresh opportunity,
-not a package upgrade. A `latest > installed` mismatch means an official release
-manifest advertises a possible package upgrade; it does not mean that package
-has been downloaded.
+Built-in nudge kinds are:
 
-The editable/source/dev modes are detected through `direct_url.json` with
-`dir_info.editable: true`; source checkouts are recognized from the module path
-and the checkout's `.git` plus `pyproject.toml`; dev-version markers also
-suppress only the `kernel_version` release-version check. Missing distribution
-metadata is treated as source/dev rather than as permission to install. In these
-modes, the checkout, branch, commit, dirty state, and import path are the useful
-truth. A `source_drift` finding can still appear as a source-integrity
-diagnostic, and an `init_config_shape` finding can still appear as
-configuration-staleness guidance; neither is package-update authority.
+- `kernel_version` on `release_version`: `running`, `installed`, `latest` (or
+  null for code already on disk), `source`, and a suggested action.
+- `source_drift` on `source_integrity`: startup and disk fingerprints.
+- `init_config_shape` on `configuration_staleness`: configuration-shape
+  guidance, not update authority.
 
-## Nudge mechanics and dismissal
+The controls `LINGTAI_NUDGE_ENABLED` and
+`LINGTAI_NUDGE_REPEAT_INTERVAL` govern publication and the post-dismiss mute
+window. Their values, invalid fallback, read point, and reload behavior live in
+`environment-variables`; producer probe gates are observation costs, not user
+cadence. Dismissal is mute, not resolution.
 
-When a Nudge is emitted, inspect its self-describing policy message before
-adjusting the process environment.
+## Packaged versus source/dev evidence
 
-`kernel_version`, `source_drift`, and `init_config_shape` are producers of the
-shared low-priority `.notification/nudge.json` envelope. The envelope carries
-`data.nudges`, a `published_at` timestamp, channel-level instructions, and a
-self-describing policy block. Those built-in producer kinds carry fixed
-`nudge_channel` metadata: `release_version` for `kernel_version`,
-`source_integrity` for `source_drift`, and `configuration_staleness` for
-`init_config_shape`. Unrelated legacy/unknown entries remain channel-less.
-`kind: kernel_version` has `running`, `installed`, `latest` (or `null` for a
-local refresh), `source`, and a suggested action. `source_drift` carries startup
-and disk fingerprints instead.
+For a packaged/non-editable runtime:
 
-The shared Nudge policy records finding identity and dismissal mute expiry in
-`.notification/.nudge_state.json`. The two global controls
-(`LINGTAI_NUDGE_ENABLED`, `LINGTAI_NUDGE_REPEAT_INTERVAL`) suppress publication
-and set the post-dismiss repeat window for an unresolved finding; their defaults,
-accepted values, reload behavior, and invalid-value fallback are registered in the
-repo-root `ENVIRONMENT_VARIABLES.md`, routed via
-`reference/environment-variables/SKILL.md`. Producer probe gates are only bounded
-observation costs, not product cadence. A producer removes an entry when its
-real fact resolves; `kernel_version` also removes its own entry when the runtime
-is intentionally release-version-silent. Dismissal is mute, not resolution;
-only a later real-reader check with zero findings resolves a problem.
+- `running != installed` normally means newer package code is already on disk
+  than this process loaded: investigate a reload, not another package install.
+- `latest > installed` means an official release manifest advertises an update;
+  it does not mean anything was downloaded.
+- Running newer than metadata indicates stale metadata or an import-path
+  mismatch; never blindly downgrade.
 
-After interpreting a nudge, use the narrowest safe action:
+Editable/source/dev detection uses `direct_url.json` with
+`dir_info.editable: true`, source checkout markers, module paths, and dev-version
+markers. Missing distribution metadata is source/dev evidence, not permission
+to install. For these runtimes, exact interpreter, both imported module paths,
+checkout, branch, commit, dirty state, and selector values are the useful facts.
+Read Git only at the source path identified by the import probe; generic Git
+status in the current agent directory proves nothing.
 
-```text
-notification(action="dismiss_channel",
-             input={"channel": "nudge", "force": null, "reason": null},
-             reasoning="acknowledge the nudges")
-```
+## Exact read-only probe
 
-Do not call `notification(action="check", input={})` merely to confirm
-dismissal. The
-generic notification protocol and guarded dismissal rules live in
-`notification-manual`; this reference owns the meaning of these two kinds.
-
-## Read-only diagnosis
-
-Inspect the current mirror and durable state without changing them:
+Use the interpreter exported by the launcher. If it is absent, stop and ask the
+launcher owner; do not substitute PATH Python or guess a venv.
 
 ```bash
-ls -l .notification/nudge.json .notification/.nudge_state.json 2>/dev/null
-sed -n '1,240p' .notification/nudge.json 2>/dev/null
-sed -n '1,240p' .notification/.nudge_state.json 2>/dev/null
-```
-
-Use the interpreter that launched the agent. The CLI exports
-`LINGTAI_RUNTIME_PYTHON`; if it is absent, use the platform-specific TUI
-runtime Python, not a convenient shell environment:
-
-```bash
-PYTHON=${LINGTAI_RUNTIME_PYTHON:-$HOME/.lingtai-tui/runtime/venv/bin/python}
+PYTHON="$LINGTAI_RUNTIME_PYTHON"
+[ -n "$PYTHON" ] || { echo "LINGTAI_RUNTIME_PYTHON is unset; stop" >&2; return 1 2>/dev/null || exit 1; }
 "$PYTHON" - <<'PY'
 import importlib.metadata as md
 import sys
 import lingtai, lingtai.kernel
 print("python=", sys.executable)
 print("lingtai_version=", getattr(lingtai, "__version__", "unknown"))
-print("lingtai_dist=", md.version("lingtai"))
-print("lingtai_file=", getattr(lingtai, "__file__", "unknown"))
-print("lingtai.kernel_file=", getattr(lingtai.kernel, "__file__", "unknown"))
 try:
+    print("lingtai_dist=", md.version("lingtai"))
     print("direct_url=", md.distribution("lingtai").read_text("direct_url.json"))
 except Exception as exc:
-    print("direct_url_error=", type(exc).__name__, str(exc)[:120])
+    print("distribution_metadata=", type(exc).__name__, str(exc)[:120])
+print("lingtai_file=", getattr(lingtai, "__file__", "unknown"))
+print("lingtai.kernel_file=", getattr(lingtai.kernel, "__file__", "unknown"))
 PY
 ```
 
-For source/dev disagreement, read-only git evidence is appropriate:
+When those paths identify a source checkout, the narrow follow-up is:
 
 ```bash
-git -C /path/to/checkout status --short --branch
-git -C /path/to/checkout log -1 --format='%H %cI %s'
-git -C /path/to/checkout remote -v
+git -C <identified-source-checkout> status --short --branch
+git -C <identified-source-checkout> log -1 --format='%H %cI %s'
 ```
 
-Replace the checkout path with the path containing the imported module; do not
-assume the current directory is that checkout. Do not print credentials or
-environment dumps.
+Do not print environment dumps, credentials, or unrelated remotes. Inspect
+`.pth`, `direct_url.json`, dist-info, or installer state only when this probe
+shows an install/import mismatch or a source/venv cutover requires it; none is a
+universal refresh check.
 
-## Troubleshooting
+## Update/install route and authority
 
-**Running and installed versions disagree.** Confirm the live interpreter and
-both module files first. If the installed distribution is newer, the safe
-meaning is “code already on disk can be loaded by a refresh.” If the running
-process is newer, inspect whether metadata or the import path is stale; do not
-blindly downgrade or install.
+For a real user-facing install or update, let Shell execute
+`https://lingtai.ai/install.sh --help` and follow its current output without
+reading or pasting the script source. That installer owns managed kernel/TUI/
+portal installation, exact-tag migration navigation, mirror comparison,
+artifact verification, and child command shapes. Bare
+`pip install --upgrade lingtai` is not the normal user instruction; pip/venv
+commands are limited to authorized diagnosis or developer verification.
 
-**Runtime and checkout disagree.** `sys.executable`, `lingtai.__file__`,
-`lingtai.kernel.__file__`, `direct_url.json`, and read-only git status identify
-which checkout/environment is actually active. A checkout's version alone does
-not prove what the running process imported.
+Tell the human what the nudge and probe established. After applicable migrations
+and writes are displayed, proceed only after receiving explicit confirmation
+and explicit human/config-owner authority for each download, install, migration,
+configuration write, and disruptive relaunch. A nudge and this manual grant none.
 
-**Release-manifest/network failure.** A failed remote request records bounded
-`last_error` state in `.nudge_state.json`; it is not evidence that an update
-exists. Check connectivity or release-mirror availability with the human. Do
-not turn a transient failure into a manual install recommendation.
+The update/build owner validates its own work before handoff and freezes one
+cutover receipt containing:
 
-**Nudge is missing or stale.** Check both files above. Missing `nudge.json` can
-mean no producer currently has an entry, a matching version cleared it, a dev
-runtime skipped it, or it was dismissed. A stale entry can be a mirror waiting
-for the next heartbeat sync; compare its kind and version pair with durable
-state. Unknown JSON files are not collected as notification channels.
+```text
+target: <exact agent/workdir>
+runtime_tuple:
+  sys_executable: <exact executable>
+  lingtai_file: <exact lingtai.__file__>
+  lingtai_kernel_file: <exact lingtai.kernel.__file__>
+  version_or_head: <exact expected version/commit>
+source_root: <optional diagnostic root>
+selectors: <intended launcher/init interpreter selector values>
+authority: <who authorized install/write/cutover>
+owner_validation: <targeted update/build/install result>
+```
 
-**Refresh did not activate new code.** A refresh only rebuilds/relaunches the
-runtime from code already visible on disk. Re-run the read-only interpreter and
-import-path probe in the new process, inspect the refresh/runtime logs, and
-check for a still-held old process or a different environment. It cannot pull a
-commit or repair an incomplete source checkout.
+Hand that receipt to `refresh-precheck` mode B. That reference owns selector
+comparison, exactly one refresh, the fresh runtime-tuple check, originating-
+channel round trip, and failure recovery. Do not duplicate them here.
 
-**Interpreter/import path is unknown.** Stop before any update action. Ask the
-human or launcher owner which process is authoritative, then compare
-`LINGTAI_RUNTIME_PYTHON`, `sys.executable`, the two module `__file__` values,
-distribution metadata, and `direct_url.json`. Do not use an unrelated shell
-Python as a substitute.
+## Mismatch diagnosis
+
+| Symptom | Read-only interpretation and next owner |
+|---|---|
+| Running and installed versions differ | Verify interpreter and both module paths. Installed newer is code-on-disk reload territory; running newer requires metadata/import diagnosis. |
+| Runtime and checkout disagree | Compare executable, module paths, `direct_url.json`, then exact Git evidence at the identified source. Resolve source/venv ownership before refresh. |
+| Release-manifest/network failure | Read bounded producer error state. It is not evidence of an update; ask about connectivity/mirror availability. |
+| Nudge is missing or stale | Compare `.notification/nudge.json` with `.notification/.nudge_state.json`; consider dev-mode silence, dismissal mute, producer resolution, and the next heartbeat sync. |
+| New code did not activate | Refresh cannot pull or repair code. Compare the expected cutover receipt to the new process and route the transaction failure to `refresh-precheck` mode C. |
+| Interpreter/import source is unknown | Stop all update/cutover action and ask the launcher owner which process and selectors are authoritative. |
+
+To acknowledge interpreted nudges, follow `notification-manual`; its narrow form
+is `notification(action="dismiss_channel", input={"channel":"nudge","force":null,"reason":null}, reasoning="acknowledge interpreted nudges")`.
+Do not call notification check merely to confirm dismissal.
 
 ## Boundaries
 
-`https://lingtai.ai/install.sh` owns install/update execution and release
-migration navigation (step 9). The Notification package manual owns channel allowlisting,
-sync concepts, and dismissal safety. `reference/refresh-precheck/SKILL.md` owns
-the ordered pre-flight and post-refresh verification pass. This reference owns
-only kernel-local read-only diagnosis and refresh mechanics; `source_drift` stays
-local and does not enter release-migration routing.
+This reference owns update/source/install/nudge/mismatch diagnosis and the
+cutover handoff. It does not own refresh ordering, preset activation, retries,
+or post-refresh receipts. It performs no download, write, install, checkout
+switch, migration, relaunch, or notification mutation by itself. `source_drift`
+stays local and outside release-migration routing; `refresh-precheck` is the
+single owner of every happy-path or recovery refresh transaction.

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -495,9 +495,6 @@ def test_skills_setup_hard_copies_standalone_intrinsic_skills(tmp_path):
         refresh_precheck_body = refresh_precheck_ref.read_text(encoding="utf-8")
         assert "name: refresh-precheck" in refresh_precheck_body
         assert "Nested system-manual reference" in refresh_precheck_body
-        assert 'system(action="refresh")' in refresh_precheck_body
-        assert 'system(action="presets")' in refresh_precheck_body
-        assert ".pth" in refresh_precheck_body
 
         # event_summary.py script exists, is referenced, and can summarize
         # a minimal SQLite sidecar using the actual events schema columns.
@@ -1145,6 +1142,54 @@ def test_skills_does_not_create_git_repo(tmp_path):
         assert not (workdir / ".library" / ".git").exists()
     finally:
         agent.stop(timeout=1.0)
+
+
+def test_refresh_guidance_owns_three_targeted_modes():
+    root = Path(__file__).resolve().parents[1]
+    manual_root = root / "src/lingtai/intrinsic_skills/system-manual"
+    reference_root = manual_root / "reference"
+    router = (manual_root / "SKILL.md").read_text(encoding="utf-8")
+    refresh = (reference_root / "refresh-precheck/SKILL.md").read_text(encoding="utf-8")
+    update = (reference_root / "runtime-update-checks/SKILL.md").read_text(encoding="utf-8")
+    router_flat = " ".join(router.split())
+    refresh_flat = " ".join(refresh.split())
+    update_flat = " ".join(update.split())
+
+    assert "Any refresh transaction: same-runtime reload" in router_flat
+    assert "Update/source/install/nudge/mismatch diagnosis and cutover handoff" in router_flat
+    assert "select one mode -> one targeted preflight -> exactly one refresh -> one targeted receipt" in refresh_flat
+    for mode in (
+        "A. Same-runtime reload",
+        "B. Source/venv cutover",
+        "C. Failure recovery",
+    ):
+        assert mode in refresh
+    assert "two before and two after" in refresh_flat
+    assert "three before and two after" in refresh_flat
+    assert "first after-check includes changed-MCP health only on that trigger" in refresh_flat
+    assert "Never inspect an unchanged subsystem" in refresh_flat
+    assert "refresh_calls: 1" in refresh
+    assert "originating_channel_round_trip" in refresh
+    for frozen_field in (
+        "runtime_tuple:",
+        "sys_executable:",
+        "lingtai_file:",
+        "lingtai_kernel_file:",
+        "version_or_head:",
+        "selectors:",
+    ):
+        assert frozen_field in update
+    assert "logs/refresh_failed_permanent.json" in refresh
+    assert refresh.count('system(action="presets"') == 1
+    for removed_universal_probe in (
+        'mcp(action="info"',
+        "git -C",
+        ".notification/nudge.json",
+    ):
+        assert removed_universal_probe not in refresh
+    assert "checks are never unconditional refresh ceremony" in refresh_flat
+    assert 'system(action="refresh"' not in update
+    assert "`refresh-precheck` is the single owner" in update_flat
 
 
 def test_resident_prompts_route_to_system_manual_nested_references():


### PR DESCRIPTION
## Summary

- replace the universal refresh checklist with three explicit modes: same-runtime reload, source/venv cutover, and failure recovery
- make every transaction follow one targeted preflight → exactly one refresh → one targeted receipt
- cap same-runtime reload at 2 before + 2 after, and source/venv cutover at 3 before + 2 after
- run owner checks only when that subsystem changed; keep update/install/nudge/mismatch diagnosis in `runtime-update-checks`
- preserve fail-loud preset, replacement-process, watcher, and one-repair/one-retry boundaries without adding a command, guard, script, or framework

## Shape

- `refresh-precheck`: 415 → 155 lines
- `runtime-update-checks`: 279 → 214 lines
- whole diff: 4 files, +333/-608
- based on current `main` `115c1a758b34b8ce3c6aedccdd278e136a295371`

## Validation

- `git diff --check`
- docs governance: 401 documents validated
- `tests/test_docs_governance.py`: 70 passed
- focused refresh contract: 1 passed
- `tests/test_skills.py`: 39 passed, 2 exact-current-base failures
- `tests/test_kernel_update_contract.py`: 4 passed, 1 exact-current-base failure
- `tests/test_architecture_documents.py`: 4 passed, 1 exact-current-base failure

The four non-candidate failures reproduce on clean current base and remain outside this diff: stale shell/file manual-copy expectations, notification install-URL expectation, and two pre-existing Psyche Anatomy orphans.

Final independent exact-patch review: **APPROVE — P0 0 / P1 0 / P2 0**. The earlier Mode-B receipt mismatch was repaired by freezing and directly comparing the exact four-field runtime tuple plus selectors.

Utilities alignment PR: https://github.com/Lingtai-AI/lingtai/pull/949

## Scope

Guidance and an existing focused test only. No runtime behavior, public command, config/auth, installer, release, refresh, or migration change.

Telegram: @lingtaidev3bot | Nickname: 澄一

Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
