### PR TITLE
docs(shell): shorten manuals and preserve execution guidance

### DIFF
--- a/src/lingtai/tools/bash/CONTRACT.md
+++ b/src/lingtai/tools/bash/CONTRACT.md
@@ -195,7 +195,7 @@ inside another action's result.
 | Action | Required `input` | Nullable-optional `input` | Success output | Error shapes |
 |---|---|---|---|---|
 | `run` (sync) | `command` | `working_dir`, `timeout` (default 30; hard ceiling `LINGTAI_TOOL_TIMEOUT_MAX_SECONDS`, default 120, floored at 30), `async`, `reminder` | `{status: "ok", exit_code, stdout, stderr, ok, command_status, warning?}` | `{status: "error", message}` — empty command, policy-denied, cwd outside sandbox, invalid/non-finite timeout, timeout above the hard ceiling (steered to `async=true`), timeout (with broad-scan hint and async steering), or spawn failure |
-| `run` (async) | `command`, `async: true` | `working_dir`, `timeout`, `reminder` | `{status: "ok", job_id, pid, message, handoff}`; `handoff` tells the model it may go idle or call `system(action='sleep')` while waiting for the terminal notification, and conditionally says that if Telegram is connected and a Task Card is available for the current turn, the model should use it to report progress via `telegram(action='manual')` and that manual's `Programmable Task Card` section; read `shell-manual` and `notification-manual` for details | `{status: "error", message}` — same validation errors, invalid boolean/non-numeric/non-finite/negative/too-large `reminder`, plus `Failed to start async job: ...` |
+| `run` (async) | `command`, `async: true` | `working_dir`, `timeout`, `reminder` | `{status: "ok", job_id, pid, message, handoff}`; `handoff` tells the model it may go idle or call `system(action='sleep')` while waiting for the terminal notification, and conditionally directs useful progress tracking to the intrinsic, channel-neutral Task Card manual; read `shell-manual` and `notification-manual` for details | `{status: "error", message}` — same validation errors, invalid boolean/non-numeric/non-finite/negative/too-large `reminder`, plus `Failed to start async job: ...` |
 | `poll` | `job_id` | — | running: `{status: "running", job_id, pid?}` while the recorded supervisor may still commit; known finished: `{status: "done", exit_status_known: true, exit_code, stdout, stderr, ok, command_status, warning?}`; unrecoverable/legacy terminal: `{status: "done", exit_status_known: false, exit_code: null, stdout, stderr}` | `{status: "error", message}` — missing/invalid `job_id`, `Job not found`, or an already terminal-consumed job |
 | `cancel` | `job_id` | — | `{status: "cancelled", job_id}` only after the supervisor has committed the held child's exact terminal status and cancellation atomically consumes/suppresses the job | `{status: "error", message}` — missing/invalid `job_id`, `Job not found`, terminal job, legacy job, or a durable cancellation request still awaiting a terminal commit (which remains pollable/remindable) |
 | `settings` | — (strict empty `{}`) | — | `{settings: [{key, current, default, configurable, comment}, ...]}` with command-policy values redacted | Fixed generic whole-action failure; never partial rows |
@@ -235,10 +235,10 @@ carry it on the wire at all; a `run` call that passes `null` (or a direct
 runtime call that omits it) still gets 1800 seconds.
 
 Agents following an async success `handoff` MUST treat Task Card guidance as
-conditional: use the Task Card only when Telegram is connected and a Task Card
-is available for the current turn, and read `telegram(action='manual')` for the
-`Programmable Task Card` details. Shell does not create or require a watcher and
-does not import or call Telegram/Task Card runtime code.
+conditional: use the intrinsic Task Card only when it is available and useful
+for the current turn, and read its channel-neutral manual for lifecycle details.
+Shell does not create or require a watcher and does not import or call Telegram/
+Task Card runtime code.
 
 ## State & storage
 

--- a/src/lingtai/tools/bash/__init__.py
+++ b/src/lingtai/tools/bash/__init__.py
@@ -72,10 +72,10 @@ _DEFAULT_ASYNC_REMINDER_SECONDS = 1800.0
 _AGENT_ASYNC_HANDOFF = (
     "While waiting, go idle or call system(action='sleep'); the terminal result "
     "will arrive and wake you as a notification; read shell-manual and "
-    "notification-manual for details. If Telegram is connected and a Task Card "
-    "is available for the current turn, use it to report progress; call "
-    "`telegram(action='manual')` and follow its `Programmable Task Card` "
-    "section for details."
+    "notification-manual for details. If a Task Card is available and useful "
+    "for the current turn, use it only for progress; read the intrinsic "
+    "`task_card(action='manual', input={}, reasoning='...')` manual for its "
+    "channel-neutral lifecycle."
 )
 _DETACHED_DAEMON_ASYNC_HANDOFF = (
     "While this daemon is still running, Shell reminder and completion events "

--- a/src/lingtai/tools/bash/_tool_family.py
+++ b/src/lingtai/tools/bash/_tool_family.py
@@ -91,49 +91,49 @@ def _shell_setting_rows(manager: Any) -> tuple[SettingRow, ...]:
             shell_kind.value,
             None,
             True,
-            "shell-manual#shell-kind",
+            "shell-manual#settings-inventory",
         ),
         SettingRow(
             "sync_timeout_default_seconds",
             _DEFAULT_TIMEOUT_SECONDS,
             _DEFAULT_TIMEOUT_SECONDS,
             False,
-            "shell-manual#sync-timeout-default",
+            "shell-manual#settings-inventory",
         ),
         SettingRow(
             "sync_timeout_max_seconds",
             resolve_timeout_max_seconds(),
             _DEFAULT_TIMEOUT_MAX_SECONDS,
             True,
-            "shell-manual#sync-timeout-ceiling",
+            "shell-manual#settings-inventory",
         ),
         SettingRow(
             "result_max_chars",
             max_output,
             50_000,
             True,
-            "shell-manual#result-size-limit",
+            "shell-manual#settings-inventory",
         ),
         SettingRow(
             "async_default",
             False,
             False,
             False,
-            "shell-manual#async-default",
+            "shell-manual#settings-inventory",
         ),
         SettingRow(
             "async_reminder_default_seconds",
             _DEFAULT_ASYNC_REMINDER_SECONDS,
             _DEFAULT_ASYNC_REMINDER_SECONDS,
             False,
-            "shell-manual#async-reminder-default",
+            "shell-manual#settings-inventory",
         ),
         SettingRow(
             "command_policy",
             "configured",
             "platform-packaged",
             True,
-            "shell-manual#command-policy",
+            "shell-manual#settings-inventory",
             _sensitive=True,
         ),
     )
@@ -148,44 +148,30 @@ RUN_INPUT_SCHEMA: dict[str, Any] = {
         "timeout": {
             "type": ["number", "null"],
             "description": (
-                "Timeout in seconds, or null for the default 30. Only for sync "
-                "execution. Hard ceiling: "
-                f"{TIMEOUT_MAX_ENV} (default {_DEFAULT_TIMEOUT_MAX_SECONDS:g}; "
-                "the effective ceiling is read from the environment at call "
-                "time, floored at 30); a value above the ceiling is refused \u2014 "
-                "use async=true instead for work that may need longer."
+                "Timeout in seconds for sync execution; null/default is 30. The "
+                f"{TIMEOUT_MAX_ENV} ceiling defaults to {_DEFAULT_TIMEOUT_MAX_SECONDS:g}, "
+                "is read per call, and is floored at 30; above it use async=true."
             ),
             "default": _DEFAULT_TIMEOUT_SECONDS,
         },
         "working_dir": {
             "type": ["string", "null"],
             "description": (
-                "Working directory for the command; use null (or an empty "
-                "string) to use the agent working directory. Must be inside "
-                "the agent working directory sandbox; paths outside it are "
-                "rejected. For external repos/paths, keep working_dir at the "
-                "agent dir and put an explicit cd in command, e.g. "
-                "cd /absolute/path && ..."
+                "Working directory; null/empty uses the agent working directory "
+                "sandbox and outside paths are rejected. For external repos, keep "
+                "the agent dir and use `cd /absolute/path && ...` in command."
             ),
         },
         "async": {
             "type": ["boolean", "null"],
-            "description": (
-                "Run command in background and return immediately with a "
-                "job_id, or null for the default false."
-            ),
+            "description": "Background execution returning a job_id; null/default is false. Use for minutes-long work.",
             "default": False,
         },
         "reminder": {
             "type": ["number", "null"],
             "description": (
-                "Last-resort async wake delay in seconds, or null for the "
-                "default 1800. Only "
-                "meaningful when async is true: if the job is still non-terminal "
-                "when the durable deadline expires, publish a system "
-                "notification reminding you to poll it; exact completion "
-                "suppresses this stale watchdog and publishes the shell "
-                "completion wake instead."
+                "Async last-resort wake delay; null uses default 1800. It reminds "
+                "you to poll a non-terminal job; completion suppresses this fallback."
             ),
             "default": _DEFAULT_ASYNC_REMINDER_SECONDS,
         },
@@ -258,16 +244,19 @@ def get_description(
     )
     return (
         f"Execute a shell command and return stdout/stderr. Active shell dialect: {dialect}.{shell_prose}{host} "
-        "The dialect and host OS are detected at setup time; calls cannot choose them. Any system program — scripts, git, curl, pip, or data pipelines. "
-        "Before ordinary shell work, read the manual: shell(action='manual', input={}, reasoning='...'). "
-        "For a first call use shell(action='run', input={'command': '...'}, reasoning='...'); "
-        "async runs return a job_id for shell(action='poll', input={'job_id': '...'}, reasoning='...') or "
-        "shell(action='cancel', input={'job_id': '...'}, reasoning='...'). "
-        "For read-only current settings use shell(action='settings', input={}, reasoning='...'). "
-        "Completed results include exit_code, ok, command_status ('success'/'failed'), and possibly warning. "
-        "The top-level status only says the shell spawned the command, even when it fails; always check exit_code/ok and warning. "
-        "Sync runs honor the timeout ceiling; on Windows a kill-on-close Job Object terminates surviving descendants, so use input.async=true for work that must outlive the command. "
-        "Prefer `rg --files` over broad recursive scans and parse JSONL line-by-line. See the manual references for async lifecycle, wakeups, and scheduling."
+        "Dialect and host OS are fixed at setup; calls cannot choose them. For short deterministic work use "
+        "shell(action='run', input={'command': '...'}, reasoning='...'). Keep working_dir inside the agent "
+        "sandbox; for an external checkout use an explicit cd in command. For minutes-long work set "
+        "input.async=true; completion/reminder events return a job_id for "
+        "shell(action='poll', input={'job_id': '...'}, reasoning='...') or "
+        "shell(action='cancel', input={'job_id': '...'}, reasoning='...') within task authority. "
+        "For deeper guidance use shell(action='manual', input={}, reasoning='...'); for read-only settings use "
+        "shell(action='settings', input={}, reasoning='...'). Completed results "
+        "include exit_code, ok, command_status ('success'/'failed'), and possibly a warning field: top-level status "
+        "only says the shell spawned/completed the command, not inner success; check exit_code/ok and fidelity fields. Sync runs honor the timeout "
+        "ceiling; on Windows a kill-on-close Job Object terminates surviving descendants, so use async for "
+        "work that must outlive the command. Read shell-manual before coding-CLI, scheduled, unfamiliar, or "
+        "recovery work; its focused references own the detail."
     )
 
 

--- a/src/lingtai/tools/bash/manual/SKILL.md
+++ b/src/lingtai/tools/bash/manual/SKILL.md
@@ -7,8 +7,8 @@ description: >
   wake-by-mailbox-drop, one-shot reminders, and safe cleanup. Per-backend CLI
   operational detail (command shapes, flags, env contracts) for daemon-backed
   CLIs lives in `daemon-manual` → `reference/cli-backends/SKILL.md`.
-version: 1.13.0
-last_changed_at: 2026-09-06T00:00:00Z
+version: 1.15.0
+last_changed_at: 2026-09-09T00:00:00Z
 related_files:
 - src/lingtai/tools/bash/__init__.py
 - src/lingtai/tools/bash/_tool_family.py
@@ -19,6 +19,7 @@ related_files:
 - src/lingtai/tools/bash/manual/reference/scheduled-work/SKILL.md
 - src/lingtai/tools/bash/manual/reference/notification-reminders/SKILL.md
 - src/lingtai/tools/bash/manual/reference/debugging-cleanup/SKILL.md
+- src/lingtai/tools/task_card/manual/SKILL.md
 - src/lingtai/tools/daemon/manual/SKILL.md
 - src/lingtai/tools/daemon/shell_prompt_events.py
 maintenance: |
@@ -27,180 +28,66 @@ maintenance: |
   changes.
 ---
 
-# Shell Manual — Router
+# Shell manual — router
 
-The `shell` tool executes one host command at a time. This manual is the
-progressive-disclosure entrypoint: keep first-call and safety rules here, then
-open the focused reference for durable async jobs, host scheduling, one-shot
-reminders, or debugging/cleanup. For ordinary short, deterministic commands,
-use the schema synchronously; for anything long-running, scheduled, or
-failure-prone, read the matching route first.
+Use the schema for a short, deterministic command. Read one focused route before
+long-lived/coding-CLI work, scheduling, an unfamiliar workflow, or recovery.
+The selected dialect, policy, and working-directory sandbox remain boundaries.
 
-## Routing table
+## Route by task
 
-| Need / keywords | Read |
+| Task | Read one direct reference |
 |---|---|
-| Run a long-lived command or coding CLI without blocking the turn; `job_id`, `poll`, `cancel`, reminder, completion wake, or relaunch | [async jobs](reference/async-jobs/SKILL.md) |
-| "Every hour", "daily", "weekdays at 9", or any other time-driven recurring work | [scheduled work](reference/scheduled-work/SKILL.md) |
-| A single future nudge while work is pending | [notification reminders](reference/notification-reminders/SKILL.md) |
-| A scheduler is silent, fires twice, exits immediately, or must be retired | [debugging and cleanup](reference/debugging-cleanup/SKILL.md) |
-| Backend-specific coding-CLI flags, environment, and parser caveats | `daemon-manual` → `reference/cli-backends/SKILL.md` |
+| Long command/CLI; `job_id`, `poll`, `cancel`, reminder, completion, relaunch, or async recovery | [async jobs](reference/async-jobs/SKILL.md) |
+| Recurring or time-triggered work | [scheduled work](reference/scheduled-work/SKILL.md) |
+| One future self-wakeup | [notification reminders](reference/notification-reminders/SKILL.md) |
+| Silent, duplicated, failed, or retired scheduler | [debugging and cleanup](reference/debugging-cleanup/SKILL.md) |
+| Unfamiliar dialect, working directory, timeout, or policy boundary | First success and Settings inventory below |
+| Backend-specific CLI flags, environment, or parser behavior | `daemon-manual` → `reference/cli-backends/SKILL.md` |
 
-The async reference supersedes the former long coding-CLI and durable-lifecycle
-block in this router. The three host/scheduler references remain the owners of
-their recipes; do not duplicate their examples here.
+## First success
 
-## First-call decision tree
+1. For a bounded command, call `shell(action="run", input={"command": "..."},
+   reasoning="...")` synchronously. Keep `working_dir` inside the sandbox; for
+   an external checkout, leave it at the granted root and use
+   `cd /absolute/path && ...` in the command. Dialect is fixed and policy still
+   applies.
+2. For work that may take minutes, set `input.async=true` and keep the returned
+   `job_id`. On completion or a genuine health-check trigger, poll once for
+   exact output; do not poll to stay active. Follow up with
+   `shell(action="poll", input={"job_id": "..."}, reasoning="...")`; cancel only
+   within authority with `shell(action="cancel", input={"job_id": "..."}, reasoning="...")`.
+   A reminder means “may still be running,” not completion; cancellation is not cleanup.
+3. Judge `exit_code`, `ok`, `command_status`, and `warning`; top-level `status`
+   only records spawn/terminal handling, not inner command success. `status:
+   "error"` means Shell could not run it. Prefer bounded `rg --files` and parse
+   JSONL line by line.
 
-1. **Short deterministic host work** (for example `ls`, `git status`, `grep`, or
-a quick bounded build): call `shell(action="run", input={"command": "..."},
-reasoning="...")` synchronously.
-2. **Anything that may run for minutes**: never block the turn. Call `run` with
-`input.async=true`, then follow the async reference and poll with the returned
-ID. A coding CLI is not a LingTai daemon; read `daemon-manual` when choosing
-between a direct CLI and a daemon backend.
-3. **Time is the trigger**: read `reference/scheduled-work/SKILL.md`.
-4. **One future self-wakeup**: read `reference/notification-reminders/SKILL.md`.
-5. **Existing scheduler trouble or retirement**: read
-`reference/debugging-cleanup/SKILL.md` before editing it.
+Unknown or late async state stays unknown: never invent an exit code,
+completion, or cancellation before durable terminal truth. Keep the job ID
+pollable after lease/return failure. Completion is authoritative; a reminder is
+fallback. Retain artifacts unless the human authorizes cleanup. Optional
+progress is channel-neutral; use `task_card(action="manual", input={})`.
+Shell creates no watcher.
 
 ## Settings inventory
 
-`shell(action="settings", input={}, reasoning="inspect applied Shell settings")`
-is read-only progressive disclosure. It returns only rows with `key`, `current`,
-`default`, `configurable`, and the exact section pointer in `comment`. The input
-is strict empty: there is no set/reset mutation form and Shell owns no settings
-file. Read the matching section before changing a value through its existing
-owner procedure, then call `settings` again. If any current value is
-unavailable, the whole action returns `SETTINGS_UNAVAILABLE` without partial
-rows.
+Call `shell(action="settings", input={}, reasoning="inspect applied Shell
+settings")` for read-only rows. The live schema/settings response owns values and
+configurability; this section owns only procedures. SHOW has no set/reset
+authority and an unavailable value fails the whole action without partial rows.
 
-### Shell kind
+| Row | Meaning, source and authorized change |
+|---|---|
+| `shell_kind` | Setup-selected `posix`, `powershell`, `cmd`, `gitbash` or `wsl`; valid capability value wins, then case-insensitive `LINGTAI_SHELL`, then platform discovery. Invalid values fall through; default is null because discovery has no universal shell. Change the capability/launcher or `setup(shell_kind=...)`, rebuild/relaunch the owning Agent, recheck SHOW. |
+| `sync_timeout_default_seconds` | Built-in 30, immutable; nullable call timeout uses it. A finite non-negative per-call timeout does not reconfigure it. |
+| `sync_timeout_max_seconds` | `LINGTAI_TOOL_TIMEOUT_MAX_SECONDS` read each call/SHOW: positive finite values win over 120, invalid/missing values use 120, and values below 30 are floored at 30. Change only the authorized process/launcher environment; relaunch if snapshotted. Work above the ceiling uses async. |
+| `result_max_chars` | Per-stream stdout/stderr capture limit, default 50000. Only an authorized embedding owner can pass positive `ShellManager(max_output=...)` before rebuilding the manager. Normal capability setup exposes no key or environment override. |
+| `async_default` | Built-in false, immutable; `input.async` selects one call. |
+| `async_reminder_default_seconds` | Built-in 1800, immutable. For one async run, `input.reminder` must be finite/non-negative within the platform timer bound; it is fallback, not completion. |
+| `command_policy` | Both values stay redacted. Authorized setup selects `yolo=true`, then `policy_file`, then packaged policy; rebuild/relaunch and verify SHOW. No rules/paths are disclosed. |
 
-`shell_kind` is the active command-language adapter: `posix`, `powershell`,
-`cmd`, `gitbash`, or `wsl`. An authorized owner may configure it. Precedence is
-a valid capability value, then valid case-insensitive `LINGTAI_SHELL`, then
-platform discovery; invalid values fall through. The projected default is
-`null` because discovery has no universal fallback. Change the capability or
-launcher configuration (or call `setup(..., shell_kind="<kind>")`), rebuild or
-relaunch the owning Agent, and verify with SHOW. Dialect selection never bypasses
-command policy or the working-directory boundary.
-
-### Sync timeout default
-
-`sync_timeout_default_seconds` is the built-in 30-second default when sync
-`run` receives `input.timeout=null` or omits it through compatibility handling.
-It is built-in-only and not family-configurable. A finite, non-negative timeout
-up to the live ceiling applies to one call only; a later SHOW still reports 30.
-
-### Sync timeout ceiling
-
-`sync_timeout_max_seconds` is the hard synchronous `input.timeout` ceiling. Its
-owner environment key is `LINGTAI_TOOL_TIMEOUT_MAX_SECONDS`: a positive finite
-value wins over 120; missing, blank, non-numeric, non-positive, or non-finite
-values use 120, and values below 30 are floored to 30. The value is read for
-each SHOW and sync run. Change it only in the authorized process/launcher
-environment (relaunch when that environment is snapshotted). Work needing more
-than the ceiling must use `input.async=true`.
-
-### Result size limit
-
-`result_max_chars` is the per-stream stdout/stderr capture limit. The built-in
-is 50000; an authorized embedding owner may pass a positive `max_output` to
-`ShellManager(...)` when constructing it. Normal setup exposes no `max_output`
-key or environment setting. Rebuild the manager and SHOW again to verify. This
-limit changes result disclosure only; it grants no command or filesystem
-authority.
-
-### Async default
-
-`async_default` is the built-in `false` when `run` does not select a mode. It has
-no config or environment key. `input.async=true` or `false` selects one call
-only and does not change a later SHOW.
-
-### Async reminder default
-
-`async_reminder_default_seconds` is the built-in 1800-second last-resort wake
-delay for async `run` without an explicit reminder. It has no config or
-environment key. For one async run, pass a finite non-negative `input.reminder`
-within the platform timer bound; that value does not change the default.
-
-### Command policy
-
-`command_policy` is the security-sensitive allowlist, denylist, or allow-all
-policy bound to this Shell owner. Both `current` and `default` are always
-`<redacted>`; policy paths and rules never enter SHOW. Precedence is capability
-`yolo=true`, then `policy_file`, then the platform-packaged policy. An
-authorized owner changes these through existing capability/setup procedures.
-SHOW has no mutation authority and remains redacted on every call.
-
-## Reading command results — never trust top-level `status` alone
-
-A completed result's top-level `status` (`ok`/`done`) says only that the shell
-spawned the command, not that the command succeeded. Always check `exit_code`
-and `ok`; `command_status` is `success` or `failed`. Read `warning` whenever it
-is present: it can identify a nonzero exit, Python traceback, missing module,
-or a bounded redacted stderr tail. Raw `stdout` and `stderr` remain available.
-A still-running poll has no `exit_code` and therefore no fidelity fields.
-
-For project code, use the repository/approved virtualenv interpreter rather
-than bare `python3`; a `No module named …` warning usually means the wrong
-interpreter was selected. The top-level `status: "error"` is reserved for the
-shell failing to run the command (validation, policy, timeout, or spawn error),
-so do not rewrite inner command failure as a transport error.
-
-## Avoid broad recursive scans and malformed log parsing
-
-Unbounded `find … -name/-path/-type`, `Path(...).rglob(...)`, `os.walk(...)`, or
-`glob('**/...')` scans over large roots commonly time out. Prefer a bounded root
-and `rg --files --hidden -g '!**/{.git,node_modules,daemons,.worktrees}/**'`
-then filter the list; narrow the root or add `-maxdepth` when appropriate.
-The timeout result may include an advisory `rg --files` recipe, but it never
-rewrites the command.
-
-`events.jsonl` and daemon logs are JSON Lines, not one JSON document. Iterate
-non-empty lines with `json.loads`, or filter with `jq -c`/`rg`; use `tail -n`
-when only recent evidence is needed.
-
-## Core async rule and first follow-up
-
-A long-running command, coding CLI, or sub-agent must **never** run
-synchronously. Use `input.async=true`; the immediate result contains a
-`job_id`, and later calls use the registered envelope, not a flat legacy shape:
-
-```text
-shell(action="run", input={"command": "<long command>", "async": true,
-                             "reminder": 1800}, reasoning="start it")
-shell(action="poll", input={"job_id": "job-<id>"}, reasoning="check it")
-```
-
-The run-only fields (`command`, `timeout`, `working_dir`, `async`, `reminder`)
-live only in `run`'s `input`; `poll` and `cancel` take only `job_id`. `null`
-means absent for nullable run options: timeout defaults to 30 for sync, async
-defaults to false, and reminder defaults to 1800. The `working_dir` must remain
-inside the active sandbox; for an external checkout keep the granted agent
-working directory and use an explicit `cd /absolute/path && ...` in `command`.
-Before ordinary shell work, read this manual; no exception. Open
-`reference/async-jobs/SKILL.md` for durable leases, reminder/completion wakes,
-relaunch-safe status, cancellation, detached-daemon behavior, and coding-CLI
-harness detail.
-
-## Host scheduling and cleanup routes
-
-LingTai has no built-in recurring scheduler. Host schedulers wake agents by
-producing channel input, usually a mailbox drop. Prefer event watchers when an
-external event is the real trigger; use cron/launchd/systemd only when time is
-the trigger or polling is the right tradeoff. Scheduler scripts must be
-idempotent, audited, logged, absolute-path based, and explicit about how they
-wake the agent. On macOS, read the scheduled-work reference's launchd
-process-tree warning. Do not leave silent janitors or hidden recurring jobs;
-read the debugging reference before retirement. A shell-created artifact is
-not automatically safe to delete: retain work unless the human explicitly
-approves a dry-run and cleanup plan.
-
-## Maintenance
-
-Keep this top-level document a short router. Put detailed async lifecycle,
-backend flags, scheduler recipes, notification payloads, and troubleshooting
-walkthroughs in the focused references above so agents load only the depth they
-need. Preserve the exact settings headings because SHOW comments link to them.
+SHOW is strict-empty and read-only; there is no Shell settings file or mutation
+verb. Verify an authorized change through its owning construction procedure and
+SHOW. Result limits affect disclosure, not authority; no setting permits a
+working-directory escape.

--- a/src/lingtai/tools/bash/manual/reference/async-jobs/SKILL.md
+++ b/src/lingtai/tools/bash/manual/reference/async-jobs/SKILL.md
@@ -3,191 +3,103 @@ name: bash-async-jobs
 description: >
   Nested shell-manual reference for durable asynchronous shell jobs: detached
   daemon routing, reminder/completion wakeups, relaunch-safe polling,
-  cancellation, and the shell-side coding-CLI harness rules.
-version: 1.0.0
-last_changed_at: 2026-09-06T00:00:00Z
+  cancellation, and shell-side coding-CLI supervision.
+version: 1.1.0
+last_changed_at: 2026-09-09T00:00:00Z
 related_files:
 - src/lingtai/tools/bash/manual/SKILL.md
 - src/lingtai/tools/bash/_async_supervisor.py
 - src/lingtai/tools/bash/_async_process.py
 - src/lingtai/tools/bash/_state_lock.py
+- src/lingtai/tools/task_card/manual/SKILL.md
 maintenance: |
-  Tracks the durable async shell-job and shell-side coding-CLI topic it
-  documents; update this reference and its parent router when that lifecycle or
-  routing changes.
+  Tracks durable async shell jobs and the shell-side coding-CLI topic; update
+  this reference and its parent router when that lifecycle or routing changes.
 ---
 
-# Async Shell Jobs Reference
+# Async shell jobs
 
-Nested shell-manual reference. Open this after the top-level manual's first-call
-rules when a background command needs durable polling, reminder/completion
-wakeup, cancellation, relaunch recovery, or coding-CLI supervision. The shell
-engine and its process adapters own execution; this page only discloses the
-operational discipline and recovery details.
+Open this after the router for a background command, coding CLI, completion or
+reminder wake, relaunch recovery, cancellation, or detached-daemon supervision.
+The engine and process adapters own execution; this page owns agent procedure.
 
-## Core async rules
+## Start and follow up
 
-A long-running agent/coding CLI session — `claude -p`, `codex exec`, `opencode
-run`, the Cursor agent CLI, or any sub-agent that may think and run tools for
-minutes — must **never** be a synchronous `shell` call. Run it with
-`input.async=true` and poll the returned `job_id`. A synchronous call blocks the
-whole turn until the child exits: you stay `ACTIVE` and stop seeing channel
-notifications (mail, refresh, interrupts). Async + poll keeps the turn
-responsive and prevents ACTIVE blockage while the child CLI works.
-
-The public envelope is used for every follow-up. Run-only fields
-(`command`, `timeout`, `working_dir`, `async`, and `reminder`) stay in `run`'s
-`input`; `poll` and `cancel` take only `job_id`:
+A command that may run for minutes must not block the turn. Keep `working_dir`
+inside the granted sandbox; for an external checkout use an explicit `cd` in the
+command. Use the registered envelope, keep the returned ID, and use `poll` only
+after completion/reminder notification or a genuine health check:
 
 ```text
-shell(action="run",
-      input={"command": "<long command>", "async": true, "reminder": 1800},
-      reasoning="start the background command")
-shell(action="poll",
-      input={"job_id": "job-<id>"},
-      reasoning="check the background command")
-shell(action="cancel",
-      input={"job_id": "job-<id>"},
-      reasoning="stop the background command")
+shell(action="run", input={"command": "<long command>", "async": true,
+                             "reminder": 1800}, reasoning="start it")
+shell(action="poll", input={"job_id": "job-<id>"}, reasoning="check it")
+shell(action="cancel", input={"job_id": "job-<id>"}, reasoning="stop it")
 ```
 
-Use a Task Card for progress only when Telegram is connected and a Task Card is
-available for the current turn. In that conditional case, read
-`telegram(action='manual')` and follow its `Programmable Task Card` section.
-Shell does not create or require a watcher; this guidance does not change the
-job lifecycle.
+Run-only fields stay in `run.input`; `poll` and `cancel` take only `job_id`.
+If `_advisory` says a poll already executed, stop tight polling: handle
+messages, do other work, or wait for a state-change trigger. A channel-neutral Task Card is optional;
+read `task_card(action="manual", input={})` before operating a watcher. Shell creates no watcher.
 
-If repeated-call `_advisory` appears on `shell(action="poll")`, the poll
-already executed. Stop tight polling: handle messages, do other work, or set a
-future reminder, then poll again only when a completion notification, reminder,
-or concrete state change warrants it.
+## Detached-daemon route
 
-## Detached daemon Shell
+A selected detached daemon has no Agent notification store, mailbox, heartbeat,
+or `.notification` route. Its jobs live under that run's private
+`<run>/shell-jobs`, while command cwd remains the granted parent workdir. A
+reminder/completion is a bounded same-run prompt event only while the daemon is
+live; it is not a parent wake or `daemon_common` checkpoint. Queue-full
+admission is retried by the live manager with capped backoff. Events carry a job
+ID, not stdout/stderr; poll for exact output at the next safe model-send
+boundary. Read `daemon-manual` for daemon lifecycle and recovery.
 
-When a **selected detached LingTai daemon** uses `shell`, it has no live Agent
-notification store, mailbox, heartbeat, or `.notification/system.json` /
-`.notification/bash.json` route. Its async job state is in that run's private
-`<run>/shell-jobs` namespace, never the task workdir's shared `system/jobs`,
-even though command cwd remains the granted parent task workdir. Its async
-reminder/completion becomes a bounded same-run prompt event only while that
-daemon is still live. A temporarily full event queue is retried by the live
-selected manager with capped backoff after capacity can drain. The event
-contains a job id but **not** command stdout/stderr; at its next safe model-send
-boundary the daemon is told to call `shell.poll` for exact output. It is not a
-parent wake or `daemon_common` checkpoint, does not auto-poll or consume the
-result, and does not keep/restart a terminal daemon. Read `daemon-manual` for
-the daemon lifecycle rule. Ordinary Agent Shell keeps the `.notification`
-behavior described below.
+## Reminder, completion, and health
 
-## Reminders, completion wakes, and idle care
+`reminder` is a last-resort wake delay chosen for the expected duration (default
+1800 seconds), not proof of completion. Durable startup and `return_handoff`
+leases prevent a relaunch from publishing the crash fallback while the first
+manager is before supervisor spawn or before its successful return transition.
+A successful run arms `returned_at + reminder`; if that bounded transition
+expires, Shell returns a pollable recovery error with the durable ID/PID rather
+than false success.
 
-Set an async `input.reminder` that matches the expected duration. Every async
-run has a last-resort reminder; `null` (or omission through the compatibility
-path) uses 1800 seconds. The value is run-only: `poll` and `cancel` never carry
-it. Pick the delay from the task's *expected* duration, not a fixed number — a
-30-second scan and a 40-minute build warrant different windows.
+A due non-terminal job publishes `bash.reminder:<job_id>` to
+`.notification/system.json`; exact supervisor terminal commit suppresses that
+watchdog and publishes authoritative completion to `.notification/bash.json`.
+These refs provide bounded/current-sink deduplication, not global exactly-once
+delivery. A sink write may remain as historical evidence after a later commit.
+This reminder is distinct from `.notification/cron.json` workflow reminders.
 
-The initial durable deadline is a crash fallback while the supervisor starts. A
-bounded durable `return_handoff` guard prevents a relaunched/second manager from
-publishing that fallback while the first manager is before supervisor `Popen`,
-or after the command is durably `running` but before async `run` has completed
-its return transition. Successful `run` atomically resets the deadline to
-`returned_at + reminder` and arms the guard, so startup latency does not consume
-the requested interval. Shell reports `status: ok` only when this still-valid
-transition wins (or exact completed/failed truth already won under the valid
-guard). If the owner resumes after expiry, it returns `status: error` with the
-durable `job_id`/`pid` and an explicit pollable-recovery message rather than
-claiming false success.
-
-If the job remains non-terminal when its final deadline expires, Shell publishes
-a `bash.reminder` event into `.notification/system.json`. The deadline and
-stable `bash.reminder:<job_id>` claim survive agent stop/relaunch: Shell re-arms
-a future deadline or retries an overdue/stale claim. Cancellation temporarily
-uses a bounded durable `suppressing` state; if the manager crashes or the
-supervisor does not commit before it expires, reminder publication becomes
-recoverable again. Exact supervisor terminal commit suppresses a
-pending/publishing/suppressing `may still be running` watchdog and publishes
-the authoritative completion wake through `.notification/bash.json`; terminal
-poll and confirmed cancellation also suppress future reminder retries.
-
-Final reminder publication and suppression are serialized, so a stale claim
-that loses the job-state lock cannot publish. If the reminder sink write won
-before terminal commit, that already-published event may remain as historical
-evidence. Stable refs are bounded/current-sink deduplication aids, not a global
-exactly-once guarantee: a crash after sink write before durable acknowledgement
-can retry after the bounded system list evicts the reminder ref, while the
-latest-only Bash slot can be overwritten by another completion.
-
-When a reminder fires, health-check rather than assume progress: poll the job,
-confirm the log is **growing**, the PID/child is **alive** if still running, the
-output file/worktree shows **progress**, and the job is not stuck on an
-interactive prompt or provider/model error. If there is no progress, do not
-keep waiting — cancel, downgrade, or switch path, and report to the human. Use
-a separate `.notification/cron.json` reminder or delayed self-email only for a
-broader workflow wake that is not tied to one Shell async job. A Bash reminder
-belongs to one persisted `job_id`; `.notification/cron.json` is a separate
-scheduled workflow wake.
+When a reminder fires, poll once and check that logs/output are growing, the
+recorded process is alive, and work is not waiting for an interactive prompt or
+provider error. If there is no progress, diagnose it; cancel or change path only within task
+authority and report the blocker;
+do not keep waiting by reflex.
 
 ## Relaunch-safe status and cancellation
 
-The launching manager records the observed supervisor identity immediately;
-the detached supervisor confirms its incarnation and persists exact wait truth.
-A missing command PID is not a terminal result while that supervisor may still
-commit: poll retries briefly, then remains recoverably `running` unless the
-supervisor is definitively gone. A retained legacy job with a still-live
-recorded PID remains conservatively `running` and uncancellable because Bash
-cannot prove that PID's incarnation; after the PID dies, one poll may return
-`exit_status_known: false` and `exit_code: null`. Unrecoverable durable state
-uses the same explicit unknown shape. Bash never invents `-1` or calls that a
-command failure.
+A missing command PID is not terminal proof while the recorded supervisor may
+still commit. Poll keeps the job recoverably `running` until bounded lease or
+supervisor-loss evidence proves otherwise. Legacy live-PID records stay
+uncancellable because incarnation cannot be proved; after death, one poll may
+return `exit_status_known: false` and `exit_code: null`. Never invent `-1`, an
+exit code, completion, or cancellation.
 
-Cancellation is a durable request to the supervisor that holds the unreaped
-child: it sends TERM, bounded KILL escalation if needed, and reports
-`cancelled` only after exact terminal commit. A timeout/error leaves poll and
-the reminder available for recovery. Terminal poll and successful cancel are
-atomic one-shot consumer actions; the durable record remains for evidence, but
-any later poll/cancel returns `Job already finished` instead of exposing a
-second result. New job IDs carry full UUID4 hex; legacy eight-hex IDs are
-accepted only to read retained old records.
+Cancellation is a durable supervisor request: TERM, bounded KILL escalation,
+then exact terminal commit. It reports `cancelled` only after that commit.
+A cancellation timeout/error remains pollable and remindable; do not call it
+stopped or retry the underlying command without reconciling its outcome.
+Terminal poll and successful cancel are atomic one-shot consumers; the durable
+record and logs remain for evidence. Later consumers receive `Job already
+finished`. New IDs use full UUID4 hex; eight-hex IDs are legacy read support.
 
-## Coding-CLI harness baseline
+## Coding-CLI baseline
 
-These two rules apply to every coding-CLI run, whether via `shell` (async +
-poll) or as a daemon backend: run `--help` before relying on any flag, and pick
-CLI-vs-daemon by the shape of the work. Per-CLI specifics (flags, env, caveats)
-are owned by `daemon-manual` → `reference/cli-backends/SKILL.md`, which
-supersedes the old bash reference guides.
-
-**Before relying on any coding CLI in automation:** run the installed CLI's own
-`--help`. Flag surfaces change between releases, so a documented flag is
-illustrative, never authoritative.
-
-**CLI vs daemon — pick by the shape of the work.** A CLI subprocess is one
-synchronous run whose transcript you read yourself; a LingTai daemon is a
-dispatched worker with its own worktree, branch, and context window.
-
-| Signal | Pick |
-|---|---|
-| "I want the answer in this conversation, now" | **CLI** |
-| "The output is a small string/snippet I'll paste somewhere" | **CLI** |
-| "I need this exact CLI model/agent/flag, or a warm attached server" | **CLI** |
-| "I want to do three of these at once" | **Daemon** (one per task) |
-| "I'll review a diff afterward, not the transcript" | **Daemon** |
-| "This will take 15+ minutes and produce a branch" | **Daemon** |
-| "This might block my main turn while a human waits" | **Daemon** or supervised background wrapper |
-| "I'm the orchestrator; the daemon is the worker" | **Daemon** |
-
-When in doubt for non-trivial work: daemon. A CLI has **no LingTai job protocol
-of its own** — "async" always means a LingTai or OS wrapper around it
-(`shell` with `input.async=true`, a supervised background wrapper, or a daemon
-backend), and that wrapper owns logs, timeout, cancellation, and recovery notes.
-Keep synchronous inline calls short and explicitly timed; do not solve a long
-task by raising the synchronous timeout to 15+ minutes while the main agent
-waits. Checkpoint the worktree, branch, goal, and recovery instructions to pad
-or a journal before dispatching anything that might outlive the turn, and prefer
-several smaller bounded calls over one monolithic prompt. Backend names,
-`backend_options`, `ask`/resume, and per-backend parser caveats belong to
-daemon-manual → `reference/cli-backends/SKILL.md`, not here.
-
-Backend-promotion criteria for a CLI that is not yet a daemon backend live in
-daemon-manual → `reference/cli-backends/SKILL.md` (`## Backend promotion gate`).
+Before relying on any installed coding CLI, run its own `--help`; flags and
+parser behavior belong to `daemon-manual` → `reference/cli-backends/SKILL.md`.
+Choose a CLI for an answer/transcript or exact model/flag; choose a daemon for
+parallel work, a branch/diff, or work likely to outlive the turn. A CLI has no
+LingTai job protocol: `async` is the Shell/OS wrapper that owns timeout, logs,
+cancellation, and recovery. Keep inline calls short, checkpoint worktree and
+recovery instructions before dispatch, and prefer several bounded calls to one
+monolith. For backend promotion criteria, use the same daemon reference.

--- a/src/lingtai/tools/bash/manual/reference/debugging-cleanup/SKILL.md
+++ b/src/lingtai/tools/bash/manual/reference/debugging-cleanup/SKILL.md
@@ -2,124 +2,66 @@
 name: bash-debugging-cleanup
 description: >
   Nested shell-manual reference for debugging silent scheduled jobs and retiring
-  cron jobs safely: scheduler fired, script ran, work landed, agent saw mail,
-  worked launchd diagnosis, cleanup, and bash work footprint hygiene.
-version: 1.0.1
-last_changed_at: 2026-07-19T00:00:00Z
+  schedulers safely: scheduler, script, work, wake, launchd, cleanup, and shell
+  work-footprint checks.
+version: 1.1.0
+last_changed_at: 2026-09-09T00:00:00Z
 related_files:
 - src/lingtai/tools/skills/manual/reference/cleanup-footprint-contract.md
 - src/lingtai/tools/bash/manual/SKILL.md
 - src/lingtai/tools/bash/manual/reference/scheduled-work/SKILL.md
 maintenance: |
-  Tracks the scheduled-job debugging/cleanup topic it documents; update when that integration changes.
+  Tracks scheduled-job debugging and cleanup; update when that integration or
+  the shared footprint recipe changes.
 ---
 
-# Debugging and Cleanup Reference
+# Debugging and cleanup
 
-Nested shell-manual reference. Open this when a scheduled job goes silent, fires
-incorrectly, or needs to be retired or cleaned up.
+Open this when a scheduler is silent, fires twice, exits early, or must be
+retired. Diagnose in order; do not assume that a successful scheduler exit means
+that the work or wake reached the agent.
 
-## Debugging cron — when things go silent
+## Silent scheduled work
 
-When a scheduled job stops working, the failure is almost always in one of these places. Walk the list in order.
+1. **Did the scheduler fire?** macOS: `launchctl list <label>` and inspect
+   `PID`/`LastExitStatus`; Linux: `systemctl --user list-timers`; cron: inspect
+   `/var/log/cron` or `journalctl -u cron` for `CMD`. Check unit syntax
+   (`plutil -lint` or `systemctl --user status`), loaded/disabled state, sleep
+   catch-up behavior, and clock time.
+2. **Did the script run?** Read its own append-only log, not only scheduler
+   stdout/stderr. A missing `[fire]` means an early launch failure; a `[fire]`
+   without completion means an in-script failure. Keep `set -euo pipefail` and
+   log the command boundary that failed.
+3. **Did work land?** Compare the script's audit evidence with the expected
+   artifact/commit/message. A logged success with no artifact is script logic,
+   not a scheduler mystery.
+4. **Did the agent see the wake?** For mailbox work, inspect human
+   `mailbox/outbox/<uuid>`, then `mailbox/sent/<uuid>`, then the recipient's
+   `mailbox/inbox/<uuid>`. Validate malformed JSON and confirm the recipient.
+   A queued mail waits for the next turn; use the scheduler reference's
+   `.refresh` rule only when prompt pickup is required.
 
-### 1. Did the scheduler fire?
+## Retire without a janitor race
 
-- macOS: `launchctl list <label>` — check `LastExitStatus` and the `PID` field. If `PID = -` and `LastExitStatus = 0` and you expect a recent fire, the schedule didn't trigger.
-- Linux systemd: `systemctl --user list-timers` — shows last and next fire times. If "last" is older than expected, the timer didn't fire.
-- crontab: check `/var/log/cron` (or `journalctl -u cron`) for "CMD" lines.
+First obtain explicit authority for stopping/removing the named scheduler and
+review a dry-run. Then:
 
-If the scheduler didn't fire, the culprit is usually:
+1. Unload the unit (`launchctl unload <plist>` or
+   `systemctl --user disable --now <timer>`), and verify it is gone.
+2. Only then remove the unit and script; archive logs if history matters.
+3. Record the unit name and retained evidence. Never delete the script first,
+   remove `.agent.lock`, or launch a parallel relaunch: the kernel owns its
+   flock and refresh watcher. On macOS, a scheduler may reap descendants when
+   its process exits; read the scheduled-work process-tree warning before
+   intentionally launching a long-lived child.
 
-- **Plist/timer file is wrong** — XML/INI parse error means the unit silently didn't load. macOS: `plutil -lint <plist>`. systemd: `systemctl --user status <timer>`.
-- **Job was unloaded** — somebody (you, an installer, an OS update) called `launchctl unload` or `systemctl disable`.
-- **Sleep/standby** — laptop was closed during the schedule. launchd handles this for `StartCalendarInterval` (catches up on wake) but not for `StartInterval`. systemd needs `Persistent=true`.
-- **Clock skew** — system time was wrong at fire time, now correct. Look at `date` output and compare to expected fire time.
+## Shell footprint
 
-### 2. Did the script run?
-
-- Check the script's own log file (the `LOG_FILE` you write to, not just stdout/stderr).
-- If `LOG_FILE` has no entry from the expected time, but the scheduler claims it fired: the script crashed before its first `log` call. Check the launchd `.err` file or systemd journal for the bash error.
-- If `LOG_FILE` has a `[fire]` entry but no completion entry: the script started but exited mid-way. `set -euo pipefail` should have made the failure visible — re-check that line is at the top.
-
-### 3. Did the work land?
-
-This is what audit blocks are for. If the script ran and logged success but the downstream artifact (commit, file, message) isn't there, the failure is in the script's logic, not in cron. Read the script's audit lines and the commands they wrap.
-
-### 4. Did the agent see the mail?
-
-If the cron drops mail and you (the agent) are debugging "why didn't I act":
-
-- Is the message in `human/mailbox/sent/<uuid>/`? If yes: the kernel claimed it; you should have seen it in your inbox.
-- Is it still in `human/mailbox/outbox/<uuid>/`? Then the kernel never claimed it. Check that you (the recipient) are running and your `to` address matches.
-- Is the file there but malformed JSON? `python3 -c "import json; json.load(open('<path>'))"` — a JSON parse error means the kernel rejected it.
-
-## Debugging session for a "silent hourly cron" (worked example)
-
-Symptom: cron is supposed to fire hourly. Last poem on the website is from 5 hours ago. Nothing in the cron log between 5h ago and now.
-
-```bash
-# Step 1: did the scheduler fire?
-launchctl list | grep ai.lingtai
-# ai.lingtai.libai-hourly  -  0
-# PID is "-" (not running) and LastExitStatus is 0 — so it's loaded but
-# either never fired or fired and exited cleanly each time.
-
-# Step 2: launchd's own logs
-log show --predicate 'process == "launchd"' --last 6h | grep libai-hourly
-# (no output) → launchd never fired the job in the last 6 hours.
-
-# Step 3: did the plist get unloaded?
-ls -la ~/Library/LaunchAgents/ai.lingtai.libai-hourly.plist
-# (file exists)
-plutil -lint ~/Library/LaunchAgents/ai.lingtai.libai-hourly.plist
-# OK → plist parses fine
-
-# Step 4: was the laptop asleep?
-pmset -g log | grep -i 'sleep\|wake' | tail -20
-# Sleep ... 5h ago, Wake ... just now → mystery solved.
-# The Mac was asleep for the missed hours. launchd catches up at most one
-# missed StartCalendarInterval fire on wake; longer outages drop the
-# missed fires entirely.
-```
-
-Fix in this case: not a code fix — a "this is how launchd works, bring the machine out of sleep at the relevant times" fact. Document the limitation, optionally add a wake-from-sleep schedule via `pmset` if hourly accuracy across closed-laptop hours matters.
-
-## Cleanup — when retiring a cron job
-
-Reverse of setup, in this order:
-
-1. `launchctl unload <plist>` (or `systemctl --user disable --now <timer>`).
-2. Verify it's gone: `launchctl list | grep <prefix>` (or `systemctl --user list-timers`).
-3. Delete the plist/unit files.
-4. Delete the script and its log files (or archive them if the human wants the history).
-5. Remove any `~/Library/LaunchAgents/<label>.plist` entry that wasn't caught above.
-
-Don't delete the script first — if the unit is still loaded and tries to fire a missing executable, you get noisy error logs.
-
-## Cleanup / Footprint for bash work
-
-`bash` can create anything the command creates: scripts, logs, downloads,
-virtualenvs, cron/launchd/systemd units, and arbitrary build artifacts. Because
-ownership is command-specific, every non-trivial bash workflow should document
-its own cleanup path near the script it creates. Never run a destructive shell
-cleanup from a manual without first showing a dry-run and getting explicit user
-consent.
-
-Footprint check: load the [shared inspection recipe](../../../../skills/manual/reference/cleanup-footprint-contract.md#shared-footprint-check-recipe)
-through `skills-manual` → `reference/cleanup-footprint-contract.md`. Combine
-its definitions with this tool-specific selection in one task-owned script;
-the selection is not a standalone executable. Inspection writes nothing.
-Appending `logs/cleanup.jsonl` is the separate, explicitly selected audit step
-in that recipe; retain this manual's cleanup/approval rules below.
-
-```python
-agent = Path.cwd()  # the relevant agent directory, not a repository root
-items = [p for p in (agent / "tmp", agent / "logs", agent / "scripts") if p.exists()]
-rows, total = footprint_check(items, tool="bash", top_n=None)
-```
-
-Recommended cadence: when retiring cron jobs, after large downloads/builds, and
-whenever a shell workflow writes outside a short-lived temp directory. Cleanup
-records belong in `logs/cleanup.jsonl`; cron/launchd/systemd retirement should
-also record the scheduler unit name that was unloaded.
+Shell may create scripts, logs, downloads, virtualenvs, scheduler units, and
+build artifacts. Retain artifacts by default. Cleanup is command-specific: show
+a dry-run and obtain explicit human authorization before destructive removal.
+For inspection, call `psyche(action="skills", input={})`, then follow
+`skills-manual` to `reference/cleanup-footprint-contract.md` and its shared
+footprint recipe. Combine it with this task's selected paths in one
+script. Inspection writes nothing. If the human selected an audit, append to
+`logs/cleanup.jsonl` and record retired scheduler units.

--- a/src/lingtai/tools/bash/manual/reference/notification-reminders/SKILL.md
+++ b/src/lingtai/tools/bash/manual/reference/notification-reminders/SKILL.md
@@ -2,40 +2,32 @@
 name: bash-notification-reminders
 description: >
   Nested shell-manual reference for one-shot wakeup reminders using
-  `.notification/cron.json`: payload shape, atomic writer, shell example, and the
-  rest checklist for agents leaving work pending.
-version: 1.0.2
-last_changed_at: 2026-07-27T00:00:00Z
+  `.notification/cron.json`: payload, atomic writer, shell example, and the
+  rest checklist for pending work.
+version: 1.1.0
+last_changed_at: 2026-09-09T00:00:00Z
 related_files:
 - src/lingtai/tools/bash/manual/SKILL.md
 - src/lingtai/tools/notification/__init__.py
 - src/lingtai/tools/notification/schema.py
+- src/lingtai/tools/bash/manual/reference/scheduled-work/SKILL.md
 maintenance: |
-  Tracks the one-shot notification-reminder topic it documents; update when that integration changes.
+  Tracks one-shot notification reminders; update when that integration changes.
 ---
 
-# Notification Reminder Reference
+# One-shot notification reminders
 
-Nested shell-manual reference. Open this when you need a one-shot reminder or a
-lightweight wakeup nudge rather than a full recurring host scheduler.
+For native Shell/Daemon jobs, rely on their completion notification; do not add
+a competing timer. Only for async work without a reliable completion wake, use
+`system(action="sleep", input={"reason": "check pending work", "force": false,
+"delay": 240}, reasoning="last-resort wake")` as a last-resort one-shot alarm; `system-manual` owns its detail.
 
-## One-shot wakeup reminders via `.notification/cron.json`
-
-Sometimes you do **not** want a recurring cron job and you do **not** want to self-send mail. You only need a lightweight alarm for your future self: "something is still pending; wake later and check it." Use a cron notification reminder for that.
-
-Typical example:
-
-```text
-⏺ Codex active. Plot regenerated (362KB, 23:38) — visibly more polished than my crude version. Waiting for caption + commit. Polling at 23:42.
-```
-
-That sentence has the right shape: current state, what changed, what remains, and the next check time. The mechanism is a scheduled script that writes one file:
-
-```text
-<agent-workdir>/.notification/cron.json
-```
-
-The kernel's notification sync reads `.notification/*.json`, injects the `cron` channel into the agent's wire context, and wakes the agent to act. After handling it, clear it with:
+For an already-authorized external workflow requiring the cron channel, schedule
+the writer below for the chosen future time. Running it now publishes now;
+it does not create a timer. A reminder writes one complete
+notification envelope to `<agent-workdir>/.notification/cron.json`; it is not a
+recurring scheduler, human notification, or guarantee across process death and
+sleep. After acting, dismiss the `cron` channel:
 
 ```text
 notification(action="dismiss_channel",
@@ -43,121 +35,59 @@ notification(action="dismiss_channel",
              reasoning="the cron reminder is handled")
 ```
 
-Use this pattern when:
+Use a custom writer only when the built-in wake is unsuitable. Do not use it
+for a human-facing message, a delay that must survive reboot (use
+launchd/systemd/crontab), or frequent polling. Set one sane wake and rest.
 
-- you are going to sleep/rest but a daemon, CLI coding agent, CI job, PR, render, download, or external process may need a follow-up;
-- the reminder is for **you**, not for the human;
-- a single check is enough, or the repeated cadence is purely mechanical;
-- self-email would add mailbox latency/state and does not buy anything.
+## Envelope
 
-Do **not** use it when:
-
-- the human needs to be notified — use the channel the human used, or an external addon if appropriate;
-- the reminder must survive process death and machine reboot but you only used a detached `sleep`; use launchd/systemd/crontab for persistence;
-- you are tempted to poll every few seconds. Set one sane reminder, then rest.
-
-### Payload shape
-
-A producer that cannot import the kernel helper should still write the full notification envelope, not a bare message. Minimal valid shape:
+A producer that cannot import the helper must still write the full shape:
 
 ```json
 {
-  "header": "Cron reminder: check Codex plot run",
+  "header": "Cron reminder: check pending work",
   "icon": "⏰",
   "priority": "normal",
   "published_at": "2026-05-18T06:42:00Z",
   "data": {
     "source": "cron-reminder",
-    "message": "Codex active. Plot regenerated (362KB, 23:38) — waiting for caption + commit.",
-    "todo": "Check Codex status, inspect caption, commit if ready.",
-    "reminder_id": "plot-caption-2026-05-17T23-42"
+    "message": "Background work is still pending.",
+    "todo": "Check the named job and inspect its output.",
+    "reminder_id": "task-followup-2026-05-18T06-42"
   }
 }
 ```
 
-Fields the agent will care about:
+Keep `published_at` as a UTC ISO timestamp and make `reminder_id` stable enough
+to recognize duplicates. `message` says what changed; `todo` says the concrete
+next action. Write through a temporary sibling and rename atomically:
 
-- `header` — short visible summary.
-- `priority` — usually `normal`; use `high` only when the check is time-sensitive.
-- `published_at` — UTC ISO timestamp; useful when the agent wakes late.
-- `data.message` — what changed since the agent rested.
-- `data.todo` — the concrete next action.
-- `data.reminder_id` — stable enough to recognize duplicate fires.
-
-### Atomic writer
-
-External scripts should write via `tmp + rename` so the kernel never sees truncated JSON:
-
-```bash
-export AGENT_DIR="/Users/<you>/work/<project>/.lingtai/<agent>"
-export REMINDER_ID="task-followup-$(date +%Y%m%d-%H%M%S)"
-
-/usr/bin/python3 - <<'PY'
-import json, os, pathlib, time
+```python
+import json, os, pathlib
 from datetime import datetime, timezone
 
 agent = pathlib.Path(os.environ["AGENT_DIR"])
-notif = agent / ".notification"
-notif.mkdir(exist_ok=True)
-now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+notification = agent / ".notification"
+notification.mkdir(exist_ok=True)
 payload = {
-    "header": "Cron reminder: check pending task",
-    "icon": "⏰",
+    "header": "Cron reminder: check pending work", "icon": "⏰",
     "priority": "normal",
-    "published_at": now,
-    "data": {
-        "source": "cron-reminder",
-        "message": "Background job still running — waiting for output + commit.",
-        "todo": "Check job status, inspect output, commit if ready.",
-        "reminder_id": os.environ.get("REMINDER_ID", "cron-reminder"),
-        "epoch": int(time.time()),
-    },
+    "published_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    "data": {"source": "cron-reminder", "message": "Work is pending.",
+             "todo": "Check job status and output.",
+             "reminder_id": os.environ.get("REMINDER_ID", "cron-reminder")},
 }
-target = notif / "cron.json"
+target = notification / "cron.json"
 tmp = target.with_suffix(".json.tmp")
-tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+tmp.write_text(json.dumps(payload, ensure_ascii=False) + "\n", encoding="utf-8")
 tmp.replace(target)
-PY
 ```
 
-### One-shot reminder from the shell
+## Rest and wake
 
-For a short local reminder where the machine is expected to stay awake, a detached sleeper is enough:
-
-```bash
-DELAY_SECONDS=240
-nohup /bin/bash -lc 'sleep '"$DELAY_SECONDS"'; export AGENT_DIR="/Users/<you>/work/<project>/.lingtai/<agent>"; /usr/bin/python3 - <<"PY"
-import json, os, pathlib, time
-from datetime import datetime, timezone
-notif = pathlib.Path(os.environ["AGENT_DIR"]) / ".notification"
-notif.mkdir(exist_ok=True)
-payload = {
-  "header": "Cron reminder: check pending daemon",
-  "icon": "⏰",
-  "priority": "normal",
-  "published_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-  "data": {
-    "source": "cron-reminder",
-    "message": "I rested while a daemon/CLI job was still active.",
-    "todo": "Read pad, then run daemon(list) or inspect the named job/PR.",
-    "reminder_id": "daemon-check-" + str(int(time.time())),
-  },
-}
-target = notif / "cron.json"
-tmp = target.with_suffix(".json.tmp")
-tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
-tmp.replace(target)
-PY' >/tmp/lingtai-cron-reminder.log 2>&1 &
-```
-
-This is not a replacement for OS scheduling: a detached sleeper can be lost if the shell/process tree is killed or the machine sleeps through the interval. For long delays or repeated checks, put the same writer into launchd/systemd/crontab following `../scheduled-work/SKILL.md`.
-
-### Rest checklist
-
-Before resting with pending work:
-
-1. Update pad with the current state and what the reminder should inspect.
-2. Set one `cron` notification reminder at a sensible check time.
-3. Include a concise state sentence and a concrete `todo`.
-4. Rest (`system(action="sleep")`) or end the turn.
-5. On wake: handle the `cron` reminder, then `notification(action="dismiss_channel", input={"channel": "cron", "force": null, "reason": null}, reasoning="...")`.
+Before resting: record the state/check target in pad. For a custom cron wake,
+save the writer as an authorized task script and schedule it once at the chosen
+time using [scheduled work](../scheduled-work/SKILL.md); do not execute it
+immediately and expect a delay. Then end the turn and rely on the event. On wake, handle the reminder, inspect the named job, and dismiss `cron`.
+A detached `sleep` writer can be lost if the process or machine stops; use the
+scheduled-work reference for longer or recurring delays.

--- a/src/lingtai/tools/bash/manual/reference/scheduled-work/SKILL.md
+++ b/src/lingtai/tools/bash/manual/reference/scheduled-work/SKILL.md
@@ -1,362 +1,163 @@
 ---
 name: bash-scheduled-work
 description: >
-  Nested shell-manual reference for cron-driven scheduled work: when to use host
-  schedulers, the LingTai wake-by-mailbox-drop contract, prompt boundaries,
-  script hygiene, macOS launchd, Linux systemd timers, crontab fallback, and the
-  launchd process-tree reaping gotcha.
-version: 1.0.1
-last_changed_at: 2026-07-19T00:00:00Z
+  Nested shell-manual reference for recurring, time-driven work: host scheduler
+  choice, LingTai wake-by-mailbox-drop, short prompts, script hygiene, macOS
+  launchd, Linux systemd timers, crontab, and process-tree hazards.
+version: 1.1.0
+last_changed_at: 2026-09-09T00:00:00Z
 related_files:
 - src/lingtai/tools/bash/manual/SKILL.md
 - src/lingtai/tools/bash/_async_supervisor.py
 maintenance: |
-  Tracks the cron-driven scheduled-work topic it documents; update when that integration changes.
+  Tracks cron-driven scheduled work; update when the scheduler integration or
+  wake contract changes.
 ---
 
-# Scheduled Work Reference
+# Scheduled work
 
-Nested shell-manual reference. Open this when the top-level `shell-manual` router
-selects host-scheduler setup for recurring or time-driven work.
+Open this for recurring or time-triggered work. The host scheduler is an
+external wake mechanism; Shell has no built-in recurring scheduler.
 
-## When to use scheduled work
+## Pick the trigger
 
-Scheduled work is for things that should happen *because time has passed*, not because someone sent a message. Three patterns to distinguish:
+- **Time-driven substantive work** (“every hour, do X”): use a host scheduler.
+- **Event-driven work with a deadline** (“when Y arrives, respond quickly”): use
+  the event source or mailbox/watch, not cron.
+- **Periodic work inside an active turn**: compare a stored timestamp in the
+  turn loop, not an external scheduler.
 
-1. **Time-driven, agent-acts** — "every hour, write one poem and ship it." Time is the trigger; the agent does the substantive work. **This is what cron is for.**
-2. **Event-driven, time-tolerant** — "when an email arrives, reply within an hour." The event is the trigger; time is just a deadline. Use the event source (IMAP poller, webhook, mailbox watch), not cron.
-3. **Inside-the-turn periodic** — "while you're already in a turn, also check Z if 30 minutes have passed since last check." This is a turn-loop idiom (compare `time.time()` against a stored timestamp), not external scheduling.
+Prefer an event watch when it is the real trigger; polling every cycle burns
+turns when nothing changed.
 
-If the human says "do X every hour" and X is substantive, you want pattern 1. If they say "be quick when Y happens," pattern 2. If they say "while you're at it, also Z," pattern 3.
+## Wake-by-mailbox contract
 
-**Don't reach for cron when a `Monitor`/watch will do.** A poll loop fires whether or not anything changed and will burn tokens on empty cycles. Cron is appropriate when the work is unconditional ("write a poem regardless") or when the polling-vs-events tradeoff genuinely favors polling (cheap check, source has no event channel).
+For an explicitly human-approved schedule using the human sender, publish one
+complete message to the human outbox (retain the scheduler `identity.via`; this
+is not an interactive human instruction or permission to expand the schedule):
 
-## The wake-by-mailbox-drop contract
+```text
+<project>/.lingtai/human/mailbox/outbox/<uuid>/message.json
+```
 
-The LingTai kernel has **no built-in scheduler**. Cron jobs interact with you the same way humans and other agents do: by writing a `message.json` to your outbox-side mailbox.
-
-The full contract:
-
-1. The cron script generates a UUID and writes one file:
-   `<project>/.lingtai/human/mailbox/outbox/<uuid>/message.json` (when the human is the sender).
-   Human is a pseudo-agent, so the file goes to the **human outbox**, not directly to your inbox. Your kernel polls every active human outbox and claims messages addressed to you on the next cycle.
-2. The kernel sees the message addressed to you, atomically renames the folder to `human/mailbox/sent/<uuid>/`, and copies it into `<your-agent>/mailbox/inbox/<uuid>/`.
-3. On your next turn, you read the inbox, see the new message, and act.
-
-That's it. **Anything that can write a JSON file to the outbox can wake you on a schedule.** launchd, systemd, crontab, `at`, an IFTTT webhook, a different agent's behavior — all the same to you.
-
-Message template (the cron script generates this, fills in `${UUID}`, `${SUBJECT}`, `${BODY}`, `${TIMESTAMP}`):
+Use a fresh UUID and a message like:
 
 ```json
 {
-  "id": "${UUID}",
-  "_mailbox_id": "${UUID}",
-  "from": "human",
-  "to": ["<your-address>"],
-  "cc": [],
-  "subject": "${SUBJECT}",
-  "message": ${BODY_AS_JSON_STRING},
-  "type": "normal",
-  "received_at": "${TIMESTAMP}",
-  "identity": {
-    "address": "human",
-    "agent_name": "human",
-    "via": "<scheduler-name>-cron"
-  }
+  "id": "<uuid>", "_mailbox_id": "<uuid>", "from": "human",
+  "to": ["<agent-address>"], "cc": [], "subject": "<short subject>",
+  "message": "Use the named skill; this is the time-bound context.",
+  "type": "normal", "received_at": "<UTC timestamp>",
+  "identity": {"address": "human", "agent_name": "human",
+                "via": "<scheduler-name>-cron"}
 }
 ```
 
-Use `via: "<scheduler-name>-cron"` (e.g. `"launchd-cron"`, `"systemd-cron"`) so you can tell scheduled mail apart from interactive mail in your audit log.
+The kernel claims the human outbox folder into `human/mailbox/sent/<uuid>/` and
+copies it to the agent's `mailbox/inbox/<uuid>/`; message handling is a separate
+step. Do not promise that delivery interrupts a long active turn; a live asleep
+listener can wake normally, but mail is not recovery for a stopped process.
+Do not refresh merely to accelerate mail. Only when the owner explicitly
+approves this schedule's refresh, publish the message first, then `touch
+<agent>/.refresh` and exit. Follow `system-manual` for lifecycle prechecks;
+the kernel's refresh watcher owns relaunching.
+Never parse or remove `.agent.lock`, wait for its path to vanish, or launch a
+second relaunch process: path existence is not the kernel's flock and causes
+duplicate agents.
 
-## When to write the prompt — short, not long
+Keep the scheduled prompt short: time-bound context plus the name of a
+versioned skill in `.library/custom/<name>/SKILL.md`; the skill owns the recipe.
+Do not embed a long command sequence in a prompt replayed every hour.
 
-A common anti-pattern: stuffing the full operational recipe ("write a poem, then run mmx with these flags, then commit, then push, then trigger the workflow…") into the cron script's prompt body. This is wrong on two axes:
+## Script hygiene
 
-- **The prompt is replayed every hour.** Updating the recipe means editing the cron script, redeploying, often touching launchd or systemd. Friction.
-- **The recipe IS knowledge that belongs to YOU.** Encode it in a custom skill at `.library/custom/<recipe-name>/SKILL.md`. The prompt then says "use your `<recipe-name>` skill" and is one sentence. The skill is editable in-place, version-controlled, and discoverable to other agents on the same network.
+- Make each fire idempotent; use a cycle marker when doing substantive work.
+- Audit the previous cycle and append `[fire]`, `[audit]`, and `[err]` records to
+  a log. Do not rely only on scheduler stdout/stderr.
+- Start scripts with `set -euo pipefail`; explicitly write `cmd || true` when a
+  failure is intentional.
+- Use absolute binary paths or set `PATH`; launchd/systemd/cron inherit sparse
+  environments. Verify the expected artifact, commit, or message after work.
+- Do not silently prune logs or work products. Deletion needs an explicit
+  human-approved dry-run and cleanup plan.
 
-Rule: **cron prompts wake you and supply the time-bound context (which hour, what just changed). Skills supply the procedure.**
+## macOS launchd
 
-Example (libai's hourly poem cron):
-
-```
-太白吾兄，又是一个时辰。
-此刻乃${HOUR_NOTE}（${NOW_LOCAL}）。
-请援用 `hourly-poem` 之技——观当世一事，作诗一首，配乐一曲，并刊于网。
-所有步骤、路径、命令皆备于该技中，依之而行即可。
-```
-
-That's the entire prompt. Six lines. The 200-line recipe lives in the skill.
-
-## Hygiene — the rules that keep scheduled scripts alive
-
-### 1. Idempotent
-
-A cron script must be safe to run **twice in a row** with no harm. Cron fires on a wall clock; nothing prevents two firings from racing (system clock changes, missed-then-caught-up firings, double-loaded launchd plists). Always check "did the work already happen for this cycle?" before doing it again.
-
-For mail-drop scripts, idempotency comes for free if you generate a fresh UUID per fire — duplicate mail in the inbox is annoying but harmless. For scripts that DO work (e.g. running a generator), guard with a marker file:
-
-```bash
-MARK="$WORKDIR/.last-fire-$(date +%Y%m%d-%H)"
-[ -f "$MARK" ] && exit 0     # already ran this hour
-# ... do the work ...
-touch "$MARK"
-```
-
-### 2. Audit the previous cycle on every fire
-
-Every fire is also a chance to verify the *previous* fire actually completed. Add an audit block at the top of the script:
-
-```bash
-# Did anything land where it should have, in the last 75 minutes?
-RECENT=$(git -C "$REPO" log origin/main --since="75 minutes ago" --oneline | wc -l | tr -d ' ')
-if [ "$RECENT" = "0" ]; then
-  echo "$(date -Iseconds) [audit] WARN: no commits in last 75min — last cron may have failed" >> "$LOG_FILE"
-fi
-```
-
-Cron failures are silent by default. Audit-on-next-fire turns the silence into a log line you can grep for.
-
-### 3. Append to a log file; never trust stdout/stderr
-
-launchd and systemd capture stdout/stderr to the paths you configure, but those files often get rotated, cleared on system updates, or simply forgotten. Your script should always also write to its own log:
-
-```bash
-LOG_FILE="${HOME}/.lingtai-tui/cron/<job-name>.log"
-log() { echo "$(date -Iseconds) $*" >> "$LOG_FILE"; }
-log "[fire] starting cycle"
-```
-
-Tag each line with a category (`[send]`, `[audit]`, `[refresh]`, `[err]`) so you can grep specific events later. Use ISO 8601 timestamps with timezone (`date -Iseconds`) — relative timestamps lie when the system reboots.
-
-### 4. `set -euo pipefail` always
-
-Without this, a typo or a transient error mid-script silently continues, leaving partial state. With it, any failure aborts the script and you see the failure in the log.
-
-```bash
-#!/bin/bash
-set -euo pipefail
-```
-
-If you genuinely need a command's failure to be ignored, opt in explicitly: `cmd || true`.
-
-### 5. Absolute paths for binaries
-
-launchd and systemd run with a sparse `PATH`. `git`, `gh`, `python3` may not be on `$PATH` even if they work fine in your shell. Use absolute paths:
-
-```bash
-GIT="/usr/bin/git"
-GH="/opt/homebrew/bin/gh"
-PYTHON="${HOME}/.lingtai-tui/runtime/venv/bin/python"
-```
-
-Or set `PATH` explicitly at the top of the script. Don't trust the inherited one.
-
-### 6. Dropping mail does NOT wake the agent — it just queues
-
-Writing to the outbox is the queue, not the doorbell. The agent will see the mail on its next turn cycle. If it's actively in a long-running turn or asleep, the mail waits until the next active turn.
-
-If you need the agent to act on the mail *promptly* (within seconds), follow the mail-drop with `touch .refresh` and **stop there**. The kernel's `_perform_refresh` (`base_agent/lifecycle.py:_perform_refresh`) handles the rest: it spawns a deferred-relaunch watcher that waits for `.agent.lock` to release and then `Popen`s the new agent itself. The cron script does not need to wait, does not need to verify, does not need to relaunch.
-
-```bash
-# Mail-drop already done above (writing message.json under human/mailbox/outbox/<uuid>/).
-# Now nudge the agent to pick it up immediately:
-touch "$PROJECT_ROOT/.lingtai/<agent>/.refresh"
-# Done. Exit. The kernel's refresh watcher handles shutdown + relaunch.
-```
-
-That's the entire refresh recipe. If the human just wants the work done eventually (within the next active turn), even the `touch .refresh` is overhead — drop the mail and exit.
-
-#### Anti-pattern — DO NOT do any of these
-
-The following pattern looks reasonable but causes **duplicate-agent accumulation** (multiple Python interpreters all running against the same workdir, observed in vivo as 6 stacked PIDs after 6 hourly fires):
-
-```bash
-# ❌ DANGEROUS — do not copy this pattern
-touch "$LIBAI_DIR/.refresh"
-WAIT_DEADLINE=$(($(date +%s) + 60))
-while [ -e "$LIBAI_DIR/.agent.lock" ]; do
-  [ $(date +%s) -gt $WAIT_DEADLINE ] && rm -f "$LIBAI_DIR/.agent.lock" && break
-  sleep 0.5
-done
-"$VENV_PYTHON" "$RELAUNCH_SCRIPT" ...   # parallel relaunch
-```
-
-Two failure modes baked in:
-
-1. **Path-existence check on `.agent.lock` is racy.** The kernel uses `fcntl.flock` for mutual exclusion, not the file's mere presence. The lockfile vanishes near the *end* of `_stop()`, but the Python interpreter can linger 30–60s after that doing HTTP teardown, mail-listener stop, and MCP child reaping. Polling for the path to disappear and then spawning a new agent races a still-living process.
-
-2. **`rm -f .agent.lock` on timeout is destructive.** flock is invisible to `rm`; you delete the path while the kernel still considers itself the owner. The new agent then creates a fresh lockfile at the same path and acquires flock on that — so you have two agents, each holding flock on a different inode at the same path. When the old process finishes shutdown and calls its tail-end `unlink(.agent.lock, missing_ok=True)`, it can delete the **new** agent's lockfile.
-
-3. **Parallel relaunch races the kernel's own watcher.** `touch .refresh` already triggers `_perform_refresh`, which spawns a deferred-relaunch process (see `base_agent/lifecycle.py:_perform_refresh`) that does the wait-for-lock-then-spawn dance correctly. Adding your own relaunch in the cron means two processes are racing to be "the new agent." Whichever loses the flock will sit in `acquire_lock(timeout=10)` for 10 seconds and then crash, but during those 10 seconds you have two Python processes visible in `ps`.
-
-**Rule:** if you find yourself parsing `.agent.lock`, polling for it, or removing it from a script, stop. The lock is the kernel's. Touch `.refresh` and exit.
-
-### 7. No janitors in the cron prompt unless the human asked
-
-Cron scripts and the skills they invoke should never silently delete work products ("janitor old mp3s," "prune old logs"). Deletion is a design decision, not a hygiene step. If the human wants pruning, they will ask for it explicitly. Otherwise leave artifacts alone — disk is cheap, lost work isn't.
-
-## macOS — launchd
-
-On macOS, the right scheduler is **launchd** (not cron). cron exists on macOS but is deprecated; launchd is the system-managed equivalent and behaves correctly across sleep/wake, reboots, and login sessions.
-
-### Plist template
-
-Save to `~/Library/LaunchAgents/<reverse-domain-name>.plist`:
+Use a user LaunchAgent at `~/Library/LaunchAgents/<label>.plist`:
 
 ```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
-  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-  <key>Label</key>
-  <string>ai.example.my-job</string>
-
-  <key>ProgramArguments</key>
-  <array>
-    <string>/bin/bash</string>
-    <string>/Users/yourname/.scripts/my-job.sh</string>
+<plist version="1.0"><dict>
+  <key>Label</key><string>ai.example.my-job</string>
+  <key>ProgramArguments</key><array>
+    <string>/bin/bash</string><string>/Users/you/.scripts/my-job.sh</string>
   </array>
-
-  <!-- Pick ONE of StartCalendarInterval or StartInterval -->
-
-  <!-- Fire at minute 0 every hour: -->
-  <key>StartCalendarInterval</key>
-  <dict>
-    <key>Minute</key>
-    <integer>0</integer>
-  </dict>
-
-  <!-- OR fire every N seconds: -->
-  <!-- <key>StartInterval</key> <integer>300</integer> -->
-
-  <key>RunAtLoad</key>
-  <false/>
-
-  <key>StandardOutPath</key>
-  <string>/Users/yourname/.scripts/my-job.out</string>
-  <key>StandardErrorPath</key>
-  <string>/Users/yourname/.scripts/my-job.err</string>
-</dict>
-</plist>
+  <key>StartCalendarInterval</key><dict><key>Minute</key><integer>0</integer></dict>
+  <key>StandardOutPath</key><string>/Users/you/.scripts/my-job.out</string>
+  <key>StandardErrorPath</key><string>/Users/you/.scripts/my-job.err</string>
+</dict></plist>
 ```
 
-### Loading
+Use one trigger (`StartCalendarInterval` or `StartInterval`), then validate and
+load/test it:
 
 ```bash
+plutil -lint ~/Library/LaunchAgents/ai.example.my-job.plist
 launchctl load ~/Library/LaunchAgents/ai.example.my-job.plist
-launchctl list | grep ai.example.my-job   # verify it's loaded
-launchctl start ai.example.my-job         # fire once for testing
-```
-
-### Unloading
-
-```bash
+launchctl list ai.example.my-job
+launchctl start ai.example.my-job
 launchctl unload ~/Library/LaunchAgents/ai.example.my-job.plist
 ```
 
-A plist edit only takes effect after `unload` + `load` (or after a reboot).
+After editing a loaded plist, unload/reload it to apply the new definition.
+`StartCalendarInterval` catches at most one missed fire after sleep;
+`StartInterval` does not provide the same catch-up. Choose the schedule with
+that limitation in mind. launchd can reap a child process tree
+when the `ProgramArguments` process exits: `&`/`disown` are not sufficient. Prefer
+the kernel refresh watcher; if a human-authorized workflow truly needs a child
+to outlive the job, use a reviewed double-fork/full-detach launcher (PPID=1)
+and verify its lifetime rather than assuming it.
 
-### macOS gotcha: launchd process-tree reaping
+## Linux systemd timer
 
-If your cron script needs to **launch a long-running daemon as a side effect** (e.g. relaunching a LingTai agent after dropping mail + refreshing), launchd will kill that daemon when the script exits unless you fully detach it.
-
-Symptom: the script's child process (your agent) starts, you see its log briefly, then it dies seconds after the script returns.
-
-Cause: launchd reaps the entire process tree of a job when the job's `ProgramArguments` process exits. `&` and `disown` (which work in interactive shells) do nothing under launchd because there's no shell job-control table.
-
-Fix: **double-fork the daemon** so it ends up with PPID=1 (init), fully detached:
-
-```python
-#!/usr/bin/env python3
-# fork-exec helper — call from the cron script
-import os, sys, subprocess
-
-def daemonize():
-    if os.fork() > 0: os._exit(0)   # parent exits
-    os.setsid()                      # detach from controlling terminal
-    if os.fork() > 0: os._exit(0)   # first child exits
-    # grandchild: PPID is now 1
-    os.chdir("/")
-    sys.stdin = open("/dev/null", "r")
-
-if __name__ == "__main__":
-    target_cmd = sys.argv[1:]
-    daemonize()
-    log_path = os.environ.get("DAEMON_LOG", "/tmp/daemon.log")
-    with open(log_path, "ab") as f:
-        subprocess.Popen(target_cmd, stdout=f, stderr=f, start_new_session=True)
-```
-
-The cron script calls this helper and exits — the grandchild survives.
-
-### Useful launchctl commands
-
-```bash
-launchctl list | grep <prefix>             # which of my jobs are loaded
-launchctl list ai.example.my-job           # full status (PID, last exit code)
-launchctl print gui/$(id -u)/ai.example.my-job   # newer macOS — full diagnostic
-log show --predicate 'process == "launchd"' --last 1h | grep ai.example   # system log lines
-```
-
-`launchctl list <label>` shows `LastExitStatus`. **Non-zero ≠ broken** (your script may exit nonzero on intentional skip paths), but a sudden change from 0 to nonzero is worth investigating.
-
-## Linux — systemd timer
-
-On modern Linux, systemd timers are the right primitive. Two unit files: a `.service` (what to run) and a `.timer` (when to run).
-
-`~/.config/systemd/user/my-job.service`:
+Create a oneshot service and timer under `~/.config/systemd/user/`:
 
 ```ini
-[Unit]
-Description=My hourly job
-
+# my-job.service
 [Service]
 Type=oneshot
-ExecStart=/bin/bash /home/yourname/.scripts/my-job.sh
-StandardOutput=append:/home/yourname/.scripts/my-job.out
-StandardError=append:/home/yourname/.scripts/my-job.err
-```
+ExecStart=/bin/bash /home/you/.scripts/my-job.sh
+StandardOutput=append:/home/you/.scripts/my-job.out
+StandardError=append:/home/you/.scripts/my-job.err
 
-`~/.config/systemd/user/my-job.timer`:
-
-```ini
-[Unit]
-Description=Run my-job every hour
-
+# my-job.timer
 [Timer]
 OnCalendar=hourly
 Persistent=true
-
 [Install]
 WantedBy=timers.target
 ```
 
-Activation:
+Activate and inspect it:
 
 ```bash
 systemctl --user daemon-reload
 systemctl --user enable --now my-job.timer
-systemctl --user list-timers          # verify scheduled
+systemctl --user list-timers
 systemctl --user status my-job.service
-journalctl --user -u my-job.service   # logs
+journalctl --user -u my-job.service
 ```
 
-`Persistent=true` matters: if the machine was off when a fire was scheduled, the timer will fire on next boot to "catch up." Drop it if catch-up firings are unwanted (e.g., "post the morning poem" should not post 3 backed-up poems after a weekend power-out).
+`Persistent=true` catches up after the machine was off; omit it when catch-up
+work would be wrong.
 
-## Linux fallback — crontab
+## crontab fallback
 
-If systemd isn't available (containers, minimal distros), use crontab. Edit:
+When systemd is unavailable:
 
-```bash
-crontab -e
+```cron
+0 * * * * /bin/bash /home/you/.scripts/my-job.sh >> /home/you/.scripts/my-job.log 2>&1
 ```
 
-Add a line:
-
-```
-0 * * * * /bin/bash /home/yourname/.scripts/my-job.sh >> /home/yourname/.scripts/my-job.log 2>&1
-```
-
-5 fields: `minute hour day-of-month month day-of-week`. The default `PATH` for crontab is even sparser than launchd's — set `PATH=` at the top of the crontab file or use absolute paths everywhere in the script.
+`crontab -e` uses five fields (minute, hour, day-of-month, month, weekday)
+and an especially sparse `PATH`; use absolute paths and keep the script
+idempotent.

--- a/tests/test_bash_async.py
+++ b/tests/test_bash_async.py
@@ -283,10 +283,10 @@ class TestBashAsync:
         assert result["handoff"] == (
             "While waiting, go idle or call system(action='sleep'); the terminal result "
             "will arrive and wake you as a notification; read shell-manual and "
-            "notification-manual for details. If Telegram is connected and a Task Card "
-            "is available for the current turn, use it to report progress; call "
-            "`telegram(action='manual')` and follow its `Programmable Task Card` "
-            "section for details."
+            "notification-manual for details. If a Task Card is available and useful "
+            "for the current turn, use it only for progress; read the intrinsic "
+            "`task_card(action='manual', input={}, reasoning='...')` manual for its "
+            "channel-neutral lifecycle."
         )
         mgr.handle({"action": "cancel", "command": "", "job_id": result["job_id"]})
 

--- a/tests/test_shell_progressive_disclosure.py
+++ b/tests/test_shell_progressive_disclosure.py
@@ -30,7 +30,9 @@ def test_shell_description_keeps_first_call_and_safety_guards():
     assert "Active shell dialect: powershell" in description
     assert "Active shell: PowerShell" in description
     assert "Host OS: Windows 11" in description
-    assert "shell(action='manual', input={}, reasoning='...')" in description
+    assert "For short deterministic work use shell(action='run'" in description
+    assert "Read shell-manual before coding-CLI, scheduled, unfamiliar, or recovery work" in description
+    assert "Before ordinary shell work, read the manual" not in description
     assert "shell(action='run', input={'command': '...'}, reasoning='...')" in description
     assert "shell(action='poll', input={'job_id': '...'}, reasoning='...')" in description
     assert "shell(action='cancel', input={'job_id': '...'}, reasoning='...')" in description
@@ -61,3 +63,39 @@ def test_shell_manual_routes_durable_async_detail_to_reference():
     assert "bash.reminder:<job_id>" in reference
     assert "Relaunch-safe status and cancellation" in reference
     assert "daemon-manual" in reference
+    assert 'task_card(action="manual", input={})' in reference
+    assert "../../../../task_card/manual/SKILL.md" not in reference
+    assert "channel-neutral Task Card" in reference
+    assert "telegram(action='manual')" not in reference
+
+
+def test_shell_installed_routes_and_full_prompt(tmp_path, monkeypatch):
+    import re
+    import socket
+    from lingtai.agent import Agent
+    from tests._service_helpers import make_gemini_mock_service
+
+    def no_connect(*args, **kwargs):
+        raise AssertionError("network forbidden in manual proof")
+
+    monkeypatch.setattr(socket.socket, "connect", no_connect)
+    agent = Agent(service=make_gemini_mock_service(), agent_name="shell-manual-proof",
+                  working_dir=tmp_path / "agent", capabilities={"shell": {}})
+    try:
+        agent._reconstruct_context()
+        assert agent._build_system_prompt()
+        assert [schema.name for schema in agent._tool_schemas].count("shell") == 1
+        result = agent._tool_handlers["shell"]({"action": "manual", "input": {},
+                                               "reasoning": "installed guide proof"})
+        root = Path(result["structuredContent"]["manual_path"]).parent
+        source = Path("src/lingtai/tools/bash/manual")
+        files = ["SKILL.md", *[f"reference/{name}/SKILL.md" for name in
+                 ("async-jobs", "scheduled-work", "notification-reminders", "debugging-cleanup")]]
+        for rel in files:
+            installed = root / rel
+            assert installed.read_bytes() == (source / rel).read_bytes()
+            for link in re.findall(r"\]\(([^)]+)\)", installed.read_text()):
+                if "://" not in link:
+                    assert (installed.parent / link.split("#")[0]).exists(), (rel, link)
+    finally:
+        agent.stop(timeout=1.0)

--- a/tests/test_shell_settings.py
+++ b/tests/test_shell_settings.py
@@ -73,50 +73,50 @@ def test_exact_rows_values_flags_redaction_and_manual_targets(tmp_path, monkeypa
             "posix",
             None,
             True,
-            "shell-manual#shell-kind",
-            "Shell kind",
+            "shell-manual#settings-inventory",
+            "Settings inventory",
         ),
         "sync_timeout_default_seconds": (
             30,
             30,
             False,
-            "shell-manual#sync-timeout-default",
-            "Sync timeout default",
+            "shell-manual#settings-inventory",
+            "Settings inventory",
         ),
         "sync_timeout_max_seconds": (
             120.0,
             120.0,
             True,
-            "shell-manual#sync-timeout-ceiling",
-            "Sync timeout ceiling",
+            "shell-manual#settings-inventory",
+            "Settings inventory",
         ),
         "result_max_chars": (
             1_234,
             50_000,
             True,
-            "shell-manual#result-size-limit",
-            "Result size limit",
+            "shell-manual#settings-inventory",
+            "Settings inventory",
         ),
         "async_default": (
             False,
             False,
             False,
-            "shell-manual#async-default",
-            "Async default",
+            "shell-manual#settings-inventory",
+            "Settings inventory",
         ),
         "async_reminder_default_seconds": (
             1_800.0,
             1_800.0,
             False,
-            "shell-manual#async-reminder-default",
-            "Async reminder default",
+            "shell-manual#settings-inventory",
+            "Settings inventory",
         ),
         "command_policy": (
             "<redacted>",
             "<redacted>",
             True,
-            "shell-manual#command-policy",
-            "Command policy",
+            "shell-manual#settings-inventory",
+            "Settings inventory",
         ),
     }
     rows = result["settings"]
@@ -146,8 +146,8 @@ def test_exact_rows_values_flags_redaction_and_manual_targets(tmp_path, monkeypa
         / "SKILL.md"
     ).read_text(encoding="utf-8")
     for _current, _default, _configurable, comment, heading in expected.values():
-        assert comment == f"shell-manual#{heading.lower().replace(' ', '-')}"
-        assert f"### {heading}" in manual
+        assert comment == "shell-manual#settings-inventory"
+        assert f"## {heading}" in manual
 
 
 def test_fresh_effective_values_are_re_read(tmp_path, monkeypatch):

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -206,7 +206,7 @@ def test_skills_setup_hard_copies_intrinsics(tmp_path):
         assert bash_md.is_file()
         bash_body = bash_md.read_text(encoding="utf-8")
         assert "name: shell-manual" in bash_body
-        assert "Nested reference catalog" in bash_body
+        assert "## Route by task" in bash_body
         assert "reference/scheduled-work/SKILL.md" in bash_body
         assert "reference/notification-reminders/SKILL.md" in bash_body
         assert "reference/debugging-cleanup/SKILL.md" in bash_body


### PR DESCRIPTION
## Summary

One-tool Shell manual simplification on exact current main `45133d6661f239df6930fb648b5b93125205bce3`. Native Luna implementation, owner independent review and bounded documentation corrections; no new worker or runtime rollout.

- Routine deterministic calls use the action schema directly. Long-running/CLI, scheduling and recovery use one focused route.
- Collapse duplicated router/async/scheduler/reminder/cleanup prose and settings headings while retaining all seven settings sources, precedence and authorized change paths.
- Preserve result fidelity, cwd/dialect/Windows lifetime, durable async leases, unknown outcomes, one-shot consumption and cancellation boundaries.
- Correct Task Card ownership/installed cross-owner routes, future-wake versus immediate publication, and explicit scheduler lifecycle/cleanup authority.
- Production edits are schema/family/SHOW/handoff prose only. Operational AST and schema-shape equality passed.

### Measured size

Entry 9,547 → 4,707 Unicode body chars (-50.7%). Five manuals 47,443 → 20,850 (-56.1%). Schema description occurrences -880; fixed-metadata family +58; resident description net -822. Async result handoff +7 separately. Not measured tokens, money or latency.

## Validation

`python -m pytest -q tests/test_shell_progressive_disclosure.py tests/test_shell_settings.py tests/test_bash_async.py tests/test_bash_async_process_contract.py tests/test_bash_shell_dialect.py tests/test_shell_kind_classifier.py tests/test_shell_kind_spawn_args.py tests/test_shell_tool_plugin_declaration.py tests/test_shell_tool_family_migration.py tests/test_shell_pr1_contract.py tests/test_intrinsic_manual_actions.py tests/test_tool_prose_section_gate.py tests/test_tool_settings_contract.py tests/test_skills.py tests/test_prompt_catalog.py tests/test_docs_governance.py tests/test_architecture_documents.py`:
- Candidate **7 failed, 409 passed in 39.51s**.
- Exact clean base **9 failed, 406 passed in 40.43s**.
- Two Shell baseline failures resolve; one real-Agent installed-manual regression added. Six remaining error blocks match exactly; one broad skills test advances from Shell to the unchanged Daemon missing-catalog assertion. Same Daemon bytes and absence verified in base.
- Test-only command-local PYTHONPATH ensures async test supervisors import the selected tree. No runtime/launch-session environment changes.

`python scripts/check_docs_governance.py --check`: 401 documents validated.
`python src/lingtai/intrinsic_skills/lingtai-kernel-anatomy/scripts/check_anatomy_drift.py --check`: six existing items, byte-identical to base.
`git diff --check`: clean.

Hermetic actual Agent + complete canonical prompt (32,089 chars): one Shell mount, five installed files byte-equal, all internal links and seven SHOW routes, and bounded real local sync command passed. Mock provider/socket connect blocked. Both production Python operational ASTs and schema-without-description match base except reviewed strings.

Self-contained HTML is delivered separately, not committed. No whole-repo/native-Windows/live-provider/production E2E or actual host-scheduler exercise. Existing MCP import, broad Daemon/Notification text, prompt-catalog and Psyche orphan failures remain. Existing Contract duplicate paragraph/lone conflict-marker text is base-identical and not newly introduced. Intermittent base UUID fixture warning is not claimed fixed.

## Scope / authorization

No handler, validation, schema field/type/default, process lifecycle, persistence or retry behavior changes. No merge, refresh, release, protected cleanup or scheduler installation occurs in this PR task. Original candidate/worktrees/logs retained.

Telegram: @lingtaidev1bot | Nickname: 知微
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
