### PR TITLE
docs(notification): shorten manual and preserve producer boundaries

### DIFF
--- a/src/lingtai/tools/notification/CONTRACT.md
+++ b/src/lingtai/tools/notification/CONTRACT.md
@@ -297,7 +297,7 @@ than dispatched, so it is not a second inbound adapter.
 - Dismissal affects notification mirrors only. Producer guards, non-force stale
   refusal, protected-channel refusal, post-molt reasons, and unrelated-event
   preservation remain in force.
-- `system` owns the `summarize` **action** and exposes no notification/dismiss
+- `context` owns the `summarize` **action**; `system` exposes no notification/dismiss
   alias. The root `summarize` boolean on this family is the unrelated
   cross-cutting result post-processing control, not an action. Because this
   family advertises it, `notification` MUST stay listed in

--- a/src/lingtai/tools/notification/__init__.py
+++ b/src/lingtai/tools/notification/__init__.py
@@ -1,17 +1,9 @@
-"""Notification's declared official host-plugin slice.
+"""Official host-plugin family for notification mirrors, hooks, and delay.
 
-``notification`` remains the sole model-facing surface for reading notification
-mirrors, atomically dismissing a mirror target, managing hook registrations,
-and applying consumer-only delay.  This module owns only the LTP family and its
-small input/result adaptations.  Notification Core continues to own real
-producer, dismissal, delay, and Store state; the declared plugin receives those
-operations through one narrow ``notification_state`` host port rather than a
-whole Agent.
-
-The public tool name, nine operational actions, strict operational input/result
-shapes, and Core authorization gates are unchanged. This slice adds the generic
-reserved read-only ``settings`` action immediately before ``manual``. The family
-is bound to the least-privilege host facade and mounted by the kernel registrar.
+This module adapts the strict LTP family only. Notification Core owns producer,
+dismissal, delay, and Store state behind the narrow ``notification_state`` port;
+the public actions and authorization gates remain unchanged, with read-only
+``settings`` before ``manual``.
 """
 from __future__ import annotations
 

--- a/src/lingtai/tools/notification/manual/SKILL.md
+++ b/src/lingtai/tools/notification/manual/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: notification-manual
 description: >
-  Router for the notification filesystem protocol and the standalone
-  `notification` tool: read when interpreting `.notification/<channel>.json`,
-  choosing producer-specific handling, or safely dismissing a mirror.
-  Large-result/context compaction belongs to `context-manual`, not here.
-version: 0.15.0
+  Entry manual for the standalone `notification` tool and its `.notification`
+  mirrors. Routine check uses the schema; read a reference for unfamiliar payload,
+  producer, dismissal, delay, or settings detail. Large-result compaction belongs
+  to `context-manual`, not here.
+version: 0.16.0
 tags: [lingtai, notifications, channels, dismiss, delay, alarm, settings, manual, force, stale, nudge, hooks, whitelist]
-last_changed_at: "2026-09-06T00:00:00Z"
+last_changed_at: "2026-09-09T05:30:00Z"
 related_files:
 - src/lingtai/prompts/meta_guidance/catalog/notification_handling.md
 - src/lingtai/tools/notification/ANATOMY.md
@@ -19,126 +19,44 @@ related_files:
 - src/lingtai/tools/notification/manual/reference/channel-model/SKILL.md
 - src/lingtai/tools/notification/manual/reference/dismissal-safety/SKILL.md
 maintenance: |
-  Tracks the routed source/resources it summarizes; update when the underlying capability or its sub-references change.
+  Keep this entry and its two references concise and aligned with the notification
+  capability; preserve their installed relative routes and unique safety rules.
 ---
 
-# Notification Manual — Router
+# Notification Manual — entry and routes
 
-`notification` is the sole agent-callable surface for reading and clearing the
-current `.notification/<channel>.json` mirrors. `system` has no notification or
-dismiss alias; compaction is `context(action='summarize')`.
-
-## Quick start
-
-The resident schema is the source of truth for eleven strict actions in the
-`action` + `input` + `reasoning` envelope. Begin with:
+Use the schema for routine `action` + `input` + `reasoning` calls; start with:
 
 ```text
 notification(action='check', input={}, reasoning='inspect current notifications')
 ```
 
-`check` is read-only and returns a placeholder whose live payload is attached by
-the kernel. After handling a notification, use the narrowest matching dismiss
-action and do not call `check` merely to confirm the clear. Follow a producer's
-own read/dismiss verb when `instructions` names one: generic dismissal clears
-the mirror only, never producer state. Reread current state after a stale
-refusal; use `force=true` only for a confirmed stale mirror, never for producer
-or protected state. Read the dismissal-safety reference before forcing and the
-channel-model reference when interpreting payloads, hooks, delay, or delivery.
+`check` returns a placeholder; read the live payload under `_meta.agent_meta.notifications.attention` and the hook under `_meta.agent_meta.guidance.transient` on that result, not an older delivered snapshot. Follow the payload's producer-specific read/dismiss instructions first. Generic dismissal affects mirrors only, not mailbox, goal, source-queue or other producer state. Choose the narrowest target; do not delete files or call `check` merely to confirm a clear.
 
-Optional fields are required-but-nullable in the provider schema; `null` means
-omitted. `dismiss_channel` requires `channel`; `dismiss_event` and
-`dismiss_ref` default `channel` to `system`. A post-molt dismissal requires a
-non-empty `continue|defer|obsolete: ...` reason. `manual` and `settings` accept
-only `input={}` and are read-only.
+## Route one owner
+
+| Need | Read |
+|---|---|
+| Payload, delivery, allowlist, hooks, delay mechanics or spill recovery | [Channel model](reference/channel-model/SKILL.md) |
+| Target selection, producer guard, stale refusal, force, protected goal or post-molt | [Dismissal safety](reference/dismissal-safety/SKILL.md); read before forcing |
+| Tool-result compaction or recovery by tool_call_id | `../context-manual/reference/summarize-manual/SKILL.md` |
+| Goal cancellation/completion | `../system-manual/reference/goal-manual/SKILL.md` |
+| Runtime/configuration nudges | `../system-manual/reference/runtime-update-checks/SKILL.md` |
 
 ## Consumer delay and expiry alarm
 
-`notification(action='delay', input={'channel': '<allowed>', 'seconds': 0 or a positive configured cap}, reasoning='...')`
-hides consumer delivery for one allowed target only. `seconds: 0` cancels the
-matching delay; a nonzero call replaces the previous live delay. Producer files
-keep receiving updates. The live cap is
-`LINGTAI_NOTIFICATION_DELAY_MAX_SECONDS` (default `600`); missing, blank,
-non-numeric, non-positive, or non-finite values use that default. `delay-alarm`
-cannot be targeted. At expiry or recovery, delivery resumes and one
-high-priority `delay-alarm` mirror records bounded evidence; persistence and
-recovery details belong to the channel-model reference.
+`notification.delay_max_seconds` is the positive cap from live `LINGTAI_NOTIFICATION_DELAY_MAX_SECONDS`, otherwise `600`; missing, blank, non-numeric, non-positive or non-finite values fall back to the default. `delay` hides one allowed consumer target, never stops its producer. Nonzero replaces the prior delay; `0` cancels only the matching target. `delay-alarm` cannot be delayed. Expiry/recovery restores delivery and publishes one latest-only alarm. For daemon, only attention is masked: payload/version/summary remain readable. See [channel model](reference/channel-model/SKILL.md).
 
-The SHOW row is `notification.delay_max_seconds`: `current` is the effective
-positive integer from the live environment or the default `600`, and invalid
-input falls back to `600`. SHOW does not write or refresh anything. Change the
-existing launcher or `env_file` only with configuration-owner approval, then
-perform the authorized refresh/relaunch and verify with `settings`.
-
-## Notification settings
-
-`notification(action='settings', input={}, reasoning='inventory')` is read-only.
-It returns exactly two rows, in order, each with only `key`, `current`, `default`,
-`configurable`, and `comment`:
-
-- `notification.max_chars` →
-  `notification-manual#block-size-cap-persistent-and-attention-lanes`
-- `notification.delay_max_seconds` →
-  `notification-manual#consumer-delay-and-expiry-alarm`
-
-The comment targets are the source of truth for meaning, precedence, accepted
-values, and authorized change/verification procedures. If either current value
-is unavailable, the whole action fails; it never returns partial rows. Channel
-payloads, accounts, hook manifests, delay state, and session state are not
-settings rows.
-
-## Root `summarize`
-
-Notification is a short-result family. Leave the root `summarize` boolean false
-when retrieving `manual`, because exact procedures and constraints matter. Use
-`context(action='summarize')` for tool-result compaction and recovery; the
-legacy `large_tool_result` reminder is only an escape hatch and never changes
-producer state.
-
-## Installed manual retrieval
-
-`notification(action='manual', input={})` reads only:
-
-```text
-<agent>/.library/intrinsic/capabilities/notification/SKILL.md
-```
-
-Success returns exactly `status`, `notification_manual`, and `manual_path`. A
-missing installed file is degraded with an empty body and an actionable `error`;
-there is no source-checkout fallback. Manual retrieval neither reads nor writes
-`.notification/`, producer state, delay state, or logs.
-
-## Hooks & whitelist
-
-External hooks must be registered with `add` before their channel is accepted.
-The effective allowlist is the built-in set, `mcp.*`, and channels registered by
-this agent's workdir; it is not process-global. `drop` revokes registration but
-never stops the hook process. Use the manifest's `how_to_cancel` to stop it.
-The channel-model reference owns the setup flow, manifest fields, registry
-behavior, and blocked-channel warn-and-flag details.
+Change the environment only with owner approval and apply it through the authorized refresh/relaunch procedure; verify the live SHOW value afterward.
 
 ## Block size cap (persistent and attention lanes)
 
-`notification.max_chars` is one shared character cap (default `10000`, bounded
-`2048..10000`) for the persistent and attention lanes. The effective value reads
-live environment `LINGTAI_NOTIFICATION_MAX_CHARS`, then valid System-v2
-`notification_max_chars`, then the default; malformed values fall through.
-Oversized payloads are atomically spilled and compacted while preserving routing
-ids, with a marker-only fallback when necessary. This is a context-size control,
-not delivery or access control. Spill names, compaction order, and recovery are
-owned by the channel-model reference.
+`notification.max_chars` is one live cap for both lanes: environment `LINGTAI_NOTIFICATION_MAX_CHARS`, then valid System-v2 `notification_max_chars`, then `10000`, clamped to `2048..10000`. Malformed values fall through. It limits context size, not access or delivery. Oversized content spills before compaction; follow the exact spill locator (or producer tool on `spill_failed`) before acting on a capped payload. See [channel model](reference/channel-model/SKILL.md).
 
-The SHOW row `notification.max_chars` reports that same effective clamped value.
-Change only through the existing authorized environment or closed System-v2 owner
-procedure; an environment/launcher change needs the authorized refresh or
-relaunch, while the file layer is hot-read. SHOW itself never writes, refreshes,
-adds an `init.json` field, or creates a Notification settings file.
+Use only the authorized environment or closed System-v2 owner procedure. The file layer is hot-read; it does not require a refresh just for this value. Environment/launcher changes need the appropriate authorized refresh/relaunch. SHOW again to verify.
 
-## Routing table
+## Notification settings and manual
 
-| Need / keywords | Read |
-|---|---|
-| First read; channel names; `.notification/*.json`; envelopes; `check`; delivery; allowlist; hooks; delay; block cap; settings sources | `reference/channel-model/SKILL.md` |
-| Which dismiss action; producer-specific handling; stale mirror; `force`; protected `goal`; post-molt reason; legacy `large_tool_result` | `reference/dismissal-safety/SKILL.md` |
-| Tool-result ranking, digest quality, `context(action='summarize')`, recovery by `tool_call_id` | `../context-manual/reference/summarize-manual/SKILL.md` |
-| Active goal cancellation/completion; runtime/kernel update nudges | `../system-manual/reference/goal-manual/SKILL.md` and `../system-manual/reference/runtime-update-checks/SKILL.md` |
+`settings` and `manual` take strict empty `input={}` and are read-only. SHOW returns two rows in order: `notification.max_chars`, `notification.delay_max_seconds`; each has only `key`, `current`, `default`, `configurable`, `comment`. Comments target the two headings above. Unavailable current truth fails the whole inventory. SHOW grants no mutation authority and creates no settings file.
+
+`manual` reads only initialized `<agent>/.library/intrinsic/capabilities/notification/SKILL.md`, returning `status`, `notification_manual`, `manual_path`. A missing file returns degraded status, empty body and actionable error, never source-tree fallback. It touches no notification, producer, delay or log state. Keep root `summarize=false` so guidance stays exact; compaction belongs to `context`, not Notification or System.

--- a/src/lingtai/tools/notification/manual/reference/channel-model/SKILL.md
+++ b/src/lingtai/tools/notification/manual/reference/channel-model/SKILL.md
@@ -1,61 +1,44 @@
 ---
 name: notification-manual-channel-model
 description: >
-  Nested notification-manual reference for LingTai's notification filesystem
-  channel protocol, allowlist, payload envelopes and instructions, nudge routing,
-  kernel sync, voluntary check behavior, and canonical producer state versus
-  notification mirrors. Read after notification-manual when interpreting,
-  producing, or debugging notification payloads; skip for dismissal policy.
-version: 0.7.0
+  Notification payload, mirror, allowlist, hook, delivery, delay, and block-cap
+  reference. Read after notification-manual when interpreting current channel
+  state or diagnosing delivery; dismissal policy belongs to dismissal-safety.
+version: 0.8.0
 tags: [lingtai, notifications, channels, protocol, sync, delay, alarm, nudge, hooks, whitelist]
-last_changed_at: "2026-09-06T00:00:00Z"
+last_changed_at: "2026-09-09T05:30:00Z"
 related_files:
 - src/lingtai/tools/notification/manual/SKILL.md
 - src/lingtai/tools/notification/schema.py
 - src/lingtai/kernel/notification_store/__init__.py
 maintenance: |
-  Tracks the notification channel-model/protocol topic it documents; update when that integration changes.
+  Keep this reference as the sole owner of channel protocol, delivery, hook,
+  delay, and block-cap detail; update its parent route when paths change.
 ---
 
 # Notification Channel Model
 
-## Files and allowlist
+## Current channel surface
 
-A channel is the filename stem in `.notification/<channel>.json`:
+A channel is the filename stem in `.notification/<channel>.json`; for example,
+`system.json` projects to `attention.system` and `mcp.telegram.json` to
+`attention["mcp.telegram"]`. Ordinary channel files are current mirrors. Daemon is a logical aggregate from Store-owned `.notification/daemon/<id>.json` mini-files; sibling `daemon.json` is only a non-authoritative compatibility report. Use Core/tool reads and dismissal, not direct edits.
+Delivered metadata can be historical, so never treat an old attention snapshot as
+canonical producer state.
 
-- `.notification/email.json` becomes `_meta.agent_meta.notifications.attention.email`;
-- `.notification/system.json` becomes `_meta.agent_meta.notifications.attention.system`;
-- `.notification/mcp.telegram.json` becomes
-  `_meta.agent_meta.notifications.attention["mcp.telegram"]`;
-- `.notification/goal.json` becomes `_meta.agent_meta.notifications.attention.goal`.
+The effective allowlist is the static built-ins + `mcp.*` + hook channels
+registered by **this agent's workdir**. It is per-agent, not process-global.
+Unknown JSON names, non-JSON entries, invalid stems, and kernel-private dotfiles
+are ignored. A present but unregistered channel emits one deduplicated
+`notification_hook` warn-and-flag event with `ref_id:
+blocked_channel:<channel>` until registration.
 
-The kernel accepts built-in channels including `email`, `system`, `soul`,
-`nudge`, `post-molt`, `tool_loop_guard`, `bash`, `btw`, `cron`, `molt`, `goal`,
-`daemon`, and `delay-alarm`; MCP bridge channels use the `mcp.` prefix. The
-**effective allowlist** is `static ∪ mcp.* ∪ the agent's own registered hook
-channels`, and is **per-agent, not process-global**: a hook channel is allowed
-only for the agent whose workdir registered it. External hooks register
-manifests via `notification(action='add', ...)`, which appends to
-`.notification/hooks.json` and allowlists the manifest's `channel`.
+Built-ins include `email`, `system`, `soul`, `nudge`, `post-molt`, `tool_loop_guard`,
+`bash`, `btw`, `cron`, `molt`, `goal`, `daemon`, and `delay-alarm`. Runtime/configuration nudges use `nudge`; its System owner routes `kernel_version` to update checks. `source_drift` stays local, never release-migration routing. See `../../../system-manual/reference/runtime-update-checks/SKILL.md`.
 
-Unknown JSON filenames are ignored by collection, and kernel publish/dismiss
-helpers reject names outside the effective allowlist, so arbitrary workdir files
-cannot enter the model-visible lane. A blocked present channel is observable:
-the kernel emits one deduplicated `notification_hook` system warn-and-flag event
-(`ref_id: blocked_channel:<channel>`) per workdir and channel until registration.
-The scan skips kernel-private dotfiles (for example `.nudge_state.json`),
-non-`.json` entries, and syntactically invalid stems because they cannot become
-channels.
+## Payload and producer ownership
 
-`nudge` is the formal channel for throttled checks: runtime update checks publish
-`data.nudges[]` entries with `kind: kernel_version`, and source-freshness checks
-may publish `kind: source_drift`; the latter stays local and never enters
-release-migration routing. Runtime update, configuration, and refresh policy is
-owned by `../../../system-manual/reference/runtime-update-checks/SKILL.md`.
-
-## Envelope and producer instructions
-
-Producer helpers write the current channel surface as a standard envelope:
+A producer writes the current channel as an envelope such as:
 
 ```json
 {
@@ -63,132 +46,80 @@ Producer helpers write the current channel surface as a standard envelope:
   "icon": "🔔",
   "priority": "normal",
   "published_at": "2026-06-10T00:00:00Z",
-  "instructions": "Optional agent-facing handling guidance.",
+  "instructions": "Optional producer-owned handling guidance.",
   "data": {"events": []}
 }
 ```
 
-`instructions` is an optional field inside one channel payload, not a channel
-name. It tells the agent how that producer expects the event to be handled or
-cleared. Producers own that directive because only they know whether the file is
-a disposable output, a mirror over canonical state, a coalesced event summary,
-or protected source of truth.
+`instructions` is inside the payload, not a channel. Read it before choosing a
+verb: the producer knows whether the file is disposable output, a mirror over
+canonical state, a coalesced event summary, or protected source of truth. A
+notification clear changes only this mirror. It must not mark mail read, change a
+goal, consume an MCP queue, or mutate any other producer-owned record. A producer with canonical state should register a generic-dismiss guard and teach its owner verb in `instructions`; hook registration only widens the allowlist, not dismissal policy. External
+writers use atomic sibling-temp replacement so readers never see partial JSON.
 
-External producers that can write the workdir may publish the same envelope to an
-allowlisted `mcp.<server>.json` path. They must use atomic sibling-temp
-replacement so readers never observe a partial JSON file.
+## Delivery and voluntary `check`
 
-## Voluntary check and model-visible delivery
+`check` returns a placeholder; the turn loop stamps the one live payload onto that
+same result. IDLE/ASLEEP wake delivery uses the same shape. During ACTIVE work,
+the current payload is copied to every eligible final ToolResultBlock, even when
+unchanged; only the newest emission is current and older holders are historical
+traces. Delivery signatures are bookkeeping, not an attachment gate. Fingerprints
+and the live holder belong to kernel sync, not `manual` or this handler.
 
-`check` returns a dict placeholder that the turn-loop post-hook stamps with the
-canonical live payload; the handler assembles no second channel representation
-and writes no notification state.
+## Consumer delay and expiry
 
-When notifications arrive while an agent is IDLE or ASLEEP, the kernel can
-synthesize the same `notification(action='check')` tool-call/result shape—same
-`action`/`input`/`reasoning` envelope, indistinguishable from a read you issued
-yourself—and wake the agent. During ACTIVE work the post-hook moves the single
-live payload onto a suitable dict-shaped tool result only on first appearance,
-material change, or a deliberate check. Delivery fingerprints and the live
-holder belong to kernel synchronization, not to the `manual` action.
+`delay` is a consumer filter, never a producer operation. One allowed target is
+recorded in private `.notification/.delay_state.json`; the target file keeps
+receiving updates. A nonzero request replaces the prior live delay, and `seconds:
+0` cancels only the matching target and makes it visible again. The finite cap is
+read live from `LINGTAI_NOTIFICATION_DELAY_MAX_SECONDS`; blank, non-numeric,
+non-positive, or non-finite values fall back to `600`.
 
-## Consumer delay filtering and expiry recovery
+For ordinary targets, coherent snapshots, voluntary checks, and wake delivery
+omit only the delayed target. A `daemon` delay masks attention only: its payload,
+byte version, and bounded summary remain readable, while `daemon:delayed=1`
+prevents daemon arrivals from moving the wake fingerprint. Other channels,
+including registered hooks, continue to wake. `delay-alarm` cannot itself be
+delayed.
 
-The `daemon` target is masked, not filtered: its payload, byte version, and
-bounded summary stay visible while its attention entry collapses to a constant
-token, so daemon arrivals stay readable but do not wake until delay expires.
-Independent channels continue to wake.
+Expiry or recovery stops filtering and publishes one high-priority latest-only
+`delay-alarm` mirror with target, requested/actual duration, byte-level
+changed/no-change, and only conservative producer-reported or retained-event
+statistics. State is atomically replaced under the established Store mutation
+lock; a stable request id makes timer/restart races overwrite one alarm rather
+than duplicate it. Malformed or unreadable delay state fails open to target
+visibility, never silence.
 
-`notification(action='delay', input={'channel': ..., 'seconds': 0 or a live configured cap})`
-is not a producer operation. Its private `.notification/.delay_state.json`
-record causes the coherent consumer snapshot, delivery fingerprint, synthetic
-wake, and voluntary `check` projection to omit exactly one allowed target while
-it is live; the target file continues receiving and retaining producer updates.
-A nonzero delay replaces the prior one, and `seconds: 0` cancels only the
-matching target and makes it visible again. The target file is never rewritten.
+## Hooks and allowlist lifecycle
 
-The finite nonzero cap is read live from
-`LINGTAI_NOTIFICATION_DELAY_MAX_SECONDS`; a missing, blank, non-numeric,
-non-positive, or non-finite value falls back to `600` with the existing bounded
-diagnostic. The process timer is only a prompt path. Every coherent sync also
-recovers a persisted overdue delay: recovery stops filtering and publishes one
-high-priority `delay-alarm` mirror in the same read/wake cycle. Its state uses
-the established native notification mutation lock plus atomic sibling
-replacement, and a stable request id makes a stale callback or restart retry
-overwrite the same latest-only alarm rather than append a duplicate.
+1. Write a watcher that atomically publishes the envelope to an allowlisted
+   `.notification/<channel>.json` path.
+2. Before starting that watcher, register it with `notification(action='add', input={...})`, supplying `name`,
+   `channel`, `source`, `description`, `how_to_modify`, and `how_to_cancel`;
+   `version` defaults to `1.0.0`, and `instructions` is optional.
+3. Read with `check`, then follow the producer instruction or narrowest dismiss.
 
-The alarm contains only byte-level change comparison plus producer-reported or
-retained-event measurements; these values are not claimed to be exact totals for
-overwrite or capped payloads. `delay-alarm` is a built-in mirror consumers may
-dismiss, but it cannot itself be delayed. Malformed or unreadable delay state
-fails open to visible target delivery. A `daemon` delay masks only its attention
-token; payload, delivered version, and bounded summary remain readable.
+`list` preserves registry order. `edit` revalidates channel uniqueness; a null-
+only edit is a no-op. `drop` revokes the channel but never stops its process.
+Corrupt or unreadable `.notification/hooks.json` gives `list`, `add`, `drop`, and
+`edit` a bounded load-failed result. Built-in channels and Store-reserved stems
+`hooks` and `large_result_acks` cannot be registered.
 
-## Canonical producer state versus mirror
+## Block cap and settings
 
-A generic channel clear changes only the `.notification/<channel>.json` surface.
-It does not mark an email read, change a goal, consume an MCP source queue, or
-mutate any other producer-owned state. A producer whose notification is a mirror
-over canonical state must register a generic-dismiss guard and teach the
-producer-specific verb in `instructions`.
-
-This separation is deliberate: the filesystem protocol gives the kernel one
-current high-attention surface, while canonical state remains under the
-producer's own schema and lifecycle.
-
-## Hook registration workflow
-
-An external hook follows this sequence:
-
-1. Write a watcher that publishes the standard envelope atomically to an
-   allowlisted `.notification/<channel>.json` path.
-2. Call `notification(action='add', input={...})` with `name`, `channel`,
-   `source`, `description`, `how_to_modify`, and `how_to_cancel`; optional
-   `version` defaults to `1.0.0`, and `instructions` teaches handling.
-3. Read the resulting channel with `check`, then use the producer instruction or
-   narrowest dismiss action. `drop` revokes registration but does not kill the
-   process.
-
-`list` returns manifests in registry order. `edit` changes named fields and
-revalidates channel uniqueness; a null-only edit is a no-op. Corrupt or
-unreadable `hooks.json` makes `list`, `add`, `drop`, and `edit` return a bounded
-load-failed result. Built-in channels and Store-reserved stems (`hooks` and
-`large_result_acks`) cannot be registered.
-
-A blocked present JSON channel emits one deduplicated
-`notification_hook` event with `ref_id: blocked_channel:<channel>` per workdir and
-channel until registration. Kernel-private dotfiles, non-JSON entries, and
-invalid stems are skipped by this scan.
-
-## Block-cap and settings detail
-
-The persistent block (`notification_persistent`) and transient attention lane
-share `LINGTAI_NOTIFICATION_MAX_CHARS` (default `10000`, clamped to `2048..10000`).
-Resolution is live environment, then valid closed System-v2
-`notification_max_chars`, then default. Invalid or malformed values contribute
-no layer value. At or under the cap, serialization is byte-identical. Above it,
-the full persistent payload is atomically spilled to
-`logs/notification-overflow-<ts>.json`; the attention lane uses a
+`notification.max_chars` is one shared live cap (`10000`, clamped to `2048..10000`)
+for persistent and attention lanes. Metadata files are not channels. Resolution is environment
+`LINGTAI_NOTIFICATION_MAX_CHARS`, then valid System-v2
+`notification_max_chars`, then default. At or under cap, serialization is
+byte-identical. Above cap, persistent output spills to
+`logs/notification-overflow-<ts>.json`; attention output uses the
 content-addressed `notification-attention-overflow-<digest8>.json` (with a
-collision suffix), and both model copies compact while preserving routing ids.
+collision suffix). Both model copies compact while preserving routing ids. If an id-only copy still cannot fit, the marker-only envelope may omit its long `path` (`path_omitted=true`) while retaining the exact basename in `spill_file`. Read the full spill before acting; if `spill_failed`, use the producer tool for full content. This is context-size control, not
+access or delivery accounting.
 
-Heavy free text is reduced in stages; if an id-only copy cannot fit, a marker-only
-envelope retains the exact spill basename, and a failed spill points back to the
-producer tool. The cap is a context-size control, not delivery accounting.
-
-The SHOW row `notification.max_chars` reports that same effective clamped value.
-To change it, obtain owner approval and use the existing environment launcher or
-closed System-v2 procedure; an environment/launcher change needs the authorized
-refresh or relaunch, while the file layer is hot-read. SHOW itself never writes,
-refreshes, adds an `init.json` field, or creates a Notification settings file.
-
-## Footprint
-
-The protocol footprint is `.notification/<channel>.json` plus kernel-owned
-notification metadata such as legacy acknowledgement state
-(`.notification/large_result_acks.json`), the hook-manifest registry
-(`.notification/hooks.json`, a single non-channel file invisible to collection),
-and consumer-delay state (`.notification/.delay_state.json`, a private dotfile
-invisible to collection). Inspect it read-only before diagnosing a producer.
-Never delete the directory or bulk-remove files—doing so bypasses the guards and
-stale checks that only the producer verb or an atomic notification action honor.
+The SHOW row reports the same effective clamped value and never writes, refreshes,
+adds `init.json`, or creates a settings file. The notification footprint also
+includes kernel-owned `large_result_acks.json`, `hooks.json`, and the private
+delay state. Inspect read-only; never delete the directory or bulk-remove files,
+because producer guards and stale checks live in the atomic actions.

--- a/src/lingtai/tools/notification/manual/reference/dismissal-safety/SKILL.md
+++ b/src/lingtai/tools/notification/manual/reference/dismissal-safety/SKILL.md
@@ -1,120 +1,92 @@
 ---
 name: notification-manual-dismissal-safety
 description: >
-  Nested notification-manual reference for choosing safe atomic notification
-  dismissal, producer-specific verbs, stale-version and force behavior,
-  protected channels, post-molt acknowledgement, and legacy large_tool_result
-  reminder escape hatches. Read after notification-manual before clearing a
-  channel or diagnosing a dismissal refusal; summarization mechanics live in
-  summarize-manual instead.
-version: 0.4.0
+  Safe notification dismissal reference: producer-owned state, atomic targets,
+  stale versions, force, protected channels, post-molt acknowledgement, hooks,
+  and legacy large-result reminders. Read after notification-manual before a
+  clear or when one is refused; compaction belongs to summarize-manual.
+version: 0.5.0
 tags: [lingtai, notifications, dismiss, force, stale, safety, hooks]
-last_changed_at: "2026-08-10T00:00:00Z"
+last_changed_at: "2026-09-09T05:30:00Z"
 related_files:
 - src/lingtai/tools/notification/manual/SKILL.md
 - src/lingtai/tools/notification/__init__.py
 - src/lingtai/tools/notification/schema.py
 maintenance: |
-  Tracks the notification dismissal-safety topic it documents; update when that integration changes.
+  Keep this reference as the sole owner of dismissal safety and refusal recovery;
+  update the parent route when its installed path changes.
 ---
 
 # Notification Dismissal Safety
 
-## Choose the narrowest owner and target
+## Owner first; mirror second
 
-Use a producer-specific verb first when a notification mirrors producer-owned
-state (e.g. `email(action='read'|'dismiss', ...)`) — a generic channel dismissal
-would clear only the high-attention mirror.
+Read the current payload's `instructions`. If the notification mirrors producer-
+owned state, call that producer's read/dismiss verb first (for example,
+`email(action='read'|'dismiss', ...)`). A generic notification dismiss clears
+only the high-attention mirror; it never removes producer history, mailbox state,
+goal semantics, or a source queue.
 
-For a dismissible notification-owned surface, choose one atomic target:
+Choose one atomic target:
 
 ```text
 notification(action='dismiss_channel',
              input={'channel': 'nudge', 'force': null, 'reason': null},
-             reasoning='...')
+             reasoning='handled the notification')
 ```
 
-`dismiss_event` and `dismiss_ref` take the same envelope with `event_id` /
-`ref_id` instead of `channel`; the schema is the exact-shape source of truth.
-What it does not say: those two **default to the `system` channel** and remove
-only matching entries from `system.data.events`, and **removing the final event
-clears the file**.
+`dismiss_channel` clears one whole mirror and requires `channel`.
+`dismiss_event` removes one matching `event_id`; `dismiss_ref` removes matching
+`ref_id` event(s). Event/ref calls default to `channel: 'system'`, target
+events in the system mirror; `channel: "daemon"` is also supported through the Core aggregate. Other channels refuse event/ref targets. Clearing the final system event removes that mirror, not producer records. The schema is
+the exact field source; cross-action fields are rejected before I/O. All three
+verbs delegate to the canonical Core policy path.
 
-All three actions delegate to the canonical notification Core dismissal helper.
-That one policy path enforces allowlists, producer guards, stale-version checks,
-protected channels, post-molt acknowledgement, and legacy reminder
-acknowledgement. The standalone tool does not reimplement Store or producer
-policy.
+## Stale versions and `force`
 
-## Stale versions, guards, and force
-
-A non-force generic dismiss compares the delivered notification version with the
-current on-disk version. If a producer updated the channel after delivery, the
-call refuses with `reason='stale_channel_version'` rather than erase unseen
-state. Read the newly delivered state first.
-
-`force=true` (semantics in the schema) is for a confirmed stale mirror — not a
-routine retry, and not a substitute for handling the producer.
+A non-force clear compares the delivered version with the current on-disk
+version. If the producer updated the channel after delivery, it refuses with
+`reason: 'stale_channel_version'`. Read the newly delivered state before making
+a decision. `force=true` is only for a confirmed stale **mirror**, never a routine
+retry and never a substitute for handling the producer. A successful clear still
+changes the mirror only.
 
 ## Protected and acknowledgement-sensitive channels
 
-`goal` is protected source of truth. A generic
-`notification(action='dismiss_channel', input={'channel': 'goal', ...})`
-refuses even with `force=true`; use `../../../system-manual/reference/goal-manual/SKILL.md` to cancel or complete active goal
-state correctly.
+`goal` is protected source of truth: generic `dismiss_channel` refuses even with
+`force=true`; use `../../../system-manual/reference/goal-manual/SKILL.md` to cancel or complete goal state. `post-molt`
+requires a non-empty decision reason in the form `continue: ...`, `defer: ...`,
+or `obsolete: ...`:
 
-The kernel-owned `post-molt` continuation channel requires a non-empty reason
-recording the decision in `continue|defer|obsolete` form — e.g.
-`reason='continue: recovered the pending work'` on
-`dismiss_channel(channel='post-molt')`.
+```text
+notification(action='dismiss_channel',
+             input={'channel': 'post-molt', 'force': null,
+                    'reason': 'continue: recovered the pending work'},
+             reasoning='acknowledge continuation')
+```
 
-## Hook channels and producer-guard interplay
+A refusal is a route, not a retry: producer guard → producer verb; stale version
+→ reread, then decide whether confirmed mirror-only `force` is justified;
+protected channel → owning manual; missing post-molt reason → record the real
+decision; one system event → use `dismiss_event` or `dismiss_ref`, not a whole
+channel clear.
 
-A registered hook channel (see the parent manual's `Hooks & whitelist`
-section) is dismissed exactly like any other allowlisted channel: the atomic
-dismiss actions clear only the `.notification/<channel>.json` mirror. Hook
-registration widens the **allowlist** for the registering agent's workdir
-(hook channels are per-agent, not process-global), not the dismissal policy —
-a hook producer whose notification mirrors canonical state should still
-register a generic-dismiss guard and teach its producer-specific verb in
-`instructions`, and the guarded refusal still applies.
+## Hooks and legacy reminders
 
-`notification(action='drop', input={'name': ...})` removes the hook's manifest
-and revokes its channel from the allowlist; it does **not** kill the hook
-process. Stopping the hook is the owner's job, documented in the manifest's
-`how_to_cancel` field. After a drop, an unregistered channel's notifications
-stop passing through and the kernel's warn-and-flag event may reappear if the
-process keeps publishing — the blocked-channel warning is cleared when a
-channel registers, so a later re-block can warn again. The warn-and-flag scan
-only flags present stems that can become channels (skipping kernel-private
-dotfiles like `.nudge_state.json`, non-`.json` entries, and syntactically
-invalid stems), so an unregistered file that could never be a channel does not
-produce a spurious "register this hook" event.
+A registered hook channel uses the same atomic dismissal and producer guards.
+Registration widens only this agent's allowlist, never producer-dismiss policy. `drop` removes the manifest and
+revokes the channel; it does **not** kill the hook process. Stop it using the
+manifest's `how_to_cancel`. If the process keeps publishing after drop, the
+kernel may emit the blocked-channel warning again.
 
-## Large results and legacy reminder escape hatch
+New large tool results are not notification events. They belong to
+`_meta.agent_meta.agent_state.current_tool_result_chars` and
+`context(action='summarize')`; `../../../context-manual/reference/summarize-manual/SKILL.md` owns digest, recovery, and
+summarize-versus-molt procedure. A persisted legacy
+`source='large_tool_result'` event can be cleared by successful summarization of
+the matching `tool_call_id`; if that is impossible, prefer
+`dismiss_ref(ref_id='large_tool_result:<tool_call_id>')` over a whole-channel
+system clear, which may remove unrelated events. The original result remains in
+chat history and `events.jsonl`.
 
-New large tool results are not notification events — they are ranked under
-`_meta.agent_meta.agent_state.current_tool_result_chars`, and
-`../../../context-manual/reference/summarize-manual/SKILL.md` owns the digest,
-`context(action='summarize')`, recovery, and summarize-versus-molt procedure.
-
-A persisted or pre-molt `source='large_tool_result'` system event may still
-exist. A successful summarize of the matching `tool_call_id` clears it. If
-summarization is no longer possible, use
-`dismiss_ref` with `ref_id='large_tool_result:<tool_call_id>'`. Whole-channel
-system dismissal also covers it but may clear unrelated system events, so prefer
-ref/event targeting. Either way the original tool result stays unchanged in chat
-history and `events.jsonl`.
-
-## On a refusal
-
-1. Check whether the channel's `instructions` name a producer action; if so, use
-   it instead of retrying the generic dismiss.
-2. Stale — read the current delivered payload before deciding on `force=true`.
-3. Protected — follow the channel's owning manual; do not retry.
-4. `post-molt` without a reason — record the real continue/defer/obsolete
-   decision.
-5. Targeting one system event — use `dismiss_event`/`dismiss_ref`, not a
-   whole-channel clear.
-
-No dismissal ever removes producer history, mailbox state, or goal semantics.
+No dismissal mutates producer state. Never bypass these guards by deleting files.

--- a/src/lingtai/tools/notification/schema.py
+++ b/src/lingtai/tools/notification/schema.py
@@ -1,27 +1,10 @@
-"""Schema data — canonical per-action input schemas and prose for ``notification``.
+"""Canonical notification input schemas and model-facing English descriptions.
 
-The notification tool exposes ``check``, the three atomic dismiss verbs
-(``dismiss_channel``, ``dismiss_event``, ``dismiss_ref``), read-only settings
-discovery, and the strictly read-only progressive-disclosure action ``manual``.
-``summarize`` is *not* a notification verb; compaction is owned by
-``context(action='summarize')``. The root ``summarize`` boolean is the
-cross-cutting LTP v2 result-post-processing control, not an action.
-
-This module holds only data: each action's own canonical strict
-``input_schema`` (:data:`INPUT_SCHEMAS`) and the canonical English prose.
-``__init__.py`` composes these into the public model-facing schema via the
-generic ``ToolFamily`` infra (``lingtai.tools.tool_family``) — see
-``__init__.py::_schema_only_family``/``get_schema``. ``lang`` is accepted on
-:func:`get_description` and :func:`get_schema` for source compatibility and
-does not select localized aliases; schema prose is canonical English,
-language-independent.
-
-Optional dismiss fields are declared in the provider-compatible nullable
-representation (``"type": ["string", "null"]`` plus membership in
-``required``) per ``tools/CONTRACT.md`` "Envelope": strict OpenAI schemas
-have no other way to express an optional field. ``__init__.py`` strips those
-nulls back to *absent* before the pre-existing dismiss handlers run, so
-``args.get("channel", "system")``-style defaulting is preserved exactly.
+This module owns data only; ``__init__.py`` composes the public family and
+``ToolFamily`` validates the closed envelope. ``summarize`` remains a root
+post-processing control, not a notification action. Nullable optional fields are
+required by strict provider schemas and are stripped back to absent before the
+existing handlers apply their defaults.
 """
 from __future__ import annotations
 
@@ -30,9 +13,8 @@ from typing import Any
 from ..tool_family.manual import MANUAL_INPUT_SCHEMA
 
 LARGE_RESULT_DISMISS_ACTION_NOTE = (
-    "Legacy large_tool_result reminders are an escape hatch only: prefer "
-    "context(action='summarize'); any dismiss clears the mirror, not the original "
-    "result. See notification-manual."
+    "Legacy large_tool_result is an escape hatch: prefer "
+    "context(action='summarize'); dismissal clears only its mirror."
 )
 
 LARGE_RESULT_FORCE_NOTE = ""
@@ -60,16 +42,16 @@ NOTIFICATION_DECLARED_ACTIONS = (
 ACTION_ORDER = (*NOTIFICATION_DECLARED_ACTIONS, "settings", "manual")
 
 _CHANNEL_DESCRIPTION = (
-    "Target channel; required for whole-channel clear; event/ref default to system. "
-    "Follow its producer verb first; generic clear is mirror-only."
+    "Channel; whole clear requires it, event/ref default to system. Follow the "
+    "producer verb first; generic clear is mirror-only."
 )
 
 _FORCE_DESCRIPTION = (
-    "Optional true only after rereading a confirmed stale mirror; never producer or "
-    "protected state. " + LARGE_RESULT_FORCE_NOTE
+    "Optional true only after rereading a confirmed stale mirror; never producer or protected "
+    "state. " + LARGE_RESULT_FORCE_NOTE
 )
 
-_REASON_DESCRIPTION = "Optional ack reason; post-molt: continue|defer|obsolete: ... ."
+_REASON_DESCRIPTION = "Optional reason; post-molt requires continue|defer|obsolete: ... ."
 
 _CHECK_INPUT_SCHEMA: dict[str, Any] = {
     "type": "object",
@@ -78,23 +60,23 @@ _CHECK_INPUT_SCHEMA: dict[str, Any] = {
     "additionalProperties": False,
 }
 
-_HOOK_NAME_DESCRIPTION = "Hook name; matched in hooks.json."
+_HOOK_NAME_DESCRIPTION = "Hook name in hooks.json."
 
-_HOOK_CHANNEL_DESCRIPTION = "Published channel stem; registration allowlists it."
+_HOOK_CHANNEL_DESCRIPTION = "Published stem; registration allowlists it."
 
-_HOOK_STRING_FIELD_DESCRIPTION = "Hook manifest field."
+_HOOK_STRING_FIELD_DESCRIPTION = "Hook manifest field; null means unchanged."
 
 _ADD_INPUT_SCHEMA: dict[str, Any] = {
     "type": "object",
     "properties": {
         "name": {"type": "string", "description": _HOOK_NAME_DESCRIPTION},
         "channel": {"type": "string", "description": _HOOK_CHANNEL_DESCRIPTION},
-        "source": {"type": "string", "description": "Producer/source identifier."},
-        "description": {"type": "string", "description": "What the hook watches."},
-        "how_to_modify": {"type": "string", "description": "How to modify it."},
+        "source": {"type": "string", "description": "Producer identifier."},
+        "description": {"type": "string", "description": "Watched source."},
+        "how_to_modify": {"type": "string", "description": "How to modify."},
         "how_to_cancel": {"type": "string", "description": "How to stop it; drop never kills it."},
-        "version": {"type": ["string", "null"], "description": "Optional version; default 1.0.0."},
-        "instructions": {"type": ["string", "null"], "description": "Optional handling guidance."},
+        "version": {"type": ["string", "null"], "description": "Version; default 1.0.0."},
+        "instructions": {"type": ["string", "null"], "description": "Handling guidance."},
     },
     "required": [
         "name",
@@ -174,10 +156,7 @@ _DISMISS_EVENT_INPUT_SCHEMA: dict[str, Any] = {
     "properties": {
         "event_id": {
             "type": "string",
-            "description": (
-                "Remove only the matching system notification event_id from "
-                ".notification/system.json instead of the whole channel."
-            ),
+            "description": "Remove matching event_id; system by default, daemon also supported.",
         },
         "channel": {"type": ["string", "null"], "description": _CHANNEL_DESCRIPTION},
         "force": {"type": ["boolean", "null"], "description": _FORCE_DESCRIPTION},
@@ -192,11 +171,7 @@ _DISMISS_REF_INPUT_SCHEMA: dict[str, Any] = {
     "properties": {
         "ref_id": {
             "type": "string",
-            "description": (
-                "Remove system notification event(s) carrying this producer "
-                "ref_id from .notification/system.json instead of the whole "
-                "channel."
-            ),
+            "description": "Remove matching ref_id events; system by default, daemon also supported.",
         },
         "channel": {"type": ["string", "null"], "description": _CHANNEL_DESCRIPTION},
         "force": {"type": ["boolean", "null"], "description": _FORCE_DESCRIPTION},
@@ -234,38 +209,35 @@ INPUT_SCHEMAS: dict[str, dict[str, Any]] = {
 }
 
 ACTION_ENUM_DESCRIPTION = (
-    "Strict action selector: each action takes its own object in input; nullable "
-    "optionals mean absent. "
-    "check: read current channels and return the live placeholder. "
-    "dismiss_channel: clear one named mirror. "
-    "dismiss_event: remove one system event by event_id; channel defaults to system. "
-    "dismiss_ref: remove matching system events by ref_id; channel defaults to system. "
-    "add: register a hook manifest and allowlist its channel. "
-    "drop: unregister a hook; it never stops the process. "
-    "edit: update a named hook and revalidate channel uniqueness. "
-    "list: show registered hook manifests. "
-    "delay: hide one allowed consumer channel (0 cancels; nonzero uses the live "
-    "cap); producer state is unchanged and expiry emits one non-delayable alarm. "
-    "settings: read-only effective setting rows. "
-    "manual: call notification(action='manual', input={}) to return the installed "
-    "notification manual; read-only."
+    "Choose one strict action; nullable optionals mean absent. "
+    "check: read current mirrors. "
+    "dismiss_channel: clear one mirror. "
+    "dismiss_event: remove an event by event_id; channel defaults to system, daemon also supported. "
+    "dismiss_ref: remove matching events by ref_id; channel defaults to system, daemon also supported. "
+    "add: register and allowlist a hook. "
+    "drop: unregister it; never stop its process. "
+    "edit: update a hook and revalidate its channel. "
+    "list: show hooks. "
+    "delay: hide one consumer channel (0 cancels; nonzero uses the live cap); "
+    "producer state is unchanged and expiry emits one non-delayable alarm. "
+    "settings: read-only setting rows. "
+    "manual: call notification(action='manual', input={}) for installed guidance; "
+    "read-only."
 ) + "\n\n" + LARGE_RESULT_DISMISS_ACTION_NOTE
 
 
 def get_description(lang: str = "en") -> str:
     return (
-        "Notification reads current channel mirrors, manages hook registrations, "
-        "and controls consumer delay. Calls use the strict action + input + "
-        "reasoning envelope; begin with notification(action='check', input={}, "
-        "reasoning='...') to inspect. Its live payload is stamped under "
-        "`_meta.agent_meta.notifications.attention` and "
-        "`_meta.agent_meta.guidance.transient`. Follow producer-specific handling "
-        "before generic dismissal: generic clear is mirror-only; reread after a "
-        "stale refusal, and use force=true only for a confirmed stale mirror, never "
-        "producer or protected state. Post-molt dismissal needs a non-empty "
-        "continue|defer|obsolete: ... reason; drop never stops its process; delay "
-        "hides consumer delivery only (0 cancels), and delay-alarm cannot be "
-        "targeted. notification(action='settings', input={}, reasoning='...') and "
+        "Notification reads channel mirrors, manages hook registrations, and applies "
+        "consumer delay. Use the strict action + input + reasoning envelope; start "
+        "with notification(action='check', input={}, reasoning='...'). Live payload: "
+        "_meta.agent_meta.notifications.attention (guidance.transient routes handling). Follow "
+        "producer instructions before generic dismissal: generic clear affects the "
+        "mirror only. Reread after a stale refusal; force=true is only for a "
+        "confirmed stale mirror, never producer or protected state. Post-molt needs "
+        "continue|defer|obsolete: ...; drop never stops its process; delay is "
+        "consumer-only (0 cancels), and delay-alarm cannot be targeted. "
+        "notification(action='settings', input={}, reasoning='...') and "
         "notification(action='manual', input={}, reasoning='...') are read-only; "
         "use context(action='summarize') for compaction."
     )

--- a/tests/test_notification_cap_doc_parity.py
+++ b/tests/test_notification_cap_doc_parity.py
@@ -23,10 +23,19 @@ def _text(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
 
+
+def _manual_text() -> str:
+    """Check the routed corpus without duplicating reference depth in the entry."""
+    entry = _text(MANUAL)
+    route = "reference/channel-model/SKILL.md"
+    assert f"]({route})" in entry
+    return entry + "\n" + _text(MANUAL.parent / route)
+
+
 def test_both_docs_mention_both_overflow_spill_namings() -> None:
     """Persistent (timestamp) and attention (content-addressed digest8) spill
     names are documented in both the manual and the LICC contract."""
-    manual = _text(MANUAL)
+    manual = _manual_text()
     contract = _text(CONTRACT)
     for label, text in (("manual", manual), ("contract", contract)):
         assert "notification-overflow-" in text, label
@@ -36,7 +45,7 @@ def test_both_docs_mention_both_overflow_spill_namings() -> None:
 def test_both_docs_mention_shared_env_bar_with_floor_and_ceiling() -> None:
     """Both documents name the shared env bar and its floor 2048 / ceiling
     10,000 clamp."""
-    manual = _text(MANUAL)
+    manual = _manual_text()
     contract = _text(CONTRACT)
     for label, text in (("manual", manual), ("contract", contract)):
         assert "LINGTAI_NOTIFICATION_MAX_CHARS" in text, label
@@ -61,7 +70,7 @@ def test_licc_describes_persistent_terminal_by_construction() -> None:
     """The LICC contract records the shared 2048 floor for BOTH lanes and the
     persistent terminal marker-only/spill_file degradation."""
     contract = _text(CONTRACT)
-    manual = _text(MANUAL)
+    manual = _manual_text()
     assert "[2048, 10,000]" in contract
     assert "spill_file" in contract
     assert "spill_file" in manual
@@ -71,8 +80,8 @@ def test_licc_describes_persistent_terminal_by_construction() -> None:
 def test_manual_describes_both_lanes_not_persistent_only() -> None:
     """The manual's cap section covers the attention lane too (marker-only
     degradation, path omission, content-addressed spill)."""
-    manual = _text(MANUAL)
-    assert "notification.attention" in manual
+    manual = _manual_text()
+    assert "_meta.agent_meta.notifications.attention" in manual
     assert "marker-only" in manual or "marker only" in manual
     assert "path_omitted" in manual
 
@@ -83,3 +92,10 @@ def test_contract_mentions_path_omitted_final_guard_and_digest8_spill() -> None:
     contract = _text(CONTRACT)
     assert "path_omitted" in contract
     assert "digest8" in contract
+
+
+def test_manual_uses_current_active_carrier_semantics() -> None:
+    manual = _manual_text()
+    assert "every eligible final ToolResultBlock" in manual
+    assert "only on first appearance" not in manual
+    assert "on first appearance, material change" not in manual

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -394,8 +394,8 @@ def test_skills_setup_hard_copies_standalone_intrinsic_skills(tmp_path):
         assert "name: notification-manual" in notification_manual_body
         assert "# Notification Manual" in notification_manual_body
         assert "<agent>/.library/intrinsic/capabilities/notification/SKILL.md" in notification_manual_body
-        assert "location: reference/channel-model/SKILL.md" in notification_manual_body
-        assert "location: reference/dismissal-safety/SKILL.md" in notification_manual_body
+        assert "](reference/channel-model/SKILL.md)" in notification_manual_body
+        assert "](reference/dismissal-safety/SKILL.md)" in notification_manual_body
         assert (
             notification_manual_md.parent / "reference" / "channel-model" / "SKILL.md"
         ).is_file()


### PR DESCRIPTION
## Summary
- One-tool Notification slice of the human-approved manual reduction batch; schema-first routine calls, two focused references, preserved SHOW anchors and producer/stale/force/goal/post-molt/delay boundaries.
- Correct source-verified guidance: live metadata locator, daemon mini-file aggregate and atomic event/ref targets, ACTIVE stamping on every eligible final ToolResultBlock, hot-read settings layer, and complete spill recovery. Correct one stale Contract owner reference from System to Context without changing its invariant.
- Runtime changes are descriptions/docstrings only. AST excluding reviewed prose and public schema excluding descriptions are identical. No Core, Store, lifecycle, config, auth, provider or platform behavior changes.
- Body characters (complete Unicode text after YAML, including whitespace): entry 6,356 → 3,736 (−41.2%); all three manuals 20,760 → 13,883 (−33.1%). Schema description occurrences plus family description: −474 characters, not measured tokens or cost.
- Native LingTai Luna supplied the initial candidate; 知微 performed source verification, bounded corrections, final owner review and independent execution of validation. No second worker/reviewer is claimed.

## Validation
Frozen clean main: `3364fe6267913ee8e00cb2e3b1dd87973b5508e2`. Final reviewed diff SHA-256: `e84d50f43cf8363cd19af407c76c7892a5fb3fa223d760c2cf28fc2717fb9cf5`.

```sh
python -B -m pytest -q tests/test_notification_tool.py tests/test_notification_settings.py tests/test_notification_cap_doc_parity.py tests/test_notification_delay_alarm.py tests/test_notification_sync.py tests/test_notification_attention_cap.py tests/test_notification_persistent_cap.py tests/test_daemon_attention_delay.py tests/test_system_dismiss.py tests/test_post_molt_notification.py tests/test_molt_notification_persistence.py tests/test_notification_schema_wire_scrub.py tests/test_large_result_no_notification.py tests/test_tool_plugin_declaration.py tests/test_tool_prose_section_gate.py tests/test_skills.py tests/test_prompt_catalog.py tests/test_docs_governance.py tests/test_architecture_documents.py tests/test_tool_settings_contract.py tests/test_intrinsic_manual_actions.py
# candidate: 526 passed, 6 failed, 1 warning
# clean base: 522 passed, 9 failed, 1 warning
python -B scripts/check_docs_governance.py --check
# PASS
python -B src/lingtai/intrinsic_skills/lingtai-kernel-anatomy/scripts/check_anatomy_drift.py --check
# 6 existing findings, byte-identical to clean base
 git diff --check
# PASS
```

Five remaining failure blocks are identical after pytest temporary-generation normalization: two prompt-catalog assertions, two MCP ServerRequestContext imports, and one Psyche orphan. The sixth standalone-skills test advances past the corrected Notification link assertions to the unchanged System `kind: kernel_version` assertion. It remains FAILED, not an identical error or whole-file pass. Three old Notification cap assertions resolve by checking the actual routed corpus; one new ACTIVE-carrier assertion is added. The same deprecation warning remains.

Task-local proof `owner-proof-v3.py` constructed a real Agent, rebuilt the complete 32,182-character prompt, verified one Notification mount, all three installed files byte-equal, all Markdown/backtick relative routes, two SHOW anchors, check placeholder, runtime AST and schema invariance. Provider service mocked and network connects blocked; not a production full-turn delivery test.

No whole-repository, native-Windows, live-provider or production E2E validation. No runtime rollout, release or cleanup. Batch merge authorized by Jason's Telegram instruction at 2026-09-09T05:21:14Z, after owner review/tests; other PRs and Agent-loop refactoring remain out of scope.

Telegram: @lingtaidev1bot | Nickname: 知微
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
