### PR TITLE
docs(task-card): simplify guidance and clarify state boundaries

### DIFF
--- a/src/lingtai/tools/task_card/__init__.py
+++ b/src/lingtai/tools/task_card/__init__.py
@@ -284,14 +284,15 @@ _DECLARED_INPUT_SCHEMAS: dict[str, dict[str, Any]] = {
 }
 
 _DESCRIPTION = (
-    "Maintain one channel-neutral Task Card per agent. start runs an existing "
-    "Python renderer inside the working directory; non-empty stdout is the full "
-    "body written atomically to taskcard/taskcard.md, then exact active is written "
-    "to taskcard/status. One watch only. Keep output truthful for meaningful "
-    "long-running, multi-step, or parallel work, not quick ritual updates. stop "
-    "pauses/preserves; remove retires then deletes, so use it only after completion, "
-    "cancellation, or abandonment. Consumers project state independently. Restart "
-    "after expiry by starting a new watch if work continues. Use settings and manual for detail."
+    "One channel-neutral Task Card per agent. For meaningful long-running, "
+    "multi-step, or parallel work, start an existing Python renderer inside the "
+    "working directory: successful non-empty stdout is the full body written to "
+    "taskcard/taskcard.md, then taskcard/status becomes exact active. One watch; "
+    "keep output truthful and skip quick ritual updates. inspect/retry use "
+    "watch_id. stop pauses and preserves; remove retires then deletes after "
+    "completion, cancellation, or abandonment. If expiry meets continuing work, "
+    "start a new watch. Consumers project independently; manual and settings route "
+    "detail."
 )
 
 _ACTION_DESCRIPTION = (

--- a/src/lingtai/tools/task_card/manual/SKILL.md
+++ b/src/lingtai/tools/task_card/manual/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: task_card-manual
 description: >
-  Read before managing the declarative Task Card / progress-watch artifact;
-  routes renderer lifecycle, settings, and projection detail while preserving
-  the one-card-per-agent contract and stop/remove distinction.
-last_changed_at: 2026-09-06T00:00:00Z
+  Read when a Task Card needs a truthful renderer, lifecycle recovery, settings,
+  or projection boundary; routine schema-sufficient calls can use the action directly.
+last_changed_at: 2026-09-09T00:00:00Z
 related_files:
 - src/lingtai/tools/task_card/__init__.py
 - src/lingtai/tools/task_card/ANATOMY.md
@@ -14,57 +13,50 @@ related_files:
 - src/lingtai/tools/task_card/manual/reference/notifications.md
 - src/lingtai/kernel/tool_plugin/CONTRACT.md
 maintenance: |
-  Keep this router aligned with the intrinsic task_card action/settings surface,
-  exact taskcard/status and taskcard/taskcard.md paths, one-card lifecycle, and
+  Keep this entry aligned with the intrinsic task_card action/settings surface,
+  exact taskcard/status and taskcard/taskcard.md paths, one-watch lifecycle, and
   the focused references it routes to. Update it with the paired Anatomy/Contract
   whenever those contracts or the renderer boundary change.
 ---
 
 # task_card manual
 
-Use `task_card` to maintain one agent-local, channel-neutral Task Card artifact.
-The capability is producer-first: it runs your renderer and writes the body and
-status; Telegram, Feishu, and other consumers decide how to read or project that
-producer state.
+`task_card` is one channel-neutral producer per agent: it writes the full body to
+`taskcard/taskcard.md` and exact `active`/`inactive` to `taskcard/status`.
 
-## First call
+## First action
 
-`task_card` is a strict LTP-v2 family. Pass `action`, that action's strict
-`input` object, and root `reasoning`; optional `summarize` is root-only. The
-public actions are `start`, `inspect`, `retry`, `stop`, `remove`, `settings`, and
-`manual`; `manual` takes `{}` and is directly callable.
+Routine schema-sufficient calls do not need this manual. For meaningful
+long-running, multi-step, or parallel work, start a truthful watch:
 
-For `start`, provide an existing Python `renderer_path` inside the working
-directory. The renderer must exit successfully and print a nonempty full body to
-stdout. The producer writes that body atomically to `taskcard/taskcard.md`, then
-writes exact `active` to `taskcard/status`. It permits one active watch per
-agent. Keep its output truthful and current: start a watch for meaningful
-long-running, multi-step, or parallel work, not ritual noise.
+```python
+task_card(action="start", input={"renderer_path": "renderer.py"},
+          reasoning="publish truthful progress for the long-running work")
+```
 
-Read [lifecycle and truthful producer use](reference/lifecycle.md) for renderer
-path gates, action ordering, restart resume, and the complete stop/remove
-lifecycle. Read [settings and cadence](reference/settings.md) for owner policy,
-ceilings, and body limits. Read [notifications and projection](reference/notifications.md)
-for typed producer events, reminders, and consumer boundaries.
+Use `action`, strict action `input`, and root `reasoning`; root `summarize` is
+optional presentation control (leave it false for exact manual text or paths).
+`renderer_path` must resolve after symlink resolution to an existing regular
+Python file inside the working directory. It must exit successfully with
+nonempty stdout, which is the full body. Over-limit output is refused, not
+truncated; the producer atomically writes the body before exact `active`. Only
+one watch is allowed. Skip quick single-step or ritual work and any renderer
+that cannot stay truthful.
 
-## When to use it
+## Lifecycle decisions
 
-Start proactively when a durable progress view materially helps a human follow
-ongoing work. Skip quick single-step work or any watch whose renderer cannot
-remain truthful. If a watch expires while work continues, restart a new watch;
-use `stop` to pause while preserving the last body, and `remove` after work is
-completed, cancelled, or abandoned. Never delete the body with Shell or File.
+Use the schema for action fields; `inspect` reports current watch/body/error.
+`stop` pauses and preserves the body; `remove`
+retires then deletes it after completion, cancellation or abandonment. Retry a
+failed stop/remove once quiescent; never bypass it with Shell/File deletion.
+Start a new watch when expired work continues. Read [lifecycle](reference/lifecycle.md)
+for shutdown/resume and stale-state caveats.
 
-## Settings
+## Settings anchors
 
-Call `settings` with exact `input={}` to SHOW the five numeric policies owned by
-`taskcard/taskcard.json`. SHOW is read-only: it never writes or migrates that
-file, and it has no set/reset form. Every row contains only `key`, `current`,
-`default`, `configurable`, and `comment`; after an authorized owner edit, call
-SHOW again. Effective truth is whole-action or failure, never partial.
-
-The stable row comments retain these anchors; their detail is in the focused
-settings reference:
+`settings` is read-only: five numeric policies in `taskcard/taskcard.json`, not a
+writer or migration trigger. Edit that document only through its authorized
+owner procedure, preserving siblings, then SHOW again. See the anchors below.
 
 ### interval-s
 See [interval-s](reference/settings.md#interval-s).
@@ -81,11 +73,18 @@ See [reminder-turns](reference/settings.md#reminder-turns).
 ### max-body-chars
 See [max-body-chars](reference/settings.md#max-body-chars).
 
-## Boundary reminder
+## Focused routes
 
-The producer owns its artifact and typed Task Card notifications only. It does
-not own transport-specific IDs, retries, layout, or a promise that an external
-channel will display every state. Consumers read `taskcard/status` and
-`taskcard/taskcard.md` independently. Keep the card a concise progressive-
-disclosure summary and put complex evidence in referenced files; see the
-[projection reference](reference/notifications.md).
+- [lifecycle and recovery](reference/lifecycle.md) — ordering, retry/error,
+  stop/remove, restart resume, expiry, and truthful renderer use.
+- [settings and cadence](reference/settings.md) — SHOW, five policies,
+  validation floors/ceilings, and one-way legacy bootstrap.
+- [notifications and projection](reference/notifications.md) — typed events,
+  reminders, resident projection, and consumer limits.
+
+## Truth boundary
+
+Report only evidence the renderer can read; never fabricate progress or claim a
+consumer sent, edited, retried, or delivered the card. Task Card owns artifacts
+and typed notifications, not transport IDs, layouts, transport retries, or
+another channel's display guarantee.

--- a/src/lingtai/tools/task_card/manual/reference/lifecycle.md
+++ b/src/lingtai/tools/task_card/manual/reference/lifecycle.md
@@ -4,7 +4,7 @@ description: >
   Focused Task Card lifecycle reference for renderer gates, truthful progress,
   artifact ordering, restart resume, and stop/remove distinction.
 version: 0.1.0
-last_changed_at: "2026-09-06T00:00:00Z"
+last_changed_at: "2026-09-09T00:00:00Z"
 tags: [lingtai, task-card, renderer, lifecycle, progress, restart]
 related_files:
 - src/lingtai/tools/task_card/manual/SKILL.md
@@ -18,74 +18,56 @@ maintenance: |
 
 # Task Card lifecycle and truthful producer use
 
-## When to use it
+## Use a watch when it helps
 
-Start a watch proactively when a human is following meaningful long-running,
-multi-step, or parallel work and a durable progress view materially helps:
-multi-daemon fleets, multi-PR batches, and long review→merge flows are typical
-cases, especially work running past roughly ten minutes. Skip quick single-step
-work or ritual updates. Keep a watch only while its renderer output is truthful
-and current; a stale card misleads more than no card. When `max_refreshes`
-expires a watch, restart a new watch when work continues mid-task rather
-than letting the card go dark.
+Start proactively for meaningful long-running, multi-step, or parallel work when
+a durable view helps a human follow it. Skip quick single-step or ritual updates.
+Keep the watch only while its renderer is truthful and current. If the refresh
+ceiling expires while work continues, start a new watch.
 
-## Producer-owned artifacts
+## Owned artifacts and renderer gate
 
-The producer writes `taskcard/taskcard.md` as the full rendered body and
-`taskcard/status` as exact `active` or `inactive`. An active watch also keeps
-`taskcard/watch.json` with its renderer, cadence, watch ID, and carried refresh
-budget so refresh/molt/agent-stop can resume it. `taskcard/taskcard.json` is the
-agent-wide policy document; normal reads are read-only and its one-way legacy
-migration is documented in [settings](settings.md). The producer does not own
-Telegram/Feishu chat IDs, portal layout, transport retries, or consumer state.
+The producer owns `taskcard/taskcard.md` (full body), exact `taskcard/status`,
+`taskcard/watch.json` (active-watch restart descriptor), and its agent-wide
+`taskcard/taskcard.json` policy. It does not own transport IDs or consumer state.
 
-## Renderer gate and publication order
+`renderer_path` must resolve to an existing regular Python file inside the agent
+working directory. The producer runs `sys.executable <renderer>` with that
+working directory as cwd; only exit `0` with non-empty stdout succeeds. Stderr is
+not the body. The configured body cap is refusal, never truncation.
 
-`renderer_path` must name an existing regular Python file that resolves inside
-the agent working directory after symlink resolution. It runs as
-`sys.executable <renderer>` with that directory as cwd. It must exit `0` and
-print a non-empty complete body to stdout; stderr is not the card body. The
-configured body limit is a refusal, never truncation; see [settings](settings.md).
+`start` runs the renderer first, atomically publishes the complete body, writes
+exact `active`, then starts the updater and saves the descriptor. A second start
+fails closed. `retry` atomically replaces only the body; status stays `active`
+until the refresh budget is exhausted. A non-exhausting renderer/publication
+failure keeps the last valid body and records producer error; success clears it.
+The final exhausted attempt retires the watch and emits the limit event.
 
-`start` runs the renderer first, atomically writes the complete body, then
-atomically writes exact `active`, and only then starts the updater and persists
-its descriptor. `retry` reruns the same renderer and atomically replaces only
-the body; status remains `active` until the last allowed refresh is consumed,
-when the successful final attempt is exhausted and becomes `inactive`. A
-non-exhausting renderer or publication failure preserves the last valid body
-and records the producer error rather than inventing progress; the exhausted
-final attempt follows the limit path. A second `start` fails closed because one
-card/watch is allowed per agent.
+## Stop, remove, and resume
 
-## Pause, terminal cleanup, and restart
-
-- `inspect` reports the one current watch, exact artifact paths, status, and the
-  last valid body; it does not create another watch.
+- `inspect` only reports the current watch, paths, status, body, and error.
 - `stop` writes `inactive` before asking the updater to stop, joins it, clears
-  the descriptor, and preserves the last body for later `retry` or inspection.
-  It is a pause, not cleanup. If the updater does not quiesce, report the
-  retryable failure and leave the watch/body retryable.
-- `remove` takes no `watch_id`: it retires the one watch exactly as `stop` does,
-  waits for quiescence, then deletes `taskcard/taskcard.md`. It leaves status
-  exactly `inactive`, clears restart state, blocks rather than deleting while a
-  watch may still run, and is idempotent when no body exists. Agents must not
-  reach around it with Shell or File deletion.
-- Agent shutdown writes `inactive`, stops the thread, and persists the carried
-  descriptor unless the watch was deliberately stopped, removed, or exhausted.
-  On the next setup the same watch ID, renderer, cadence, ceiling, and remaining
-  refresh budget are rehydrated. Corrupt, missing, escaped, gone, or exhausted
-  descriptors are cleared and left `inactive`; a transient resume failure keeps
-  the last body and lets the live watch retry.
-
-A refresh-limit exhaustion retires the watch, writes `inactive`, clears the
-descriptor, and emits one typed limit event. If the underlying work continues,
-start a new watch rather than letting the card go dark. Use `stop` while work is
-paused and `remove` once it is completed, cancelled, or abandoned.
+  the descriptor, and preserves the body. A successful stop releases the watch
+  handle; continuation uses a new start, not retry of the stopped id. If the thread remains alive, report a
+  retryable failure and leave the watch retryable.
+- `remove` has empty input: it retires the one watch as `stop` does, waits for
+  quiescence, then deletes `taskcard/taskcard.md`. It leaves exact `inactive`,
+  clears restart state, blocks rather than deleting during a live watch, and is
+  idempotent when no body exists. Never delete the body with Shell or File.
+- Agent shutdown writes `inactive`, stops the thread, and preserves the descriptor
+  with its remaining refresh budget unless deliberately stopped, removed, or
+  exhausted. Setup resumes the same watch id, renderer, cadence, ceilings, and
+  remaining budget, with timeout/refresh ceilings clamped to current owner policy.
+  Missing, corrupt, escaped, gone, or exhausted descriptors do not resume a watch.
+  The current discard path clears the descriptor but can leave an existing
+  `active` status file unchanged: inspect actual artifacts; do not treat that
+  status alone as a live updater or assume discard settled it to `inactive`.
+  This is an existing implementation limitation, not permission to delete state.
+  A transient renderer failure during valid resume keeps the old body and lets
+  the live watch retry.
 
 ## Truthful progress
 
-The renderer is the real producer of progress. Read the underlying work state,
-include only evidence available to the producer, and update the body when that
-state materially changes. Do not promise that a consumer transport edited,
-sent, retried, or delivered a card; those consumers only read the producer's
-artifact and apply their own rules.
+Read the underlying work state and include only evidence available to the
+renderer. Do not claim that a consumer sent, edited, retried, or delivered the
+card; consumers only read the producer artifacts and apply their own rules.

--- a/src/lingtai/tools/task_card/manual/reference/notifications.md
+++ b/src/lingtai/tools/task_card/manual/reference/notifications.md
@@ -4,7 +4,7 @@ description: >
   Focused Task Card reference for typed producer notifications, reminders,
   change-gated resident projection, and limits on consumer guarantees.
 version: 0.1.0
-last_changed_at: "2026-09-06T00:00:00Z"
+last_changed_at: "2026-09-09T00:00:00Z"
 tags: [lingtai, task-card, notifications, projection, reminders]
 related_files:
 - src/lingtai/tools/task_card/manual/SKILL.md
@@ -21,55 +21,41 @@ maintenance: |
 
 ## Typed producer boundary
 
-The producer emits only `TaskCardErrorNotification`,
-`TaskCardRecoveredNotification`, and `TaskCardLimitNotification` through its
-family adapter. The granted native port exposes only
+Only `TaskCardErrorNotification`, `TaskCardRecoveredNotification`, and
+`TaskCardLimitNotification` cross the family adapter. Its native port exposes
 `publish_error`, `publish_recovered`, `publish_limit`, `submit_reminder(turns)`,
-and `clear_reminder()`. A generic publisher, arbitrary keyword fields, foreign
-source/channel, or caller-supplied priority/extra metadata is refused.
+and `clear_reminder()`. Generic publishers, arbitrary keyword fields, foreign
+source/channel, and caller-supplied priority/extra metadata are refused.
 
-The host adapter pins the established wire policy: error and recovered states
-use `task_card.error`, refresh exhaustion uses `task_card.limit`, and events go
-to the system channel with bounded extras, idempotency, and priority. The
-producer owns event content and deduplication identity; it does not select a
-transport or another channel.
+The host pins the established wire policy: error and recovered use
+`task_card.error`, refresh exhaustion uses `task_card.limit`; events use the
+system channel, bounded extras, idempotency, and priority. The producer chooses
+event content and deduplication identity, never a transport.
 
-A non-exhausting renderer failure after a valid watch preserves the last body
-and emits a deduped error state; a later successful publication emits recovery.
-An exhausted final failure suppresses that error and, like a successful final
-refresh, emits one limit event whose guidance says to start a new watch if work
-remains. Notification failure must not turn a truthful producer state into a
-false one.
+A non-exhausting renderer failure keeps the last body and emits a deduped error;
+a later success emits recovery. An exhausted final failure suppresses that error
+and emits one limit event telling the agent to start a new watch if work remains.
+Notification failure does not turn producer state into false success.
 
-## Absent/stale reminders
+## Reminders and resident projection
 
 After the configured `reminder_turns` completed text turns (default `10`), the
-producer asks the agent to check whether the card is absent or stale and update
-or retire it only if useful. The counter resets after a successful publication
-(`start`, refresh, or resume), so a watch that keeps publishing does not reach
-the absent/stale reminder threshold. The reminder resurfaces the decision; it
-does not re-inject an unchanged body.
+producer asks whether the card is absent or stale and whether an update or
+retirement is useful. Successful publication resets the counter; a reminder does
+not re-inject an unchanged body.
 
-## Resident projection
+The agent's resident `_meta.agent_meta.taskcard` view is change-gated: unchanged
+body/status bytes are not repeatedly injected, while first appearance or material
+change may attach a fresh payload. A missing card gets a generic route to this
+manual. The resident projection has a separate fixed `TASKCARD_MAX_CHARS=2000` cap: a
+larger active body is reported as refused without its text. Raising the producer
+`max_body_chars` does not raise this resident cap. The producer also refuses
+over-limit output rather than truncating it. Keep goal, status and next step
+within the resident budget; link complex evidence elsewhere.
 
-The card is resident in `_meta.agent_meta.taskcard` for the agent's own view and
-may be read by human-facing consumers. Projection is change-gated: unchanged
-body/status bytes are not repeatedly re-injected, while a first appearance or
-material change can attach a fresh payload. If no card is present, the resident
-hint is generic and routes the agent to the `task_card` manual.
+## Consumer boundary
 
-The body cap is a producer guard: oversized renderer output is refused rather
-than truncated. Keep the card focused on the current goal, status, and next
-step; put complex progress in reports, logs, or checklists referenced by the
-card. A consumer may compare bytes and apply its own edit/send rate limits, but
-those are not promises made by this capability. A real changed body remains a
-real producer update even when a consumer chooses when or how to display it.
-
-## No hidden external projection promise
-
-Task Card owns the producer artifact and the typed events, not Telegram, Feishu,
-portal, chat IDs, message edits, retries, or delivery guarantees. Consumers
-independently read `taskcard/status` and `taskcard/taskcard.md` and interpret
-missing, invalid, or inactive state. Do not report a consumer-side projection
-as producer progress; the renderer must report only evidence from the underlying
-work.
+Task Card owns producer artifacts and typed events, not Telegram/Feishu/portal
+IDs, message edits, retries, or delivery guarantees. Consumers independently read
+`taskcard/status` and `taskcard/taskcard.md` and interpret missing, invalid, or
+inactive state. Consumer display is never producer progress.

--- a/src/lingtai/tools/task_card/manual/reference/settings.md
+++ b/src/lingtai/tools/task_card/manual/reference/settings.md
@@ -4,7 +4,7 @@ description: >
   Focused Task Card settings reference for the read-only SHOW inventory,
   owner-document validation, cadence, safety ceilings, migration, and body cap.
 version: 0.1.0
-last_changed_at: "2026-09-06T00:00:00Z"
+last_changed_at: "2026-09-09T00:00:00Z"
 tags: [lingtai, task-card, settings, cadence, ceilings, migration]
 related_files:
 - src/lingtai/tools/task_card/manual/SKILL.md
@@ -17,77 +17,66 @@ maintenance: |
 
 # Task Card settings and cadence
 
-## SHOW and owner document
+## SHOW only
 
-Call `task_card(action="settings", input={})` with exact empty input. The
-provider returns exactly five rows, in owner order: `interval_s`, `timeout_s`,
-`max_refreshes`, `reminder_turns`, and `max_body_chars`. Each row has only
-`key`, `current`, `default`, `configurable`, and `comment`; comments point to the
-stable anchors in the parent `task_card-manual`.
+Call `task_card(action="settings", input={}, reasoning="inspect Task Card settings")`.
+It returns exactly five rows, in this order: `interval_s`, `timeout_s`,
+`max_refreshes`, `reminder_turns`, `max_body_chars`. Each row contains only
+`key`, `current`, `default`, `configurable`, and `comment`. SHOW reads effective
+values; it does not write, migrate, or provide a set/reset form. An unavailable
+inventory fails as a whole, with no partial rows or raw exception detail.
 
-SHOW reads fresh effective values without creating or changing
-`taskcard/taskcard.json` and without running its one-time legacy migration. A
-`configurable: true` row means an authorized owner may create or edit that JSON
-object outside SHOW, preserving sibling fields; it does not make SHOW a writer.
-After an authorized edit, call SHOW again. Invalid or missing fields fall back
-independently to their own built-in defaults. If effective truth is unavailable,
-the whole bounded inventory fails with no partial rows or raw exception detail.
-Renderer paths, body/status/watch contents, notification state, and unknown
-owner fields are never projected.
+A configurable row permits an authorized owner edit of `taskcard/taskcard.json`
+outside SHOW, preserving sibling fields. After that edit, call SHOW again. All
+numeric fields reject booleans. Paths, body/status/watch contents, notification
+state, and unknown owner fields are never projected. Invalid or missing fields
+fall back independently to their built-in defaults.
 
 ## interval-s
 
-`interval_s` is the polling cadence in seconds for a newly started or resumed
-watch. The valid owner value is finite and at least `1`; otherwise the default
-is `5`. An explicit `start.interval_s` also obeys only that one-second floor and
-has no ceiling: a slower cadence is honored. The value is read at each `start`
-or persisted-watch resume; a running watch keeps its captured cadence.
+Polling cadence for a new/resumed watch. Valid owner value: finite number `>= 1`;
+default `5`. An explicit `start.interval_s` obeys only that floor (slower values
+are honored). A running watch keeps its captured cadence; resume carries the
+stored cadence rather than substituting a new default.
 
 ## timeout-s
 
-`timeout_s` is the ceiling, in seconds, for one renderer execution, not the
-watch's lifetime. The valid owner value is finite and at least `0.1`; otherwise
-the default is `10`. An omitted `start.timeout_s` uses the configured ceiling;
-an explicit value may lower it but is silently capped at that ceiling if larger.
-A running watch keeps its captured ceiling.
+One renderer execution ceiling, not total watch lifetime. Valid owner value:
+finite number `>= 0.1`; default `10`. Omitted `start.timeout_s` uses the ceiling;
+an explicit value may lower it and is capped at that ceiling when larger. A live
+watch keeps its captured ceiling; resume re-clamps its stored value to current
+owner policy.
 
 ## max-refreshes
 
-`max_refreshes` is the refresh ceiling for a newly started or resumed watch. A
-valid owner value is a positive integer; otherwise the default is `2000`. An
-explicit `start.max_refreshes` may lower but never exceed the configured ceiling.
-Before `taskcard/taskcard.json` exists, SHOW may preview a genuinely customized
-positive legacy Telegram ceiling; the legacy untouched default `1000` is
-ignored. Preview does not write the new document.
+Refresh ceiling for a new/resumed watch. Valid owner value: positive integer;
+default `2000`. An explicit value may lower but never exceed the configured
+ceiling. Before the intrinsic document exists, SHOW may preview a genuinely
+customized legacy Telegram ceiling, but does not write it.
 
 ## reminder-turns
 
-`reminder_turns` is the number of completed text turns between absent-or-stale
-Task Card reminders. A valid owner value is a positive integer; otherwise the
-default is `10`. It is read on each completed text turn, so changing the owner
-document applies at that seam rather than changing an already-running watch's
-captured cadence.
+Completed text turns between absent/stale reminders. Valid owner value: positive
+integer; default `10`. It is read at each completed-text-turn seam.
 
 ## max-body-chars
 
-`max_body_chars` is the maximum rendered body accepted by the producer. A valid
-owner value is an integer at least `100`; otherwise the default is `2000`. It is
-read on each publication. An oversized body is refused, never truncated, and
-the last valid body remains visible.
+Maximum rendered body accepted by the producer. Valid owner value: integer `>=100`;
+default `2000`. It is read on each publication. Oversized output is refused, never
+truncated, and the last valid body remains on disk. The separate resident
+projection still caps text at 2000 characters; see [projection](notifications.md).
 
-## Resolution, floors, and the one-way migration
+## Resolution and one-way migration
 
 The five fields resolve independently from `taskcard/taskcard.json`; malformed
-siblings do not discard valid values. `start` resolves the first three fresh;
-`reminder_turns` and `max_body_chars` are read at their application seams. The
-first resolution made when the intrinsic JSON document does not exist may read
-`telegram/taskcard.json` only to carry forward a valid customized positive
-`max_refreshes` different from that retired design's untouched `1000` default.
-It then writes the intrinsic document whether the result was migrated or built
-in, and later changes to the legacy file are never consulted. If the intrinsic
-document already exists but is malformed, it remains the sole owner and fields
-fall back to built-ins.
+siblings do not discard valid values. The first resolution when that intrinsic
+file does not exist may read `telegram/taskcard.json` only to carry forward a
+valid customized positive `max_refreshes` different from the retired design's
+untouched default `1000`. It then writes the intrinsic document whether anything
+migrated or built in. Later legacy changes are never consulted. If the intrinsic
+file already exists but is malformed, it remains the sole owner and fields fall
+back to built-ins.
 
-Thus the safety contract is monotonic: `interval_s` cannot go below `1`,
-`timeout_s` cannot go below `0.1`, refresh/reminder counts stay positive, and
-explicit timeout/refresh requests cannot exceed their configured ceilings.
+Thus `interval_s` cannot be below `1`, `timeout_s` cannot be below `0.1`, counts
+stay positive, and explicit timeout/refresh requests cannot exceed their configured
+ceilings.

--- a/tests/test_task_card_controller.py
+++ b/tests/test_task_card_controller.py
@@ -1289,3 +1289,32 @@ def test_undecodable_intrinsic_config_falls_back_without_consulting_legacy(agent
     assert result["status"] == "ok"
     assert result["max_refreshes"] == 2000
     manager.handle({"action": "stop", "input": {"watch_id": result["watch_id"]}, "reasoning": "cleanup"})
+
+
+def test_manual_first_call_runs_through_public_family(manager, agent, monkeypatch):
+    import ast
+    import re
+
+    manual = Path(__file__).resolve().parents[1] / "src/lingtai/tools/task_card/manual/SKILL.md"
+    code = re.search(r"```python\n(.*?)\n```", manual.read_text(), re.S).group(1)
+    call = ast.parse(code).body[0].value
+    kwargs = {k.arg: ast.literal_eval(k.value) for k in call.keywords}
+    _write_renderer(agent._working_dir, "print('truthful sample')", "renderer.py")
+    monkeypatch.setattr(manager, "_spawn", lambda watch: None)
+    try:
+        result = manager.handle(kwargs)
+        assert result["status"] == "ok"
+        root = agent._working_dir / "taskcard"
+        assert (root / "taskcard.md").read_text().strip() == "truthful sample"
+        assert (root / "status").read_text() == "active"
+    finally:
+        manager.handle({"action": "remove", "input": {}, "reasoning": "finish isolated sample"})
+
+
+def test_manual_distinguishes_resident_cap_and_producer_policy():
+    from lingtai.kernel.meta_block import TASKCARD_MAX_CHARS
+
+    root = Path(__file__).resolve().parents[1] / "src/lingtai/tools/task_card/manual"
+    projection = (root / "reference/notifications.md").read_text()
+    assert f"TASKCARD_MAX_CHARS={TASKCARD_MAX_CHARS}" in projection
+    assert "Raising the producer" in projection


### PR DESCRIPTION
## Summary
- Task Card-only manual reduction: routine schema-first start, compact lifecycle/settings/projection routes; preserve exact artifact ordering, one-watch, stop/remove, error/limit/restart, five SHOW anchors and authorized owner policy.
- Correct source-verified guidance: successful stop releases the watch handle; resume carries cadence but re-clamps ceilings; configurable producer body cap is distinct from fixed 2000-character resident cap. Document existing stale-descriptor limitation without changing Core/manager/Contract.
- Entry Unicode body 3158 → 2844 (−9.9%); four manuals 14370 → 11558 (−19.6%). Resident family description −24 chars; schema descriptions unchanged. Not measured token/cost savings. This already-short entry is not forced to meet an artificial reduction target.
- Native Luna initial candidate; 知微 source review, bounded corrections and independent validation. No extra worker/reviewer claimed. Only one production description constant, four manuals and two tests in the direct controller module change.

## Validation
Frozen clean main `d90629af5eb5d2bea39b071fa246c59205a2ba6a`; reviewed diff SHA-256 `e992870b3ddb26674988c4d09fc02a292f0957120991f83ec2ca3571a2c29e6f`.
```sh
python -B -m pytest -q tests/test_task_card_controller.py tests/test_task_card_notifications.py tests/test_task_card_resident_shared.py tests/test_task_card_event_projection_shared.py tests/test_telegram_task_card_rows.py tests/test_intrinsic_manual_actions.py tests/test_tool_prose_section_gate.py tests/test_tool_plugin_declaration.py tests/test_skills.py tests/test_prompt_catalog.py tests/test_docs_governance.py tests/test_architecture_documents.py tests/test_tool_settings_contract.py
# candidate: 362 passed / 6 failed / 1 warning
# clean base: 360 passed / 6 failed / 1 warning
python -B scripts/check_docs_governance.py --check
# PASS
python -B src/lingtai/intrinsic_skills/lingtai-kernel-anatomy/scripts/check_anatomy_drift.py --check
# 6 existing findings, byte-identical to baseline
git diff --check
# PASS
```
All six normalized failure blocks identical (pytest temporary generation only): standalone-skills System assertion, two prompt catalog assertions, two MCP ServerRequestContext imports, one Psyche orphan. Same deprecation warning. The full changed controller module has 72 tests with no failure. Two new checks execute the actual first-call Markdown example through the public family and distinguish resident cap from producer policy.

Actual Agent full prompt31,863 chars, unique Task Card mount, four installed files byte-equal, relative links and five SHOW anchors PASS. Local real start/inspect/retry/stop/remove passed with a task-created renderer; AST/schema unchanged except reviewed description. Provider mocked/socket network blocked, not channel delivery or production E2E.

## Existing limitations, not fixed
Isolated candidate/base probes are identical: a 3000-character body is accepted with producer max_body_chars=5000 but resident projection refuses it at fixed2000. Clearing an invalid empty watch descriptor leaves an existing active status file unchanged, even though no watch resumes. This contradicts the expected stale-to-inactive outcome; it is explicitly an unfixed implementation limitation, not a relaxed Contract. No silent file cleanup or engine expansion.

No whole-repo/native-Windows/live-provider/production E2E, runtime rollout, config/auth changes, release or cleanup. Merge follows Jason's THIS-BATCH after-review authorization TG15921 at2026-09-09T05:21:14Z, not unrelated PRs or Agent-loop implementation.

Telegram: @lingtaidev1bot | Nickname: 知微
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
