### PR TITLE
docs(vision): simplify manual routes and clarify setup boundaries

### DIFF
--- a/src/lingtai/tools/vision/__init__.py
+++ b/src/lingtai/tools/vision/__init__.py
@@ -1,38 +1,17 @@
-"""Vision capability — image understanding via VisionService.
+"""Vision capability for one-image understanding via ``VisionService``.
 
-Adds the ability to analyze images. Requires a VisionService instance,
-created either explicitly or via the ``provider``/``api_key`` factory.
+The public action-separated ``vision`` root exposes ``analyze``, ``check``,
+``list``, ``settings``, and ``manual``. The operational action values are unchanged;
+generic composition adds the new
+reserved ``settings`` action before ``manual``. ``analyze`` uses one selected
+route, while a non-null ``preset`` explicitly borrows an authorized preset for
+one call. Relative image paths use the workdir and a null question selects the
+default prompt.
 
-Usage:
-    agent.add_capability("vision", vision_service=my_svc)
-    agent.add_capability("vision", provider="anthropic", api_key="sk-...")
-
-The native mlx pseudo-provider (Apple MLX, on-device) remains available
-through explicit ``add_capability(..., provider="mlx")`` opt-in, but it is
-intentionally not advertised in ``PROVIDERS`` or first-run/check-caps
-surfaces: it is macOS-only and requires an on-device model.
-
-``local`` is a first-class generic local OpenAI-compatible provider: it
-points at any OpenAI-compatible vision server on your machine (Ollama, LM
-Studio, vLLM, llama.cpp, …) via ``base_url`` (default
-``http://localhost:11434/v1``) and requires an explicit ``model``. The
-operator-owned endpoint configuration lives in ``settings/vision.json``
-(``base_url``, ``model``, optional ``api_key``/``max_tokens``); capability
-kwargs override the file. No API key is required — local servers ignore the
-value, so a placeholder is synthesized. Configure it with
-``add_capability("vision", provider="local", model="<pulled-model>")``, via
-``manifest.capabilities.vision``, or via ``settings/vision.json``.
-
-``vision`` is migrated to the LingTai Tool Protocol v2 action-separated shape
-(``src/lingtai/tools/CONTRACT.md``): one public ``vision`` tool whose canonical
-children are ``analyze``/``check``/``list`` plus the family-owned reserved
-``settings``/``manual`` actions, composed and dispatched by the generic
-``lingtai.tools.tool_family`` infrastructure. The public tool name and
-operational action values are unchanged; generic composition adds the new
-reserved ``settings`` action immediately before ``manual``. The call envelope
-moved from flat arguments to ``action``/``input``/``reasoning``/``summarize``.
-Provider routing, credential/identity resolution, and every action result
-shape are untouched by that migration.
+Routes never silently choose a provider, model, credential, preset, MCP, or CLI.
+Local and MLX routes are explicit; Claude vision points to an explicit
+``claude -p`` action. Unsupported setup and request failures return sanitized
+manual guidance.
 """
 from __future__ import annotations
 
@@ -542,18 +521,18 @@ _ANALYZE_INPUT_SCHEMA: dict[str, Any] = {
     "properties": {
         "image_path": {
             "type": "string",
-            "description": "Image file path; relative paths use the workdir",
+            "description": "Existing image file path; relative paths use the workdir",
         },
         "question": {
             # Strict OpenAI object branches express an optional field as a
             # required nullable property. Null means absent, and the analyze
             # handler then applies the same default prompt it always has.
             "type": ["string", "null"],
-            "description": "Image question; null uses `Describe what you see in this image.`",
+            "description": "Question about the image; null uses the default prompt",
         },
         "preset": {
             "type": ["string", "null"],
-            "description": "Optional manifest.preset.allowed route to borrow; null uses the default",
+            "description": "Authorized manifest.preset.allowed route to borrow once; null uses default",
         },
     },
     "required": ["image_path", "question"],
@@ -569,7 +548,7 @@ _CHECK_INPUT_SCHEMA: dict[str, Any] = {
     "properties": {
         "preset": {
             "type": ["string", "null"],
-            "description": "Optional manifest.preset.allowed route to check; null checks the default without an image",
+            "description": "Authorized preset to check; null checks default without an image",
         },
     },
     "required": ["preset"],
@@ -637,11 +616,11 @@ class VisionConfiguration:
 
 
 _DESCRIPTION = (
-    "Analyze an image on one explicit route. Use vision(action='analyze', "
-    "input={'image_path': '...', 'question': null}, reasoning='...'); null "
-    "question uses the default image prompt. Use check to verify a route, list "
-    "to enumerate allowed routes, settings for the read-only applied snapshot, "
-    "and manual for guidance. A non-null preset is an explicit "
+    "Analyze one image: vision(action='analyze', "
+    "input={'image_path': '...', 'question': null}, reasoning='...'). Paths use the "
+    "workdir and null uses the default image prompt. Use check, list, settings, "
+    "or manual for route identity, declarations, the read-only applied snapshot, "
+    "or guidance. A non-null preset must name an authorized "
     "manifest.preset.allowed borrow and uses that preset's own identity. "
     "Failures are sanitized; no provider, model, credential, preset, or MCP "
     "fallback is automatic."

--- a/src/lingtai/tools/vision/manual/SKILL.md
+++ b/src/lingtai/tools/vision/manual/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: vision-manual
 description: >
-  Choose a Vision action, route, setting, or backend reference without
-  automatic provider/credential fallback.
-last_changed_at: 2026-09-06T00:00:00Z
+  Use the Vision schema directly for ordinary image analysis; route setup,
+  borrowing, settings, and recovery to focused references.
+last_changed_at: 2026-09-09T00:00:00Z
 related_files:
   - src/lingtai/tools/vision/__init__.py
   - src/lingtai/tools/vision/ANATOMY.md
@@ -16,116 +16,93 @@ related_files:
   - src/lingtai/tools/vision/manual/reference/backends.md
 maintenance: |
   Keep this page a short provider-neutral router and the settings action
-  read-only. Keep every setting anchor stable and route depth to the focused
+  read-only. Keep every setting anchor stable and route depth to focused
   references. Do not add provider, credential, endpoint, CLI, or MCP fallback;
   never import, expose, or link a secret.
 ---
+
 # Vision manual
 
-This installed, provider-neutral manual is guidance only. The static declaration
-owns its `manual="vision"` destination; the reserved action reads this body and
-path, not a host-global or another family's skill. It does not discover, install,
-start, or invoke a backend.
+Routine calls use the schema directly; load only the reference needed for setup
+or recovery. This installed manual reads no configuration and invokes no provider.
 
-## Choose an action
+## First action
 
-`vision` has one strict action-separated root. Every call requires
-`action`, `input`, and `reasoning`; `input` must match the selected child. Use
-these first-call forms:
+```text
+vision(action="analyze", input={"image_path": "...", "question": null}, reasoning="...")
+```
 
-- **Analyze an image:**
-  `vision(action="analyze", input={"image_path": "...", "question": null}, reasoning="...")`.
-  `image_path` is required; a relative path is resolved from the workdir.
-  `question: null` means `Describe what you see in this image.`. Add
-  `preset: "<allowed reference>"` only to explicitly borrow a route listed in
-  `manifest.preset.allowed`.
-- **Check a route:**
-  `vision(action="check", input={"preset": null}, reasoning="...")`.
-  `null` checks the default route; a reference checks that explicitly borrowed
-  route without sending an image.
-- **List routes:** `vision(action="list", input={}, reasoning="...")`.
-  This mechanically lists the active route and vision-capable allowed presets;
-  it constructs no provider service or credential.
-- **Show applied settings:**
-  `vision(action="settings", input={}, reasoning="...")`. This is SHOW-only:
-  it does not read, validate, set, reset, or write configuration.
-- **Load guidance:** `vision(action="manual", input={}, reasoning="...")`.
+One existing image per call; relative paths use the workdir and null selects the
+default image prompt. PNG/JPEG/WebP/GIF have known MIME types, not a guarantee of
+provider support. Success is `{"status": "ok", "analysis": text}`; failures are
+structured errors. The schema owns all five actions and strict input fields.
 
-Unknown actions, root fields, or cross-action input fields fail before provider,
-credential, image, or manual-child work. `preset` is an explicit authorization
-boundary, not fallback: the allowed preset's own provider/model/credential
-identity is used for that request. A default failure remains a sanitized error;
-Vision never automatically switches provider/model/credential, preset, MCP, or
-CLI, and Vision never auto-invokes MCP. Alternatives are instructions for a
-later explicit operator action.
+## Choose depth
 
-For action details and result shapes, read
-[actions](reference/actions.md). For route identity, borrowing, Claude CLI,
-active-preset guidance, and safety, read [routing](reference/routing.md). For
-local servers, MLX, setup, and troubleshooting, read
-[backends](reference/backends.md).
+- [Actions and results](reference/actions.md): `check` resolves a route without
+  an image (not live model acceptance); `list` reads declarations without service
+  or credential construction; `settings` shows the applied bind snapshot.
+- [Routing](reference/routing.md): allowed-preset borrowing, Claude CLI, recovery.
+- [Backends](reference/backends.md): local server/model setup, MLX, troubleshooting.
+- [Settings](reference/settings.md): exact source/precedence and owner procedures.
 
-## Settings anchors
+## Route and authority boundary
 
-The settings action returns exactly `key`, `current`, `default`,
-`configurable`, and `comment` for the applied bind snapshot. Sensitive values
-and path-like models are redacted. SHOW never mutates or re-reads state. Each
-anchor below is stable; read the [settings reference](reference/settings.md)
-for source, precedence, redaction, and the existing owner procedure.
+Without `preset`, use the configured service or active provider's own compatible
+identity. A non-null `preset` must be in `manifest.preset.allowed`; it borrows the
+allowed preset's own provider/model/endpoint/wire/credential for one call, without
+switching the active preset. Missing or unsupported routes fail closed.
+
+No provider, model, credential, preset, MCP, or CLI fallback is automatic. Vision
+never auto-invokes MCP. Ask the
+human before changing authorization/configuration, installing a server, or
+pulling a model. Alternatives require an explicit later action. Never print keys,
+tokens, environment values, headers, or private URLs.
+
+## Setting anchors
+
+SHOW is read-only: fresh rows from the applied snapshot, no file/environment
+re-read or configuration validation/write. Rows contain only `key`, `current`,
+`default`, `configurable`, `comment`; sensitive fields and path-like models are
+redacted. Unavailable truth fails the entire inventory, never guessed rows.
+Follow the exact owner section below, make only authorized changes, then
+refresh/relaunch and SHOW again.
 
 ## Setting: provider
-
-The current direct-route provider; no provider default or automatic switch.
+See [provider](reference/settings.md#setting-provider).
 
 ## Setting: base-url
-
-The bound endpoint override or route-owned endpoint; sensitive values are redacted.
+See [base-url](reference/settings.md#setting-base-url).
 
 ## Setting: model
-
-The bound route model; path-like values are redacted and no hidden local model is assumed.
+See [model](reference/settings.md#setting-model).
 
 ## Setting: api-key
-
-Whether the bound route applied credential material; raw values are never shown.
+See [api-key](reference/settings.md#setting-api-key).
 
 ## Setting: api-key-env
-
-Whether an explicit credential-variable pointer was applied; SHOW never reads the environment.
+See [api-key-env](reference/settings.md#setting-api-key-env).
 
 ## Setting: max-tokens
-
-The route's response-token cap where supported; route defaults remain owner-defined.
+See [max-tokens](reference/settings.md#setting-max-tokens).
 
 ## Setting: api-compat
-
-The route compatibility family where applicable; it grants no provider access.
+See [api-compat](reference/settings.md#setting-api-compat).
 
 ## Setting: wire-api
-
-The configured compatible wire where applicable; route support still controls construction.
+See [wire-api](reference/settings.md#setting-wire-api).
 
 ## Setting: default-headers
-
-Whether provider-owned headers were applied; the mapping is always redacted.
+See [default-headers](reference/settings.md#setting-default-headers).
 
 ## Setting: token-path
-
-Whether a Codex OAuth identity path was applied; path and token material are redacted.
+See [token-path](reference/settings.md#setting-token-path).
 
 ## Setting: instructions
-
-Whether Codex Responses instructions were applied; instruction text is redacted.
+See [instructions](reference/settings.md#setting-instructions).
 
 ## Setting: max-output-tokens
-
-The optional Codex Responses output cap, distinct from `max_tokens`.
+See [max-output-tokens](reference/settings.md#setting-max-output-tokens).
 
 ## Setting: timeout
-
-The Codex request timeout where applicable; changing it grants no retry or network authority.
-
-If a route, local settings document, model, or credential is unavailable, the
-whole settings inventory fails closed rather than returning partial or guessed
-rows. To change a value, use its existing owner procedure, refresh or relaunch,
-and then SHOW again; this manual never performs that change.
+See [timeout](reference/settings.md#setting-timeout).

--- a/src/lingtai/tools/vision/manual/reference/actions.md
+++ b/src/lingtai/tools/vision/manual/reference/actions.md
@@ -6,60 +6,45 @@ related_files:
   - src/lingtai/tools/vision/__init__.py
   - src/lingtai/tools/vision/CONTRACT.md
 maintenance: |
-  Keep examples aligned with the declaration-owned action schemas and the
-  installed manual router. Preserve strict input, first-call, and no-fallback
-  semantics when updating examples.
+  Keep examples aligned with declaration-owned action schemas and the installed
+  router. Preserve strict input, first-call, and no-fallback semantics.
 ---
 # Vision actions reference
 
 ## Call shape
 
-`vision` is one action-separated tool with five strict actions:
+The root requires `action`, `input`, and `reasoning`; optional `summarize` is host
+presentation control. Inputs are strict and action-specific:
 
-- `vision(action="analyze", input={"image_path": "...", "question": null},
-  reasoning="...")` — the direct image request. `image_path` and nullable
-  `question` are required fields; `null` selects the default prompt
-  `Describe what you see in this image.`. The optional nullable `preset` field
-  explicitly borrows one allowed preset's vision service for this call.
-- `vision(action="check", input={"preset": null}, reasoning="...")` — resolve
-  the default route without an image. The `preset` field is required and must
-  be `null` or an allowed preset reference. A non-null value resolves the
-  borrowed provider/model and constructs its service, but never calls a
-  provider or sends image data.
-- `vision(action="list", input={}, reasoning="...")` — mechanically enumerate
-  the active route and vision-capable presets in `manifest.preset.allowed`.
-  It reads route declarations only: it constructs no provider service and
-  reads no credential.
-- `vision(action="settings", input={}, reasoning="...")` — show the applied
-  bind-time configuration as rows containing exactly `key`, `current`,
-  `default`, `configurable`, and `comment`. Input is strictly `{}`. This action
-  never sets, resets, validates, re-reads, or writes configuration. Follow each
-  row's exact `comment` into the top manual's stable setting anchor, then use
-  the settings reference for meaning and the owner procedure.
-- `vision(action="manual", input={}, reasoning="...")` — load the installed
-  top-level Vision manual. Its input is strictly empty; it reads that manual's
-  body/path and performs no config, credential, provider, image, or analyze
-  operation.
+- **analyze** — `{"image_path": "...", "question": null, "preset": null}`.
+  `image_path` and nullable `question` are required; null uses
+  `Describe what you see in this image.`. `preset` is an optional explicit
+  borrow of one `manifest.preset.allowed` route.
+- **check** — `{"preset": null}`. Null checks the default; a string checks an
+  authorized borrowed route. It may construct a service and resolve its own
+  credential, but never sends an image; success is not a live server/model test.
+- **list** — `{}`. Mechanically lists the active route and allowed vision-capable
+  presets; it constructs no service or credential.
+- **settings** — `{}`. Shows the applied bind snapshot as rows with exactly
+  `key`, `current`, `default`, `configurable`, and `comment`; it never reads,
+  validates, sets, resets, or writes configuration.
+- **manual** — `{}`. Reads the installed Vision manual body/path only.
 
-`reasoning` is required on every action and is invocation metadata; it never
-becomes part of child input. Optional `summarize` is a root presentation
-control. An unknown action, root field, or cross-action input field is rejected
-before provider, credential, image, or manual-child work.
+Unknown actions or root/input fields, non-object input, and cross-action fields
+are rejected before provider, credential, image, or manual work.
 
 ## Result shapes
 
-- `analyze` success is exactly `{"status": "ok", "analysis": text}`.
-- `check` success is exactly `{"status": "ok", "route": route,
-  "provider": provider, "model": model}`.
-- `list` success is `{"status": "ok", "default": default,
-  "presets": presets, "count": count}`; entries contain route identity, not
-  credentials.
-- `settings` success is `{"settings": [...]}` with only the five row fields
-  above; unavailable truth fails as a fixed no-row result.
-- `manual` success is exactly `{"status": "ok", "action": "manual",
-  "manual": body, "manual_path": path}`; a missing installed manual returns a
-  truthful degraded result rather than another family's guidance.
+- `analyze` success: exactly `{"status": "ok", "analysis": text}`.
+- `check` success: exactly `{"status": "ok", "route": route, "provider": provider, "model": model}`;
+  it never sends an image.
+- `list` success: `{"status": "ok", "default": default, "presets": presets, "count": count}`;
+  entries contain route identity, not credentials.
+- `settings` success: `{"settings": [...]}` with only the five row fields;
+  unavailable truth returns the fixed no-row failure.
+- `manual` success: exactly `{"status": "ok", "action": "manual", "manual": body, "manual_path": path}`;
+  a missing installed manual is truthful `degraded` guidance.
 
-Setup, authorization, image, provider, or empty-response failures are
-structured errors with sanitized guidance; raw exception contents,
-credentials, and unsanitized endpoints never enter a result.
+Missing image, setup, authorization, provider, request, or empty-response
+failures remain structured and sanitized. Alternatives are instructions for a
+later explicit action; no provider/model/credential/preset/MCP fallback runs.

--- a/src/lingtai/tools/vision/manual/reference/backends.md
+++ b/src/lingtai/tools/vision/manual/reference/backends.md
@@ -7,118 +7,70 @@ related_files:
   - src/lingtai/tools/vision/settings.py
   - src/lingtai/tools/vision/CONTRACT.md
 maintenance: |
-  Keep backend setup examples and troubleshooting provider-neutral where the
-  implementation is provider-neutral. All installation, model, endpoint, and
-  configuration changes require explicit operator consent and existing owner
-  procedures.
+  Keep backend setup and troubleshooting provider-neutral where possible. Any
+  installation, model, endpoint, or configuration change requires explicit
+  operator consent and its existing owner procedure.
 ---
 # Vision backend reference
 
-## Local vision (generic OpenAI-compatible provider)
+## Local OpenAI-compatible server
 
-`provider="local"` points the `vision` capability at any local
-OpenAI-compatible vision server (Ollama, LM Studio, vLLM, llama.cpp server, ...)
-by URL. It needs no API key (a placeholder is synthesized; local servers ignore
-it), defaults `base_url` to `http://localhost:11434/v1`, and requires an
-explicit `model` - there is no hidden default model, because a silently assumed
-model masks misconfiguration.
+`provider="local"` targets a local server that accepts OpenAI Chat Completions
+image input (Ollama, LM Studio, vLLM, llama.cpp, or equivalent). It needs no API
+key, uses `http://localhost:11434/v1` when no endpoint is supplied, and **requires
+an explicit vision `model`**. The tool supplies no hidden model. The endpoint and
+model are operator-owned; capability values override `settings/vision.json`.
 
-The endpoint is operator-owned. Configure it in `settings/vision.json` (the
-family-owned file, like `settings/web.json`), in the capability manifest, or
-both (capability kwargs override the file).
+Obtain human authorization before installation, downloads, or configuration.
 
-### 1. Pick and install a server + pull a vision model
+1. Install/start an image-capable server and obtain its model. For Ollama,
+   `ollama pull moondream` is one example; a text-only model rejects images.
+2. **Select the route first** under `manifest.capabilities` in the active
+   init/preset configuration:
 
-Any server that speaks the OpenAI Chat Completions API with image support
-works. Examples:
+   ```json
+   {"vision": {"provider": "local"}}
+   ```
 
-- **Ollama** (easiest): install from <https://ollama.com>, then pull a
-  vision-capable model. `moondream` is a good small default (~1.7 GB, runs on
-  CPU or a small GPU, fine for OCR and basic description):
+   An already-active `local` provider also selects it. The settings file alone does not select
+   a local provider: without that selection Vision keeps the active route.
+3. Supply the model/endpoint in `settings/vision.json` (agent workdir):
 
-      ollama pull moondream
+   ```json
+   {"schema_version": 1, "base_url": "http://localhost:11434/v1",
+    "model": "moondream", "max_tokens": 1024}
+   ```
 
-  Other vision-capable Ollama models exist (`llava`, `qwen2.5vl`, ...). The
-  model must be a vision model - a text-only model fails at request time with a
-  "does not support images" style error.
+   Or put `model`, `base_url`, and `max_tokens` beside `provider` in the
+   capability above. Capability values win, but an invalid present local file
+   still blocks setup; kwargs do not bypass file validation.
 
-- **LM Studio**: start a local server with an image-capable model, note the
-  port (default `http://localhost:1234/v1`).
-- **vLLM / llama.cpp server**: serve a multimodal model and point `base_url` at
-  its `/v1` endpoint.
+   The file accepts only `schema_version`, `base_url`, `model`, `api_key`, and
+   `max_tokens`, within 64 KiB. Duplicate/unknown fields, invalid values,
+   non-regular files, or unstable reads fail setup rather than falling back.
+4. Refresh/relaunch through the existing authorized procedure, then `check` and
+   `analyze`. Check confirms route construction, not server/model readiness.
+   Use the server's expected `/v1` endpoint. `api_key` may be omitted when the
+   server needs no authentication; Vision then supplies an SDK placeholder.
 
-### 2. Configure the endpoint
+### Local failures
 
-Two equivalent owner procedures are available; capability input wins over the
-file. The public settings action only shows the bound result.
+- **No direct vision provider** — use the default active compatible route, borrow
+  an allowed preset explicitly, or configure `provider="local"`; then refresh.
+- **Explicit model required** — set the exact model the server serves.
+- **Settings invalid** — fix the owner file's schema, fields, types, or size;
+  refresh rather than relying on guessed defaults.
+- **Connection refused** — start the local server and retry explicitly.
+- **Model not found / images rejected** — list models and select a vision model.
+- **Wrong response or missing `/v1`** — use the server's OpenAI Chat Completions
+  `/v1` endpoint, then check again.
 
-**`settings/vision.json`** (agent working dir, applies on next refresh):
+## Apple MLX
 
-    {
-      "schema_version": 1,
-      "base_url": "http://localhost:11434/v1",
-      "model": "moondream",
-      "max_tokens": 1024
-    }
-
-`api_key` is optional and omitted here. Only `schema_version` plus the
-documented fields are allowed; an invalid file is a hard setup error surfaced
-as manual guidance.
-
-**Capability manifest** (`init.json` or the active preset's
-`manifest.capabilities`):
-
-    "vision": {
-      "provider": "local",
-      "model": "moondream"
-    }
-
-    "vision": {
-      "provider": "local",
-      "model": "moondream",
-      "base_url": "http://localhost:11434/v1",
-      "max_tokens": 1024
-    }
-
-`model` is required and must name a model the server actually serves. `base_url`
-defaults to `http://localhost:11434/v1`; change it when the server runs on a
-non-default port (the `/v1` OpenAI-compatible suffix is required). `api_key` is
-optional - local servers ignore it, so a placeholder is synthesized.
-
-> **Preset note.** `vision` is always registered; an explicit `capabilities.vision`
-> entry is **not** required to make the tool appear. The default route inherits
-> the active LLM's own Responses API. A capability-manifest entry (in
-> `init.json` or the active preset) is only needed to override that default,
-> e.g. to point at `provider="local"`. To borrow another preset's vision
-> service for a single call, list that preset in `manifest.preset.allowed` and
-> pass `preset` on the analyze call; no `capabilities.vision` edit is needed.
-
-### 3. Use it
-
-After configuring and refreshing, the `vision` tool is available:
-
-    vision(action="analyze", input={"image_path": "/path/to/image.png", "question": null}, reasoning="...")
-
-A successful call returns `{"status": "ok", "analysis": "..."}`. If you get a
-sanitized setup failure instead, check the troubleshooting table below.
-
-### 4. Troubleshooting local vision
-
-| Symptom | Likely cause / fix |
-|---|---|
-| "No direct vision provider was configured" | No explicit provider and no usable active-LLM route. The tool is always registered; either borrow an allowed preset's vision service via the `preset` option, or configure a local route (see below), then refresh. |
-| "Local vision needs an explicit model" | No `model` is set in `settings/vision.json` or the capability manifest. Set `model` to a pulled/served vision model name, then refresh. |
-| "Local vision settings are invalid" | `settings/vision.json` has an unknown field, bad type, or a schema_version other than 1. Fix the file and refresh. |
-| Connection refused on the endpoint | The local server is not running. Start it (`ollama serve` or the desktop app) and retry. |
-| "model '<name>' not found" | The model was never pulled or has a different name. Run `ollama list` (or your server's model list) and set `model` to the exact name. |
-| "does not support images" / vision request rejected | The configured model is text-only. Pull/serve a vision model (e.g. `moondream`) and point `model` at it. |
-| "...missing the '/v1' suffix..." (from the service) | `base_url` is missing the OpenAI-compatible suffix. Use e.g. `http://localhost:11434/v1`. |
-| HTML/JSON parse failure on the response | The server returned a non-ChatCompletion body - usually the route is wrong (see previous row) or the server is too old. Upgrade and use `/v1`. |
-| GPU not used / slow | The server offloads to the GPU only when the model fits VRAM. `moondream` fits most GPUs; larger models fall back to CPU. |
-
-### 5. Apple MLX (macOS only)
-
-The native on-device MLX pseudo-provider (`provider="mlx"`) is available as an
-explicit opt-in for Apple Silicon. It is not advertised in check-caps; pass
-`model` (an `mlx-community/...` vision model) and `max_tokens`. It requires no
-API key.
+`provider="mlx"` is an explicit Apple-Silicon, macOS-only on-device route. It
+requires `mlx-vlm` and no API key. Loading is lazy on the first analysis and may
+fetch model assets; `check` does not verify installation, cache, or offline readiness. Its route-owned default is
+`mlx-community/paligemma2-3b-ft-docci-448-8bit` with `max_tokens=512`; pass an
+explicit model to choose another. MLX is not silently selected, advertised as a
+fallback, or installed by this manual. Ask the human before installing the
+package or downloading a model.

--- a/src/lingtai/tools/vision/manual/reference/routing.md
+++ b/src/lingtai/tools/vision/manual/reference/routing.md
@@ -7,112 +7,64 @@ related_files:
   - src/lingtai/tools/vision/CONTRACT.md
   - src/lingtai/tools/vision/BEHAVIORS.md
 maintenance: |
-  Keep routing and authorization language aligned with the Vision resolver.
-  Alternatives remain explicit instructions: do not introduce automatic
-  provider, model, credential, preset, MCP, or CLI fallback.
+  Keep routing and authorization aligned with the Vision resolver. Alternatives
+  remain explicit instructions: never add provider, model, credential, preset,
+  MCP, or CLI fallback.
 ---
 # Vision routing reference
 
-## Route behavior and failures
+## Default route
 
-`vision` is always registered. With no explicit provider or `preset`, the default
-route follows the active provider's own compatible identity (model, endpoint,
-wire, and credential) or an explicitly configured Vision service. Missing or
-unsupported identity fails closed to manual guidance. There is no hidden model,
-legacy credential, provider switch, or automatic MCP/provider fallback.
+With no `preset`, Vision uses the configured Vision service or the active
+provider's own compatible model, endpoint, wire, and credential. An unsupported
+or incomplete identity fails closed with sanitized guidance. There is no hidden
+model, legacy credential, provider switch, or automatic MCP/provider fallback.
 
-An explicit `preset` request is different from fallback. The reference must be
-listed in `manifest.preset.allowed`; Vision then loads that preset read-only and
-uses the allowed preset's own `manifest.llm` and `manifest.capabilities.vision`
-identity. That can include resolving the allowed preset's own `api_key` or
-`api_key_env`, or selecting its own Codex OAuth-pool identity, in order to build
-the requested borrowed service. Borrowing is therefore authorized credential
-routing for one call: it does not switch the active preset, lend the active
-preset's model/credential to the borrowed route, or silently choose another
-preset after a failure. An unlisted, unreadable, or incomplete preset fails
-closed with sanitized guidance.
+Codex spellings `codex`, `codex-pool`, and `codex_pool` are one compatibility
+family; spelling does not choose direct versus pool. A nonblank active
+`codex_auth_path` selects direct auth, otherwise the active Codex pool identity is
+used. An unrelated active provider cannot lend its model, endpoint, or credential.
+Unsupported wires remain manual-only.
 
-A direct setup or request failure reports the failure type and points here for
-explicit alternatives; it never exposes exception contents. A mention of MCP,
-a local server, another preset, or the Claude CLI is an instruction for a later
-explicit operator/agent action, not an automatic fallback or invocation.
+## Borrow one authorized route
 
-## Borrow flow
+A non-null preset is explicit one-call borrowing, never fallback:
 
-To use another already-authorized preset's vision service for one image request:
+1. `vision(action="list", input={}, reasoning="...")` shows active and allowed
+   route declarations without constructing a service or reading credentials.
+2. `vision(action="check", input={"preset": "<allowed reference>"}, reasoning="...")`
+   resolves the borrowed provider/model without sending an image. Construction
+   may resolve that preset's own credential.
+3. `vision(action="analyze", input={"image_path": "...", "question": null,
+   "preset": "<allowed reference>"}, reasoning="...")` sends one image through
+   that selected service.
 
-1. Run `vision(action="list", input={}, reasoning="...")` to see which allowed
-   preset declarations advertise vision and their endpoint classification.
-2. Run `vision(action="check", input={"preset": "<allowed preset>"},
-   reasoning="...")` to resolve that preset's provider/model without sending
-   an image. Route construction may resolve that preset's own credential.
-3. Run `vision(action="analyze",
-   input={"image_path": "...", "question": null,
-   "preset": "<allowed preset>"}, reasoning="...")` to send one image request
-   through the explicitly selected service.
+The reference must be present in `manifest.preset.allowed`; Vision loads it
+read-only and uses its own `manifest.llm` plus `manifest.capabilities.vision`
+identity. It cannot switch the active preset, lend active credentials, or invoke
+another provider after failure. An unlisted, unreadable, or incomplete preset
+fails closed. Ask the human before changing authorization or configuration.
 
-The allowed list is the authorization boundary. Borrowing never silently
-switches the active preset and never auto-invokes MCP or another provider. If
-the selected route fails, inspect the returned manual guidance and ask the
-operator before changing configuration, preset authorization, or installing a
-backend.
+## Claude route
 
-## Claude backend: use the Claude CLI for vision
+Claude-family providers (`claude-code`, `claude_code`, `claude-p`) are manual-only
+for Vision. Run the operator's explicit CLI action, for example:
 
-When the active provider is a Claude-family backend (`claude-code`, `claude_code`,
-or the `claude-p` vision alias), the vision capability does not proxy Claude's
-own CLI authentication. The analyze call fails closed with explicit guidance
-instead of constructing a service:
+```text
+claude -p "Analyze this image: /path/to/image.png"
+```
 
-> You are using claude as backend, therefore to use vision run `claude -p`;
-> see the vision manual for more details.
+The CLI reads the referenced file and uses its own authentication and cost model;
+Vision never proxies that authentication or invokes the command. JPEG, PNG, and
+GIF (first frame) are documented CLI inputs. Consult the official
+[CLI reference](https://code.claude.com/docs/en/cli-reference) and
+[image workflows](https://code.claude.com/docs/en/common-workflows) for current
+limits; an optional MCP or other skill is likewise an explicit action.
 
-### How Claude CLI vision works
+## Provider-specific method and safety
 
-Claude Code attaches images by file path: when the prompt references an image
-path, the CLI reads the file and sends it to the model as an image input block
-alongside the text. `-p` / `--print` is the non-interactive print mode, so the
-analysis is returned as plain text on stdout — ideal for scripting.
-
-- Run in print mode with the image path referenced in the prompt:
-  `claude -p "Analyze this image: /path/to/image.png"`.
-- Supported image formats include JPEG, PNG, and GIF (GIF uses the first
-  frame). The CLI uses its own authentication (claude.ai subscription, API
-  key, or a configured provider) and its own cost model.
-
-### Progressive disclosure to the official docs
-
-For authoritative details, progressively read the Claude Code CLI documentation:
-
-- CLI reference: <https://code.claude.com/docs/en/cli-reference>
-- Image workflows: <https://code.claude.com/docs/en/common-workflows>
-
-This manual never auto-invokes the CLI; running `claude -p` is an explicit
-operator/agent action with the CLI's own auth and cost model.
-
-## Stay on the active preset
-
-Inspect the identity already shown in the prompt: the current provider, model,
-and sanitized endpoint. The default route follows that active LLM; do not
-substitute another provider, model, credential, endpoint, or wire protocol, and
-never silently switch or auto-invoke an MCP. If the active route cannot see
-images, the call fails explicitly. Use a borrowed route only by naming an
-already-authorized preset in the `preset` field; its own credential may be
-resolved for that explicit request.
-
-## Find the current preset's method
-
-Use the `skills` capability's catalog to search installed skills for a manual
-matching that provider/model or preset. Read the matching manual before trying
-its documented method or official-page pointer. If no matching manual is
-present, report that no discoverable vision method is available.
-
-An optional MCP or other skill may be described by that preset manual, but it is
-always an explicit operator/agent action. This manual never auto-loads or
-auto-invokes MCP.
-
-## Safety
-
+Use the `skills` catalog to find the current preset/provider manual; if none is
+installed, report that no discoverable method is available. A route failure is
+not permission to edit files, install a backend, or retry a non-idempotent action.
 Never request or print API keys, OAuth tokens, environment values, headers, or
-full unsanitized URLs. Missing provider, model, or endpoint fields are simply
-unknown; do not fill them with guesses.
+unsanitized URLs. Missing fields remain unknown; do not guess them.

--- a/src/lingtai/tools/vision/manual/reference/settings.md
+++ b/src/lingtai/tools/vision/manual/reference/settings.md
@@ -7,133 +7,108 @@ related_files:
   - src/lingtai/tools/vision/settings.py
   - src/lingtai/tools/vision/CONTRACT.md
 maintenance: |
-  Keep the thirteen setting anchors in the router stable. Document only the
+  Keep the thirteen setting anchors in the router stable. Describe only the
   applied, read-only snapshot and existing owner procedures; never add a writer
   or imply provider/credential fallback.
 ---
 # Vision settings reference
 
-## Settings inventory
+## Applied snapshot
 
-The inventory freezes the effective values used when Vision binds during boot
-or `system(action="refresh", input={}, reasoning="apply approved Vision config")`.
-SHOW does not re-read a file, environment variable, preset, or provider. If the
-provider or required model is not truthfully available, the local owner file is
-invalid, or an opaque injected service has no attributable owner route, the
-whole action returns `SETTINGS_UNAVAILABLE`; it never fabricates or emits
-partial rows. `configurable: true` means an existing owner procedure can change
-the value outside SHOW, not that this action can mutate anything.
-
-Each setting below names its own source and precedence because the routes do
-not share one universal chain. Every real change requires owner authorization,
-an edit through the named file/config/preset procedure, refresh or relaunch as
-stated, and a second SHOW to verify the newly applied snapshot.
+Rows describe the values used when Vision binds at boot or after an authorized
+refresh/relaunch. SHOW does not re-read files, environment, presets, or clients.
+It returns no rows when route truth, required model, local settings, or an
+opaque injected service has no attributable owner route; it never guesses or returns a partial snapshot.
+`configurable: true` means an existing owner procedure can change a value, not
+that SHOW can mutate it. Change through that owner, refresh/relaunch, then SHOW
+again. Sensitive fields render both current and default as `<redacted>`, even when unused;
+internal presence markers/nulls are not exposed.
 
 ## Setting: provider
 
-The current direct-route provider. It comes from the explicit Vision capability
-or, when compatible, the active provider. There is no provider default and no
-automatic provider switch. Change `manifest.capabilities.vision.provider` in
-the active `init.json`/preset, then refresh. Routing changes do not grant
-credentials, installation, or network authority.
+Explicit Vision provider, otherwise a compatible active provider; no default or
+automatic switch. Change the active capability/preset, refresh, and check.
 
 ## Setting: base-url
 
-The effective endpoint override. It comes from the explicit Vision capability,
-the same-provider active route, or — for `provider="local"` —
-`settings/vision.json` and then `http://localhost:11434/v1`. MiMo and Codex
-services also have their constructor endpoints. The value is sensitive and
-always redacted. Edit the existing capability/preset or local owner file,
-refresh, and SHOW again; never paste a private endpoint into logs or chat.
+Explicit endpoint, same-provider endpoint, or local `settings/vision.json` then
+`http://localhost:11434/v1`; route constructors own other defaults. Always redacted.
 
 ## Setting: model
 
-The model identifier used by the bound route. It comes from the explicit Vision
-capability, the same-provider active route, the local owner file, or the
-successfully constructed service. Public identifiers are shown exactly; a
-path-like model value is private, so SHOW redacts both current and default.
-Local Vision has no model default. Only the explicit MLX route has a
-Vision-owned model default. Change the active capability/preset or local owner
-file, ensure any model pull/install has separate human approval, refresh, and
-verify with SHOW.
+Explicit capability, active route, local owner file, or constructed service.
+Public identifiers remain visible; path-like values are redacted. Local requires
+one; MLX owns its explicit-route default.
 
 ## Setting: api-key
 
-Whether API credential material was applied. The resolved value comes from an
-explicit capability `api_key_env`/`api_key`, the same-provider credential, or
-the local owner file; local Vision otherwise uses a non-secret SDK placeholder.
-Codex and MLX do not consume this field. Current and default are always
-redacted—SHOW retains only presence, never raw material. Change the owner secret
-store or launcher configuration, then relaunch or refresh without printing it.
+Presence of applied credential only. It may come from explicit capability,
+active route, or local owner file; local otherwise uses an SDK placeholder.
+Codex/MLX do not consume this field; SHOW still redacts it.
 
 ## Setting: api-key-env
 
-Whether an explicit capability credential-variable pointer was applied. The
-pointer is resolved once during bind before raw-key fallback. Its name and value
-are both sensitive and redacted; there is no default. Change
-`manifest.capabilities.vision.api_key_env` and the launcher/secret-manager
-environment through their existing owner procedures, then relaunch or refresh.
-SHOW never reads or changes the process environment.
+Presence of an explicit credential-variable pointer, resolved once before raw-key
+fallback. Name and value are redacted; SHOW never reads or changes the environment.
 
 ## Setting: max-tokens
 
-The direct service's positive response-token cap. An explicit capability value
-wins; local Vision next reads `settings/vision.json`. OpenAI-compatible,
-Anthropic-compatible, MiMo, and local services default to `1024`; MLX defaults
-to `512`; routes that do not consume this field show `null`. Edit the existing
-capability/preset or local owner file, refresh, and verify with SHOW.
+Positive response-token cap. Explicit capability wins, then local owner file;
+service defaults are 1024 for API/local routes and 512 for MLX where applicable,
+otherwise `null`. Gemini has no Vision-owned cap default.
 
 ## Setting: api-compat
 
-The compatibility family selected from explicit Vision configuration or the
-same active provider's defaults. Accepted values are `openai` or `anthropic`
-where the relay supports that protocol. There is no default and an irrelevant
-route shows `null`. Change the owning capability/provider configuration,
-refresh, run `check`, and verify with SHOW. It does not grant provider access.
+Compatibility family from explicit Vision or active-provider defaults (`openai` or
+`anthropic` where supported); irrelevant routes show `null`. It grants no access.
 
 ## Setting: wire-api
 
-The effective OpenAI-compatible wire. Accepted configuration values are
-`auto`, `chat_completions`, or `responses`; route support still decides whether
-construction succeeds. Local/OpenAI-compatible services normally resolve to
-`chat_completions`, while Codex is `responses`; non-applicable routes show
-`null`. Change the owning capability or same-provider configuration, refresh,
-run `check`, and verify with SHOW.
+Effective wire: configured `auto`, `chat_completions`, or `responses` subject to
+route support. Local/OpenAI-compatible routes normally use `chat_completions`,
+Codex uses `responses`, and irrelevant routes show `null`.
 
 ## Setting: default-headers
 
-Whether provider-owned HTTP headers were applied to a compatible service.
-Explicit Vision headers precede same-provider defaults. The complete mapping,
-including header names, is sensitive and always redacted; no headers is the
-`null` default. Edit the owning capability/provider configuration, refresh, and
-SHOW again without logging the mapping.
+Whether provider headers were applied. Explicit headers precede active defaults;
+the mapping and names are always redacted, including when no headers apply.
 
 ## Setting: token-path
 
-Whether a Codex OAuth identity path was applied. It comes from an explicit
-Vision value, the same provider's `codex_auth_path`, or authorized pool
-selection. Non-Codex routes show `null`. The path and token material are
-sensitive and always redacted. Use the existing Codex login/account-pool or
-preset procedure, then refresh and SHOW; never copy the file or token to output.
+Whether a Codex OAuth identity path was applied from explicit value, active
+`codex_auth_path`, or authorized pool selection. Non-Codex routes do not consume it;
+SHOW still redacts path and token presence.
 
 ## Setting: instructions
 
-Whether Codex Responses instructions were applied. Explicit Vision
-instructions win; the Codex service otherwise owns its concise-assistant
-default. Non-Codex routes show `null`. The text is sensitive and always
-redacted. Edit the active capability/preset, refresh, and SHOW again; never put
-credentials or authorization in instructions.
+Whether Codex Responses instructions were applied. Explicit text wins over the
+Codex service default; non-Codex routes do not consume it, and SHOW still redacts it.
 
 ## Setting: max-output-tokens
 
-The optional Codex Responses output cap. Accepted values are positive integers
-supported by the backend, or `null` to omit it; the default is `null`. Change
-the active capability/preset only after validating backend support, refresh,
-run `check`, and verify with SHOW. This is distinct from `max_tokens`.
+Optional positive Codex Responses output cap; `null` omits it and is the default.
+It is distinct from `max_tokens` and needs backend support.
 
 ## Setting: timeout
 
-The Codex request timeout in positive finite seconds. An explicit capability
-value wins; Codex defaults to `120.0`, and non-Codex routes show `null`. Change
-the active capability/preset, refresh, and verify with SHOW. A larger timeout
-changes wait tolerance only; it grants no network, provider, or retry authority.
+Positive finite Codex request timeout; explicit value wins and the default is
+`120.0`. Non-Codex routes show `null`; a larger value grants no retry/network authority.
+
+SHOW is read-only even when a row is configurable. Do not paste endpoints, keys,
+OAuth paths, headers, or instructions into output; follow the owning capability,
+preset, local-file, launcher, or Codex account procedure instead.
+
+## Authorized change routes
+
+- `provider`, `api_compat`, `wire_api`, `default_headers`, `instructions`,
+  `max_output_tokens`, `timeout`: existing Vision capability/active-preset or
+  same-provider configuration; verify backend support before editing.
+- `base_url`, `model`, `max_tokens`: same owners; the local route additionally
+  reads `settings/vision.json`, with capability values taking precedence.
+- `api_key`, `api_key_env`: owner secret store/launcher and explicit capability
+  pointer; `api_key_env` resolves before raw-key fallback. Never print either.
+- `token_path`: existing Codex login/account-pool or explicit capability/preset
+  procedure; never copy OAuth files into output.
+
+After an authorized edit, refresh/relaunch and SHOW again. These routes grant no
+new installation, credential, network, or retry authority.

--- a/tests/test_vision_settings.py
+++ b/tests/test_vision_settings.py
@@ -402,3 +402,37 @@ def test_ordinary_analyze_action_is_unchanged(tmp_path):
     service.analyze_image.assert_called_once_with(
         str(image), prompt="Describe what you see in this image."
     )
+
+
+def test_local_manual_selects_provider_before_owner_file_example(tmp_path):
+    import re
+
+    manual = Path(__file__).resolve().parents[1] / "src/lingtai/tools/vision/manual"
+    body = (manual / "reference/backends.md").read_text(encoding="utf-8")
+    examples = [json.loads(value) for value in re.findall(r"```json\n(.*?)\n\s*```", body, re.S)]
+    capability = examples[0]["vision"]
+    assert capability["provider"] == "local"
+    document = examples[1]
+    _write_local_settings(tmp_path, **{k: v for k, v in document.items() if k != "schema_version"})
+    with patch("lingtai.services.vision.openai.OpenAIVisionService") as factory:
+        # File alone must not select a route or construct a client.
+        unselected = setup(_StubAgent(tmp_path))
+        assert "settings" not in _show(unselected)
+        factory.assert_not_called()
+        selected = setup(_StubAgent(tmp_path), **capability)
+        assert _by_key(_show(selected))["provider"]["current"] == "local"
+        assert factory.call_args.kwargs["model"] == document["model"]
+    assert "file alone does not select" in body
+
+
+def test_setting_anchor_routes_to_exact_detail_and_redaction_is_explicit():
+    manual = Path(__file__).resolve().parents[1] / "src/lingtai/tools/vision/manual"
+    root = (manual / "SKILL.md").read_text(encoding="utf-8")
+    reference = (manual / "reference/settings.md").read_text(encoding="utf-8")
+    for key in _KEYS:
+        slug = key.replace("_", "-")
+        section = root.split(f"## Setting: {slug}\n", 1)[1].split("\n## ", 1)[0]
+        assert f"reference/settings.md#setting-{slug}" in section
+        assert f"## Setting: {slug}" in reference
+    assert "both current and default" in reference
+    assert "even when unused" in reference


### PR DESCRIPTION
## Summary
- Simplify only Vision manuals, module/schema descriptions and two focused documentation regressions. No runtime logic, inputs/results, route/credential policy, Contract or dependencies change.
- Entry body 4,392 → 3,331 chars (−24.2%); five bodies 24,418 → 15,920 (−34.8%). Public schema-description occurrences 840 → 794, family description 506 → 490 (combined −62). Module docstring −1,274 is **not** counted as model-resident savings; no token/cost claim.
- Correct the usable local setup sequence: select `provider="local"` before the owner-file example; file-only config does not select a route, and invalid present local settings still block kwargs overrides.
- Route all 13 SHOW anchors directly to exact owner details; document redaction of both current/default even when a sensitive field is unused, and keep authorized change paths.
- Clarify that check is route construction, not live server/model or MLX offline readiness; restore official Claude CLI/image links. Preserve explicit allowed-preset identity, no automatic fallback, and installation/credential authority.

## Validation
Exact clean base: `eddb273c5c30b6f9945bf10f590ff3f462734f63`.
- `PYTHONPATH=src python3.14 -B -m pytest -q tests/test_vision_settings.py` → **12 passed**. Both added doc tests failed before prose correction, then passed; setup-example test also uses the actual family setup and a recording local factory.
- Complete affected file set: `test_tool_family_vision_migration.py test_vision_capability.py test_vision_services.py test_vision_settings.py test_intrinsic_manual_actions.py test_tool_prose_section_gate.py test_tool_plugin_declaration.py test_skills.py test_prompt_catalog.py test_docs_governance.py test_architecture_documents.py test_tool_settings_contract.py` via `PYTHONPATH=src python3.14 -B -m pytest -q tests/<file> ...` → candidate **403 passed / 6 failed / 1 warning**; clean base **401 / 6 / 1 warning**. All six error blocks identical after pytest-temp-root normalization only.
- Existing failures: System standalone-skill assertion; two prompt-catalog assertions; two MCPServerRequestContext environment-import blocks; existing Psyche anatomy orphan. They remain FAIL, not counted as pass. First candidate had an owned phrase assertion; restored exact authorization/no-MCP wording and reran the entire set.
- `python3.14 -B scripts/check_docs_governance.py --check` → **400 documents + docs.yaml PASS**.
- `python3.14 -B src/lingtai/intrinsic_skills/lingtai-kernel-anatomy/scripts/check_anatomy_drift.py --check` → six baseline findings, byte-identical.
- `git diff --check` → PASS.
- Hermetic real `Agent` construction/full prompt (31815 chars), unique Vision mount, five installed manuals byte-equal, all internal links and 13 SHOW routes, recording-service check/analyze → PASS (mock LLM/socket connect blocked).
- AST equal except reviewed module docstring/descriptions; composed schema equal except description. Reviewed all removed guidance, owner Contract/Anatomy/VN001–VN007 and relevant resolver/service bodies. Owner review of the original native Luna candidate; no replacement worker.

## Boundaries
No full-repo/native-Windows/live-provider/MLX/production E2E claim. No live rollout, backend/model install, configuration/auth changes or cleanup. Local-only HTML explainer prepared and browser-checked; not committed. One Vision PR in the human-authorized manual batch.

Telegram: @lingtaidev1bot | Nickname: 知微
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
