### PR TITLE
docs(mcp): simplify manual routes and correct lifecycle guidance

### DIFF
--- a/src/lingtai/tools/mcp/__init__.py
+++ b/src/lingtai/tools/mcp/__init__.py
@@ -1,58 +1,21 @@
-"""MCP capability — per-agent registry of MCP servers (pure presentation).
+"""Read-only presentation of the per-agent MCP registry.
 
-Symmetric to the ``knowledge`` / ``skills`` capabilities:
+The public ``mcp`` family has strict-empty LTP v2 ``info``, ``settings``, and
+``manual`` actions. ``info`` re-reads registry/identity data, renders this
+plugin's protected prompt section, and reports health; ``settings`` shows only
+safe effective init projections; ``manual`` reads the installed router. None
+registers, activates, configures, troubleshoots, or grants permission to change
+a server. Registry/catalog membership is not proof that a child is active.
 
-- Per-agent registry lives at ``<agent>/mcp_registry.jsonl`` (sibling to
-  ``init.json``). One JSON record per line.
-- The capability scans the registry on setup, validates each line, and renders
-  the registry as XML into the system prompt's ``mcp`` section.
-- Boot-time decompression: any name in ``init.json``'s ``addons: [...]`` list
-  that isn't already in the registry gets appended from the kernel-shipped
-  catalog (``lingtai/mcp_catalog.json``). Append-only, idempotent.
-- All registry mutations (register, deregister, update) happen via file
-  operations from the agent (``write``, ``edit``). The capability provides
-  guidance via the umbrella SKILL.md, with ``info`` re-rendering the prompt
-  section and reporting health while ``manual`` returns the manual body.
+Registry validation, catalog decompression, identity projection, and XML
+rendering belong to ``lingtai.services.mcp_registry``. This module is only the
+agent-callable tool slice and receives the declared host's workdir and protected
+prompt-section ports—not the whole Agent. Registry/config mutations remain
+explicitly authorized ``write``/``edit`` operations outside this tool.
 
-Tool surface: ``info`` returns the current registry and a runtime health
-snapshot without the manual body; ``settings`` shows the two MCP-owned
-top-level init settings; ``manual`` returns the umbrella manual body on demand.
-All three are action children of one LTP v2 ``ToolFamily`` (see
-``lingtai/tools/CONTRACT.md`` "Envelope"): the public tool name stays ``mcp`` and
-the public action values are ``info``/``settings``/``manual``, carried in the
-canonical
-``action`` + ``input`` + ``reasoning`` + ``summarize`` envelope with a strict
-empty ``input`` per action. The existing actions' observable results are
-unchanged.
-
-Ownership: this module is the agent-callable *tool* slice only. The registry
-machinery it renders (validation, JSONL I/O, catalog load, identity projection,
-addon decompression, XML build) is a service and lives at
-``lingtai/services/mcp_registry.py``; it is imported lazily inside ``setup`` and
-the handlers, per the ``lingtai.tools → lingtai`` lazy-back-edge rule.
-
-Declared host plugin: ``mcp`` is the first official family to recut onto the
-kernel-owned declared host-plugin contract
-(``lingtai/kernel/tool_plugin/CONTRACT.md``). :data:`DECLARATION` is a static
-``ToolPluginDeclaration`` built at import, before any Agent exists; ``mcp`` is a
-reserved official name in ``lingtai.kernel.tool_plugin``, so a second
-declaration of it is refused before anything binds or mounts. The family no
-longer receives the whole ``Agent``: :func:`_bind` gets a ``ToolPluginHost``
-granting exactly the two ports this capability actually consumes — ``workdir``
-(read the registry and the installed manual) and ``prompt_section`` (rewrite
-its own protected ``mcp`` section). Nothing about the public tool — name,
-``["info", "settings", "manual"]`` action enum, strict-empty inputs, result shapes
-including the tool-specific ``mcp_manual`` body key — changed with it.
-
-Usage: ``Agent(capabilities=["mcp"])`` or via init.json.
-
-The source package is also an Agent Plugins v1.0.0 *documentation package*: its
-``plugin.json`` and sole owned ``skills/mcp-manual/`` skill are validated by the
-existing plugin-registry reader when Agent installs intrinsic manuals. That
-packaging does not select, register, or activate an external plugin and never
-creates an ``mcp_registry.jsonl`` record; the static declaration above remains
-the only route that mounts this model-facing tool.
-"""
+The package also ships the single ``mcp-manual`` documentation skill through the
+standard plugin reader. Packaging installs that manual but does not select,
+register, activate, or create an ``mcp_registry.jsonl`` record."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Mapping
@@ -149,14 +112,12 @@ def _flatten_manual_result(mcp_result: dict) -> dict:
 # ---------------------------------------------------------------------------
 
 _DESCRIPTION = (
-    "SIGNPOST ONLY: this read-only tool does not register, activate, configure, "
-    "or troubleshoot MCP servers. `info` only re-reads the registry and returns "
-    "health; `settings` shows MCP-owned configuration; `manual` returns the "
-    "mcp-manual body. Before registering, deregistering, updating, or "
-    "troubleshooting, read `mcp-manual` (call `manual` for its body), call "
-    "`info` for the current health snapshot, and obtain explicit authorization. "
-    "Registry changes use "
-    "write/edit on mcp_registry.jsonl followed by system(action=\"refresh\")."
+    "SIGNPOST ONLY: does not register, activate, configure, or troubleshoot MCP servers. "
+    "`info` only re-reads the registry and identity health; `settings` shows MCP-owned configuration; "
+    "`manual` returns the mcp-manual body. All use input={}; routine inspection needs no manual. "
+    "Before changes read manual + exact README, call info, obtain explicit human authorization; "
+    "use file edits then one System refresh. Registration is not active proof. "
+    "Never publish raw registry problems or credentials."
 )
 
 # The owner-defined action and reserved manual action take no arguments; the

--- a/src/lingtai/tools/mcp/skills/mcp-manual/SKILL.md
+++ b/src/lingtai/tools/mcp/skills/mcp-manual/SKILL.md
@@ -1,13 +1,12 @@
 ---
 name: mcp-manual
 description: >
-  Router for the read-only `mcp` capability. It distinguishes catalog,
-  registered, and active servers; routes curated and third-party setup to their
-  exact references; and documents the safe info/settings/manual preflight.
-  Read before changing configuration. It does not teach the MCP protocol
-  itself; use `lingtai-kernel-anatomy`'s MCP protocol reference.
-version: 3.5.0
-last_changed_at: 2026-08-29T00:00:00Z
+  Read-only MCP status router: distinguish catalog, registered, and active servers;
+  inspect effective settings safely; and route authorized setup or recovery to the
+  exact provider and runtime references. Routine info/settings/manual calls need
+  no ritual manual reading. This is not an MCP protocol guide.
+version: 3.6.0
+last_changed_at: 2026-09-09T03:20:00Z
 related_files:
 - src/lingtai/tools/skills/manual/reference/cleanup-footprint-contract.md
 - src/lingtai/tools/mcp/__init__.py
@@ -21,162 +20,91 @@ related_files:
 - src/lingtai/tools/mcp/skills/mcp-manual/scripts/find_readme.py
 - tests/test_mcp_settings.py
 maintenance: |
-  Tracks the routed source/resources it summarizes; update when the underlying capability or its sub-references change.
+  Keep this short router aligned with the routed references, installed manual layout, and mcp description; update when MCP behavior, setup ownership, or safety boundaries change.
 ---
 
-# MCP capability — router
+# MCP capability
 
-`mcp` is a read-only presentation capability. It renders the per-agent
-`mcp_registry.jsonl` into the protected `<registered_mcp>` prompt section and
-reports registry health; it never registers, activates, configures, or
-troubleshoots a server. Configuration and registry mutations belong to
-explicitly authorized `write`/`edit` calls, not this tool.
-
-## Mandatory preflight
-
-Before registering, updating, deregistering, or troubleshooting a server:
-
-1. Read the route below and the relevant provider/server README. Never guess
-   install commands, environment variables, or config fields.
-2. Call `mcp(action="info", input={}, reasoning="check MCP registry health")`.
-   Treat its `registry_path`, `registered`, and `problems` as the current health
-   snapshot.
-3. Obtain explicit human authorization before editing. After the edit, call
-   `system(action="refresh")`, then call `info` again.
-
-`/addon` is retired. `/mcp` is the only current TUI command for this surface;
-it is read-only status/config inspection, not a setup wizard. Do not direct a
-human there for addon configuration.
-
-## Three states
-
-Keep these states separate for this agent:
-
-1. **Catalog** — a reference entry shipped by the kernel. Curated names are
-   `imap`, `telegram`, `feishu`, `wechat`, `whatsapp`, and `cloud_mail`.
-2. **Registered** — a valid record in `mcp_registry.jsonl` (beside `init.json`),
-   listed in `<registered_mcp>`.
-3. **Active** — a server process is running and its tools are mounted. A record
-   or successful `info` call alone is not proof of activity.
-
-The usual promotion is **catalog → registry → active**. File edits plus one
-controlled `system(action="refresh")` advance the relevant layer; refresh does
-not restart a healthy child.
-
-## Route table
-
-| Need | Read first |
-|---|---|
-| Set up `imap`, `telegram`, `feishu`, `wechat`, `whatsapp`, or `cloud_mail` | [`reference/curated-addons.md`](reference/curated-addons.md), then exact provider docs |
-| Add a third-party `npx`/`uvx`/HTTP server | [`reference/third-party-and-legacy.md`](reference/third-party-and-legacy.md), then its README |
-| Use legacy `mcp/servers.json` | [`reference/third-party-and-legacy.md`](reference/third-party-and-legacy.md) |
-| Update, deregister, or diagnose failures | [`reference/troubleshooting.md`](reference/troubleshooting.md) |
-| Check identity, manual paths, or runtime/venv provenance | [`reference/runtime-and-identity.md`](reference/runtime-and-identity.md) |
-| Ask about protocol, env injection, or LICC | `lingtai-kernel-anatomy` → `reference/mcp-protocol.md` |
-| Inspect footprint before approved cleanup | `skills-manual` → `reference/cleanup-footprint-contract.md` |
-
-For curated addon setup, read `reference/curated-addons.md` (the exact
-curated-addons contract), then the provider docs before editing; never infer
-addon fields from memory.
-
-### README gate
-
-A server README is authoritative for installation, config fields, env vars, and
-errors. For an installed Python distribution, prefer the bundled script with
-the runtime venv's Python:
-
-```bash
-<runtime-venv-python> \
-  .library/intrinsic/capabilities/mcp/scripts/find_readme.py <distribution-or-module>
-```
-
-The script tries an editable source README, then wheel `METADATA`; pass
-`--module <importable-module>` when needed. If no local README exists, use the
-registered `<homepage>` with `web_read`; runtime self-description is last resort.
-
-## Tool surface
-
-All actions use the strict-empty LTP v2 envelope; `summarize` is root-only
-presentation metadata:
+`mcp` is a **read-only signpost**, not a server-management API. Every action
+uses strict `input={}`; routine inspection needs no prerequisite reading:
 
 ```text
-mcp(action="info", input={}, reasoning="inspect registry")
-mcp(action="settings", input={}, reasoning="show MCP settings")
-mcp(action="manual", input={}, reasoning="read the MCP router")
+mcp(action="info", input={}, reasoning="inspect MCP registry health")
+mcp(action="settings", input={}, reasoning="show effective MCP settings")
+mcp(action="manual", input={}, reasoning="read MCP guidance")
 ```
 
-- `info` re-reads registry/identities, re-renders the protected prompt section,
-  and returns health without the manual body.
-- `settings` is a bounded SHOW of exactly `init.addons` and `init.mcp`.
-- `manual` returns this body as `mcp_manual` plus the installed `manual_path`,
-  with no registry I/O or mutation.
+- **info** re-reads registry/identity caches, reconciles the protected prompt
+  section, and returns contents, problems and registry path—not the manual.
+- **settings** reads effective init values; it neither edits nor proves liveness.
+- **manual** returns this installed body as flat `mcp_manual` and `manual_path`,
+  without registry I/O. Missing installation yields a degraded result, not fallback.
 
-Leave `summarize=false` for `settings` and `manual`, and for `info` whenever
-exact names, IDs, problems, or paths matter. Summarization is only a
-presentation choice; errors are never summarized.
+None registers, activates, configures, or fixes a server. Leave root
+`summarize=false` when exact names or paths matter. Registry `problems` can
+contain raw invalid lines: never publish the whole result or raw diagnostics;
+report only line numbers and sanitized reasons, not credentials or private paths.
 
-## Identity and public paths
+## States and change gate
 
-`info` attaches `identity` only for a matching registry record with a non-empty
-addon-published `accounts` list. The cached source is
-`system/mcp_identities/<name>.json` (`lingtai.mcp.identity.v1`), not a network
-call. Only allowlisted non-secret account alias/provider name or ID/display
-name and routing counts are exposed; tokens, passwords, app/refresh/access
-secrets, headers, and unknown fields are dropped. Prompt XML narrows the
-projection again and excludes volatile verification timestamps. Use the addon's
-`accounts` action for richer detail. See
-[`reference/runtime-and-identity.md`](reference/runtime-and-identity.md).
+**Catalog** is the kernel-shipped reference; **registered** is a valid
+`mcp_registry.jsonl` record beside `init.json`; **active** means a live server
+with mounted tools. A record or `info` success does not prove active status.
 
-`manual_path` is the truthful host-local installed-skill path, not a config path
-or proof that a server is active. A missing skill returns a degraded result
-with an empty body, the path, and an error; it never falls back to another
-manual. Do not copy private diagnostic paths into public setup instructions.
+Before setup, update, deregistration or recovery: read the matching route and
+exact server README, call `info`, and obtain explicit human authorization before edits.
+Registry/config changes use authorized file write/edit, then **one** controlled
+System refresh and live verification. Public refresh requests an Agent relaunch;
+it is not merely the pre-handoff failed-child retry hook. See runtime ownership
+below before changing a launcher. `/addon` is retired; `/mcp` is the only current TUI command for this surface.
+It is read-only status/config inspection, not a setup wizard.
+
+## Routes
+
+| Need | Read |
+|---|---|
+| Curated addon setup: exact provider docs and Telegram/Cloud Mail/WeChat hazards | [curated addons](reference/curated-addons.md#the-four-step-setup) |
+| Third-party registry or legacy stdio/HTTP activation | [third-party and legacy](reference/third-party-and-legacy.md) |
+| Update, deregister, missing tools or failure | [troubleshooting](reference/troubleshooting.md) |
+| Identity cache, installed paths, venv/source provenance | [runtime and identity](reference/runtime-and-identity.md) |
+| Protocol, env injection or LICC | `lingtai-kernel-anatomy` → `reference/mcp-protocol.md` |
+| Footprint inspection / separately approved cleanup | `skills-manual` → `reference/cleanup-footprint-contract.md` |
+
+## README gate
+
+Installation, config fields, env vars and error meanings come from the exact
+server README—never guess. For an installed Python package use:
+
+```bash
+<runtime-venv-python> .library/intrinsic/capabilities/mcp/scripts/find_readme.py <distribution>
+```
+
+Add `--module` for module-to-distribution lookup. The helper prefers editable
+source README, then wheel `METADATA`. If absent, browse the registered public
+`homepage` with `web(action="browse", input={"url":"<homepage>", "link_ref":null,
+"cursor":null, "extract":null, "max_chars":null}, reasoning="read server README")`.
+Runtime self-description is the last resort; the helper installs/fetches nothing.
 
 ## Configuration settings
 
-`mcp(action="settings", input={}, reasoning="show MCP settings")` is SHOW-only.
-Success is exactly `{"settings": [...]}`; each row has exactly `key`,
-`current`, `default`, `configurable`, and `comment`, in that order. The whole
-inventory is bounded to 65,536 UTF-8 bytes. Any source/read/serialization
-failure returns one fixed no-row failure, never a partial inventory or exception
-text. There is no set/reset form and this action writes nothing.
+SHOW returns exactly `{"settings": [...]}`; each row has `key`, `current`,
+`default`, `configurable`, `comment`, in that order. The inventory is bounded to
+65,536 UTF-8 bytes. Source/read/serialization failure returns one fixed no-row
+failure, not partial values or exception text.
 
-| Key | Meaning | Default / projection | Authorized change |
-|---|---|---|---|
-| `init.addons` | Fresh canonical effective addon list used by boot/refresh, not the decompressed registry or live health. | `[]`, shown as configured | Edit top-level `init.json` `addons`, refresh, then SHOW again. Removing a name does not delete its registry row. |
-| `init.mcp` | Fresh canonical effective activation object. | Logically `{}`, but both `current` and `default` are `<redacted>`; no names, commands, paths, env, or credentials. | Edit top-level `init.json` `mcp`, refresh, then use `info` and the addon's action. A healthy child needs a full relaunch for a changed launch spec. |
+| Key | Meaning | Authorized change |
+|---|---|---|
+| `init.addons` | Fresh canonical effective list; default `[]`, not registry/live health. | Edit top-level `init.json` `addons`, refresh, SHOW again. Removal does not delete a registry row. |
+| `init.mcp` | Fresh canonical activation mapping; both current and default always `<redacted>`. | Edit top-level `init.json` `mcp`, refresh, then verify the child/tool/account—not just `info`. Registry membership gates activation. |
 
-These rows exclude the registry, identity files, legacy `mcp/servers.json`,
-curated private config/session data, Task Cards, agent identity, and live
-process state. Registry membership still gates top-level `init.mcp` activation.
+SHOW excludes registry/identity files, legacy `mcp/servers.json`, private addon
+config/session data, Task Cards and live process state. It grants no edit authority.
 
-## Cleanup / Footprint
+## Cleanup / footprint
 
-MCP leaves `mcp_registry.jsonl`, optional `mcp/servers.json`, and
-`.mcp_inbox/<name>/...` event files. Curated addons may own additional stores;
-read their manual before including them. Never delete credentials, message or
-audit records, active registry/process state, or recovery evidence blindly.
-
-Load the [shared inspection recipe](../../../skills/manual/reference/cleanup-footprint-contract.md#shared-footprint-check-recipe)
-and combine it with this MCP-owned selection; the default check writes and
-deletes nothing:
-
-```python
-agent = Path.cwd()  # relevant agent directory, not a repository root
-items = [p for p in (agent / "mcp_registry.jsonl", agent / "mcp", agent / ".mcp_inbox") if p.exists()]
-rows, total = footprint_check(items, tool="mcp", top_n=None)
-```
-
-Run the check after adding/removing servers, when `.mcp_inbox` grows, and before
-sharing a project. Show the dry-run report and obtain explicit user consent
-before any archive or deletion; without consent, stop. Prefer an authorized
-registry/activation edit followed by `system(action="refresh")` over deleting
-state. Any separately selected audit/apply step records timestamp, tool, mode,
-candidate count/bytes/path summary, and approval in `logs/cleanup.jsonl`; do not
-call that audit write read-only.
-
-Runtime/venv swap and child provenance are in
-[`reference/runtime-and-identity.md`](reference/runtime-and-identity.md). Curated
-and third-party schemas are in [`reference/curated-addons.md`](reference/curated-addons.md)
-and [`reference/third-party-and-legacy.md`](reference/third-party-and-legacy.md);
-update/failure recovery is in [`reference/troubleshooting.md`](reference/troubleshooting.md).
+Inspect only selected MCP-owned registry, legacy activation, inbox and addon
+assets using the shared route above; default inspection writes/deletes nothing.
+Never blindly delete credentials, messages, audit records, active state or
+recovery evidence. Present a dry-run and obtain explicit consent before archive
+or deletion. Any separately approved audit/apply write records timestamp, mode,
+candidate count/bytes, path summary and approval in `logs/cleanup.jsonl`.

--- a/src/lingtai/tools/mcp/skills/mcp-manual/reference/curated-addons.md
+++ b/src/lingtai/tools/mcp/skills/mcp-manual/reference/curated-addons.md
@@ -3,146 +3,126 @@ related_files:
 - src/lingtai/tools/mcp/skills/mcp-manual/SKILL.md
 - src/lingtai/tools/mcp/skills/mcp-manual/reference/troubleshooting.md
 maintenance: |
-  Kernel-curated MCP addon setup contract routed to from mcp/skills/mcp-manual/SKILL.md and cross-linked from troubleshooting.md; update it whenever a curated addon (imap/telegram/feishu/wechat/whatsapp/cloud_mail) changes its config fields or install story.
+  Owns the curated addon setup route and its provider-specific hazards; update when a curated addon, launcher owner, config field, or install story changes.
 ---
 
 # Curated addons — imap / telegram / feishu / wechat / whatsapp / cloud_mail
 
-LingTai's first-party email and chat integrations. They now ship inside the `lingtai` distribution under `lingtai.mcp_servers.{imap,telegram,feishu,wechat,whatsapp,cloud_mail}` so a single kernel release carries the curated MCP surface atomically. Historical `lingtai_*` names may still appear in old configs or compatibility source, but new configurations must use the bundled `lingtai.mcp_servers.*` modules; do not assume a historical wrapper is importable in the active runtime. Historical standalone package names remain useful as provenance/homepage names, but the normal runtime path no longer depends on separate addon wheels.
+These first-party servers ship in the `lingtai` distribution as
+`lingtai.mcp_servers.{imap,telegram,feishu,wechat,whatsapp,cloud_mail}`. Historical
+`lingtai_*` distribution names may remain in old configs and provenance, but do
+not assume their wrappers are importable; new configuration uses the bundled
+modules. Set the curated config path through the addon's documented env var
+(for example `LINGTAI_IMAP_CONFIG` or `LINGTAI_TELEGRAM_CONFIG`).
 
 ## The four-step setup
 
-1. **Read the curated setup docs before editing config.** The table below gives the registry/module/env/config-file names. If exact provider-specific fields are needed, inspect the shipped module resources or the catalog `homepage` for that addon. Field names like `email_password` (imap), `bot_token` (telegram), `app_id`/`app_secret` (feishu), and gewechat host (wechat) are addon-specific; do not guess them from memory. Make exact configuration changes only within explicit human authorization; this contract is the setup procedure, not a TUI setup screen.
-
-2. **Add the addon to `init.json`.** Append the registry name to the top-level `addons:` list, then add an `mcp.<name>` activation entry. For a curated addon this entry is **activation + account configuration only** — the canonical shape carries no `command`/`args`/`type` at all, just the `env` your addon's config file path lives under. The running kernel's own catalog derives the entire launcher (`type`, interpreter, module `args`, and the `lingtai` import source) at load time — see "MCP child processes run in their own runtime" below — so there is nothing launcher-shaped to keep in sync across a venv move:
+1. **Read the curated setup docs before editing.** Use this route and the catalog `homepage` or
+   shipped resources for exact provider fields. Never guess fields, install
+   commands, or environment variables: for example `email_password` (imap),
+   `bot_token` (telegram), `app_id`/`app_secret` (feishu), and WeChat's host are
+   addon-specific. Obtain explicit human authorization before editing.
+2. **Activate in `init.json`.** Add the name to top-level `addons` and add
+   `mcp.<name>` with account configuration, normally only its config-file `env`:
 
    ```json
-   {
-     "addons": ["imap"],
-     "mcp": {
-       "imap": {
-         "env": {
-           "LINGTAI_IMAP_CONFIG": ".secrets/imap.json"
-         }
-       }
-     }
-   }
+   {"addons":["imap"],"mcp":{"imap":{"env":{"LINGTAI_IMAP_CONFIG":".secrets/imap.json"}}}}
    ```
 
-   An older config that still carries `type`/`command`/`args` (e.g. copied from a pre-existing setup, or from the worked example above in an older version of this doc) keeps working: those fields are read-compatible legacy inputs, silently accepted by the JSON schema, but ignored for the actual launch with one bounded warning naming them. LingTai never rewrites or migrates them out of your `init.json` — trim them yourself if you want the file to read as canonical, or leave them; either way the running launcher is unaffected.
+   The running kernel's catalog owns a curated launcher's `type`, interpreter,
+   module `args`, and `PYTHONPATH`. Existing `type`/`command`/`args` or
+   `env.PYTHONPATH` are read-compatible legacy fields: they are ignored for
+   launch, produce one bounded warning, and are not rewritten. If the catalog
+   has no safe stdio launcher, it skips the entry rather than falling back.
+3. **Create the config file** at the referenced path using the addon/provider schema verbatim.
+4. **Run one** `system(action="refresh", input={"reason":"activate approved MCP configuration",
+   "preset":null,"revert_preset":null}, reasoning="apply authorized setup")`.
+   This requests an Agent relaunch; verify the new live child, mounted tool and
+   intended account separately. Do not confuse the pre-handoff retry hook with
+   the complete refresh lifecycle.
 
-3. **Create the config file** at the path referenced by the env var (e.g. `.secrets/imap.json`). Use the schema from the addon docs — copy it verbatim, don't paraphrase.
+For orientation: `imap` → `lingtai.mcp_servers.imap`, `telegram` →
+`lingtai.mcp_servers.telegram`, `feishu` → `lingtai.mcp_servers.feishu`,
+`wechat` → `lingtai.mcp_servers.wechat`, `whatsapp` →
+`lingtai.mcp_servers.whatsapp`, and `cloud_mail` →
+`lingtai.mcp_servers.cloud_mail`. The module name is diagnostic/catalog
+information, not a launcher to copy into a canonical curated entry.
 
-4. **Run `system(action="refresh")`.** The `mcp` capability decompresses the catalog record into `mcp_registry.jsonl`, the loader spawns the subprocess, and the omnibus tool (`imap`, `telegram`, etc.) appears in your tool surface.
+## Runtime ownership
 
-## MCP child processes run in their own runtime
+A curated main-agent child uses the current Agent's interpreter, catalog module
+args, and imported source root. A third-party `init.json` entry or legacy
+`mcp/servers.json` child instead owns its effective `type`/`command`/`args`/`env`;
+a daemon/plugin MCP uses that task/plugin's config; HTTP has no local
+interpreter. Do not assume any non-curated or standalone child shares the Agent's
+venv, site-packages, source, or environment. See
+[runtime-and-identity](runtime-and-identity.md) for authorized registry
+reconciliation and the fail-closed provenance probe; process inspection alone is
+not proof.
 
-Each current curated addon shown in this file is launched as a separate **stdio Python subprocess** with its own environment. For a **non-curated** route — a third-party `init.json` entry, or the legacy `mcp/servers.json` direct mount — `type`/`command`/`args`/`env` all come from that entry's own **active activation spec**, exactly as before. A **curated** addon activated via `init.json`'s `mcp.<name>` entry (registry record's `source` exactly `lingtai-curated`) is different in kind, not just interpreter-pinned: the running kernel's own packaged `mcp_catalog.json` owns the *entire* launcher — `type`, `command` (the running Agent's own `sys.executable`), and module `args` — and the child's `PYTHONPATH` is set outright to this Agent's own currently-imported `lingtai` source root. `init.json`'s `mcp.<name>` entry for a curated addon is activation + account config only: its presence activates the addon, and its non-launch `env` (e.g. `LINGTAI_IMAP_CONFIG`) passes through untouched. Any `command`/`args`/`type`/`env.PYTHONPATH` the entry also carries are read-compatible legacy inputs — accepted by the schema, ignored for the launch with one bounded warning, never read from and never rewritten into `init.json` or `mcp_registry.jsonl`. This is not merely interpreter pinning: the MCP stdio transport's default env allowlist excludes `PYTHONPATH`, so even the right interpreter could still resolve `lingtai` from that interpreter's own site-packages instead of this Agent's actual source; owning `PYTHONPATH` outright is what makes the child's package source actually match the main agent's. If the catalog cannot supply a safe stdio launcher for a name registered as curated, the entry is skipped with a warning rather than falling back to any legacy field. Daemon-launched MCPs (task `mcp` registrations, plugin `mcp.json` servers) are a separate route entirely: they spawn from that task/plugin's own config, never from `init.json`'s `mcp.<name>` entries or `mcp_registry.jsonl`, so none of this applies to them. Do not assume a non-curated, legacy, or daemon-launched child shares the main agent's Python, site-packages, `PYTHONPATH`, or environment:
+## Telegram readiness (standalone hazards)
 
-- **A non-curated (third-party) `init.json` entry, a legacy `mcp/servers.json` child, or a daemon-launched MCP does not automatically share the main agent's runtime.** Refreshing the agent onto a different source tree (for example an agent-scoped `PYTHONPATH` override or an editable checkout) changes the main process imports, but that stdio child still resolves its own modules from the interpreter named by its activation `command`. If the child needs the new code too, set `PYTHONPATH` (or the equivalent import override) explicitly in that entry's `env`, or install the new package version into the child's venv. A curated addon activated via `init.json`'s `mcp.<name>` entry needs none of this — see above.
-- **Behavior that lives in an MCP child is only as new as that child's code.** Rendering, projection, and channel-side logic inside `lingtai.mcp_servers.*` (for example Telegram Task Card footer projection) executes in the child. After a code change to those modules, verify the child's interpreter and import resolution before reporting that a change is live: run a one-shot probe with the exact configured `command` and `env` that prints `sys.executable`, `lingtai.__file__`, and the selected `lingtai.mcp_servers.<name>.__file__`. For a curated addon, the whole probe tuple — interpreter, module `args`, and `PYTHONPATH` — is the running Agent's own, never the `command`/`args`/`PYTHONPATH` strings (if any) stored in `init.json`. (Process inspection such as `lsof` is at best a platform-specific corroboration, not proof of the loaded Python module.)
-- **The child venv is a normal package environment.** Site-packages for that interpreter is authoritative unless the activation `env` (or, for a curated addon, the kernel-owned `PYTHONPATH`) overrides the import path. For a curated addon, that interpreter and source root are the main agent's own, so diagnosing "change not visible" starts with whether the Agent process itself has relaunched onto the new venv. For a non-curated, legacy, or daemon-launched child, it still starts with that entry's own activation `command`/`env` tuple. HTTP MCP entries have no local subprocess or interpreter at all; the stdio/subprocess guidance above applies only to stdio entries.
+A healthy registry record is not a usable listener. After one controlled refresh
+or relaunch:
 
-## Venv swap does not auto-reconcile registry records
+1. Confirm one live Telegram child, the `telegram` tool, and the intended account
+   are mounted. For curated Telegram, editing stored `command`/`args` cannot fix
+   a stale module; probe `sys.executable`, `lingtai.__file__`, and
+   `lingtai.mcp_servers.telegram.__file__` first.
+2. `getMe` and a deliberate direct send prove **outbound only**. Do not call
+   `getUpdates` yourself while the listener owns long polling: a second poller
+   contends for updates.
+3. Have an allowed user send a fresh message; prove inbound delivery (LICC inbox
+   or the Telegram `read` action with `input={"chat_id":<known-chat-id>}`) and
+   reply using the returned compound message ID. Use the full action/input/reasoning
+   envelope, not flat `chat_id` or `message_id` arguments. Account listing or
+   outbound send alone is not end-to-end proof.
+4. Keep one lifecycle transition—never start a duplicate parent. Protect secrets:
+   directory `0700`, config `0600`; use placeholders, never real tokens, IDs,
+   private paths, or raw logs.
+5. Task Card changes that are real output still consume a real Telegram
+   edit/send and its flood-control/rate-limit budget. Diff-skipping protects only
+   **unchanged** bytes; avoid deliberate churn.
 
-- **A venv swap does not move live children by itself, and boot/refresh never rewrites existing registry records.** The [self-contained reconcile command and exact contract](runtime-and-identity.md#authorized-venv-swap-and-registry-truth) define which records it rewrites, the fail-closed invalid-registry abort, and why registry truth is not any child's spawn source; do not restate that mechanism here. What is specific to curated addons: for a non-curated or legacy child, the live interpreter/env still come from that entry's own activation spec (`init.json`'s `mcp.<name>` or `mcp/servers.json`), not from this reconcile. For a **daemon-launched** MCP (task `mcp` registrations, plugin `mcp.json` servers), the live command/env come from that task/plugin's own config, never from this registry, so the reconcile has no effect on a daemon-launched child either way. Only a curated **main-agent** `init.json` entry is affected, and even there the effect is cosmetic to the registry file only — the Agent derives its live launcher fresh from its own catalog at load time (see above), so the reconcile is never required for that child's own spawn, only for keeping the durable registry record itself truthful. Either way, a full agent relaunch (not just `refresh`, which only retries failed MCPs) is required before an already-running curated child picks up a new venv. Verify with the one-shot provenance probe above; if it still resolves to the old venv, relaunch — do not claim PASS.
+## Cloud Mail
 
-## Module names
+`cloud_mail` is a self-hosted Cloud Mail REST client, **not IMAP/SMTP**. It polls
+`POST /public/emailList` and delivers inbound mail through LICC. Its config env
+is `LINGTAI_CLOUD_MAIL_CONFIG` (relative paths resolve under the agent dir), and
+its detailed action surface is `cloud_mail(action="manual", input={}, reasoning="read Cloud Mail guidance")`.
 
-| Registry name | Historical distribution | Module name        |
-|---------------|-------------------------|--------------------|
-| `imap`        | formerly `lingtai-imap`     | `lingtai.mcp_servers.imap`     |
-| `telegram`    | formerly `lingtai-telegram` | `lingtai.mcp_servers.telegram` |
-| `feishu`      | formerly `lingtai-feishu`   | `lingtai.mcp_servers.feishu`   |
-| `wechat`      | formerly `lingtai-wechat`   | `lingtai.mcp_servers.wechat`   |
-| `whatsapp`    | formerly `lingtai-whatsapp` | `lingtai.mcp_servers.whatsapp` |
-| `cloud_mail`  | (no standalone distribution) | `lingtai.mcp_servers.cloud_mail` |
+- Public-token auth from `admin_email`/`admin_password` via `/public/genToken`
+  supports read/poll/search. `user_email`/`user_password` via `/login` plus
+  `send_account_id` are optional and enable `send`; sending is a real external
+  **side effect** and is unavailable without user credentials.
+- The first poll silently seeds `<agent_dir>/cloud_mail/<alias>/watermark.json`
+  (set `notify_existing: true` to opt into existing mail). `allowed_senders` is
+  case-insensitive and filtered senders still advance the watermark. Attachments
+  are unsupported.
 
-This table is for orientation, not for `init.json`: a curated `mcp.<name>` entry does not need `["-m", "lingtai.mcp_servers.feishu"]` (or any other `args`) at all — the running kernel's own `mcp_catalog.json` supplies the module `args` for you at load time (see "MCP child processes run in their own runtime" above). The module name matters when reading `mcp_catalog.json` itself, tracing a curated child's stack trace, or writing the legacy `mcp/servers.json` route for a non-curated server. Historical distribution names are retained only for provenance and compatibility notes.
-
-## Telegram setup/readiness checklist
-
-Use this checklist as the Telegram setup acceptance test. It is intentionally separate from the generic catalog/registry steps above: a healthy registry record is not proof that the live listener is usable.
-
-1. **Confirm the live child resolves the current Telegram module.** For a curated `telegram` addon (`source` exactly `lingtai-curated`), the launch module (`-m lingtai.mcp_servers.telegram`), interpreter, and `PYTHONPATH` are derived fresh from the running kernel's own catalog at load time — see "MCP child processes run in their own runtime" above. Editing `command`/`args` in `init.json` or `mcp_registry.jsonl` for a curated entry has no effect on the actual launch; only `LINGTAI_TELEGRAM_CONFIG` (or the agent-relative equivalent) in that entry's `env` matters. If the child instead fails with `ModuleNotFoundError`, leaves the stdio child down, or surfaces to the parent as a closed MCP/closed-resource symptom, that means the running kernel's own installed source is stale or broken, not that the registry needs a module-name edit: run the one-shot provenance probe above to confirm the resolved `sys.executable` and `lingtai.mcp_servers.telegram.__file__`, then correct the kernel install/venv rather than hand-editing `init.json`/`mcp_registry.jsonl`. Do not diagnose that symptom as a Telegram token failure until the probe confirms the live module. Only a **non-curated** or legacy `mcp/servers.json` Telegram entry keeps its own literal `command`/`args` — a stale `-m lingtai_telegram` is an actual, editable bug only there.
-
-2. **Check both registry and runtime layers.** `mcp(action="info", input={}, reasoning="check registry state after addon setup")` proves only that the registry is readable and reports its records/problems. It does **not** prove that a child is mounted. After one controlled refresh or relaunch, confirm there is one live Telegram MCP child/server, the `telegram` tool is mounted, and the intended configured account is mounted; an `info` entry by itself is insufficient.
-
-3. **Separate outbound from inbound proof.** Startup `getMe` and one deliberate direct send prove only outbound Bot API reachability. They do not prove that the listener is receiving updates or that inbound events reach the host agent. Do not call the Bot API `getUpdates` yourself while the Telegram listener may own long polling; a second poller can contend for updates and invalidate the test.
-
-4. **Make one controlled lifecycle change.** After editing a sidecar or Telegram config, perform exactly one controlled `system(action="refresh")` or one controlled relaunch, then inspect the resulting child and mount. Do not start a duplicate parent. A passing readiness check requires the live Telegram MCP child/server **and** its account mounted after that single transition.
-
-5. **Prove the complete inbound/reply path.** Have an allowed-user producer send a fresh test message. Verify the producer's inbound read reaches the host (LICC inbox delivery or `telegram(action="read", chat_id=<chat-id>)`), then reply on that same channel with `telegram(action="reply", message_id=<inbound-message-id>, text=<sanitized-test-reply>)` or the equivalent channel send. An account listing, `getMe`, or an outbound send alone is not end-to-end proof.
-
-6. **Lock down the config.** The secrets directory must be mode `0700` and the Telegram config must be mode `0600`:
-
-   ```bash
-   chmod 700 .secrets
-   chmod 600 .secrets/telegram.json
-   ```
-
-   Use placeholders such as `<bot-token>`, `<allowed-user-id>`, `<chat-id>`, and `<inbound-message-id>` in examples and reports; never include real tokens, IDs, private paths, or raw logs.
-
-## Cloud Mail setup
-
-`cloud_mail` is a REST client for a self-hosted [Cloud Mail](https://github.com/maillab/cloud-mail) deployment (Cloudflare Workers). It is **not** IMAP/SMTP — it talks to Cloud Mail's HTTP API. Inbound mail is discovered by polling Cloud Mail's `POST /public/emailList` and delivered to your inbox via LICC.
-
-- **Env var:** `LINGTAI_CLOUD_MAIL_CONFIG` — path to the config JSON (resolved relative to the agent dir when not absolute).
-- **Omnibus tool:** `cloud_mail`. Its action surface is owned by the addon's own manual — `cloud_mail(action="manual")`.
-- **Auth model:** the addon mints a *public token* from `admin_email`/`admin_password` via `/public/genToken` for read/poll/search, and logs in with `user_email`/`user_password` via `/login` for `send`. If user creds are absent, read/check/search/poll still work; only `send` is disabled with a clear error.
-- **Watermark:** the first poll seeds the per-account high-water mark silently (no flood of old mail) unless `notify_existing: true`. State lives under `<agent_dir>/cloud_mail/<alias>/watermark.json`.
-
-Config schema (plaintext; copy verbatim, never commit real passwords):
+Use the provider's exact schema; a redacted shape is:
 
 ```json
-{
-  "accounts": [
-    {
-      "alias": "cloudmail",
-      "base_url": "https://mail.example.com",
-      "admin_email": "admin@example.com",
-      "admin_password": "REDACTED",
-      "user_email": "admin@example.com",
-      "user_password": "REDACTED",
-      "send_account_id": 1,
-      "allowed_senders": ["only-this@example.com"],
-      "poll_interval": 30,
-      "notify_existing": false
-    }
-  ]
-}
+{"accounts":[{"alias":"cloudmail","base_url":"https://mail.example.com","admin_email":"admin@example.com","admin_password":"REDACTED","user_email":"admin@example.com","user_password":"REDACTED","send_account_id":1,"allowed_senders":["only-this@example.com"],"poll_interval":30,"notify_existing":false}]}
 ```
 
-`user_email`/`user_password`/`send_account_id` are optional and only required for `send`. `allowed_senders` (case-insensitive) limits which inbound senders raise an inbox event; the watermark still advances for filtered senders so they never replay. Attachments are not supported in this first pass.
+## WeChat bootstrap
 
-## After it's running
+WeChat has a separate bootstrap lifecycle:
 
-Inbound events (new emails, chat messages) flow into your `.mcp_inbox/<name>/` via the LICC v1 inbox callback contract — the kernel auto-injects them into your next turn as `[system]` messages. You don't poll; the kernel does. Outbound calls go through the omnibus tool: `imap(action="send", ...)`, `telegram(action="send", ...)`, etc. Each addon owns its own action surface and side-effect rules — pull it with `<addon>(action="manual")`; this file stops at setup.
+1. Ensure the current `lingtai` runtime venv contains `lingtai-wechat-bootstrap`;
+   run it by full venv path, not by assuming it is on system `PATH`.
+2. The MCP's `LINGTAI_WECHAT_CONFIG` relative path (typically
+   `.secrets/wechat/config.json`) resolves under `LINGTAI_AGENT_DIR` first;
+   project-root paths remain a backward-compatible fallback. Prefer an
+   agent-relative bootstrap target. Bootstrap writes `config.json` and
+   `credentials.json` together—do not copy credentials manually.
+3. WSL browser opening falls back to printing an HTML path when `cmd.exe /c
+   start` and `wslview` are unavailable.
+4. After bootstrap, use the authorized System refresh above, then
+   `wechat(action="check", input={}, reasoning="verify WeChat readiness")`.
+   On `metadata.event_type: "session_expired"`, re-run bootstrap.
 
-## WeChat setup checklist
-
-WeChat has unique pitfalls that catch agents off-guard. Walk this checklist on every new WeChat setup to avoid wasting the human's time:
-
-1. **Ensure LingTai's runtime venv is current** — the `lingtai-wechat-bootstrap` script is installed by the `lingtai` wheel and lives inside the venv, not necessarily on the system PATH.
-
-2. **Run bootstrap with the full venv path.** The `LINGTAI_WECHAT_CONFIG` relative path (typically `.secrets/wechat/config.json`) resolves against `LINGTAI_AGENT_DIR` first (the agent working dir, like imap/telegram/feishu), then falls back to the project root for backward compatibility. **Preferred:** write secrets into the agent dir, e.g. from the project root:
-   ```bash
-   ~/.lingtai-tui/runtime/venv/bin/lingtai-wechat-bootstrap .lingtai/<agent>/.secrets/wechat
-   ```
-   Older setups that wrote `.secrets/wechat` at the **project root** still work via the backward-compat fallback — no migration is required (`Lingtai-AI/lingtai#336`).
-
-3. **No manual credential copy needed** — `config.json` and `credentials.json` are written together in whichever directory you point bootstrap at, and the MCP reads `credentials.json` next to `config.json`.
-
-4. **WSL users**: bootstrap auto-detects WSL and uses `cmd.exe /c start` or `wslview` to open the browser. If neither works, it prints the HTML file path for manual opening.
-
-5. **Refresh the MCP** after bootstrap writes credentials:
-   ```
-   system(action="refresh")
-   ```
-
-6. **Test the connection**:
-   ```
-   wechat(action="check")
-   ```
-
-7. **Session expiry** — WeChat sessions expire (~30 days). When expired, a LICC event with `metadata.event_type: "session_expired"` arrives. Re-run the bootstrap to re-authenticate.
+Inbound events arrive through `.mcp_inbox/<name>/` and are injected by the
+kernel; read each addon's own manual for outbound action side effects. This
+reference stops at setup and readiness.

--- a/src/lingtai/tools/mcp/skills/mcp-manual/reference/runtime-and-identity.md
+++ b/src/lingtai/tools/mcp/skills/mcp-manual/reference/runtime-and-identity.md
@@ -7,177 +7,103 @@ related_files:
 - tests/test_mcp_identity_discovery.py
 - tests/test_tool_family_mcp_migration_parity.py
 maintenance: |
-  Owns the detailed identity, installed-manual path, and runtime/venv provenance gates routed from mcp-manual; update it when identity projection, curated launcher ownership, or manual-path behavior changes.
+  Owns identity projection, installed-manual paths, launcher ownership, and venv/source provenance; update when those contracts change.
 ---
 
 # MCP identity and runtime provenance
 
-This reference owns details intentionally kept out of the model-facing schema
-and the short `mcp-manual` router. It is diagnostic guidance, not an MCP
-registration or server-management API.
+This is diagnostic guidance, not a registration or server-management API.
 
 ## Identity projection
 
 `mcp(action="info", input={}, reasoning="inspect MCP identity")` reads the
-addon-published, non-secret document
-`system/mcp_identities/<name>.json`. The document uses schema
-`lingtai.mcp.identity.v1`; it is a cached filesystem record and does not make a
-network request.
+addon-published cache `system/mcp_identities/<name>.json` (schema
+`lingtai.mcp.identity.v1`); it makes no network request. It attaches an
+`identity` block only to a matching registry record whose `accounts` list is
+non-empty. The projection allowlists account alias, provider username/ID or
+display name, bot marker, and non-secret routing counts. It drops tokens,
+passwords, app/refresh/access secrets, headers, and unknown fields. Prompt
+`<registered_mcp>` narrows it again and removes volatile `last_verified_at`.
+Missing, unrelated, or empty identity files produce no identity. Use the addon's
+`accounts` action for richer detail—never private config.
 
-An `identity` block is attached only to a matching `mcp_registry.jsonl` record
-when the identity has a non-empty `accounts` list. The `info` projection
-allowlists the account alias, provider username/ID/display name, bot marker,
-and non-secret routing counts. It drops tokens, passwords, app secrets,
-refresh/access tokens, headers, and unknown fields. The prompt's
-`<registered_mcp>` XML narrows the projection again and excludes volatile
-`last_verified_at` so prompt content remains cache-stable. A missing, unrelated,
-or empty identity record produces no `identity` member. For richer account
-information, use the addon's own `accounts` action; never read private config as
-a shortcut.
-
-## Manual and public-path gate
+## Installed manual and public paths
 
 The reserved `manual` action reads exactly the installed
-`.library/intrinsic/capabilities/mcp/SKILL.md` below the granted agent workdir.
-It performs no registry scan, identity read, rescan, or mutation. Its public
-result is the existing flat shape:
+`.library/intrinsic/capabilities/mcp/SKILL.md` below the agent workdir and does
+no registry/identity I/O or mutation. Its flat public result is:
 
 ```json
 {"status":"ok","mcp_manual":"<full body>","manual_path":"<host-local path>"}
 ```
 
-A missing skill returns `status: "degraded"`, an empty `mcp_manual`, the
-truthful host-local `manual_path`, and an error; it never falls back to another
-manual. `manual_path` and `registry_path` are diagnostic host-local values, not
-configuration inputs or proof of an active child. Do not copy private absolute
-paths into public docs, and do not infer a server's activation from either path.
+When missing, it returns `status: "degraded"`, an empty body, the truthful path,
+and an error; it never falls back to another manual. `manual_path` and
+`registry_path` are diagnostic host-local values, never config inputs or proof
+that a child is active. Do not publish private absolute paths.
 
-## Curated versus non-curated child ownership
+## Who owns a child's launch
 
-A curated addon activated through `init.json`'s `mcp.<name>` entry is owned by
-the running kernel's own `mcp_catalog.json`. That catalog derives the stdio
-type, the running Agent's `sys.executable`, the module args, and the child's
-entire `PYTHONPATH` from the Agent's current imported source root. The curated
-entry's non-launch `env` (for example `LINGTAI_IMAP_CONFIG`) passes through;
-legacy `type`/`command`/`args`/`env.PYTHONPATH` fields are accepted for
-read-compatibility but ignored for launch with one bounded warning. If the
-catalog has no safe stdio launcher, do not fall back to those legacy fields.
+| Route | Effective owner |
+|---|---|
+| Curated addon in main-agent `init.json` (`source == "lingtai-curated"`) | Running kernel `mcp_catalog.json`: Agent `sys.executable`, catalog module args, and Agent source-root `PYTHONPATH`; only non-launch account `env` passes through. |
+| Non-curated `init.json` entry | That entry's effective `type`/`command`/`args`/`env`. |
+| Legacy `mcp/servers.json` | Its direct activation spec. |
+| Daemon task/plugin MCP | That task/plugin's config, never the main registry. |
+| HTTP | No local subprocess or interpreter. |
 
-A non-curated third-party `init.json` entry and the legacy
-`mcp/servers.json` route own their own `type`/`command`/`args`/`env` activation
-spec. Daemon task/plugin MCPs are a separate route owned by that task or
-plugin's configuration; they never spawn from `mcp_registry.jsonl` or the
-main-agent `init.json` entry. HTTP entries have no local interpreter. Never
-assume that a child shares the main Agent's interpreter, site-packages, source
-root, or environment unless the effective provenance is checked.
+For curated entries, legacy `type`/`command`/`args`/`env.PYTHONPATH` are accepted
+for compatibility, ignored for launch with one bounded warning, and never used as
+a fallback if the catalog lacks a safe stdio launcher. Never assume a
+third-party, legacy, daemon, or plugin child shares the Agent's interpreter,
+site-packages, source root, or environment.
 
 ## Authorized venv swap and registry truth
 
-A venv swap never rewrites the registry automatically. After an authorized
-swap, reconcile canonical curated records explicitly with the **new** runtime
-interpreter. There is no kernel helper: use an authorized `shell` call (or an
-equivalent reviewed `file.write`/`file.edit` operation). This self-contained
-recipe is fail-closed, atomic, order-preserving, and never appends records:
+A venv swap does not reconcile `mcp_registry.jsonl` automatically. Rewriting its
+curated command is optional metadata reconciliation, not required for curated
+main-agent spawning (the running kernel owns that launcher). Only after
+inspecting MCP `info` and obtaining explicit registry-write
+authorization, run the operation under the **new** absolute interpreter with an
+absolute agent directory. Use this fail-closed, atomic, order-preserving,
+non-appending procedure:
 
-```bash
-NEW_PYTHON=/absolute/path/to/new/venv/bin/python
-AGENT_DIR=/absolute/path/to/agent/dir
+1. Confirm the registry exists and call the shared `read_registry(agent_dir)`.
+   If it reports any invalid or duplicate line, report only its line number
+   and a sanitized reason; never print the `raw` field or whole problems list.
+   Abort before writing. Error strings may also quote unsafe input.
+2. Preserve every line and its ending. For each first-seen record whose
+   `source` is exactly `lingtai-curated`, set only `command` to the new process's
+   `sys.executable`; do not append records or alter independent-interpreter
+   overrides. If nothing changed, write nothing.
+3. If changed, create a temporary file in the registry's directory, write the
+   preserved lines with `ensure_ascii=False`, flush and `fsync`, copy the old
+   mode, then `os.replace` it. On any error, remove only the temporary file and
+   re-raise. Before replacement the original remains unchanged; after replacement,
+   an error does not prove rollback. Preserve evidence and inspect the outcome
+   before retrying, rather than promising the old file is still authoritative.
 
-"$NEW_PYTHON" - "$AGENT_DIR" <<'PY'
-import json, os, sys, tempfile
-from pathlib import Path
-
-agent_dir = Path(sys.argv[1])
-if not agent_dir.is_absolute():
-    raise SystemExit("AGENT_DIR must be an absolute path")
-registry = agent_dir / "mcp_registry.jsonl"
-print(f"target registry: {registry}")
-print(f"interpreter: {sys.executable}")
-if not registry.is_file():
-    raise SystemExit(f"no registry at {registry}")
-
-from lingtai.services.mcp_registry import read_registry
-_valid, problems = read_registry(agent_dir)
-if problems:
-    for problem in problems:
-        print(f"problem line {problem['line']}: {problem['error']}")
-    raise SystemExit("registry has problems; aborting without writing")
-
-lines = registry.read_text(encoding="utf-8").splitlines(keepends=True)
-seen: set[str] = set()
-changed: list[str] = []
-for index, raw in enumerate(lines):
-    if not raw.strip():
-        continue
-    try:
-        record = json.loads(raw)
-    except json.JSONDecodeError:
-        continue  # defensive; the preflight already rejected invalid lines
-    name = record.get("name")
-    if not name or name in seen:
-        continue
-    seen.add(name)
-    if record.get("source") == "lingtai-curated" and record.get("command") != sys.executable:
-        record["command"] = sys.executable
-        ending = "\n" if raw.endswith("\n") else ""
-        lines[index] = json.dumps(record, ensure_ascii=False) + ending
-        changed.append(name)
-
-if changed:
-    fd, temporary = tempfile.mkstemp(
-        dir=str(registry.parent), prefix=".mcp_registry.jsonl.", suffix=".tmp"
-    )
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as handle:
-            handle.write("".join(lines))
-            handle.flush()
-            os.fsync(handle.fileno())
-        os.chmod(temporary, registry.stat().st_mode & 0o777)
-        os.replace(temporary, registry)
-    except BaseException:
-        try:
-            os.unlink(temporary)
-        except OSError:
-            pass
-        raise
-    print(
-        f"reconciled {len(changed)} curated command(s): "
-        f"{', '.join(changed)} -> {sys.executable}"
-    )
-else:
-    print("no curated command needed reconciling")
-PY
-```
-
-Run it only after inspecting `mcp(action="info")` and obtaining explicit
-registry-write authorization. It rewrites every canonical `lingtai-curated`
-record whose stored `command` differs, and aborts before writing if
-`read_registry()` reports any invalid or duplicate line. An intentional
-independent-interpreter override must be excluded or left unreconciled.
-
-This changes durable registry truth only. It is not activation and is never the
-spawn source for a non-curated, legacy, daemon-launched, or plugin-launched
-child. A curated main-agent child still derives `type`, `command`, `args`, and
-its entire `PYTHONPATH` from the running kernel's own catalog and runtime, not
-from stored registry or `init.json` launch fields. A healthy curated child picks
-up a new venv only after a full Agent relaunch: `refresh` retries failed children
-but does not restart healthy ones. Apply the provenance gate below before
-claiming the swap is live.
+This rewrites durable registry truth only. It is never the spawn source for
+non-curated, legacy, daemon, or plugin children, and has no effect on HTTP. A
+curated main-agent child still derives launcher, args, and `PYTHONPATH` from the
+running kernel catalog/runtime. A changed curated runtime must be verified after the Agent relaunch.
+The internal `_retry_failed_mcps` hook skips healthy clients and uses captured
+launch specs. The public System refresh invokes that hook **then requests a
+full Agent relaunch**; it does not promise healthy children survive unchanged.
+A refresh receipt is handoff intent, not proof the new process/child is ready.
 
 ## Fail-closed provenance check
 
-After a venv or source change, run one one-shot probe using the child's
-**effective** command and environment. It must print and compare:
+After a venv or source change, probe the child's **effective** command and
+environment and compare all three paths:
 
 - `sys.executable`;
 - `lingtai.__file__`; and
 - `lingtai.mcp_servers.<name>.__file__`.
 
-For a curated main-agent entry, effective means the Agent's own interpreter,
-its catalog-derived module args, and its own source root as the child's entire
-`PYTHONPATH`—never strings stored in `init.json` or the registry. For a
-non-curated/legacy child, use that entry's configured command and environment;
-for a daemon child, use its task/plugin configuration. If the probe still
-resolves the old venv or source, the gate fails: report **requires relaunch**
-and do not claim the change is live. Process inspection alone is corroboration,
-not proof of imported module provenance.
+For curated main-agent MCPs, effective means the Agent's own interpreter,
+catalog-derived module args, and current source root; never use launcher strings
+stored in `init.json` or the registry. For non-curated/legacy use that entry's
+command and env; for a daemon use its task/plugin config. If any path still
+resolves the old venv/source, report **requires relaunch** and do not claim the
+change is live. Process inspection such as `lsof` is only corroboration.

--- a/src/lingtai/tools/mcp/skills/mcp-manual/reference/third-party-and-legacy.md
+++ b/src/lingtai/tools/mcp/skills/mcp-manual/reference/third-party-and-legacy.md
@@ -2,89 +2,83 @@
 related_files:
 - src/lingtai/tools/mcp/skills/mcp-manual/SKILL.md
 maintenance: |
-  Third-party/legacy MCP wiring reference routed to from mcp/skills/mcp-manual/SKILL.md; update it whenever the npx/uvx/HTTP server wiring path or the legacy mcp/servers.json mechanism changes.
+  Owns third-party and legacy MCP wiring; update when registry, mcp/servers.json, transport fields, or secret handling changes.
 ---
 
 # Third-party and legacy MCP routes
 
-Two routes for non-curated MCPs: the **registry route** (recommended, gated by `mcp_registry.jsonl`) and the **legacy `mcp/servers.json` route** (ungated, kept for quick experiments).
+Non-curated servers have two routes: the **registry route** (recommended,
+gated by `mcp_registry.jsonl`) and legacy `<working_dir>/mcp/servers.json`
+(ungated, useful for a short experiment). Neither route grants permission to
+install, configure, or disclose credentials.
 
 ## Registry route (recommended)
 
-For any non-curated MCP — typically `npx`/`uvx`-launched servers from the broader MCP ecosystem.
+1. Read the server README first. Use the top-level [README gate](../SKILL.md#readme-gate):
+   `find_readme.py` for an installed Python package, otherwise Web `browse` on the
+   public server homepage. Obtain the exact install command, env vars, and schema.
+2. With explicit human authorization, append one valid JSON record atomically to
+   `mcp_registry.jsonl`, preserving existing lines. Registry records use
+   **`transport`**, not the activation field `type` shown below.
+3. Add its `init.json` `mcp.<name>` activation entry.
+4. Run one authorized System refresh (the complete envelope is in
+   [curated setup](curated-addons.md#the-four-step-setup)), then MCP `info` and
+   verify the relaunched child/tool separately. A registry record is not active proof.
 
-1. **Fetch the MCP's setup doc.** If it's pip-installed, use the bundled
-   `find_readme.py` script; otherwise (npx/uvx servers) `web_read` the homepage
-   URL. Both routes use the top-level [README gate](../SKILL.md#readme-gate). Either way, get
-   the install command, env vars, and config schema before writing any config.
-2. Append a single JSON record to `mcp_registry.jsonl` (one line, atomic write). For the schema, see `lingtai-kernel-anatomy reference/file-formats.md` §6.5.
-3. Add an `init.json` `mcp.<name>` activation entry.
-4. Run `system(action="refresh")`.
+A minimal **registry line** (replace the placeholders from the README):
 
-Benefits: gives you the `<homepage>` field used by the top-level [README gate](../SKILL.md#readme-gate) as its fallback URL, allow-listing, and registry health diagnostics via `mcp(action="info", input={}, reasoning="check registry health")`.
+```json
+{"name":"example","summary":"Example MCP server","transport":"stdio","command":"npx","args":["-y","<server-package>"],"source":"third-party","homepage":"https://example.invalid"}
+```
 
-## Legacy `mcp/servers.json` route
+Required fields: `name` matches `^[a-z][a-z0-9_-]{0,30}$`; `summary` is nonempty
+and at most 200 characters; `source` is nonempty; `transport` is `stdio` or
+`http`. Stdio requires string `command`, with optional string-list `args`;
+HTTP requires string `url`. Optional `homepage` is a nonempty string.
+Do not use `source: "lingtai-curated"` for a third-party launcher.
 
-A second route still exists: `<working_dir>/mcp/servers.json`. The kernel loads it on startup with no registry validation — useful for quick experiments or for personal MCPs you don't want to register globally. Same JSON shape as the registry route, but mounted directly without the catalog → registry → active promotion.
+The separate `init.json` `mcp.example` value uses the **activation** shape in
+the next section (`type`, command/args/env or URL/headers). Registry contents do
+not supply that third-party launch configuration. The registry gates membership
+and supplies homepage/diagnostics; manual/info remain read-only.
+
+## Legacy `mcp/servers.json`
+
+This file is loaded directly at startup without registry validation or the
+catalog → registry → active promotion. Use it only when intentionally wiring a
+single short-lived server; use the registry route for anything to keep. Copy the
+server's documented shape, never invent fields:
 
 ```json
 {
   "vision": {
     "type": "stdio",
     "command": "npx",
-    "args": ["-y", "@z_ai/mcp-server"],
-    "env": {
-      "Z_AI_API_KEY": "your-key",
-      "Z_AI_MODE": "ZAI"
-    }
+    "args": ["-y", "<server-package>"],
+    "env": {"<KEY>": "<secret-from-approved-source>"}
   },
-  "web-search": {
+  "remote": {
     "type": "http",
-    "url": "https://api.z.ai/api/mcp/web_search_prime/mcp",
-    "headers": {
-      "Authorization": "Bearer your-key"
-    }
+    "url": "https://example.invalid/mcp",
+    "headers": {"Authorization": "Bearer <approved-key>"}
   }
 }
 ```
 
-MiniMax's own `web_search` tool wires the same way, as a stdio server:
+## Common fields
 
-```json
-{
-  "minimax-web-search": {
-    "type": "stdio",
-    "command": "npx",
-    "args": ["-y", "minimax-coding-plan-mcp"],
-    "env": {
-      "MINIMAX_API_KEY": "your-key"
-    }
-  }
-}
-```
+| Field | stdio | http |
+|---|---|---|
+| `type` | `"stdio"` (default) | `"http"` (required) |
+| `command`, `args` | executable and arguments | not applicable |
+| `env` | subprocess environment | not applicable |
+| `url`, `headers` | not applicable | endpoint and HTTP headers, often auth |
 
-Use the registry route for anything you want to keep. Use `mcp/servers.json` when you just want to wire up a single server quickly.
+## Credentials
 
-MiniMax and Zhipu's own search results are no longer available through the
-built-in `web` capability's `search` action; wire either MCP server through
-one of the two routes above and call its `web_search`/`web_search_prime` tool
-directly.
-
-## Server config fields (both routes)
-
-| Field      | stdio                       | http                              |
-|------------|-----------------------------|-----------------------------------|
-| `type`     | `"stdio"` (default)         | `"http"` (required)               |
-| `command`  | executable (e.g. `npx`)     | —                                 |
-| `args`     | command-line arguments      | —                                 |
-| `env`      | env vars for the subprocess | —                                 |
-| `url`      | —                           | streamable-http endpoint          |
-| `headers`  | —                           | HTTP headers (typically auth)     |
-
-## API keys and secrets
-
-Plaintext credentials in `mcp_registry.jsonl` or `mcp/servers.json` are the simplest path. For sensitive keys:
-
-- **stdio servers**: env vars in the `env` field referencing values from `.env` (the agent's `env_file`). Some servers, including curated integrations such as `imap`, require literal credentials in a separate config file pointed at by an env var — see the relevant setup docs before writing secrets.
-- **http servers**: keys go in the `headers` field (typically `Authorization: Bearer ...`).
-- Never commit `mcp/servers.json` or addon config files to version control if they contain secrets.
+Prefer the agent's approved env-file mechanism for stdio values when the server
+supports it; some addons require literal credentials in a separate config file
+pointed to by an env var. HTTP credentials belong in the documented `headers`
+shape, usually `Authorization: Bearer <key>`. Read the server README for its
+actual contract. Never commit `mcp/servers.json`, addon configs, or plaintext
+credentials.

--- a/src/lingtai/tools/mcp/skills/mcp-manual/reference/troubleshooting.md
+++ b/src/lingtai/tools/mcp/skills/mcp-manual/reference/troubleshooting.md
@@ -3,53 +3,61 @@ related_files:
 - src/lingtai/tools/mcp/skills/mcp-manual/SKILL.md
 - src/lingtai/tools/mcp/skills/mcp-manual/reference/curated-addons.md
 maintenance: |
-  MCP troubleshooting reference routed to from mcp/skills/mcp-manual/SKILL.md and cross-linking curated-addons.md; update it as new boot-error patterns or update/deregister flows are discovered.
+  Owns MCP update, deregistration, diagnostics, and recovery routing; update when boot failures or lifecycle semantics change.
 ---
 
 # MCP troubleshooting
 
-## Updating, deregistering
+Before an update, deregistration, or diagnosis, read the applicable setup README,
+obtain explicit human authorization for edits, and call `mcp(action="info", input={}, reasoning="inspect registry and problems")`.
+The snapshot includes registry contents, invalid-line/config problems, path,
+counts, and status. `info` reads afresh without changing registry/config.
+Problems may include raw invalid lines or quoted input: disclose only line
+numbers and sanitized reasons, never the whole list, raw logs or credentials.
 
-- **Update**: edit the matching line in `mcp_registry.jsonl` in place. Same schema. Then `system(action="refresh")`.
-- **Deregister**: remove the matching line. Note: this does NOT stop a running MCP — to deactivate, also remove the entry from `init.json`'s `mcp` section.
+## Update and deregister
 
-## Diagnosing problems
+- **Update:** edit the matching `mcp_registry.jsonl` record in place, preserving
+  its schema; apply one authorized System refresh using the
+  [setup envelope](curated-addons.md#the-four-step-setup); call `info` again.
+  For non-curated launcher changes, edit the activation owner too; a registry
+  command alone is not the active launch spec.
+- **Deregister:** remove the matching registry line. This does **not** stop a
+  running child. For a curated addon remove its `addons` name as well, or boot
+  can register it again. Remove the matching activation from its actual owner
+  (`init.json` `mcp` or legacy `mcp/servers.json`), then request one authorized
+  refresh and verify the child is gone. The retry hook alone does not stop it.
+  Do not delete credentials or recovery state as a substitute.
 
-Call `mcp(action="info", input={}, reasoning="diagnose MCP registry problems")` to see:
-- The current registry contents
-- The `problems` list (invalid registry lines, missing config, etc.)
-- A runtime health snapshot (registry path, count, status per server)
+Invalid registry lines may be skipped with a refresh warning, so always verify
+with a fresh `info`. Never treat registry membership as active proof.
 
-Invalid registry lines are skipped silently with a warning at refresh time, so always verify with `mcp(action="info", input={}, reasoning="verify the registry after editing")` after editing.
+## Common failures
 
-## Common boot failures
+- **Cryptic `KeyError`:** a required config field is missing. Re-read
+  `curated-addons.md` for curated servers or the exact third-party README; copy
+  exact names (`email_password`, not `password`; `bot_token`, not `token`).
+- **Start failure / command not found:** for non-curated entries, check the
+  configured executable/venv or `npx`/`uvx` on `PATH`. Curated entries never read
+  `init.json` `command`/`args`/`type`; probe the running kernel catalog/runtime
+  instead—editing those legacy fields cannot fix it. HTTP has no local command.
+- **Tools absent:** after authorized config edit, make one controlled refresh (or
+  one relaunch), then call `info` and verify the live mount. Do not start a
+  duplicate parent.
+- **HTTP 401/403:** check the README's exact `headers` key and auth format; do
+  not paste a key into a report.
+- **Boots but calls say manager not initialized:** inspect the agent's stderr or
+  `logs/agent.log` for the underlying config/path error, fix through the owning
+  route, and refresh.
+- **Curated module/closed-resource symptom:** first run the effective provenance
+  probe in [runtime-and-identity](runtime-and-identity.md). Do not diagnose a
+  token failure until the live interpreter and module are confirmed.
 
-**Boot failure with cryptic `KeyError`**
-The MCP subprocess hit a missing config field. The error message *is* the missing field name. For kernel-curated addons, first re-read `curated-addons.md`, then use the catalog homepage for deep provider docs if needed. For third-party Python MCPs, fetch the server README (see §When in doubt, step 1).
+## When uncertain
 
-Check the exact field name spelling — `email_password` not `password`, `bot_token` not `token`, etc. This is the single most common failure mode and the docs always have the correct field name.
-
-**`MCP server failed to start` / "command not found"**
-For a **non-curated** third-party entry, the `command` path in your `init.json` `mcp.<name>` entry doesn't have the executable — for Python servers, confirm the venv path is correct; for `npx`/`uvx` servers, confirm those tools are on `PATH`. A **kernel-curated** addon (`source == "lingtai-curated"`) never reads `command`/`args`/`type` from `init.json` at all — the running kernel's own `mcp_catalog.json` derives the whole launcher, so editing or "fixing" that field in `init.json` has no effect; see `curated-addons.md` "MCP child processes run in their own runtime". A curated addon that still fails to start is a kernel/environment problem (e.g. the registered name is missing from the current `mcp_catalog.json` — check the agent log for a "no stdio entry for it" warning), not an `init.json` field to edit.
-
-**Tools not appearing in your tool surface**
-You forgot to `system(action="refresh")` after editing config. Refresh and re-check `mcp(action="info", input={}, reasoning="confirm the refreshed registry")`.
-
-**HTTP 401 / 403 from an http-type server**
-API key missing or malformed in the `headers` field. Format is usually `"Authorization": "Bearer <key>"`. Check the MCP's README for the exact header name and value format.
-
-**Server boots but tool calls fail with "MCP manager not initialized" or similar**
-Eager-start failed silently. Check the agent's stderr / `logs/agent.log` for the underlying exception. Usually a config field missing or wrong path. Fix and refresh.
-
-## When in doubt
-
-1. Read the relevant docs — `curated-addons.md` for kernel-curated addons, or a
-   third-party README via the bundled script (`<pkg-name>` is the installed
-   distribution name; use the runtime venv's Python):
-   ```bash
-   ~/.lingtai-tui/runtime/venv/bin/python3 \
-     .library/intrinsic/capabilities/mcp/scripts/find_readme.py <pkg-name>
-   ```
-2. `mcp(action="info", input={}, reasoning="inspect registry and problems")` to see registry + problems.
-3. Tail `logs/agent.log` for the actual error message.
-4. Re-read the setup/troubleshooting section — most MCP docs document common errors with exact symptom strings.
+1. Read the curated route or third-party README (local `find_readme.py`, then
+   public `<homepage>` with Web `browse`).
+2. Call `mcp(action="info", input={}, reasoning="verify MCP registry health")`.
+3. Inspect the actual error in `logs/agent.log` without exposing secrets.
+4. If the remedy changes registry/config, stop until explicit authorization is
+   present; then perform one edit, one refresh, and one verification.

--- a/src/lingtai/tools/mcp/skills/mcp-manual/scripts/find_readme.py
+++ b/src/lingtai/tools/mcp/skills/mcp-manual/scripts/find_readme.py
@@ -1,25 +1,11 @@
 #!/usr/bin/env python3
-"""Find and print the locally-installed README for an MCP server's Python package.
+"""Print an installed MCP package README, preferring editable source then wheel
+``METADATA``. Exit 2 means no local README; use the registry homepage with
+Web ``browse``. The README is authoritative for install, config fields, env vars,
+and troubleshooting; this utility performs no installation or network access.
 
-Usage:
-    python3 find_readme.py <pkg-name>          # e.g. some-mcp-package
-    python3 find_readme.py --module <modname>  # e.g. some_mcp_server (resolves to dist)
-
-Resolution order:
-    1. Editable install     -> repo's README.md / .rst / .txt on disk
-    2. PyPI / wheel install -> README embedded in dist-info METADATA (PEP 566)
-    3. Neither found        -> exit 2 with a hint to fall back to homepage URL
-
-Exit codes:
-    0  README printed to stdout (source label printed to stderr)
-    1  argument error
-    2  README not found locally; fall back to homepage <web_read>
-
-Why this exists:
-    MCP server READMEs are the canonical install / config / troubleshooting
-    docs (config field names, env vars, error meanings). Reading the local
-    copy is faster, version-accurate, and works offline -- preferred over
-    fetching the homepage URL with web_read.
+Usage: ``find_readme.py <distribution>`` or
+``find_readme.py --module <importable-module>``.
 """
 from __future__ import annotations
 
@@ -31,13 +17,7 @@ import importlib.metadata as md
 
 
 def _find_editable_readme(dist: md.Distribution) -> tuple[str, str] | None:
-    """If `dist` is an editable install, return (content, source-label) for its
-    on-disk README. Otherwise return None.
-
-    Editable installs (`pip install -e <path>`) write a PEP 610 `direct_url.json`
-    into dist-info with `dir_info.editable: true` and a `file://` URL pointing
-    at the source repo.
-    """
+    """Return an editable-install README and its source label, or ``None``."""
     try:
         durl_text = dist.read_text("direct_url.json")
     except (FileNotFoundError, OSError):
@@ -65,13 +45,7 @@ def _find_editable_readme(dist: md.Distribution) -> tuple[str, str] | None:
 
 
 def _find_metadata_readme(dist: md.Distribution, pkg_name: str) -> tuple[str, str] | None:
-    """Return the README embedded in the wheel's METADATA file (PEP 566), or None.
-
-    Modern build backends (setuptools >= 61, hatchling, pdm, poetry) embed the
-    package's README into METADATA's Description field when `pyproject.toml`
-    declares `readme = "README.md"`. This survives PyPI publish -> pip install
-    so non-editable users get the same docs.
-    """
+    """Return the wheel ``METADATA`` README, or ``None``."""
     meta = dist.metadata
     body: str | None = None
     if hasattr(meta, "get_payload"):
@@ -92,12 +66,7 @@ def _find_metadata_readme(dist: md.Distribution, pkg_name: str) -> tuple[str, st
 
 
 def find_readme(pkg_name: str) -> tuple[str | None, str]:
-    """Return (content, source-label-or-error) for `pkg_name`.
-
-    Tries editable repo first, then dist-info METADATA. content is None when
-    neither path yields a README; in that case the second element describes
-    the failure reason for stderr.
-    """
+    """Return ``(content, source-or-error)`` using local README sources only."""
     try:
         dist = md.distribution(pkg_name)
     except md.PackageNotFoundError:
@@ -115,15 +84,7 @@ def find_readme(pkg_name: str) -> tuple[str | None, str]:
 
 
 def _resolve_module_to_dist(module_name: str) -> str | None:
-    """Map an importable module name (e.g. `some_mcp_server`) to its owning
-    distribution name. Returns None if no install can be located.
-
-    Tries `packages_distributions()` first (works for normal wheels via
-    `top_level.txt`), then falls back to the standard underscore-to-hyphen
-    convention -- editable installs via `.pth` files don't always populate
-    `packages_distributions`, but their distribution name is usually the
-    obvious transform of the module name.
-    """
+    """Resolve an importable module to its installed distribution, if any."""
     try:
         dists = md.packages_distributions().get(module_name, [])
     except Exception:

--- a/tests/test_mcp_settings.py
+++ b/tests/test_mcp_settings.py
@@ -162,3 +162,37 @@ def test_real_agent_starts_mounts_settings_and_builds_complete_prompt(tmp_path):
         assert "prompt-private-marker" not in complete_prompt
     finally:
         agent.stop(timeout=1.0)
+
+
+def test_manual_registry_example_is_a_valid_record_not_an_activation_spec():
+    import re
+    from lingtai.services.mcp_registry import validate_record
+
+    root = Path(__file__).parents[1] / "src/lingtai/tools/mcp/skills/mcp-manual"
+    text = (root / "reference/third-party-and-legacy.md").read_text()
+    blocks = re.findall(r"```json\n(.*?)\n```", text, re.S)
+    records = [json.loads(block) for block in blocks if '"transport"' in block]
+    assert records, "Registry setup needs an actual transport-based record"
+    for record in records:
+        assert validate_record(record) == (True, None)
+    assert '"type"' in text, "Keep the separate activation format"
+
+
+def test_manual_distinguishes_retry_hook_from_public_refresh_relaunch():
+    root = Path(__file__).parents[1] / "src/lingtai/tools/mcp/skills/mcp-manual"
+    text = (root / "reference/runtime-and-identity.md").read_text()
+    assert "_retry_failed_mcps" in text
+    assert "public System refresh" in text
+    assert "relaunch" in text
+    assert "does not restart healthy ones" not in text
+
+
+def test_manual_problem_reporting_does_not_recommend_raw_registry_disclosure():
+    root = Path(__file__).parents[1] / "src/lingtai/tools/mcp/skills/mcp-manual"
+    runtime = (root / "reference/runtime-and-identity.md").read_text()
+    entry = (root / "SKILL.md").read_text()
+    assert "sanitized reason" in runtime
+    assert "`raw`" in runtime and "never print" in runtime
+    assert "print the problems" not in runtime
+    assert "web_read" not in entry
+    assert "skills-manual" in entry


### PR DESCRIPTION
## Summary
- MCP-only manual reduction: 8 files, 429 insertions / 637 deletions; five manuals, module descriptions, README-helper docstrings and three direct documentation regressions. Runtime logic, configuration schema, inputs/results, Contract and dependencies unchanged.
- Entry body 8,313 → 4,794 (−42.3%); five bodies 41,375 → 23,610 (−42.9%). Schema descriptions unchanged at 584 chars; family 522 → 489 (combined −33). Module docstring −2,167 is **not** counted as resident savings; no token/cost claim.
- Distinguish internal failed-child retry from public System refresh, which subsequently requests Agent relaunch. Handoff receipt is not live readiness.
- Provide a valid registry `transport` example separate from activation `type`; preserve curated catalog/interpreter/source ownership, independent third-party/legacy/task launchers and HTTP boundaries. Deregistration also removes curated addons declaration to avoid boot re-registration.
- Fix invalid flat examples and README/installed reference routes. Preserve Telegram one-poller and inbound proof, Cloud Mail watermark, WeChat bootstrap, exact two-row SHOW, explicit authorization and protected cleanup.
- Stop recommending raw diagnostic disclosure: existing info problems may include raw invalid lines/quoted input. Demonstrated with fake data only; new guidance permits only line number and sanitized reason. **No runtime redaction fix in this PR.**

## Validation
Exact clean base: `c8f2bb41115ef0774fd47d9ebb8024b9f8bcc6f7`.
- Changed complete file `tests/test_mcp_settings.py`: **9 passed**; three added documentation checks failed before prose correction, then passed. Two pre-existing signpost/TUI wording assertions were restored without weakening tests; final entire set rerun.
- 13 complete files via `PYTHONPATH=src python3.14 -B -m pytest -q tests/<file> ...`: candidate **270 passed / 7 failed / 1 warning**, base **267 / same 7 / 1 warning**. All seven full failure blocks identical after pytest-temporary-root normalization only.
- Files: `test_mcp_settings.py test_signpost_tool_descriptions.py test_tool_family_mcp_migration_parity.py test_mcp_builtin_plugin_package.py test_mcp_capability.py test_intrinsic_manual_actions.py test_tool_prose_section_gate.py test_tool_plugin_declaration.py test_skills.py test_prompt_catalog.py test_docs_governance.py test_architecture_documents.py test_tool_settings_contract.py`.
- Existing failures: System standalone-skill assertion; two prompt-catalog assertions; three MCP SDK import failures; existing Psyche anatomy orphan. Not counted as PASS.
- Separately attempted `test_mcp_identity_discovery.py` and `test_mcp_skill_manuals.py`: **both collection EXIT 2 on both trees**, installed MCP SDK lacks ServerRequestContext. These files did not execute; SDK untouched.
- `python3.14 -B scripts/check_docs_governance.py --check`: **400 docs + docs.yaml PASS**. Anatomy drift: six byte-identical baseline findings. `git diff --check`: PASS.
- Hermetic actual Agent/full prompt (31714 chars), one MCP mount, 5 installed manual bodies + helper byte-equal, all 9 internal links, 2 SHOW rows/anchors, fake info registry preservation/raw passthrough: PASS. Mock LLM, socket connect blocked; no real credentials or server.
- Both Python ASTs equal except reviewed docstrings/descriptions; schema equal except description. Owner reviewed all removed guidance, MCP Contract/Anatomy/MC001 and relevant real lifecycle/launch/registry/addon bodies. One original native Luna worker, no replacement worker.

## Boundaries and residuals
No full-repo/native-Windows/real external server/provider/production E2E. No runtime rollout, installation, auth/config changes or cleanup. Existing helper runtime fallback hint still says web_read; manual correctly routes Web browse, helper logic untouched. Local static HTML prepared/browser-checked, not committed. One MCP PR in authorized manual batch.

Telegram: @lingtaidev1bot | Nickname: 知微
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
