### PR TITLE
docs(psyche): simplify domain manuals and preserve source boundaries

### DIFF
--- a/src/lingtai/intrinsic_skills/lingtai-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/lingtai-manual/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: lingtai-manual
 description: |
-  Read before changing character/identity in `system/lingtai.md`, choosing forced versus self-evolve mode, or applying durable identity edits.
+  Read before changing character/identity in `system/lingtai.md`, choosing forced
+  versus self-evolve mode, or applying durable identity edits.
 version: 2.0.0
-last_changed_at: 2026-07-28T00:00:00-07:00
+last_changed_at: 2026-09-09T00:00:00Z
 related_files:
 - src/lingtai/tools/lingtai/__init__.py
 - src/lingtai/tools/lingtai/_lingtai.py
@@ -12,47 +13,43 @@ related_files:
 - src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
 - src/lingtai/tools/context/manual/SKILL.md
 maintenance: |
-  Keep the manual-only public route through psyche, generic file ownership, the no-hot-load rule, identity modes, and the context reconstruction route synchronized with code.
+  Keep the manual-only Psyche route, generic file ownership, no-hot-load rule,
+  identity modes, and context reconstruction route aligned with code.
 ---
 
 # LingTai Manual
 
-Your 灵台 is the character that distinguishes you from every other agent. Its
-durable source is `system/lingtai.md`; canonical reconstruction renders it into
-the protected `character` system-prompt section.
+LingTai (`灵台`) is the character that distinguishes this agent from others.
+Its durable source is `system/lingtai.md`; reconstruction renders it into the
+protected `character` prompt section.
 
 ## Public call
 
 ```text
-psyche(action="lingtai", input={}, reasoning="load identity guidance", summarize=false)
+psyche(action="lingtai", input={}, reasoning="load identity guidance")
 ```
 
-That is the **only** public LingTai call, and it just returns this manual. It
-performs no disk or prompt mutation. There is no update, load, or reload action
-and no compatibility alias.
+This is the only public LingTai call and only returns this manual. It performs no
+disk or prompt mutation; there is no update, load, or reload action or alias.
 
-## Change durable identity with file
+## Change durable identity
 
-Your durable identity is an ordinary file. Rewrite it with
-`file(action="write", input={"file_path": "system/lingtai.md", ...})` — carrying
-forward everything you intend to keep — or make a bounded, unambiguous change
-with `file(action="edit", ...)` on the same path. Neither hot-loads the prompt;
-apply with one `context(action="rebuild", ...)`. The full model is
-`psyche-manual` → "The one mutation model".
+Rewrite with
+`file(action="write", input={"file_path": "system/lingtai.md", "content": "..."}, reasoning="rewrite identity")`
+or make a bounded exact change with
+`file(action="edit", input={"file_path": "system/lingtai.md", "old_string": "...", "new_string": "...", "replace_all": null}, reasoning="edit identity")`.
+Preserve all character content you intend to keep when rewriting.
+Neither hot-loads the prompt; use one
+`context(action="rebuild", input={}, reasoning="apply identity change")`.
 
-## Identity modes
+- **Self-evolve:** an absent or empty **resolved** `lingtai` value (inline or
+  from `lingtai_file`) preserves and composes the self-authored file. These
+  inputs belong to top-level `init.json`, not `settings/psyche.json`.
+- **Forced:** a nonempty configured identity materializes into the file on every
+  reconstruction, so a file edit is replaced at the next rebuild, refresh, or
+  molt.
 
-- **Self-evolve:** configured `lingtai`/`lingtai_file` is absent or empty.
-  Reconstruction preserves and composes your self-authored
-  `system/lingtai.md`.
-- **Forced:** configuration resolves to a nonempty identity. Every
-  reconstruction materializes that configured value into `system/lingtai.md`
-  before composing it, so a file change is replaced at the next rebuild,
-  refresh, or molt.
-
-Keep character separate from operator `covenant`, third-party `base_prompt`,
-and mechanical name/manifest `identity`. Names remain
-`system(action="name_set"|"name_nickname")`.
-
-Before molt, tend identity once when the task's lessons genuinely changed who
-you are; use `context-manual` for the journal/summary/molt procedure.
+Keep character separate from operator `covenant`, third-party `base_prompt`, and
+mechanical `identity`; names remain `system(action="name_set"|"name_nickname")`.
+Before molt, update identity only when the task's lessons genuinely changed who
+you are, then use `context-manual` for the journal/summary/molt procedure.

--- a/src/lingtai/intrinsic_skills/pad-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/pad-manual/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: pad-manual
 description: |
-  Read before editing the living Pad, pinning references, or preparing Pad state for rebuild/molt.
+  Read before editing the living Pad, pinning references, or preparing Pad state
+  for rebuild/molt.
 version: 2.0.0
-last_changed_at: 2026-07-28T00:00:00-07:00
+last_changed_at: 2026-09-09T00:00:00Z
 related_files:
 - src/lingtai/tools/pad/__init__.py
 - src/lingtai/tools/pad/_pad.py
@@ -12,58 +13,56 @@ related_files:
 - src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
 - src/lingtai/tools/context/manual/SKILL.md
 maintenance: |
-  Keep the manual-only public route through psyche, generic file ownership of both durable sources, the no-hot-load rule, delayed activation, and the context-manual route synchronized with code. Pad exposes no mutating action.
+  Keep the manual-only Psyche route, generic file ownership, no-hot-load rule,
+  delayed activation, pinned-reference hazards, and context-manual route aligned
+  with Pad code and Contract.
 ---
 
 # Pad Manual
 
-Pad is your living index in `system/pad.md`, plus a durable list of pinned
-read-only references in `system/pad_append.json`.
+Pad is the living index in `system/pad.md` plus the pinned read-only paths in
+`system/pad_append.json`.
 
 ## Public call
 
 ```text
-psyche(action="pad", input={}, reasoning="load Pad guidance", summarize=false)
+psyche(action="pad", input={}, reasoning="load Pad guidance")
 ```
 
-That is the **only** public Pad call, and it just returns this manual. Pad has no
-mutating action: both of its durable sources are ordinary files you edit with
-`file`. There is no append, edit, load, or reload action and no compatibility
-alias.
+This is the only public Pad call and only returns this manual. It has no append,
+edit, load, or reload action and no compatibility alias.
 
-## Mutate durable Pad content with file
+## Edit Pad sources
 
-Pad's durable sources are ordinary files. Rewrite with
-`file(action="write", input={"file_path": "system/pad.md", ...})`; make an exact
-replacement with `file(action="edit", ...)` on the same path. Neither hot-loads
-the prompt — apply with one `context(action="rebuild", ...)`. The full model is
-`psyche-manual` → "The one mutation model".
+Use the generic `file` owner: rewrite with
+`file(action="write", input={"file_path": "system/pad.md", "content": "..."}, reasoning="rewrite Pad")`
+or make a bounded exact change with
+`file(action="edit", input={"file_path": "system/pad.md", "old_string": "...", "new_string": "...", "replace_all": null}, reasoning="edit Pad")`.
+Neither call hot-loads the prompt. Apply one
+`context(action="rebuild", input={}, reasoning="apply Pad change")` when immediate
+activation is needed.
 
-## Pin references
+Keep Pad to current goal, state, next action, blockers, collaborators, and useful
+pointers; archive completed narrative in knowledge.
 
-The pinned list lives in `system/pad_append.json`: a JSON array of paths, each
-workdir-relative or absolute. Edit it like any other durable file —
+## Pinned references
+
+`system/pad_append.json` is an ordinary JSON array of workdir-relative or
+absolute paths. Edit it with the same full `file` envelope, for example:
 
 ```text
 file(action="write", input={"file_path": "system/pad_append.json",
   "content": "[\"notes/design.md\", \"src/api.py\"]"}, reasoning="pin references")
 ```
 
-Write `[]` to clear the list. Reconstruction reads each listed file and appends
-its contents to the Pad section as read-only reference.
+Write `[]` to clear it. File writes do not validate the pinned list or its
+aggregate size; confirm the paths and UTF-8 contents yourself. Reconstruction
+rereads every listed file and appends its
+contents to Pad, so list edits and pinned-file edits appear only after rebuild,
+refresh, or molt. A missing path is reported as `append_not_found` at compose time,
+not rejected at write time; pinned text also consumes context budget, so keep the
+list short and text-only.
 
-Reconstruction re-reads each pinned file every time, so an edit to the list —
-or to a pinned file — appears only after the next rebuild.
-
-Two things to know, because nothing validates this list for you any more: a path
-that does not exist is reported as `append_not_found` at compose time rather than
-rejected at write time, and pinned content counts against your context budget —
-keep the list short and text-only.
-
-Keep Pad concise: current goal, state, next action, blockers, collaborators, and
-pointers to substantive knowledge/artifacts. Archive completed narrative in
-knowledge, not in an ever-growing Pad. Before molt, make durable Pad state
-accurate, rebuild only if needed in the current context, then follow
-`context-manual` for the journal/summary/molt procedure.
-
-Results are short; leave root `summarize` false.
+Before molt, make durable Pad state accurate, rebuild only if needed in the
+current context, then follow `context-manual` for journal/summary/molt procedure.
+Leave root `summarize` false for exact guidance.

--- a/src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: psyche-manual
-last_changed_at: 2026-09-06T00:00:00Z
+last_changed_at: 2026-09-09T00:00:00Z
 description: >
-  Short routing table for the four durable domains — pad, lingtai (灵台), knowledge,
-  and skills — with one shared file-mutation/rebuild model; routes settings and the
-  separate `.rules` heartbeat signal to focused references.
+  Compact router for Psyche's four durable domains (pad, lingtai, knowledge,
+  skills), the shared file→rebuild model, redacted settings, and the separate
+  `.rules` heartbeat reference.
 related_files:
 - src/lingtai/tools/psyche/CONTRACT.md
 - src/lingtai/tools/psyche/ANATOMY.md
@@ -23,89 +23,76 @@ related_files:
 - tests/test_psyche_family.py
 - tests/test_avatar_rules.py
 maintenance: |
-  This is the psyche family's own manual, loaded by
-  `psyche(action='manual', input={}, reasoning='...')`.
-  Keep it a short router: settings and `.rules` procedures belong to the two
-  focused references below. Update it with src/lingtai/tools/psyche/{CONTRACT,ANATOMY}.md
-  when the public action inventory, durable-source ownership, or rebuild model
-  changes; keep the `.rules` signpost aligned with `avatar-manual § 9` and
-  `_check_rules_file`.
+  Keep this short router aligned with the psyche Contract/Anatomy, installed
+  domain manuals, settings anchors, and the `.rules` lifecycle signpost. Put
+  detailed procedure in the focused references rather than expanding this entry.
 ---
 
 # Psyche
 
-`psyche` is the one public root for the four durable domains that survive a molt:
-
-> pad + lingtai + knowledge + skills = psyche
+Psyche is the read-only public root for **pad + lingtai + knowledge + skills**.
+Routine schema-sufficient calls may go directly to their action. For unfamiliar
+or consequential work, read the matching domain manual first; use this router
+only if the domain is unclear. There is no required router-then-domain double read.
 
 ## Routing table
 
-| Call | Returns | Durable source it teaches |
-|---|---|---|
-| `psyche(action="pad", input={}, reasoning="load Pad guidance")` | `pad-manual` | `system/pad.md` and pinned Pad references |
-| `psyche(action="lingtai", input={}, reasoning="load identity guidance")` | `lingtai-manual` | `system/lingtai.md` (灵台 / character) |
-| `psyche(action="knowledge", input={}, reasoning="load knowledge guidance")` | the knowledge manual | `knowledge/<name>/KNOWLEDGE.md` entries |
-| `psyche(action="skills", input={}, reasoning="load skills guidance")` | the skills manual | `.library/{intrinsic,custom}/` and configured skill paths |
-| `psyche(action="settings", input={}, reasoning="inspect Psyche settings")` | a fully redacted settings view | Psyche's owner inputs and applied snapshot |
-| `psyche(action="manual", input={}, reasoning="load the routing table")` | this router | — |
+| Call (strict `input={}`) | Returns / owner |
+|---|---|
+| `psyche(action="pad", input={}, reasoning="load Pad guidance")` | Pad manual: `system/pad.md`, `system/pad_append.json` |
+| `psyche(action="lingtai", input={}, reasoning="load identity guidance")` | LingTai manual: `system/lingtai.md` |
+| `psyche(action="knowledge", input={}, reasoning="load knowledge guidance")` | Knowledge manual: `knowledge/<name>/KNOWLEDGE.md` |
+| `psyche(action="skills", input={}, reasoning="load skills guidance")` | Skills manual: `.library/{intrinsic,custom}/` and configured paths |
+| `psyche(action="settings", input={}, reasoning="inspect Psyche settings")` | redacted settings SHOW |
+| `psyche(action="manual", input={}, reasoning="load the routing table")` | this router |
 
-All six calls use strict empty `input` (`input={}`); any key is rejected before dispatch.
-Every action is read-only. For an unfamiliar domain, call manual first; the
-returned domain manuals own the detailed procedure.
+All six actions require strict empty `input` and are read-only: no authoring,
+editing, pinning, installing, migration, catalog rescan, or prompt reload. Keep
+root `summarize=false` when exact guidance matters.
 
 ## One mutation model
 
-`psyche` has no mutating action. To change durable content, use `file.write` for
-a full rewrite or `file.edit` for an exact replacement on the owning source, then
-apply it once with `context(action="rebuild", input={}, reasoning="apply durable changes")`.
-A file mutation never hot-loads the prompt; passive refresh or molt may apply the
-same candidate. There is no per-domain reload, and catalog setup/refresh remains
-owned by Skills or Knowledge.
+Change durable content with `file.write` (full rewrite) or `file.edit` (exact
+replacement) on its owning path, then apply one
+`context(action="rebuild", input={}, reasoning="apply durable changes")` (or let
+refresh/molt reconstruct). File mutation never hot-loads; there is no per-domain
+reload, and Skills/Knowledge retain catalog ownership.
 
-## Lifecycle ownership
+## Lifecycle and settings
 
-`psyche` owns no lifecycle action: `context` owns `molt`, `summarize`, and
-`rebuild`, while `system` owns identity/name. Full reconstruction composes the
-enabled durable sections together; domain manuals own their own catalog and
-source procedures.
-
-## Settings
-
-`psyche(action="settings", input={}, reasoning="inspect Psyche settings")` is a
-SHOW-only action with fully redacted values. Read the [settings reference](reference/settings/SKILL.md)
-for the complete owner-document contract and application procedure.
+`context` owns `molt`, `summarize`, and `rebuild`; `system` owns lifecycle
+controls and mechanical names. LingTai owns self-authored character guidance.
+`settings` is SHOW-only, fully redacted, and reports the last successful applied
+snapshot. Read [the settings reference](reference/settings/SKILL.md) for grammar,
+precedence, timing, rollback, and all eight anchors.
 
 ### Setting pad
-Owner/default/apply contract: [settings reference](reference/settings/SKILL.md#setting-pad).
+[settings reference](reference/settings/SKILL.md#setting-pad)
 
 ### Setting pad file
-Owner/default/apply contract: [settings reference](reference/settings/SKILL.md#setting-pad-file).
+[settings reference](reference/settings/SKILL.md#setting-pad-file)
 
 ### Setting base prompt
-Owner/default/apply contract: [settings reference](reference/settings/SKILL.md#setting-base-prompt).
+[settings reference](reference/settings/SKILL.md#setting-base-prompt)
 
 ### Setting base prompt file
-Owner/default/apply contract: [settings reference](reference/settings/SKILL.md#setting-base-prompt-file).
+[settings reference](reference/settings/SKILL.md#setting-base-prompt-file)
 
 ### Setting covenant
-Owner/default/apply contract: [settings reference](reference/settings/SKILL.md#setting-covenant).
+[settings reference](reference/settings/SKILL.md#setting-covenant)
 
 ### Setting covenant file
-Owner/default/apply contract: [settings reference](reference/settings/SKILL.md#setting-covenant-file).
+[settings reference](reference/settings/SKILL.md#setting-covenant-file)
 
 ### Setting comment
-Owner/default/apply contract: [settings reference](reference/settings/SKILL.md#setting-comment).
+[settings reference](reference/settings/SKILL.md#setting-comment)
 
 ### Setting comment file
-Owner/default/apply contract: [settings reference](reference/settings/SKILL.md#setting-comment-file).
+[settings reference](reference/settings/SKILL.md#setting-comment-file)
 
 ## Network rules protocol (`.rules`)
 
-`.rules` is a separate heartbeat signal, not a Psyche action or a rebuild API.
-Read the [network-rules reference](reference/network-rules/SKILL.md) before using
-that boundary.
-
-## `summarize`
-
-Use the short-result profile and leave root `summarize` `false`: manual actions
-return exact guidance, while settings returns its redacted view.
+`.rules` is a separate heartbeat signal, not a Psyche action or rebuild API. Read
+the [network-rules reference](reference/network-rules/SKILL.md) before using it;
+its atomic write, consumption, replacement, and verification hazards differ from
+ordinary file→rebuild.

--- a/src/lingtai/intrinsic_skills/psyche-manual/reference/network-rules/SKILL.md
+++ b/src/lingtai/intrinsic_skills/psyche-manual/reference/network-rules/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: psyche-network-rules-reference
-last_changed_at: 2026-09-06T00:00:00Z
+last_changed_at: 2026-09-09T00:00:00Z
 description: >
   Deep reference for the separate `.rules` heartbeat signal: authorized atomic
   writes, consumption, replacement, persistence, verification, and boundaries.
@@ -11,100 +11,51 @@ related_files:
 - src/lingtai/tools/avatar/manual/SKILL.md
 - tests/test_avatar_rules.py
 maintenance: |
-  Keep this reference synchronized with `_check_rules_file` and the Avatar
-  manual's signpost. `.rules` is not a Psyche action; preserve that boundary and
-  do not turn this reference into a generic instruction or mutation API.
+  Keep this reference synchronized with `_check_rules_file` and Avatar's
+  signpost. `.rules` is not a Psyche action; preserve its distinct mechanism,
+  consumption, and authorization boundary.
 ---
 
 # Psyche network-rules reference
 
-This page is the detailed procedure behind the short `.rules` signpost in
-[`psyche-manual`](../../SKILL.md). It documents a separate heartbeat signal, not
-an action exposed by Psyche.
+`.rules` is a heartbeat signal, not a Psyche action or generic instruction API.
+The agent heartbeat (`_check_rules_file`) consumes it, unlike ordinary durable
+edits, which require file→`context.rebuild`.
 
-## Network rules protocol (`.rules`)
+## Write and consume
 
-`.rules` is a real mechanism, but it is **not** owned by `psyche`, `avatar`, or
-any other action tool — there is no `psyche(action='rules')` and no generic
-instruction API for it. It is a plain signal file consumed by an agent's own
-heartbeat loop (`_check_rules_file` in
-`src/lingtai/kernel/base_agent/lifecycle.py`), documented here because it is
-easy to confuse with the ordinary Psyche edit-then-`context.rebuild` model
-above — the two are deliberately different mechanisms:
-
-- **Ordinary Psyche edit:** write a durable source file (`system/pad.md`,
-  `system/lingtai.md`, a `KNOWLEDGE.md`/`SKILL.md`, or the Psyche owner
-  document), then call `context(action="rebuild", ...)` (or wait for
-  refresh/molt) to recompose **all** enabled sections at once.
-- **`.rules`:** use Shell to write a `.rules` file to the explicitly authorized
-  target agent's working-directory root. Its next runnable heartbeat reads and
-  unlinks the signal before deciding whether to apply it; no explicit rebuild
-  or refresh is needed. A read or unlink failure leaves the signal unconsumed
-  and stops processing, so file disappearance alone is not proof of success.
-
-### Write through Shell
-
-First prepare the complete approved UTF-8 rule body and confirm the exact target
-path. For example, in a POSIX shell (use the active shell's equivalent elsewhere):
+Write the complete approved UTF-8 body atomically to the explicitly authorized
+agent workdir root (POSIX example; use the active shell’s equivalent elsewhere):
 
 ```sh
 target='/absolute/path/to/authorized-agent'
 body='/absolute/path/to/approved-rules.txt'
 tmp=$(mktemp "$target/.rules.XXXXXX") &&
-  cat "$body" > "$tmp" &&
-  mv "$tmp" "$target/.rules"
+  cat "$body" > "$tmp" && mv "$tmp" "$target/.rules"
 ```
 
-The temporary file is in the target directory so the final rename exposes the
-complete signal, not a partly written body. If a command fails, stop and inspect
-that exact temporary file; do not announce success or blindly replay the batch.
-For multiple agents, confirm an explicit target list and perform/report the write
-for each target. There is no automatic descendant broadcast or post-spawn fan-out.
-Do not write `system/rules.md` as a substitute for this live signal workflow.
+A failed command requires inspection of that exact temporary file; do not blindly
+replay or announce success. Confirm each target separately—there is no descendant
+broadcast. Do not substitute `system/rules.md` for this live signal.
 
-Consumption semantics, exactly as implemented:
+The next runnable heartbeat reads and unlinks `.rules` before deciding whether to
+apply it. Read/unlink failure leaves it unconsumed and stops processing, so disappearance
+alone is not proof of success. A nonempty body completely replaces
+`system/rules.md` and the protected `rules` section; whitespace-only content is a
+consumed no-op. Identical content is consumed without rewrite or flush. Changed
+content persists and flushes, logging `rules_loaded`; a canonical-file write failure
+aborts before prompt mutation and logs `rules_write_error`.
 
-- **Complete replacement, not a merge.** A non-empty `.rules` body entirely
-  replaces the canonical `system/rules.md` content and the protected `rules`
-  prompt section — it is never appended to or merged with prior rules.
-- **Empty is a no-op.** Whitespace-only or empty `.rules` content is consumed
-  (the signal file is deleted either way) but writes nothing and triggers no
-  prompt refresh.
-- **Identical content is a no-flush no-op.** If the `.rules` body (stripped)
-  equals the existing `system/rules.md` (stripped), the signal is consumed
-  but `system/rules.md` is not rewritten and the system prompt is not
-  reflushed.
-- **Changed content persists and flushes.** A genuinely different body
-  overwrites `system/rules.md`, rewrites the protected `rules` prompt
-  section, and flushes the live system prompt — logged as `rules_loaded`.
-  A write failure while persisting the canonical file is logged as
-  `rules_write_error` and aborts before any prompt mutation.
-- **Boot/rebuild injection.** `system/rules.md` is also re-read directly into
-  the protected `rules` prompt section on ordinary agent construction and on
-  every full reconstruction (`context.rebuild`, refresh, molt) — independent
-  of any pending `.rules` signal. This is what makes existing rules survive a
-  molt, refresh, or resume even without a fresh `.rules` write; an empty or
-  missing `system/rules.md` at reconstruction time removes the section.
+Boot and every full rebuild/refresh/molt reread `system/rules.md` independently;
+a missing or empty canonical file removes the section. Identical comparison
+ignores leading/trailing whitespace. A pending `.rules` file is not yet applied,
+and an empty signal cannot clear existing rules.
+Verify the canonical file on disk and the effective protected section only after
+that agent's heartbeat processed the signal (or after later reconstruction).
 
-**Verification.** The canonical value is `system/rules.md` on disk — read it
-directly. The effective (currently composed) value is what the protected
-`rules` prompt section holds; a `.rules` write is only reflected there after
-that *same agent's own* next heartbeat tick actually processed it (or after
-any subsequent boot/rebuild/refresh/molt, which re-reads the same canonical
-file). A `.rules` file that has not yet ticked is real on disk as a pending
-signal, not yet visible in the prompt — the same "written but not applied"
-distinction as an unbuilt Psyche source edit, but on the heartbeat's cadence
-instead of an explicit `context.rebuild` call.
+## Boundary
 
-**Cross-agent writes are scoped by what you can reach, not by a privilege
-check.** `avatar` used to own an admin/karma-gated `rules` action that wrote
-`.rules` to a caller's own directory and to every descendant in its avatar
-tree; that action and its authorization check were both **removed**, not
-replaced by a new guard anywhere else. Today, writing a `.rules` file to
-another agent's directory (e.g. a sibling avatar) is an ordinary filesystem
-write — typically via `shell` naming that agent's explicit path — subject
-only to whatever access the same-OS-user trust model already gives you, not
-to any dedicated authorization mechanism. This paragraph is documentation,
-not enforcement: do not treat it, or any other prose, as proof that a write
-outside your own directory is authorized — only the human's actual scope and
-the target's real accessibility decide that.
+Writing another reachable agent's `.rules` file is an ordinary filesystem write,
+not a dedicated avatar authorization path. Reachability is not permission: only
+actual human scope and the target's real accessibility authorize the write. Keep
+this distinction visible when operating across agents.

--- a/src/lingtai/intrinsic_skills/psyche-manual/reference/settings/SKILL.md
+++ b/src/lingtai/intrinsic_skills/psyche-manual/reference/settings/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: psyche-settings-reference
-last_changed_at: 2026-09-06T00:00:00Z
+last_changed_at: 2026-09-09T00:00:00Z
 description: >
   Deep reference for Psyche's redacted settings SHOW, strict owner-document
-  grammar, precedence, timing, and the eight setting anchors.
+  grammar, precedence, timing, rollback, and eight stable anchors.
 related_files:
 - src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
 - src/lingtai/tools/psyche/settings.py
@@ -12,124 +12,86 @@ related_files:
 - tests/test_psyche_family.py
 - tests/test_psyche_prompt_settings.py
 maintenance: |
-  Keep this reference aligned with Psyche's applied-snapshot provider,
-  `settings/psyche.json` parser, reconstruction rollback, redaction, and the
-  stable `psyche-manual#setting-*` anchors. The parent psyche manual remains the
-  short router; move depth here rather than expanding that always-sent body.
+  Keep this focused reference aligned with the applied-snapshot provider,
+  `settings/psyche.json` parser, reconstruction rollback, redaction, and stable
+  `psyche-manual#setting-*` anchors. Keep the parent as a short router.
 ---
 
 # Psyche settings reference
 
-This page is the detailed procedure behind the short settings signpost in
-[`psyche-manual`](../../SKILL.md). It owns the exact settings grammar and
-application details; Psyche's public action remains SHOW-only.
+This page owns settings grammar and application details; the public `settings`
+action remains SHOW-only.
 
-## Settings
+## Settings SHOW
 
-`psyche(action="settings", input={}, reasoning="inspect Psyche prompt configuration")`
-is SHOW only. It returns exactly `pad`, `pad_file`, `base_prompt`,
-`base_prompt_file`, `covenant`, `covenant_file`, `comment`, then `comment_file`.
-Every row has exactly `key`, `current`, `default`, `configurable`, and `comment`
-in that order. Both `current` and `default` are always `<redacted>` for every
-row, including empty or absent values. The action reports the applied snapshot
-from the last successful full reconstruction. Ambient source edits do not change
-SHOW until rebuild, refresh, or molt applies them; a failed reconstruction keeps
-the last successful snapshot. A provider/snapshot failure returns only the fixed
-bounded `SETTINGS_UNAVAILABLE` failure, never partial rows or parser details.
+```text
+psyche(action="settings", input={}, reasoning="inspect Psyche prompt configuration")
+```
 
-`settings/psyche.json` is Psyche's deliberately small owner document. It is
-optional: a missing file means schema v1 with all six owner values absent. When
-present it must be UTF-8 JSON object `{"schema_version": 1, ...}` with no keys
-other than `base_prompt`, `base_prompt_file`, `covenant`, `covenant_file`,
-`comment`, and `comment_file`; each present value is a string (including `""`).
-Duplicate/unknown keys, Boolean/non-1 versions, non-regular or symlink files,
-files over 64 KiB, unstable reads, invalid UTF-8/JSON, and read failures reject
-the complete reconstruction before prompt publication. There is no environment
-layer, `set`, `reset`, patch action, migration, or writeback.
+The result has exactly eight rows in this order: `pad`, `pad_file`,
+`base_prompt`, `base_prompt_file`, `covenant`, `covenant_file`, `comment`,
+`comment_file`. Every row has exactly `key`, `current`, `default`, `configurable`, and `comment`; both values are always `<redacted>`, including
+empty/null defaults. It reports the last successfully applied reconstruction,
+not ambient edits. All eight rows are configurable, but SHOW is not a content
+comparison: even after a successful change it remains fully redacted. A failed
+reconstruction preserves that snapshot; provider failure returns only the fixed
+`SETTINGS_UNAVAILABLE` failure, never partial rows or parser details. The complete
+SHOW response also has the generic 65,536-byte UTF-8 bound.
 
-The legacy top-level init spellings for these six fields are compatibility-known
-but inert. They neither configure the prompt nor populate SHOW. For each owner
-pair, a readable `*_file` wins; a missing file falls back to inline. `~` expands
-and relative pointers resolve against the agent workdir. Edit the owner document
-with `file.write`/`file.edit`, then use `context.rebuild` (or refresh/molt) to
-apply it atomically.
+## Owner document
 
-**Upgrade / external-writer note:** before reconstructing an agent that still
-stores any of these six values in `init.json`, copy them into
-`settings/psyche.json`; the runtime never migrates or writes them back. An
-existing resolved `base_prompt` or `covenant` may continue through its
-`system/base_prompt.md` or `system/covenant.md` mirror, but `comment` has no
-mirror and is removed when the owner document does not supply it. Fresh project,
-recipe, TUI, Avatar, or other external seed writers must emit the Psyche owner
-document instead of relying on the inert init spellings.
+`settings/psyche.json` is optional. If present, it is a stable-read UTF-8 JSON
+object beginning `{"schema_version": 1, ...}` with only the six string fields
+`base_prompt`, `base_prompt_file`, `covenant`, `covenant_file`, `comment`, and
+`comment_file`. Duplicate/unknown keys, wrong versions/types, invalid
+UTF-8/JSON, Boolean versions, symlinks/non-regular files, reads over 64 KiB, races, and I/O
+failures reject the candidate before prompt publication. There is no environment
+layer, mutation action, migration, or writeback.
+
+For each pair, a readable `*_file` wins; a missing file falls back to inline.
+`~` expands and relative pointers resolve against the agent workdir. Edit this
+owner with `file.write`/`file.edit`, then apply atomically with `context.rebuild`
+(or refresh/molt), after explicit configuration authorization. Legacy top-level
+init spellings for **these six fields** are inert; external writers must emit
+this owner document. Before an authorized upgrade/reconstruction, preserve and
+transfer any still-needed legacy values into it: the runtime never migrates them.
+Base/covenant may fall back to existing mirrors, while comment has no mirror and
+is removed when absent. Invalid owner input is rejected before refresh teardown;
+failed final publication restores the prior prompt generation, mirrors and SHOW.
+
+Pad seeds are different: top-level `init.json` `pad`/`pad_file` remain their owner;
+they are not fields in `settings/psyche.json` (which rejects them). There is no
+environment layer for them. Edit the authorized seed source or its referenced
+file; full reconstruction resolves it again. To change a nonempty durable Pad,
+edit `system/pad.md` instead—changing its configured seed will not overwrite it.
 
 ### Setting pad
-
-- **Meaning and default:** the configured UTF-8 initial Pad seed. Its meaningful
-  default is the empty string.
-- **Source and precedence:** top-level `pad_file` wins when it names a readable
-  file; otherwise top-level inline `pad` is the fallback. Reconstruction
-  materializes, validates, and path-resolves that shape once; SHOW reports the
-  resulting applied snapshot without rereading either source.
-- **Configurable:** `true`, because the operator may edit the authorized root
-  init source or the file it names. SHOW still fully redacts the effective body.
-- **Apply timing and procedure:** active or passive full reconstruction seeds
-  `system/pad.md` only when that durable body is missing or empty. A nonempty
-  durable Pad is preserved. To replace one, edit `system/pad.md` through the Pad
-  procedure, then call `context(action="rebuild", input={}, reasoning="apply Pad change")`;
-  changing only the configured seed does not overwrite a nonempty durable Pad.
+Configured initial Pad seed; default `""`. `pad_file` wins when readable,
+otherwise inline `pad`; reconstruction seeds `system/pad.md` only when missing or
+empty and never overwrites a nonempty durable Pad.
 
 ### Setting pad file
-
-- **Meaning and default:** the configured file pointer supplying the initial Pad
-  seed. It has no meaningful default, so its underlying default is `null`.
-- **Source and precedence:** top-level `pad_file` only. `~` expands and a
-  relative path resolves against the agent working directory. A readable file
-  supplies `pad`; a missing or blank pointer falls back to inline `pad`. SHOW
-  fully redacts the resolved pointer as well as the Pad body.
-- **Configurable:** `true`, because the operator may edit the authorized root
-  init source. No environment or settings-file layer exists.
-- **Apply timing and procedure:** the pointer is re-read on full reconstruction,
-  but its content remains only an initial seed for a missing/empty
-  `system/pad.md`. To change a nonempty durable Pad, use the Pad file procedure
-  and rebuild instead of expecting `pad_file` to overwrite it.
-
-A second SHOW before reconstruction deliberately reports the same applied
-snapshot. After an authorized rebuild/refresh/molt succeeds, another SHOW can
-verify that discovery remains available, but because both values are always
-redacted it cannot reveal or compare the underlying content.
+Initial Pad pointer; default `null`, resolved against workdir. It is still only a
+seed for a missing/empty Pad.
 
 ### Setting base prompt
-
-The optional third-party/application prompt body; default `""`, configurable
-`true`. Psyche resolves it once per reconstruction, writes nonempty content to
-`system/base_prompt.md`, and otherwise falls back to that mirror. The kernel
-renders it after raw `principle` and before the remaining Batch 1 sections.
+Optional third-party prompt body; default `""`; nonempty content mirrors to
+`system/base_prompt.md`.
 
 ### Setting base prompt file
-
-Optional pointer; default `null`, configurable `true`. A readable file wins
-over `base_prompt`; its path is fully redacted and follows the owner-document
-relative/`~` rules above.
+Optional pointer; default `null`; a readable file wins over inline.
 
 ### Setting covenant
-
-Optional protected operator-contract body; default `""`, configurable `true`.
-Nonempty resolved content mirrors to `system/covenant.md` and uses the existing
-protected covenant section; absent owner content falls back to that mirror.
+Optional protected operator contract; default `""`; nonempty content mirrors to
+`system/covenant.md`.
 
 ### Setting covenant file
-
-Optional pointer; default `null`, configurable `true`. A readable file wins
-over `covenant`; the pointer and resolved body remain fully redacted.
+Optional pointer; default `null`; a readable file wins over inline.
 
 ### Setting comment
-
-Optional unprotected comment-section body; default `""`, configurable `true`.
-Unlike base prompt and covenant, comment has no `system/*.md` mirror: an absent
-owner value removes the section on the applied reconstruction.
+Optional unprotected comment; default `""`; unlike the other prompt bodies it has
+no `system/*.md` mirror.
 
 ### Setting comment file
-
-Optional pointer; default `null`, configurable `true`. A readable file wins
-over `comment`; it is fully redacted and has no mirror behavior.
+Optional pointer; default `null`; a readable file wins over inline and remains
+redacted.

--- a/src/lingtai/tools/knowledge/manual/SKILL.md
+++ b/src/lingtai/tools/knowledge/manual/SKILL.md
@@ -1,208 +1,77 @@
 ---
 name: knowledge-manual
 description: >
-  Read before creating/organizing private durable knowledge
-  (`knowledge/<name>/KNOWLEDGE.md`), nested indexes, or cross-references;
-  explains how knowledge differs from portable skills.
+  Read before creating or organizing private durable knowledge
+  (`knowledge/<name>/KNOWLEDGE.md`) or cross-references; use it for local memory,
+  not portable procedures.
 version: 1.0.0
-last_changed_at: "2026-07-19T00:00:00Z"
+last_changed_at: "2026-09-09T00:00:00Z"
 related_files:
 - src/lingtai/tools/skills/manual/reference/cleanup-footprint-contract.md
 - src/lingtai/tools/knowledge/__init__.py
 - src/lingtai/tools/knowledge/ANATOMY.md
 - src/lingtai/tools/knowledge/CONTRACT.md
 maintenance: |
-  Tracks the routed source/resources it summarizes; update when the underlying capability or its sub-references change.
+  Keep the routed private-store/source ownership, catalog rebuild timing,
+  file-operation examples, nesting rule, and cleanup consent route aligned with
+  the Knowledge capability.
 ---
 
-# The Knowledge Capability
+# Knowledge Manual
 
-Knowledge is an agent's private long-term memory. It is for facts, decisions, observations, local paths, mail context, and operational lessons that are useful to this agent but are not necessarily portable to every other agent.
+Knowledge is private, local long-term memory: facts, decisions, observations,
+paths, mail context, and operational lessons. It has no public capability tool;
+`psyche` only returns this signpost. Skills are portable procedures, while
+knowledge may contain private paths, IDs, and logs. Reusable how-to belongs in a
+skill; shared skills must not point inward to private knowledge.
 
-The private-memory capability is named `knowledge`. It registers **no** public
-tool. It owns the private catalog composer that scans `<agent>/knowledge/` and
-injects the catalog into your `knowledge` prompt section; the only model-facing
-surface is the read-only signpost `psyche(action="knowledge", ...)`, which
-returns this manual and nothing else.
+## Layout and catalog
 
-## Knowledge vs skills
+Each entry is `<agent>/knowledge/<name>/KNOWLEDGE.md`, optionally with
+`references/`, `scripts/`, `assets/`, or `notes/`. Its YAML needs `name` and
+`description`. The prompt receives only each entry's name, description, and
+location; read the body on demand. Setup/refresh and every full rebuild rescan
+the store and recompose the catalog.
 
-Knowledge and skills are **isomorphic in layout and progressive disclosure**:
-each entry is a folder with a marker file (`KNOWLEDGE.md` here, `SKILL.md`
-there), the prompt carries only the catalog, and a top-level entry may act as a
-routing/index parent over nested children. They are physically separate stores
-with different audiences:
+A top-level entry may be a short routing/index parent with nested children. Keep
+one hook and relative child path per child, and put the substance in the child;
+use the Skills manual's nested reference pattern for the catalog shape.
 
-| Term / path | Meaning |
-|---|---|
-| `knowledge` capability | Private per-agent durable memory catalog (no public tool). |
-| `<agent>/knowledge/<name>/KNOWLEDGE.md` | One private knowledge entry. |
-| `skills` capability | Catalog of reusable portable procedures (no public tool). |
-| `.library/intrinsic`, `.library/custom`, `.library_shared` | Skill shelves holding `SKILL.md` files — never private `knowledge` entries. |
-
-Knowledge is **private, local, and non-portable** by default: it may reference
-agent-local paths, mail IDs, and logs. Skills are **reusable, shareable, and
-portable**.
-
-**Direction matters:** private knowledge may point outward to skills; shared
-skills must not point inward to private knowledge paths, mail IDs, or local
-logs. If content is a reusable how-to another agent could apply without your
-private context, write a skill instead.
-
-## Layout
-
-Each entry is a folder under `<agent>/knowledge/` with a `KNOWLEDGE.md` file:
-
-```text
-<agent>/knowledge/
-└── <name>/
-    ├── KNOWLEDGE.md
-    ├── references/
-    ├── scripts/
-    ├── assets/
-    └── notes/
-```
-
-`KNOWLEDGE.md` starts with YAML frontmatter:
-
-```markdown
----
-name: <name>
-description: One short sentence shown in the prompt catalog.
-version: 1.0.0
----
-
-# Title
-
-Full notes live here.
-```
-
-Required fields are `name` and `description`. Supporting files are optional and can be any useful text, script, data sample, log, or asset.
-
-## Progressive disclosure
-
-The system prompt only receives a compact catalog: each entry's `name`, `description`, and `location`. The body of `KNOWLEDGE.md` and supporting files stay on disk until you explicitly read them. This keeps the prompt small while still making the memory discoverable.
-
-The catalog is rescanned for you: setup/refresh and every full `context.rebuild` re-read `knowledge/` and recompose the section. Use `read` on the listed `location` when an entry becomes relevant.
-
-## Call shape
-
-Knowledge has one public call, and it just returns this manual:
+## Public call and first action
 
 ```text
 psyche(action="knowledge", input={}, reasoning="load knowledge guidance")
 ```
 
-Every call carries exactly four root fields — `action`, `input`, `reasoning`
-(all required) and the optional root `summarize`.
+The strict-empty call creates, edits, searches, rescans, and loads nothing. For an
+ordinary schema-sufficient call no ritual manual reload is needed; read this page
+when authoring or reorganizing an unfamiliar store.
 
-It takes a strict-empty `input`: there is no argument to pass, and any field you
-put inside `input` is rejected before the action runs. This is a signpost — it
-never creates, edits, searches, rescans, or loads entries.
+## Author, edit, read, apply
 
-Mutation and loading belong to the generic `file` family:
-
-- author or fully rewrite an entry with
-  `file(action="write", input={"file_path": "knowledge/<name>/KNOWLEDGE.md", "content": "..."}, reasoning="...")`;
-- make a bounded exact change with
-  `file(action="edit", input={"file_path": "knowledge/<name>/KNOWLEDGE.md", "old_string": "...", "new_string": "...", "replace_all": null}, reasoning="...")`;
-- load a body on demand with
-  `file(action="read", input={"file_path": "<location>", "offset": null,
-  "limit": null, "max_chars": null}, reasoning="...")`.
-
-Writing an entry does not hot-load the catalog. Apply it with one
-`context(action="rebuild", input={}, reasoning="...")`, or let passive
-refresh/molt reconstruction apply it.
-
-### `summarize`
-
-Loading this manual follows the **short-result** profile: root `summarize` is
-available but normally unnecessary — leave it false, so exact procedure and
-constraints are not summarized away. `summarize` is a root field; it is never
-part of `input`.
-
-### Settings
-
-Knowledge owns no settings surface. Psyche's separate `settings/psyche.json`
-does not configure Knowledge, and no `settings/psyche.knowledge.json` exists.
-Nothing here reads settings.
-
-## Nesting and sub-knowledge
-
-A top-level entry may act as a **routing/index parent** with nested children that
-hold the substance — exactly the nested-reference pattern documented in the
-skills manual.
-
-For the routing/index parent pattern — when to use it, how the parent stays a
-short scannable index, how children carry the detail, relative child paths,
-keeping the catalog in sync — **read the skills manual's nested reference
-section** (`.library/intrinsic/capabilities/skills/SKILL.md`, "Nested
-skill/reference pattern for umbrella manuals") and apply the same shape with
-`KNOWLEDGE.md` in place of `SKILL.md`.
-
-Compact example of a routing parent with sub-knowledge children — a project's
-incident log:
+Use the generic `file` owner with complete envelopes:
 
 ```text
-knowledge/project-x-incidents/
-├── KNOWLEDGE.md                                   # routing/index ONLY
-├── 2026-05-13-cache-stampede/KNOWLEDGE.md         # child — the detail
-└── 2026-05-21-token-leak/KNOWLEDGE.md             # child
+file(action="write", input={"file_path": "knowledge/<name>/KNOWLEDGE.md", "content": "---\nname: <name>\ndescription: ...\n---\n..."}, reasoning="write knowledge")
+file(action="edit", input={"file_path": "knowledge/<name>/KNOWLEDGE.md", "old_string": "...", "new_string": "...", "replace_all": null}, reasoning="edit knowledge")
+file(action="read", input={"file_path": "<location>", "offset": null, "limit": null, "max_chars": null}, reasoning="read knowledge")
 ```
 
-The parent `KNOWLEDGE.md` is a short index: one line per child with a hook and the
-child's relative path; each child holds the full write-up. Keep names
-filesystem-safe and descriptive, point at children by relative path, and use
-nesting to group related entries, not to hide information.
+Writing does not hot-load the catalog. Apply one
+`context(action="rebuild", input={}, reasoning="refresh knowledge catalog")`, or
+let passive refresh/molt reconstruction apply it. Psyche's
+`settings/psyche.json` does not configure Knowledge and there is no Knowledge
+settings, set, reset, migration, or writeback action.
 
-## Cross-references
+## Cross-references and cleanup
 
-Knowledge entries may reference one another by relative path or by catalog name. Prefer links that remain valid if the whole agent directory moves:
+Prefer move-stable relative links such as `../architecture/KNOWLEDGE.md`. A
+knowledge entry may point outward to a reusable Skills manual, never the reverse.
 
-```markdown
-See also: ../architecture/KNOWLEDGE.md
-See also: ../../people/reviewers/KNOWLEDGE.md
-```
-
-Knowledge may also reference skills when a reusable procedure exists:
-
-```markdown
-For the repeatable workflow, read `.library/intrinsic/capabilities/skills/SKILL.md`.
-```
-
-## When to create knowledge
-
-Create or update a knowledge entry when the information is useful beyond the current turn but is not a portable procedure:
-
-- project-specific decisions and rationale;
-- collaborator preferences and review history;
-- local repo paths, branch relationships, and known gotchas;
-- incident notes and debugging evidence;
-- conclusions from research that are specific to this agent's work.
-
-## Cleanup / Footprint
-
-Knowledge entries live under `knowledge/<name>/KNOWLEDGE.md` plus supporting
-files. They are durable memory, not cache. Cleanup usually means consolidation,
-renaming, or archiving stale entries after review; never delete knowledge just to
-save space unless the user explicitly agrees after a dry-run report and the content is backed up or no
-longer useful.
-
-Footprint check: load the [shared inspection recipe](../../skills/manual/reference/cleanup-footprint-contract.md#shared-footprint-check-recipe)
-through `skills-manual` → `reference/cleanup-footprint-contract.md`. Combine
-its definitions with this tool-specific selection in one task-owned script;
-the selection is not a standalone executable. Inspection writes nothing.
-Appending `logs/cleanup.jsonl` is the separate, explicitly selected audit step
-in that recipe; retain this manual's cleanup/approval rules below.
-
-```python
-agent = Path.cwd()  # the relevant agent directory, not a repository root
-root = agent / "knowledge"
-items = [p for p in root.iterdir() if p.is_dir()] if root.is_dir() else []
-rows, total = footprint_check(items, tool="knowledge", top_n=30)
-```
-
-Recommended cadence: before molt if knowledge sprawl is confusing, after major
-projects, and monthly for long-lived agents. If cleanup is approved with explicit user consent, record the
-entries consolidated/removed in `logs/cleanup.jsonl` and apply the catalog change
-with `context(action="rebuild", input={}, reasoning="refresh after cleanup")`.
+Knowledge is durable memory, not cache: do not delete it just to save space.
+Cleanup normally consolidates, renames, or archives stale entries. For a footprint
+report, use `skills-manual` → `reference/cleanup-footprint-contract.md` and
+select only `knowledge/`; inspection writes nothing. The shared recipe’s optional
+audit append is a separate write, not an automatic side effect of inspection. Show the dry-run,
+explain what would change, obtain explicit user consent, and record an approved
+cleanup in `logs/cleanup.jsonl` before rebuilding the catalog.

--- a/src/lingtai/tools/psyche/__init__.py
+++ b/src/lingtai/tools/psyche/__init__.py
@@ -49,14 +49,15 @@ _DECLARED_INPUT_SCHEMAS = {
 }
 
 _ACTION_ENUM_DESCRIPTION = (
-    "Choose one Psyche operation. Every action takes strict input={} and is "
-    "read-only; load the returned manual before acting on an unfamiliar domain.\n"
-    "pad: return pad-manual for system/pad.md and pinned Pad references.\n"
-    "lingtai: return lingtai-manual for system/lingtai.md (灵台 / character).\n"
-    "knowledge: return the knowledge manual for durable KNOWLEDGE.md entries.\n"
-    "skills: return the skills manual for the configured .library catalog.\n"
-    "settings: show Psyche's fully redacted settings view.\n"
-    "manual: return the psyche routing table."
+    "Choose one read-only Psyche route; every child takes strict input={}. "
+    "Routine inspection needs no manual reload; read the matching domain manual first "
+    "for unfamiliar or consequential work.\n"
+    "pad: Pad manual for system/pad.md and pinned references.\n"
+    "lingtai: identity manual for system/lingtai.md (灵台 / character).\n"
+    "knowledge: private KNOWLEDGE.md memory manual.\n"
+    "skills: .library catalog and configured-roots manual.\n"
+    "settings: fully redacted applied-settings SHOW.\n"
+    "manual: Psyche routing table and shared mutation/rebuild model."
 )
 
 
@@ -91,15 +92,14 @@ _FAMILY = _build_family(None)
 
 def get_description(lang: str = "en") -> str:
     return (
-        "SIGNPOST ONLY: psyche routes four durable domains — pad, lingtai "
-        "(灵台), knowledge, and skills. Every action takes strict input={} and is "
-        "read-only; it never authors, edits, pins, installs, rescans, or loads "
-        "anything. Call manual first for an unfamiliar domain. Durable changes "
-        "use file.write for a full rewrite or file.edit for an exact replacement, "
-        "then one explicit context.rebuild (or passive refresh/molt); file "
-        "mutation never hot-loads the prompt. Psyche owns no lifecycle action: "
-        "context owns rebuild/molt and system owns identity. Results are exact; "
-        "leave root summarize false."
+        "SIGNPOST ONLY: routes pad, lingtai (灵台), knowledge, and skills, with redacted settings "
+        "and manual guidance. Every action is read-only with strict input={}; it "
+        "never authors, edits, pins, installs, rescans, or loads anything. "
+        "routine schema-sufficient calls need no manual reload, while unfamiliar "
+        "or consequential domain work should call the matching manual first. "
+        "Change durable sources with file.write/file.edit, then one "
+        "context.rebuild (or refresh/molt); edits never hot-load. context owns "
+        "rebuild/molt and system owns lifecycle/names; leave root summarize false."
     )
 
 

--- a/src/lingtai/tools/skills/manual/SKILL.md
+++ b/src/lingtai/tools/skills/manual/SKILL.md
@@ -1,72 +1,45 @@
 ---
 name: skills-manual
 description: >
-  Read before authoring/installing/sharing a skill (`.library/custom/<name>/`),
-  adding a skills path, or diagnosing an entry missing from the catalog built
-  from `.library/{intrinsic,custom}/` plus `init.json`. Individual skills own
-  their own procedures — this does not document the bundled skills themselves.
+  Read before authoring, installing, or sharing a skill in
+  `.library/custom/<name>/`, adding configured skill roots, or diagnosing a
+  catalog entry; this teaches the Skills system, not bundled skill procedures.
 version: 1.2.0
-last_changed_at: "2026-07-27T04:30:00-07:00"
+last_changed_at: "2026-09-09T00:00:00Z"
 related_files:
 - src/lingtai/tools/skills/manual/reference/cleanup-footprint-contract.md
+- src/lingtai/tools/skills/manual/assets/skill-template.md
+- src/lingtai/tools/skills/manual/scripts/validate.py
 - src/lingtai/tools/skills/__init__.py
 - src/lingtai/tools/skills/ANATOMY.md
 - src/lingtai/tools/skills/CONTRACT.md
 maintenance: |
-  Tracks the routed source/resources it summarizes; update when the underlying capability or its sub-references change.
+  Keep this router aligned with the Skills capability, its installed template and
+  validator, the nested-reference routing shape, and the cleanup reference.
 ---
 
-# The Skills Capability
+# Skills Manual
 
-This is the skills capability's own manual — how the skills *system* works, not
-what is inside it. The capability scans `.library/` plus any extra paths declared
-in `init.json`, builds a YAML catalog, and injects it into your system prompt.
+Skills are reusable, portable procedures. The capability scans `.library/` plus
+configured roots, builds a compact YAML catalog, and injects that catalog into the
+prompt. A skill is usable only after it is installed in a scanned root **and** a
+catalog rebuild (or passive refresh/molt) has picked it up. A URL, temporary clone,
+or newly written file is not loaded yet.
 
-**The one rule behind everything below:** a skill exists for you only after it is
-(1) installed into an already-scanned skill root and (2) picked up by a catalog
-rescan. A shared URL, a temporary clone, or a file you just wrote is not yet in
-the catalog.
+## Sources and roots
 
-The active rescan is one
-`context(action="rebuild", input={}, reasoning="rescan skills catalog")`; passive
-refresh and molt reconstruction rescan too. Every write/install step in this
-manual ends with that rebuild. Changing which *roots* are scanned is a different,
-config-owner case — see "Adding a skills path" below.
-
-## On-disk layout
-
-Your skill catalog lives at `<agent>/.library/`:
-
-```
+```text
 <agent>/.library/
-├── intrinsic/
-│   ├── capabilities/
-│   │   └── <cap>/<manual files>
-│   └── addons/
-│       └── <addon>/<manual files>
-└── custom/
+├── intrinsic/                 # CLI-managed; rewritten on refresh; do not edit
+│   ├── capabilities/<cap>/    # installed capability manuals
+│   └── addons/<addon>/
+└── custom/                    # agent-owned skills
 ```
 
-- `intrinsic/` — **CLI-managed.** Wiped and rewritten from kernel-shipped manual
-  bundles on every refresh. Do not edit; your edits will be erased.
-  `capabilities/<cap>/` holds each loaded capability's manual (`skills/`,
-  `email/`, `context/`); `addons/<addon>/` holds each loaded addon's
-  (`imap/`, `telegram/`, `feishu/`).
-- `custom/` — **your territory.** Authored skills live here; the CLI never
-  touches this directory.
-
-### Adding a skills path
-
-Additional roots come from `init.json` at `manifest.capabilities.skills.paths` —
-typically `~/.lingtai-tui/utilities/`, plus any project-specific roots.
-`init.json` is the ground truth: there is no runtime state, so whatever is in
-`paths` at setup time is the exact set scanned.
-
-Changing that list is **configuration**, not authoring, and it is the one case a
-plain rebuild cannot apply — a rebuild rescans the roots already configured, it
-does not re-read `init.json` capability config. Edit the list with
-`file(action="edit", input={"file_path": "init.json", "old_string": "...", "new_string": "...", "replace_all": null}, reasoning="...")`
-and then re-run capability setup with the exact refresh envelope:
+Additional roots are `manifest.capabilities.skills.paths` in `init.json` (the
+configuration ground truth). A plain rebuild rescans already configured roots; it
+does not reread changed configuration. To add a root, obtain authorization, exact
+edit `init.json`, then apply the full refresh envelope:
 
 ```text
 system(action="refresh",
@@ -74,433 +47,131 @@ system(action="refresh",
        reasoning="apply changed skills configuration")
 ```
 
-Editing `init.json` is a config-owner action: confirm you are authorized to
-change this agent's configuration before doing it.
+`.library_shared/` is opt-in, not a default; ordinary sharing installs into each
+receiver's `custom/`. If Skills is disabled, files remain on disk but no catalog is
+injected.
 
-`../.library_shared/` is an **opt-in** local-network sharing root, not a default.
-For ordinary sharing, install into each receiving agent's `custom/` instead.
-
-If the skills capability is not loaded, the files still exist on disk — you just
-get no catalog in your prompt. Reach the manuals with
-`file(action="read", input={"file_path": "...", "offset": null, "limit": null, "max_chars": null}, reasoning="...")`,
-`file(action="grep", input={"pattern": "...", "path": ".library", "glob": null, "max_matches": null}, reasoning="...")`,
-or `file(action="glob", input={"pattern": "**/SKILL.md", "path": ".library"}, reasoning="...")`.
-
-## The catalog, and checking its health
-
-The `skills` section of your system prompt is a YAML list. Each skill is one
-`- name: <name>` block with a `location:` (absolute path to that skill's
-`SKILL.md`) and a `description:` block scalar. To read a skill's body, `read` the
-file at its `location`.
-
-Skills is one action of the `psyche` LTP v2 family. That root is closed and
-exactly `action`, `input`, `reasoning`, `summarize`. `action`, its nested `input`
-object, and **root `reasoning`** are required; root `summarize` is an optional
-boolean, absent or false by default. Every psyche action takes the **empty**
-input object — there is no field to pass — and no *input branch* admits
-`reasoning`, `_reasoning`, or `summarize`: those are root envelope fields and are
-never nested inside `input`.
+## Public route and first action
 
 ```text
 psyche(action="skills", input={}, reasoning="load skills guidance")
 ```
 
-This call returns this SKILL.md body. It is the only public Skills call, and it
-performs no catalogue scan or prompt injection. A `status` of `"degraded"`
-carries an error message naming the fix — typically a missing manual under
-`intrinsic/capabilities/skills/`, meaning the initializer did not install
-manuals correctly.
-
-The catalogue itself is reconciled for you: setup/refresh and every full
-`context(action="rebuild", input={}, reasoning="...")` rescan `.library/` plus
-your configured skills paths and recompose the `skills` prompt section. When a
-skill you expect is missing, add or fix it on disk and rebuild.
-
-An unknown action, or any key at all inside `input`, fails before the manual is
-read, with a typed envelope failure
-(`{"status": "failed", "error_code": ...}`).
-
-### `summarize` for this family
-
-Loading this manual follows the **bulky-result** profile: this body is long, so
-`summarize=true` is reasonable when you only need the gist, but calls meant to
-follow an exact procedure should keep the default `summarize=false` so precise
-steps, paths, and constraints are not summarized away. `summarize` is a root,
-cross-cutting field — never nested inside `input`, and never an implementation
-argument. A call that fails always returns its exact, unsummarized error
-regardless of `summarize`.
-
-### Settings
-
-There is no Skills-owned settings file — in particular no action-level
-`settings/psyche.skills.json`. Psyche's separate `settings/psyche.json` does
-not configure Skills. The
-catalogue's only configuration input is `manifest.capabilities.skills.paths`
-in `init.json`, described above.
-
-To pin a skill's body into your pad so it survives a molt and rides in the cached
-system-prompt prefix, add its `location` to the JSON array in
-`system/pad_append.json`:
+This strict-empty signpost performs no scan, injection, create, edit, or load.
+Routine schema-sufficient calls need no ritual manual reload; read this route when
+the catalog, roots, or skill lifecycle is unfamiliar. To inspect a cataloged body,
+use its `location` with the complete read call:
 
 ```text
-file(action="write",
-     input={"file_path": "system/pad_append.json",
-            "content": "[\"<location>\"]"},
-     reasoning="pin a skill as durable reference")
+file(action="read", input={"file_path": "<location>", "offset": null, "limit": null, "max_chars": null}, reasoning="read cataloged skill")
 ```
 
-then apply it with one
-`context(action="rebuild", input={}, reasoning="apply pinned references")`.
+`context(action="rebuild", input={}, reasoning="rescan skills catalog")` rescans
+`.library/` and configured roots and recomposes the Skills section. A degraded
+manual result usually means the intrinsic manual was not installed correctly.
 
-Pinning is cheap per-token over a session; repeated `read`s of the same file are
-not. Pad semantics (the read-only reference section, clearing with `[]`, and
-budget discipline) belong to `pad-manual` — read it there.
+## Nested reference pattern
 
-## External skill intake (default flow)
+Use the **Nested skill/reference pattern for umbrella manuals** only when one
+parent must route to substantial children. The catalog scanner treats a directory that already has a `SKILL.md` as a skill boundary, so the parent must inject children's routing metadata explicitly. Every parent carries both:
 
-When a human, peer, or repository URL shares a skill, do not treat the URL or a
-temporary clone as loaded. The default flow is local-first:
+1. a `## Nested reference catalog` fenced YAML list (`name`, relative `location`,
+   `description`) for each child; and
+2. a human-readable `## Routing table` mapping the same needs to the same paths.
 
-1. **Clone or copy into this agent's `<agent>/.library/custom/<skill-name>/`.**
-   Keep repository metadata when the skill has an upstream, so future syncs can
-   use `git pull --ff-only`.
-2. **Validate before trusting it** — run the bundled validator (below) against
-   the installed folder and inspect `SKILL.md` frontmatter plus any referenced
-   `scripts/`, `assets/`, or `references/`.
-3. **Rescan the catalog** — call
-   `context(action="rebuild", input={}, reasoning="rescan skills catalog")`.
-   Until that rebuild (or a passive refresh/molt reconstruction) the skill is
-   only a file on disk.
-4. **Load it by catalog entry** — `file(action="read", input={"file_path":
-   "<location>", "offset": null, "limit": null, "max_chars": null}, reasoning="...")`
-   on the cataloged `location:`, and follow any nested references. Record the
-   commit or source URL in your task notes when it matters.
-
-Use a temporary/quarantine clone only to pre-inspect an untrusted source; move or
-re-clone a reviewed copy into `.library/custom/<skill-name>/` before relying on
-it. **Installing a skill does not authorize the external side effects it
-describes** — normal human authorization boundaries still apply.
-
-**Sharing works the same way in reverse.** Send peers the source URL (or artifact
-path) plus this recipe. Each receiving agent clones/copies it into its own
-`.library/custom/<name>/`, validates it, then rebuilds its own context. That
-keeps ownership, updates, and rollback local to the agent actually using the
-skill.
-A network may instead maintain `.library_shared/<name>/`; add `../.library_shared` to each participating
-agent's `manifest.capabilities.skills.paths`. Do not assume `.library_shared` is loaded by default:
-it is an explicit opt-in with a shared stewardship burden, never the default
-distribution path.
-
-## Authoring a new skill
-
-Create `<agent>/.library/custom/<skill-name>/SKILL.md` starting with YAML
-frontmatter — use
-`file(action="write", input={"file_path": ".library/custom/<skill-name>/SKILL.md", "content": "..."}, reasoning="...")`
-— then rescan with one
-`context(action="rebuild", input={}, reasoning="rescan skills catalog")`:
-
-```
----
-name: <skill-name>
-description: One-line description of what this skill does
-version: 1.0.0
-# Required for LingTai-maintained skills; optional for custom/external skills.
-last_changed_at: "2026-06-29T08:00:00Z"
----
-
-Full instructions in Markdown below...
-```
-
-Required: `name`, `description`. Optional: `version`, `author`, `tags`,
-`last_changed_at`.
-
-**LingTai-maintained skill metadata.** Every skill bundle maintained inside a
-LingTai repository — intrinsic capability manuals, standalone intrinsic skills,
-MCP manual bundles, TUI preset utility skills, and their nested reference
-`SKILL.md` files — must carry `last_changed_at` as an ISO 8601 timestamp with
-timezone (`"2026-06-29T08:00:00Z"`). Update it in the same commit as any
-substantive edit to the skill body. For a historical backfill or metadata-only
-edit, derive the value from git history
-(`git log -1 --format=%cI -- path/to/SKILL.md`) so it points at the latest
-meaningful content change rather than the bookkeeping commit.
-
-`tags` is a list of lowercase, hyphenated strings aiding discoverability and
-(eventually) tier filtering, along three axes — language/runtime (`python`,
-`fortran`, `bash`, `node`), domain (`physics`, `mhd`, `plasma`, `ml`, `web`), and
-type (`solver`, `workflow`, `reference`, `cheatsheet`). Example:
-`tags: [python, physics, mhd, solver]`. Tags are best-effort metadata, not
-load-bearing — the catalog still finds skills without them.
-
-**Check for name collisions first.** Two skills sharing a `name` collide in the
-catalog:
-
-```text
-shell(action="run",
-      input={"command": "grep -rh '^name:' .library/ ~/.lingtai-tui/utilities/ 2>/dev/null",
-             "timeout": null, "working_dir": null, "async": null, "reminder": null},
-      reasoning="check for skill name collisions")
-```
-
-On a hit: rename, or adapt the existing skill instead of forking a second one.
-
-### Starting from the template
-
-```
-cp .library/intrinsic/capabilities/skills/assets/skill-template.md \
-   .library/custom/<skill-name>/SKILL.md
-```
-
-The template carries placeholder slots (`[SKILL_NAME]`,
-`[ONE_LINE_DESCRIPTION]`, …) and a soft heading skeleton (`When this applies` /
-`Procedure` / `What to expect` / `Constraints` / `Scripts` / `Assets`). It works
-for code/executable skills as-is; for reference-style skills (manuals,
-cheatsheets, chronicles) delete the `Procedure` section and write prose — a note
-at the top of the template says so.
-
-### Validating before installing or publishing
-
-```
-python3 .library/intrinsic/capabilities/skills/scripts/validate.py \
-   [--require-last-changed-at] .library/custom/<skill-name>/
-```
-
-It checks required frontmatter (`name`, `description`), unfilled `[PLACEHOLDER]`
-slots left over from the template, broken internal references (paths under
-`scripts/`, `assets/`, `references/` mentioned in `SKILL.md` that do not exist on
-disk), and `chmod +x` on Python scripts under `scripts/`. Exits 1 on any FAIL, 0
-on PASS (warnings allowed). Add `--require-last-changed-at` for
-LingTai-maintained bundles. Run it after authoring, after installing an external
-skill, and before any broader distribution.
-
-### Self-test before publishing
-
-The validator catches structure, not content. After writing, walk your skill as a
-fresh agent:
-
-1. **Decision-tree test** — start at SKILL.md's first decision and follow each
-   branch. Does every reference file exist? Is the content reachable from the
-   routing hub?
-2. **Assertion test** — `grep` the actual codebase/filesystem for every claim:
-   file paths, API signatures, parameter names, default values. Do NOT trust your
-   memory of the code.
-3. **Regression test** — fix what you found, then repeat step 2.
-
-This catches what the validator cannot see: fictional file paths (e.g.
-referencing a `helmholtz*.f90` that does not exist), API signatures from an older
-code version, and default parameter values that have since changed. Treat it as
-mandatory for skills documenting an external codebase — fabricated paths and
-stale signatures are the most damaging failure mode.
-
-## Structuring a skill
-
-| Content | Shape |
-|---|---|
-| Under ~300 lines, or one path through it | Flat `SKILL.md` |
-| Multi-topic reference, decision tree, ≥300 lines | Two-level: `SKILL.md` router + `reference/<topic>.md` files |
-| Umbrella router whose children need their own frontmatter, scripts, or assets | Nested skill/reference pattern (below) |
-
-### Two-level progressive disclosure
-
-```
-<skill-name>/
-├── SKILL.md              # Routing hub: decision tree + quick start + topic table
-├── README.md             # GitHub-facing description (humans, not agents)
-└── reference/
-    ├── topic-a.md        # Self-contained deep-dive, loaded on demand
-    └── topic-b.md
-```
-
-`SKILL.md` is a **decision tree** (~150–180 lines): the agent picks a path, then
-does a single `read` on the right reference file. Each reference covers ONE topic
-(100–300 lines). The agent loads ~150 lines plus one reference instead of a
-1000-line monolith. Do not use this for simple skills — single-API wrappers,
-linear checklists, prose-only references.
-
-Reference implementations: `huangzesen/laps-skill`,
-`huangzesen/helmholtz-skill`.
-
-### Nested skill/reference pattern for umbrella manuals
-
-Use this when a parent skill is itself a **router** and some children need to
-behave like mini-skills: their own frontmatter, trigger summary, future
-`scripts/` or `assets/`, and a stable addressable folder. This is second-layer
-progressive disclosure inside one top-level catalog entry, not a way to hide
-unrelated reusable skills.
-
-```
-<parent-skill>/
-├── SKILL.md                         # Top-level cataloged router
-└── reference/
-    ├── topic-a/
-    │   └── SKILL.md                 # Nested reference, loaded only via parent
-    └── topic-b/
-        └── SKILL.md
-```
-
-**Key rule: a nested `reference/<topic>/SKILL.md` is not automatically promoted
-to the global catalog.** The catalog scanner treats a directory that already has
-a `SKILL.md` as a skill boundary and does not descend into it for additional
-entries. The parent must therefore inject the children's routing metadata explicitly
-and keep the heavy procedural content in the children.
-
-Every such parent must contain **both**:
-
-1. a `## Nested reference catalog` section with a fenced YAML list, one item per
-   child (`name`, `location`, `description`); and
-2. a human-readable `## Routing table` (or equivalent decision table) mapping
-   needs to the same child `location`s.
+The YAML is a machine-readable routing table, not decoration. Do not leave the parent as only a prose list of links. Child locations are relative to the parent
+and each nested child has its own frontmatter:
 
 ```yaml
 - name: parent-topic-a
   location: reference/topic-a/SKILL.md
-  description: |
-    Nested <parent-skill> reference for ... Read this after loading
-    <parent-skill> when ...
-- name: parent-topic-b
-  location: reference/topic-b/SKILL.md
-  description: |
-    Nested <parent-skill> reference for ...
+  description: Nested child for the topic-a route
 ```
 
-The YAML catalog is not decoration — it is the machine-readable routing table for
-the second layer. Keep it in sync with child frontmatter and with the human
-routing table. Do not leave the parent as only a prose list of links.
+Keep this catalog and the human routing table in sync. For the broader example, enter `system-manual` →
+`reference/substrate-manual/SKILL.md`. Validate the parent **and each child**
+separately using the installed validator’s full path and each folder as its argument.
+For example, from the parent folder:
+`python3 <agent>/.library/intrinsic/capabilities/skills/scripts/validate.py reference/topic-a/`.
+Child names must be unique within the parent; describe the parent and read trigger.
+Verify the installed/copied child tree as well as parent metadata. Independent
+workflows should remain top-level skills, not hidden children.
 
-Use nested references when all of these hold: callers should enter through one
-umbrella skill first; the child is substantial enough to deserve frontmatter and
-possibly its own `scripts/` or `assets/` later; exposing it standalone would clutter
-the catalog or bypass important routing context; and the parent can clearly say
-when to read each child. Do **not** use them for independent workflows agents
-should find directly from the top-level catalog — those belong in
-`.library/custom/<name>/`, an opt-in shared root such as `.library_shared/<name>/`,
-or an intrinsic skill root.
+## External skill intake (default flow)
 
-Nested child conventions:
+A shared URL or temporary clone is not installed: the skill is
+   only a file on disk until a reviewed copy reaches a scanned root. Copy/clone
+into `<agent>/.library/custom/<skill-name>/`, retain useful upstream metadata, and
+inspect `SKILL.md` plus referenced scripts/assets/references. For each install, run the bundled validator, rebuild, and read the cataloged location. Each receiving agent clones/copies it into its own `.library/custom/<name>`. Do not assume `.library_shared` is loaded by default. If a shared root is explicitly chosen, add `../.library_shared` to each participating agent's configured paths:
 
-- Each child `reference/<topic>/SKILL.md` carries normal skill frontmatter:
-  `name` and `description` required, `version`/`tags` optional, plus
-  `last_changed_at` when the parent is maintained inside a LingTai repository.
-  `name` should be unique within the parent and descriptive
-  (`system-manual-sqlite-log-query`, `daily-reflection-data-collection`) even
-  though it is not globally cataloged.
-- The child `description` and the parent catalog `description` should open by
-  saying it is nested, name the parent, and give the trigger condition:
-  `Nested system-manual reference for ...`.
-- `location` in the parent YAML catalog is relative to the parent folder, so it
-  survives copy/install moves and resolves next to the parent `SKILL.md`.
-- The parent stays the routing hub. Resident prompts and sibling skills route to
-  the parent first, then the nested reference; do not bypass the parent unless
-  the caller already has parent context loaded.
-- Tests should verify both levels: the parent body contains the YAML catalog,
-  every child `name`/`location`, and the human routing table; the
-  installed/copied tree contains each child `SKILL.md` with valid frontmatter and
-  key content.
-- The validator handles one skill folder at a time — validate the parent, then
-  each nested child folder directly, e.g.
-  `python3 .../validate.py reference/topic-a/` from the parent skill folder.
+```text
+python3 .library/intrinsic/capabilities/skills/scripts/validate.py .library/custom/<skill-name>/
+context(action="rebuild", input={}, reasoning="rescan skills catalog")
+```
 
-Reference implementations: `system-manual` is a top-level router with nested
-`reference/substrate-manual/SKILL.md`, `reference/procedures-manual/SKILL.md`,
-and `reference/sqlite-log-query/SKILL.md`. Utility routers such as
-`swiss-knife`, `web-manual`, and `daily-reflection` use the same two-part
-shape: YAML child metadata first, human routing table second.
+`last_changed_at` is optional for custom/external skills. Add
+`--require-last-changed-at` when validating a LingTai-maintained bundle; this is
+not the default for third-party intake. Record the reviewed source URL/commit.
 
-### Cleanup / Footprint contract for tool manuals
+A quarantine copy is for inspection only; install the reviewed copy into `custom/`
+before relying on it. To check for a name collision first, use the complete shell
+call `shell(action="run", input={"command": "grep -rh '^name:' .library/", "timeout": null, "working_dir": null, "async": null, "reminder": null}, reasoning="check for skill-name collision")`. Check already configured extra roots too;
+rename or reuse an existing skill on a collision. The example only scans `.library/`.
+Installation never authorizes side effects described by the skill. For sharing, send the source URL or artifact path and this local-install /
+validate / rebuild recipe; each receiver owns its copy and rollback.
 
-Every tool/capability manual that owns persistent state must include a
-`Cleanup / Footprint` section. It is a contract, not a janitor: it teaches agents
-what the tool leaves behind and how to audit it safely. The required fields, the
-consent rule, the self-audit rule, and the standard `logs/cleanup.jsonl` record
-snippet live in [`reference/cleanup-footprint-contract.md`](reference/cleanup-footprint-contract.md)
-— read it before writing or reviewing such a section.
+To author a skill, use the complete write envelope
+`file(action="write", input={"file_path": ".library/custom/<skill-name>/SKILL.md", "content": "..."}, reasoning="author skill")`, then put at least this frontmatter in the file:
 
-## When to create a skill
+```yaml
+---
+name: <skill-name>
+description: What it does, when to use it, and when not to use it
+version: 1.0.0
+last_changed_at: "2026-09-09T00:00:00Z"
+---
+```
 
-**Do** when the task is repeatable with consistent steps; the procedure needs
-domain knowledge not reliably available without notes; the workflow involves
-multi-step orchestration or error handling worth codifying; or you want to share
-expertise with other agents in the network.
+Use the bundled `assets/skill-template.md` as a starting point. Maintained bundles
+must update `last_changed_at` with substantive edits. Validate frontmatter,
+placeholders, referenced files, and script executability; warnings do not turn a
+failed frontmatter or broken-reference check into a pass. The validator exits 0
+only when required checks pass.
 
-**Do NOT** when it is a one-off with no reuse value; the task is just "call this
-one API endpoint" (pick it up at the call site); or the instructions are
-personality or style preferences — those live in the covenant or your lingtai
-character, not here.
+For maintained metadata-only/backfill changes, derive `last_changed_at` from
+`git log -1 --format=%cI -- path/to/SKILL.md`, not the bookkeeping date. Required
+frontmatter is `name` and `description`; version/author/tags remain optional.
 
-## Writing a good skill
+Keep simple linear procedures flat; use a small router with self-contained
+references for multi-topic work. Put brittle repeated operations in scripts and
+concrete templates in assets. Create skills for reusable competence, not one-off
+tasks or personality/style preferences (those belong in character/covenant).
 
-1. **Trigger-optimized description.** The `description` is the only thing visible
-   in the catalog without loading the file, so it must answer: what does this
-   skill do, what domain is it for, and when should the agent reach for it vs
-   skip? Aim for 2–4 sentences, and spell out what it does NOT cover — that is
-   what stops an agent loading the file on a superficial match.
+A standalone published skill also needs a human-facing README (status, license,
+contributors), separate from agent instructions. Publishing requires separate
+authorization: copy authored content to a task-owned export directory before
+initializing its repository; do not initialize a new repository inside the
+existing agent tree. Retain reviewed upstream metadata for future sync/rollback.
 
-   - Bad: `description: "Helmholtz solver"` — what about it? when would I use it?
-   - Good: `description: "Python implementation of the Helmholtz algorithm — an iterative alternating-projection method for constructing divergence-free, constant-magnitude 3D vector fields. Used to generate SPAW initial conditions for MHD simulations."`
-2. **Numbered steps in imperative form.** "Extract the text...", not "You should
-   extract...".
-3. **Concrete templates in `assets/`** rather than prose describing the desired
-   output format.
-4. **Deterministic scripts in `scripts/`** for fragile or repetitive operations —
-   a script that always produces the same result beats prose the LLM must
-   re-derive every time.
-5. **Keep `SKILL.md` focused.** Target under 500 lines; offload dense content to
-   references and heavy logic to scripts.
-6. **Structure subdirectories conventionally.** `scripts/` for executables,
-   `references/` for supplementary context (schemas, cheatsheets, worked
-   examples), `assets/` for templates and static files.
+Before publishing or trusting a skill, walk every routing branch, verify paths and
+API claims against the code/filesystem, and repeat after corrections. This catches
+stale signatures and fictional references that structural validation cannot.
 
-## SKILL.md vs README.md
+## Catalog scope and settings
 
-Skills published as standalone repos need both — they serve different audiences.
-
-| File | Audience | Loaded by |
-|---|---|---|
-| `SKILL.md` | LingTai agents | `skills` capability (system prompt) |
-| `README.md` | Humans browsing GitHub | Not loaded by agents |
-
-They are not redundant: `README.md` carries project status, license, contributor
-notes, and screenshots that agents do not need, while `SKILL.md` carries
-frontmatter fields (`tags`, `version`, machine-readable description) humans do
-not parse. If you only ship through an opt-in shared root such as
-`.library_shared/` and never publish to GitHub, you can omit `README.md`.
-
-## Publishing to GitHub
-
-To share a skill outside the network — with humans, external collaborators, or as
-a standalone resource:
-
-1. Author it in `<agent>/.library/custom/<name>/` as usual.
-2. Copy out: `cp -r .library/custom/<name> /tmp/<name>`.
-3. `cd /tmp/<name> && git init && git add . && git commit -m "Initial release"`.
-4. Add `README.md` (human-facing — see above).
-5. `gh repo create <owner>/<name>-skill --public --source=. --push`.
-
-Do NOT `git init` inside `.library/custom/` directly — it is a subtree of your
-agent working directory and you would entangle two repos. Always copy out first.
-Once published, other agents install it with `git clone` into their
-`.library/custom/` and rebuild their context.
+The catalog contains each entry's `name`, `description`, and `location`; read its
+body only on demand. There is no Skills-owned settings file and no
+`settings/psyche.skills.json`; Psyche's owner document does not configure Skills.
+Pin a relevant body in Pad only through the Pad manual and rebuild afterward.
 
 ## Cleanup / Footprint
 
-Skills live under `.library/intrinsic/`, `.library/custom/`, opt-in shared skill
-paths when configured, and any extra paths configured in `init.json`. Intrinsic
-skills are runtime-owned; do not delete them. Custom skills are portable
-procedure memory: cleanup should usually mean validation, renaming,
-consolidation, or git removal through a reviewed PR — not ad-hoc `rm`.
-
-Footprint check: load the [shared inspection recipe](reference/cleanup-footprint-contract.md#shared-footprint-check-recipe)
-through `skills-manual` → `reference/cleanup-footprint-contract.md`. Combine
-its definitions with this tool-specific selection in one task-owned script;
-the selection is not a standalone executable. Inspection writes nothing.
-Appending `logs/cleanup.jsonl` is the separate, explicitly selected audit step
-in that recipe; retain this manual's cleanup/approval rules below.
-
-```python
-agent = Path.cwd()  # the relevant agent directory, not a repository root
-items = [p for p in (agent / ".library" / "custom", agent / ".library" / "intrinsic", agent.parent / ".library_shared") if p.exists()]
-rows, total = footprint_check(items, tool="skills", top_n=None)
-```
-
-Recommended cadence: after authoring/publishing skills, before recipe export, and
-monthly for shared libraries. Destructive cleanup requires a dry-run report,
-explicit user consent, and a git commit/PR when the skill root is tracked.
+Skills leave intrinsic and custom libraries plus any configured extra roots. Never
+blindly delete intrinsic runtime state. For a read-only footprint report, load the
+[shared recipe](reference/cleanup-footprint-contract.md#shared-footprint-check-recipe)
+and select `.library/intrinsic/`, `.library/custom/`, and explicitly configured
+roots; inspection writes nothing. Cleanup means reviewed validation, renaming,
+consolidation, archive, or a PR—not ad-hoc removal. First show a dry-run, explain
+what changes, obtain explicit user consent, and record approved work in
+`logs/cleanup.jsonl`; then rebuild the catalog. The recipe's audit append is a
+separate explicit write.

--- a/tests/test_psyche_family.py
+++ b/tests/test_psyche_family.py
@@ -1006,3 +1006,40 @@ def test_substrate_prompt_section_is_untouched_by_the_rename(tmp_path):
         assert agent._prompt_manager.read_section("substrate") == body
     finally:
         agent.stop(timeout=1.0)
+
+
+def test_manual_docs_keep_pad_seed_owner_explicit():
+    root = Path(__file__).parents[1] / "src/lingtai/intrinsic_skills/psyche-manual"
+    text = (root / "reference/settings/SKILL.md").read_text()
+    assert "top-level `init.json` `pad`/`pad_file`" in text
+    assert "not fields in `settings/psyche.json`" in text
+    assert "[Anchor details](SKILL.md#" not in text
+
+
+def test_manual_docs_preserve_external_skill_timestamp_option():
+    root = Path(__file__).parents[1] / "src/lingtai/tools/skills/manual"
+    text = (root / "SKILL.md").read_text()
+    assert "optional for custom/external" in text
+    assert "validate.py --require-last-changed-at .library/custom/<skill-name>/" not in text
+    assert "metadata-only" in text
+
+
+def test_manual_docs_installed_relative_links_resolve(tmp_path):
+    import re
+
+    agent = _agent(tmp_path, capabilities={"knowledge": {}, "skills": {}})
+    try:
+        for action in MANUAL_ACTIONS:
+            result = _call(agent, action)
+            path = Path(result["manual_path"])
+            paths = [path]
+            if action == "manual":
+                paths += [path.parent / "reference/settings/SKILL.md",
+                          path.parent / "reference/network-rules/SKILL.md"]
+            for source in paths:
+                for link in re.findall(r"\]\(([^)]+)\)", source.read_text()):
+                    if "://" in link:
+                        continue
+                    assert (source.parent / link.split("#")[0]).exists(), (source, link)
+    finally:
+        agent.stop(timeout=1.0)


### PR DESCRIPTION
## Summary
- Psyche-only reduction: seven manuals, public description strings and three focused documentation regressions. 9 files, +430/−957; no runtime logic, configuration grammar, input/result shape, Contract or dependency changes.
- Entry 3,630 → 3,139 (−13.5%); all seven bodies 50,728 → 24,106 (−52.5%). Schema-description occurrences 776→777; family583→567; combined−15 chars. No token/cost claim.
- Direct matching-domain manual rather than mandatory router-then-domain double reading; fix installed Knowledge cross-owner route and remove settings self-links.
- Restore exact Pad/Pad-file top-level init ownership, separate from the six-field Psyche owner document; retain nonempty Pad preservation, resolved forced/self-evolve semantics, pinned-file verification, last-good generation and full SHOW redaction.
- Keep custom/external last_changed_at optional; strict validator flag only for LingTai-maintained bundles. Restore metadata-only history, nested child validation, flat-vs-router criteria and separate authorized publication/export directory.
- Preserve private Knowledge → portable Skills direction, full file envelopes, .rules single-target/atomic/consume/empty-noop semantics, and all configuration/cleanup authority.

## Validation
Exact clean base `978c51314786c4399c721275af91b63bf5786663`.
- `PYTHONPATH=src python3.14 -B -m pytest -q tests/test_context_ownership_redesign.py tests/test_catalog_helpers.py tests/test_psyche_family.py tests/test_psyche_prompt_settings.py tests/test_pad_lingtai_split.py tests/test_pad.py tests/test_lingtai_facade.py tests/test_knowledge.py tests/test_tool_family_knowledge_migration_parity.py tests/test_skills.py tests/test_validate_skill.py tests/test_avatar_rules.py tests/test_signpost_tool_descriptions.py tests/test_intrinsic_manual_actions.py tests/test_tool_prose_section_gate.py tests/test_tool_plugin_declaration.py tests/test_tool_settings_contract.py tests/test_prompt_catalog.py tests/test_docs_governance.py tests/test_architecture_documents.py` → candidate **436 passed / 6 failed / 1 warning**, clean base **433 / same6 / 1 warning**. All six full failure blocks equal after pytest temporary-root normalization only.
- Changed complete test_psyche_family.py: **86 passed** in the full run. Three new docs tests failed before prose correction, then passed; initial old Skills/signpost phrase assertions restored without weakening tests before final full rerun.
- Baseline failures remain: System standalone-skill assertion, two prompt-catalog assertions, two MCP SDK imports, Psyche anatomy orphan. Not PASS, not a full-repo claim.
- `python3.14 -B scripts/check_docs_governance.py --check` → **400 docs + docs.yaml PASS**. Anatomy drift: six existing byte-identical findings. `git diff --check` PASS.
- Hermetic actual Agent + full prompt (31654 chars), one Psyche mount, five manual actions, seven installed bodies byte-equal,11 links,8 SHOW rows/anchors, delayed owner application/nonempty Pad retention/task-local rules update and empty no-op → PASS (mock LLM, socket connect blocked).
- AST identical except two reviewed description strings; schema identical except description. All seven candidate bodies/removed guidance reviewed; relevant Psyche and domain contracts compared with actual parser/catalog/composer/lifecycle code. Original native Luna candidate, no replacement worker.

## Boundaries
No full-repo/native-Windows/real provider/production Agent E2E; no rollout/config/auth/cleanup. Some unchanged old Pad/LingTai/Skills/Knowledge Contract prose still names retired standalone roots; current Psyche Contract/code/tests own the live surface. No opportunistic Contract or engine normalization. Self-contained HTML prepared and browser-checked; not committed.

Telegram: @lingtaidev1bot | Nickname: 知微
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
