### PR TITLE
docs(wechat): simplify manuals and clarify uncertain outcomes

### DIFF
--- a/src/lingtai/mcp_servers/wechat/SKILL.md
+++ b/src/lingtai/mcp_servers/wechat/SKILL.md
@@ -1,13 +1,12 @@
 ---
 name: wechat-mcp-manual
 description: |
-  Progressive-disclosure usage manual for the WeChat MCP tool. Read this when you
-  need detail beyond the resident action catalog: safe send/reply operations,
-  inbound and outbound media, QR login, settings, account ownership, or poller
-  recovery. Pulled on demand via action='manual'; it is not required before every
-  send.
-version: 2.0.0
-last_changed_at: "2026-09-07T00:00:00Z"
+  Progressive-disclosure usage manual for WeChat/iLink: first safe read, exact
+  IDs, external send/reply, media partials, and standalone poller/setup hazards.
+  Use the schema for routine calls; load this manual for media details,
+  unfamiliar results, setup, or recovery.
+version: 2.1.0
+last_changed_at: "2026-09-09T03:15:00Z"
 related_files:
 - src/lingtai/mcp_servers/ANATOMY.md
 - src/lingtai/mcp_servers/wechat/manager.py
@@ -34,92 +33,71 @@ maintenance: |
   provider behavior, setup boundary, settings projection, or public actions change.
 ---
 
-# WeChat MCP — usage manual (progressive disclosure)
+# WeChat MCP
 
-The `wechat` MCP exposes one strict LTP-v2 tool. The `manual` action returns this
-file on demand; the resident description and action catalog are intentionally
-short so ordinary tool calls do not load operational detail.
+Use the schema for routine calls; this progressive disclosure guide adds media,
+setup/recovery and unfamiliar result details, not a per-send reading ritual.
 
-## Public family and first-call boundaries
+## First safe action
 
-The root envelope is closed `{action, input, reasoning, summarize?}`. `action`,
-`input`, and `reasoning` are required. `input` is a closed object owned by the
-selected action; host-only fields, aliases, and legacy flat arguments are not
-accepted. The exact public actions are listed below; `settings` is immediately
-before `manual`.
+```json
+{"action":"check","input":{},"reasoning":"find WeChat conversations"}
+```
 
-- `send` and `reply` cause real external side effects. Verify the recipient and
-  content first. A provider-accepted request is not proof of delivery and must
-  not be automatically replayed.
-- Use a `user_id` returned by `check`, `read`, or `contacts`; do not invent a
-  recipient. `reply` needs the `message_id` of an inbound message from `read`.
-- `media_path` is an outbound file operation. Keep the file in the agent's
-  allowed working area; text and media can produce a partial outcome.
-- Login and configuration are owner/setup procedures, not messaging actions.
-  Never print, paste, or share the admin login QR, bot token, or credentials.
-- iLink `getUpdates` has one consumer per bot account. The MCP holds a per-account
-  poller lock and refuses a second poller; after a refresh or recovery, reconcile
-  with `read` before replying so a replay cannot cause a duplicate response.
-- `settings` is SHOW-only and `manual` is the route to this guide. Read the
-  focused reference only when its topic is needed.
+Then `read` an exact `user_id` from `check`, `read`, or `contacts`. For `reply`, use
+an inbound `message_id` from `read`; do not invent recipients. `search` matches
+inbox bodies by regex; it cannot prove that an outgoing reply is absent.
+Calls require
+`action`, closed action-owned `input`, and `reasoning`; optional `summarize` is
+boolean. The advertised schema owns the action catalog and validation.
 
-## Settings anchors
+## External effects and recovery
 
-The settings provider's `comment` values point to these stable anchors. The
-setup reference owns the detail; SHOW remains read-only.
+`send`/`reply` are real external side effects: obtain authority and verify recipient
+and content. Success is provider acceptance, not delivery (`delivery_confirmed`
+is false); never replay an accepted request. `reply` cannot fall back to a new
+recipient if its inbound target or sender is missing.
+
+`media_path` is a file inside the allowed working directory. Text precedes media;
+partial results or uncertain errors require reconciliation, not whole-request
+replay. A missing local sent record does not prove nothing was accepted. Read
+[operations](reference/operations.md) for result/read-state limits and
+[media](reference/media.md) for paths, validation and upload stages.
+
+`getUpdates` has one consumer per bot account. The per-account lock refuses a
+second poller; do not delete its lockfile or start another. After refresh, worker
+failure or recovery, use `read` to reconcile merged inbox/sent history before
+replying. Local history is context, not a delivery receipt.
+
+Login, configuration and credential replacement require the owner's setup
+authorization. Avatar sessions must not reconfigure this MCP. Never share the
+admin login QR, token or credentials. See [setup/recovery](reference/setup.md);
+host addon activation remains owned by `mcp-manual`.
+
+## Settings SHOW
+
+`settings` takes `input={}` and returns the startup snapshot without writing or
+rereading owner files. Five sensitive rows redact both `current` and `default`;
+only `poll_interval` is displayed. An unavailable row fails the whole inventory.
+SHOW grants no configuration authority. Each stable anchor routes directly:
 
 ## setting-config-path
-
-See [`reference/setup.md#setting-config-path`](reference/setup.md#setting-config-path).
+[Resolved config source](reference/setup.md#setting-config-path).
 
 ## setting-base-url
-
-See [`reference/setup.md#setting-base-url`](reference/setup.md#setting-base-url).
+[Endpoint precedence](reference/setup.md#setting-base-url).
 
 ## setting-poll-interval
-
-See [`reference/setup.md#setting-poll-interval`](reference/setup.md#setting-poll-interval).
+[Polling interval/default](reference/setup.md#setting-poll-interval).
 
 ## setting-allowed-users
-
-See [`reference/setup.md#setting-allowed-users`](reference/setup.md#setting-allowed-users).
+[Inbound allow-list](reference/setup.md#setting-allowed-users).
 
 ## setting-bot-token
-
-See [`reference/setup.md#setting-bot-token`](reference/setup.md#setting-bot-token).
+[Login secret](reference/setup.md#setting-bot-token).
 
 ## setting-user-id
+[Backend identity](reference/setup.md#setting-user-id).
 
-See [`reference/setup.md#setting-user-id`](reference/setup.md#setting-user-id).
-
-## Resident action catalog
-
-| Action | Input and purpose |
-|---|---|
-| `send` | `user_id` plus `text` and/or `media_path`; deliver a new message |
-| `check` | `{}`; list conversations and unread counts |
-| `read` | `user_id`, optional `limit`; read merged inbox/sent history |
-| `reply` | `message_id` plus `text`; respond to a specific inbound message |
-| `search` | `query`, optional `user_id`; regex-search inbox messages |
-| `contacts` | `{}`; list saved contacts |
-| `add_contact` | `user_id` plus `alias`; save a local contact alias |
-| `remove_contact` | `alias` or `user_id`; remove a saved contact |
-| `accounts` | `{}`; list configured account details |
-| `settings` | `{}`; show the read-only startup configuration inventory |
-| `manual` | `{}`; return this progressive-disclosure guide |
-
-All calls still require the root `reasoning` string. Exact schemas, required
-fields, nullability, and validation remain owned by the advertised tool schema.
-
-## Focused references
-
-| Need | Read |
-|---|---|
-| Send/reply, reading, contacts, account results, errors, and replay-safe operations | [`reference/operations.md`](reference/operations.md) |
-| Outbound attachments, inbound files, magic-byte checks, and partial media delivery | [`reference/media.md`](reference/media.md) |
-| QR login, config/credentials, poller startup, settings SHOW, and recovery | [`reference/setup.md`](reference/setup.md) |
-
-These sidecars ship with the package but are not embedded in the `manual` result.
-Use the relative links above; do not infer setup fields or provider behavior from
-memory. Human-facing addon registration and activation remain the host's
-`mcp-manual` procedure, not this provider manual.
+Sidecars ship with the package but are not embedded in `manual`; follow the
+relative links only when their detail is needed.

--- a/src/lingtai/mcp_servers/wechat/_family.py
+++ b/src/lingtai/mcp_servers/wechat/_family.py
@@ -51,18 +51,17 @@ def _wechat_input_schemas() -> dict[str, dict[str, Any]]:
         {
             "user_id": {
                 "type": "string",
-                "description": "WeChat user ID (e.g. wxid_abc123@im.wechat)",
+                "description": "Exact user_id from check, read, or contacts.",
             },
             "text": {
                 "type": "string",
-                "description": "Message text content",
+                "description": "Text to send to the verified recipient.",
             },
             "media_path": {
                 "type": "string",
                 "description": (
-                    "Absolute path to a file to send as media. "
-                    "Type detected from extension: "
-                    ".jpg/.png=image, .mp4=video, .wav/.mp3=voice, other=file."
+                    "Readable file inside the allowed working area; type follows its "
+                    "extension. Text plus media may have a partial outcome."
                 ),
             },
         },
@@ -76,11 +75,11 @@ def _wechat_input_schemas() -> dict[str, dict[str, Any]]:
             {
                 "user_id": {
                     "type": "string",
-                    "description": "WeChat user ID (e.g. wxid_abc123@im.wechat)",
+                    "description": "Exact user_id from check, read, or contacts.",
                 },
                 "limit": {
                     "type": "integer",
-                    "description": "Max messages to return (default 10)",
+                    "description": "Maximum messages to return (default 10).",
                 },
             },
             required=["user_id"],
@@ -89,11 +88,11 @@ def _wechat_input_schemas() -> dict[str, dict[str, Any]]:
             {
                 "message_id": {
                     "type": "string",
-                    "description": "Message ID from read results (for reply action)",
+                    "description": "Exact inbound message_id returned by read.",
                 },
                 "text": {
                     "type": "string",
-                    "description": "Message text content",
+                    "description": "Reply text for that inbound message.",
                 },
             },
             required=["message_id", "text"],
@@ -102,11 +101,11 @@ def _wechat_input_schemas() -> dict[str, dict[str, Any]]:
             {
                 "query": {
                     "type": "string",
-                    "description": "Search query (regex pattern)",
+                    "description": "Regular-expression query for inbox bodies.",
                 },
                 "user_id": {
                     "type": "string",
-                    "description": "WeChat user ID (e.g. wxid_abc123@im.wechat)",
+                    "description": "Optional exact user_id from check or contacts.",
                 },
             },
             required=["query"],
@@ -116,7 +115,7 @@ def _wechat_input_schemas() -> dict[str, dict[str, Any]]:
             {
                 "user_id": {
                     "type": "string",
-                    "description": "WeChat user ID (e.g. wxid_abc123@im.wechat)",
+                    "description": "Exact user_id from check, read, or contacts.",
                 },
                 "alias": {
                     "type": "string",
@@ -129,7 +128,7 @@ def _wechat_input_schemas() -> dict[str, dict[str, Any]]:
             {
                 "user_id": {
                     "type": "string",
-                    "description": "WeChat user ID (e.g. wxid_abc123@im.wechat)",
+                    "description": "Saved user_id to remove.",
                 },
                 "alias": {
                     "type": "string",
@@ -166,16 +165,13 @@ def wechat_schema() -> dict[str, Any]:
     if "oneOf" in inputs:
         inputs["anyOf"] = inputs.pop("oneOf")
     schema["properties"]["action"]["description"] = (
-        "send: deliver text and/or media_path to user_id. "
-        "check: list conversations and unread counts. "
-        "read: read merged inbox/sent history (user_id; optional limit). "
-        "reply: send text for a read message_id. "
-        "search: regex-search inbox messages (query; optional user_id). "
-        "contacts: list saved contacts. "
-        "add_contact: save a contact (user_id, alias). "
-        "remove_contact: remove by alias or user_id. "
-        "accounts: list configured account details. "
-        "settings: show the read-only startup configuration inventory. "
+        "check/read first; use exact user_id/message_id returned by the tool. "
+        "send/reply are external effects: verify content, treat acceptance as not "
+        "delivery, and never replay accepted requests. Actions: send (user_id + "
+        "text/media_path), check, read (user_id; optional limit), reply "
+        "(message_id + text), search (regex query; optional user_id), contacts, "
+        "add_contact (user_id + alias), remove_contact (alias or user_id), accounts, "
+        "settings (SHOW-only), and "
         + WECHAT_PLUGIN.manual_action_description()
     )
     return schema

--- a/src/lingtai/mcp_servers/wechat/manager.py
+++ b/src/lingtai/mcp_servers/wechat/manager.py
@@ -85,16 +85,15 @@ _HISTORY_INDEX_VERSION = 1
 SCHEMA = _family.WECHAT_SCHEMA
 
 DESCRIPTION = (
-    "WeChat via the iLink Bot API for text and media messaging plus inbound "
-    "LICC delivery. Actions: send (user_id with text and/or media_path), check "
-    "(conversations and unread counts), read (merged inbox/sent history), "
-    "reply (message_id and text), search (regex), contacts, add_contact, "
-    "remove_contact, accounts, settings (read-only startup snapshot), and "
-    "manual (progressive-disclosure guide). send/reply reach real users: verify "
-    "the user_id and content, and do not replay a provider-accepted request. "
-    "Media can have a partial outcome. Login/configuration belongs to the "
-    "orchestrator's owner setup flow; only one poller may run per bot account. "
-    "Avatar sessions must not reconfigure this MCP."
+    "Standalone WeChat/iLink messaging. Use check/read/search first and exact "
+    "IDs from check/read/contacts. send/reply are real effects: verify recipient "
+    "and content; provider acceptance is not delivery and accepted requests are "
+    "never replayed. media_path must stay in the allowed workdir and text+media "
+    "may be partial. One poller per bot account; refresh/recovery requires read "
+    "reconciliation. Login/configuration belongs to owner setup; never share the "
+    "admin QR or credentials. Avatar sessions must not reconfigure this MCP. "
+    "Actions: send, check, read, reply, search, contacts, add_contact, remove_contact, "
+    "accounts, settings, manual."
 )
 
 

--- a/src/lingtai/mcp_servers/wechat/reference/media.md
+++ b/src/lingtai/mcp_servers/wechat/reference/media.md
@@ -1,11 +1,11 @@
 ---
 name: wechat-media-reference
 description: |
-  Focused WeChat media reference: contained outbound paths, extension-based
-  message types, text-plus-media ordering and partial outcomes, inbound file
-  validation, and safe recovery from cache or upload failures.
-version: 1.0.0
-last_changed_at: "2026-09-07T00:00:00Z"
+  WeChat attachment details: allowed outbound paths, extension types, text-plus-
+  media partial outcomes, inbound file validation, official CDN stages, and safe
+  recovery. Load from the main manual before an attachment operation.
+version: 1.1.0
+last_changed_at: "2026-09-09T03:15:00Z"
 related_files:
 - src/lingtai/mcp_servers/wechat/SKILL.md
 - src/lingtai/mcp_servers/wechat/manager.py
@@ -18,58 +18,53 @@ related_files:
 - tests/test_wechat_media_upload_diagnostics.py
 maintenance: |
   Tracks WeChat media type detection, validation warnings, upload stages, and
-  partial-delivery guidance; update when provider media fields, containment, or
+  partial-delivery guidance; update when provider fields, containment, or
   diagnostics change.
 ---
 
 # WeChat media
 
-Use this reference for attachments and inbound files. `send` remains an external
-side effect; confirm `user_id` and content before starting an upload.
+`send` remains an external effect: confirm the exact `user_id` and content before
+starting an upload.
 
-## OUTBOUND `media_path`
+## Outbound `media_path`
 
-- The public schema advertises `media_path` as a file path. The outbound-file
-  resolver requires a readable file within the agent's allowed working area and
-  rejects paths outside that boundary before any message is sent.
-- The suffix selects the WeChat item type: common image suffixes (`.jpg`,
-  `.jpeg`, `.png`, `.gif`, `.webp`, `.bmp`) are images; video suffixes (`.mp4`,
-  `.avi`, `.mov`, `.mkv`) are video; voice suffixes (`.wav`, `.mp3`, `.ogg`,
-  `.silk`, `.amr`) are voice; other suffixes are sent as files. This is an
-  extension mapping, not content inspection for outbound files.
-- `text` and `media_path` may be supplied together. The manager sends them as two
-  recipient-visible messages, text first and media second. It validates the path
-  before sending text, preventing a missing or disallowed file from causing an
-  avoidable text-only send.
-- A later upload or media-reference failure can still leave the text delivered.
-  The result reports a partial outcome and disables automatic replay; do not
-  resend the entire text-plus-media request without reconciling what happened.
+Use a readable file. Relative paths resolve against the agent workdir; absolute
+paths must also remain inside it after symlink and `..` resolution. Containment
+and `is_file()` are checked before text, but reading the bytes happens later.
+The suffix selects the item type:
 
-## INBOUND MEDIA AND FILES
+- image: `.jpg`, `.jpeg`, `.png`, `.gif`, `.webp`, `.bmp`
+- video: `.mp4`, `.avi`, `.mov`, `.mkv`
+- voice: `.wav`, `.mp3`, `.ogg`, `.silk`, `.amr`
+- any other suffix: file
 
-Inbound items are saved as local artifacts and represented in message text with
-bounded tags such as `[Image: path]`, `[Voice: "transcript" (audio: path)]`,
-`[File: name (path)]`, and `[Video: path]`. Verify the path exists and is readable
-before analysis; a path in a message is not a request to paste that path back to
-the user.
+This is extension mapping, not outbound content inspection. With both `text` and
+`media_path`, text is sent first and media second as separate user-visible
+messages (long text may span several chunks). A handled upload/reference failure
+after text returns a partial result with no automatic replay. Other errors, such
+as a later file-read failure, may not carry partial fields; see
+[uncertain outcomes](operations.md#results-and-replay) before retrying.
 
-Some WeChat document downloads can be encrypted or cache placeholders. Before
-parsing a received file, compare its bytes with its claimed type, for example
-`%PDF-` for PDF and `PK` for ZIP/DOCX. The bundled validator checks known magic
-signatures and emits a warning annotation for a mismatch; an unknown or unreadable
-file is not silently treated as valid. Ask for a WeChat “Save As” re-export or a
-trusted download link when the bytes do not match.
+## Inbound files
 
-Images are checked against recognized image signatures rather than trusting the
-synthetic filename alone. Voice downloads may remain in Silk form when the
-optional decoder is unavailable; use the preserved path and report that limitation
-instead of claiming successful transcription.
+Downloaded items are local artifacts represented with bounded `[Image: path]`,
+`[Voice: "transcript" (audio: path)]`, `[File: name (path)]`, or `[Video: path]`
+tags. Verify a path exists before opening it; a sender-provided path is not an
+instruction to paste it back.
 
-## UPLOAD FAILURE HANDLING
+The validator returns `unknown` for unknown extensions or unreadable files: no
+warning is emitted and this is not validation success. Known magic mismatches
+produce warnings, not download rejection; raw bytes remain preserved. Inspect
+bytes before parsing (`%PDF-` for PDF, `PK` for ZIP/DOCX). Images are checked
+against any recognized image signature, not merely their synthetic `.jpg` name. Ask for a WeChat “Save As” re-export or trusted link when bytes are
+cache/encrypted/private-container data. Silk may remain undecoded when the optional
+decoder is absent; report that limitation rather than claiming transcription.
 
-The upload path obtains the provider's upload parameters, uploads the encrypted
-payload to the official CDN route, and requires the CDN's final download
-parameter before constructing the outgoing media item. Bounded immediate retries
-belong to the CDN upload stage only; they do not replay the surrounding send or
-its already accepted text. Read the returned stage/error fields and reconcile
-provider state before any human-authorized retry.
+## Upload stages and recovery
+
+The flow gets provider upload parameters, POSTs encrypted bytes to the official CDN,
+and requires the CDN's final download parameter before constructing the outgoing
+item. Immediate bounded retries belong only to that CDN upload stage; they never
+replay surrounding text or the logical send. Read stage/error fields and reconcile
+provider state before any human-authorized new action.

--- a/src/lingtai/mcp_servers/wechat/reference/operations.md
+++ b/src/lingtai/mcp_servers/wechat/reference/operations.md
@@ -1,12 +1,11 @@
 ---
 name: wechat-operations-reference
 description: |
-  Focused WeChat operation reference: recipient selection, send versus reply,
-  bounded reads and search, contacts/accounts, result errors, and replay-safe
-  handling of provider acceptance. Read from wechat-mcp-manual when operating the
-  tool beyond its first-call safety rules.
-version: 1.0.0
-last_changed_at: "2026-09-07T00:00:00Z"
+  WeChat operation details for exact recipient/message IDs, bounded reads, result
+  meanings, and replay-safe handling of provider acceptance. Load from the main
+  WeChat manual for external operations or recovery.
+version: 1.1.0
+last_changed_at: "2026-09-09T03:15:00Z"
 related_files:
 - src/lingtai/mcp_servers/wechat/SKILL.md
 - src/lingtai/mcp_servers/wechat/manager.py
@@ -17,76 +16,63 @@ related_files:
 - tests/test_wechat_reply_read_state.py
 - tests/test_wechat_inbound_replay.py
 maintenance: |
-  Tracks the WeChat manager's action/result semantics and replay-safe operating
-  guidance; update when action dispatch, history views, acknowledgement handling,
-  or local side effects change.
+  Tracks WeChat action/result semantics and replay-safe operation guidance; update
+  when dispatch, history views, acknowledgement, or local side effects change.
 ---
 
 # WeChat operations
 
-This is a focused reference for the `wechat` action family. The public envelope
-and safety boundaries remain in the parent [`SKILL.md`](../SKILL.md); this file
-only adds operational detail.
+The parent [`SKILL.md`](../SKILL.md) owns the closed envelope and first-action route.
+This reference adds the operation semantics that matter after discovery.
 
-## SEND versus REPLY
+## Send and reply
 
-- `send` starts a new message for the supplied `user_id`. It requires `text`,
-  `media_path`, or both; the recipient ID is routing data, not a contact alias.
-- `reply` takes an inbound `message_id` from `read`, resolves its original
-  sender, and sends the supplied `text`. It fails when the message cannot be
-  found or its sender cannot be determined; it does not silently become a new
-  recipient-less send.
-- A successful reply marks its target inbound message read. A failed send does
-  not mark it read.
-- Both actions deliver to real WeChat users. A successful result records
-  provider acceptance, but `delivery_confirmed` remains false because the
-  provider does not prove recipient delivery.
+- `send` starts a new message for the supplied exact `user_id`; it requires `text`,
+  `media_path`, or both.
+- `reply` takes an inbound `message_id` from `read`, resolves its original sender,
+  and sends `text`. Missing message or sender is an error, never a fresh send.
+- A successful reply marks its target inbound message read. A failed send does not.
+- Provider acceptance is not delivery confirmation: successful results keep
+  `delivery_confirmed: false`. Do not replay an accepted request automatically.
 
-## CHECK, READ, AND SEARCH
+## Check, read, and search
 
-- `check` returns recent conversation aggregates with `user_id`, optional saved
-  alias, total count, unread count, latest preview metadata, and date. Unread
-  counts concern inbound messages; outgoing records are included for context but
-  are not unread messages.
-- `read` requires `user_id` and accepts an optional `limit` (default 10). It
-  returns the newest bounded view merged from inbox and sent records, labels
-  outgoing records, and marks returned inbound records read.
-- `search` requires a regular-expression `query`, optionally filtered by
-  `user_id`. It searches inbox message bodies and returns at most 20 matches; an
-  invalid regular expression is an action error.
-- After a worker refresh, molt, or recovery, use `read` to reconcile the merged
-  view before replying. Do not infer that an unread preview is a new message or
-  that the absence of a search match proves no outgoing reply exists.
+- `check` returns conversation aggregates with `user_id`, optional alias, total and
+  inbound-unread counts, latest preview, and date. Outgoing records add context but
+  are not unread.
+- `read` requires `user_id`; optional `limit` defaults to 10. It returns the newest
+  bounded view merged from inbox and sent records, labels outgoing records, and
+  marks returned inbound records read.
+- `search` requires a regular-expression `query`, optionally filtered by `user_id`;
+  it searches inbox bodies and returns at most 20 matches. Invalid regex is an error.
+- After refresh, worker failure, or recovery, read the merged history before
+  replying. A preview or absent search match does not prove that a reply is new or
+  absent.
 
-## CONTACTS AND ACCOUNTS
+## Contacts and account view
 
-- `contacts` lists locally saved aliases. `add_contact` persists an alias for a
-  `user_id`; `remove_contact` accepts either an existing alias or a user ID.
-  These are local state changes, not proof that WeChat accepted a contact
-  relationship remotely.
-- `accounts` reports the configured account view. Treat account IDs and paths as
-  potentially sensitive metadata; it never authorizes changing credentials.
-  Login and credential replacement belong to the owner procedure in
-  [`setup.md`](setup.md).
+`contacts` lists local aliases. `add_contact` persists an alias for a `user_id` and
+`remove_contact` accepts an alias or user ID; neither changes or proves a remote
+contact relationship. `accounts` reports configured account metadata and does not
+authorize credential changes. Treat IDs and paths as sensitive metadata.
 
-## RESULTS AND ERROR SURFACING
+## Results and replay
 
-- Successful business actions return a result object. Failures use an `error`
-  field (for example, missing identifiers, an unknown message, invalid regex, or
-  an unreadable outbound file); surface that error instead of assuming success.
-- Send acknowledgement accepts the provider's missing/null `ret` or integer
-  zero only when `errcode` is absent or integer zero. Nonzero or invalid values
-  remain failures. This is provider acceptance, not delivery confirmation.
-- A text-plus-media send can return `status: partial` when text was accepted but
-  the media stage failed. Its result carries `partial_delivery` for compatibility,
-  precise provider-acceptance fields, and `automatic_retry_allowed: false`.
-  Reconcile state before deciding what to do next; never replay the whole request
-  automatically.
+Failures return an `error` (for example, missing IDs, unknown message, invalid regex,
+or unreadable file); surface it. Send acknowledgement accepts missing/null `ret` or
+non-boolean integer zero only when `errcode` is absent or non-boolean integer
+zero. Strings, floats, booleans and an explicit null `errcode` fail. An empty,
+malformed or non-object response also fails.
 
-## INBOUND REPLAY AND POLLER STATE
+Text-plus-media can return `status: partial` with `partial_delivery`, precise
+provider-acceptance fields, and `automatic_retry_allowed: false`: text may already
+be accepted while media failed. Reconcile before a human-authorized new action.
 
-The manager persists cursor progress and bounded stable inbound signatures so a
-stale cursor after a worker failure does not normally create a second local
-message. This is a replay guard, not permission to send twice. Reply at most once
-per inbound `message_id`, and reread the merged history after a refresh before
-performing another external side effect.
+Not every uncertain outcome has these fields. If a later text chunk fails, file
+reading fails after text, or persistence fails after acceptance, the error may
+lack partial fields and a sent record. A missing sent record is not evidence of
+zero acceptance. Stop and reconcile with the recipient/provider before a newly
+authorized attempt; do not automatically replay the whole request.
+
+The manager's cursor/signature guard suppresses normally repeated inbound landings;
+it is not permission to send twice. Reply at most once per inbound `message_id`.

--- a/src/lingtai/mcp_servers/wechat/reference/setup.md
+++ b/src/lingtai/mcp_servers/wechat/reference/setup.md
@@ -1,12 +1,11 @@
 ---
 name: wechat-setup-reference
 description: |
-  Focused WeChat setup and recovery reference: config/credentials resolution,
-  QR or headless login, read-only settings SHOW, per-account poller locking,
-  session expiry, and safe owner procedures. Read before changing setup or
-  diagnosing startup.
-version: 1.0.1
-last_changed_at: "2026-09-08T00:00:00Z"
+  WeChat owner setup and recovery: config/credential resolution, QR or headless
+  login, read-only settings, one-poller locking, session expiry, and safe restart.
+  Load before changing setup or diagnosing startup.
+version: 1.1.0
+last_changed_at: "2026-09-09T03:15:00Z"
 related_files:
 - src/lingtai/mcp_servers/wechat/SKILL.md
 - src/lingtai/mcp_servers/wechat/server.py
@@ -20,88 +19,83 @@ related_files:
 - tests/test_wechat_settings.py
 - ENVIRONMENT_VARIABLES.md
 maintenance: |
-  Tracks WeChat configuration, login, settings projection, and poller recovery
-  guidance; update when owner procedures, path precedence, redaction, or startup
-  behavior changes.
+  Tracks WeChat configuration, login, settings projection, and poller recovery;
+  update when owner procedures, path precedence, redaction, or startup behavior changes.
 ---
 
 # WeChat setup and recovery
 
-Registration and activation are host-owned. This reference covers the provider's
-files, login, startup, and read-only settings after the host has selected the
-curated WeChat addon.
+Registration and activation belong to the host. This reference covers provider
+files, owner login, startup, SHOW, and recovery after the host selects WeChat.
+Obtain explicit authority before login, changing configuration/credentials,
+stopping another owner or restarting the MCP; avatars must not reconfigure it.
 
-## CONFIGURATION FILES
+## Configuration and credentials
 
-`LINGTAI_WECHAT_CONFIG` points to `config.json`; the required sibling
-`credentials.json` is loaded from the same directory. An absolute config path is
-used as-is. A relative path prefers `LINGTAI_AGENT_DIR`, then the legacy project
-root for compatibility; without an agent directory, the process working directory
-is used. Put new configuration under the agent directory and use the `settings`
-action for redacted active verification; treat host status diagnostics as local
-and do not paste them into public reports.
+`LINGTAI_WECHAT_CONFIG` points to `config.json`; sibling `credentials.json` is read
+from the same directory. Absolute paths are used as-is. Relative paths resolve
+against `LINGTAI_AGENT_DIR` first, then its legacy project root (two parents up)
+if no file exists at the first candidate. Without an agent directory, use the
+process working directory instead. Prefer the agent directory for new setups.
 
-The authored `config.json` fields are:
+`config.json` may contain `base_url`, legacy `cdn_base_url`, `poll_interval` (float,
+default `1.0`), and optional `allowed_users`. A falsy allow-list preserves
+unrestricted compatibility behavior. Credentials contain the login-produced
+`bot_token`, account `user_id`, and optional effective `base_url`; never print,
+paste, commit, or diagnose their contents. Login writes credentials atomically with
+mode `0600`.
 
-## setting-config-path
+### setting-config-path
+`config_path` is the sensitive resolved `config.json` path captured at startup; it
+is not an authored config field.
 
-`config_path` is the sensitive resolved `config.json` path captured at manager
-startup. It is not an authored JSON field; `LINGTAI_WECHAT_CONFIG` is its source.
+### setting-base-url
+`base_url` uses truthy `credentials.json.base_url`; otherwise it uses config
+`base_url`, defaulting to the provider endpoint only when that config key is
+absent. Explicit null/empty config values do not select that default. The manager
+loads legacy `cdn_base_url` but does not pass it to its upload call; changing it
+does not override uploads through this tool.
 
-## setting-base-url
+### setting-poll-interval
+`poll_interval` is converted with Python `float`; default is `1.0`. Choose a
+positive finite value: runtime construction accepts zero/negative values, while
+a nonfinite snapshot makes SHOW fail. This guidance is not stricter validation.
 
-`base_url` is the endpoint fallback: a truthy `credentials.json.base_url` wins,
-then this config value, then the provider default. `cdn_base_url` is retained for
-configuration compatibility and is not a current upload-destination override when
-the provider supplies its upload route.
+### setting-allowed-users
+`allowed_users` is the optional inbound sender allow-list. Missing, null, empty, or
+other falsy values mean unrestricted compatibility behavior.
 
-## setting-poll-interval
+### setting-bot-token
+`bot_token` is the required login-produced secret; it has no default and is always
+redacted by SHOW.
 
-`poll_interval` is converted with Python `float`; default `1.0`. Use a positive
-finite value even though the loader does not reject every non-positive value.
+### setting-user-id
+`user_id` is the required login-produced account identity; it has no default and is
+redacted by SHOW. It is distinct from recipient IDs used by messaging actions.
 
-## setting-allowed-users
+## QR login (owner procedure)
 
-`allowed_users` is an optional inbound sender allow-list. A missing, null, empty,
-or other falsy value means unrestricted compatibility behavior; a truthy value is
-used as the configured sender set.
-
-`credentials.json` contains the login-produced `bot_token`, account `user_id`,
-and optional effective `base_url`. Treat the file as secret material: do not
-print, paste, commit, or include it in diagnostics. The login writer uses an
-atomic replacement and mode `0600`.
-
-## setting-bot-token
-
-`bot_token` is the required secret written by QR login. It has no default and is
-always redacted by SHOW; replace it only through the login/bootstrap procedure.
-
-## setting-user-id
-
-`user_id` is the required account identity written by QR login. It has no default
-and is redacted by SHOW; it is distinct from recipient IDs used by actions.
-
-## QR LOGIN
-
-Use the existing owner bootstrap procedure, not a messaging action:
+Use the existing bootstrap, not a messaging action:
 
 ```text
 lingtai-wechat-bootstrap <config-directory>
 ```
 
-For a headless host, the same login core is available through the documented
-`cli_login('<config-directory>')` entry point. It creates a default config when
-needed, displays a QR in the terminal (or uses the browser bootstrap flow), polls
-for confirmation, and writes sibling credentials on success. The QR authorizes
-the backend account; it is an admin login QR, not a contact or group QR. Never
-share it. After credentials are saved, restart or refresh the WeChat MCP through
-the host owner procedure, then use `settings` to verify only the redacted active
-snapshot.
+For a headless host, use the kernel environment's Python:
 
-If the session expires, rerun the login/bootstrap flow and restart the MCP. Do
-not hand-edit a token or attempt to repair credentials through `settings`.
+```text
+python -c "from lingtai.mcp_servers.wechat.login import cli_login; cli_login('<config-directory>')"
+```
 
-## SETTINGS SHOW
+It uses the same flow. It creates config when needed, displays an admin login QR,
+polls for confirmation, and atomically replaces sibling credentials, including
+any existing login. Confirm the target directory and replacement authority first. The QR authorizes the
+backend account; it is not a contact/group QR. Never share it. After login, restart
+or refresh the MCP through the host procedure and use `settings` only for redacted
+verification. Session expiry is a reason to request authorized login/restart,
+not permission to hand-edit a token or repair credentials through SHOW.
+
+## Settings SHOW
 
 Call the strict-empty action:
 
@@ -109,56 +103,30 @@ Call the strict-empty action:
 {"action":"settings","input":{},"reasoning":"inspect active WeChat settings"}
 ```
 
-Success is exactly `{"settings":[...]}`; each row has only `key`, `current`,
-`default`, `configurable`, and `comment`. The six keys are `config_path`, `base_url`,
-`poll_interval`, `allowed_users`, `bot_token`, and `user_id`, in that order.
-Sensitive rows redact both `current` and `default`; SHOW never writes, resets, or
-rereads owner files, and any unavailable/invalid row fails the complete inventory
-rather than returning a partial one. A `configurable` row describes the owner
-procedure for the next manager construction, not a mutation input to this action.
+Success is `{"settings":[...]}` with rows containing only `key`, `current`,
+`default`, `configurable`, and `comment`, in order: `config_path`, `base_url`,
+`poll_interval`, `allowed_users`, `bot_token`, `user_id`. Sensitive rows redact
+both values. SHOW is read-only: it never writes, resets, or rereads owner files;
+unavailable/invalid truth returns one bounded `SETTINGS_UNAVAILABLE` result
+(`status: failed`, `error_code`, `message`), with no rows or automatic retry. All
+six rows are configurable through their owner procedures. A row describes the
+owner procedure for the next manager construction, not a mutation input.
 
-Change the selected owner file or login credentials through the procedure above,
-restart/refresh at the required boundary, and call SHOW again. Do not expose the
-resolved config path, endpoint, allow-list, token, or account identity in chat or
-public diagnostics; the redacted settings result is the safe verification view.
+## One poller per account
 
-## ONE POLLER PER ACCOUNT
+The iLink updates stream is single-consumer. The MCP holds an exclusive per-account
+POSIX lock for the poller's lifetime and refuses a second poller; on platforms
+without `fcntl`, startup fails rather than pretending safety. Normal exit releases
+the lock. Do not delete lockfiles blindly: presence on disk alone does not prove a
+lock is held.
 
-The iLink updates stream is single-consumer. The MCP takes an exclusive per-account
-POSIX lock for the lifetime of the poller and fails startup with a clear error if
-another process already holds it. A normal process exit releases the lock; do not
-delete lockfiles blindly. Stop or reconfigure the other owner process, then
-restart the intended MCP. On a platform without `fcntl`, startup fails rather
-than pretending duplicate-poller safety exists.
-
-### Why `PollerLockBusy` can persist
-
-`PollerLockBusy` is decided when the MCP server starts, not on every tool call.
-If lock acquisition fails, the server keeps the manager unavailable and records
-the startup exception so later actions can return the same diagnostic. Those
-actions do not reacquire the lock or rebuild the manager. The reported holder PID
-is therefore a startup-time snapshot: if that process exits later, the operating
-system releases its POSIX lock, but the failed MCP server still needs a restart.
-The lockfile intentionally remains on disk; its presence alone does not mean the
-lock is still held.
-
-### Recovery sequence
-
-1. Inspect the holder named by the error before stopping anything:
-
-   ```text
-   ps -p <holder-pid> -o pid,command
-   lsof -p <holder-pid> 2>/dev/null | grep cwd
-   ```
-
-   Identify which project owns that process and confirm which project should keep
-   the account. Do not stop an unknown owner merely because the PID appears in an
-   earlier error.
-2. Gracefully stop or reconfigure the duplicate owner, then verify that the PID is
-   gone. Do not delete the lockfile: process exit releases the lock, while removing
-   the file can race with another acquisition.
-3. Restart or refresh the intended WeChat MCP through the host owner's supported
-   procedure. Repeating ordinary WeChat tool calls in the already-failed server
-   cannot recover its manager, and starting another poller is not a workaround.
-4. After recovery, use `check` or `read` to reconcile recent history before
-   sending or replying, so a recovered client does not duplicate a response.
+If `PollerLockBusy` persists, the failed server keeps its startup-time diagnostic
+and does not reacquire or rebuild its manager on ordinary calls. Inspect the named
+holder and confirm the owning project; do not stop an unknown PID. With exact
+authority, gracefully stop
+or reconfigure the duplicate owner, verify it is gone, then restart/refresh the
+intended MCP through the host procedure. The holder PID is a startup snapshot,
+not current liveness. Inspect locally with `ps -p <pid> -o pid,command` and
+`lsof -p <pid> 2>/dev/null | grep cwd`; do not publish raw diagnostics.
+Reconcile with `read` before
+sending or replying.

--- a/src/lingtai/mcp_servers/wechat/server.py
+++ b/src/lingtai/mcp_servers/wechat/server.py
@@ -62,13 +62,11 @@ log = logging.getLogger("lingtai.mcp_servers.wechat")
 
 
 _SERVER_INSTRUCTIONS = (
-    "lingtai-wechat: WeChat client via iLink Bot API. "
-    "Configure via the LINGTAI_WECHAT_CONFIG env var pointing at config.json "
-    "(credentials.json must live in the same directory; produced by the "
-    "QR-code login flow). "
-    "Inbound messages flow into the host agent's inbox via LICC. "
-    "Setup, config schema, and troubleshooting: "
-    "https://github.com/Lingtai-AI/lingtai-wechat"
+    "Standalone WeChat/iLink client. Use check/read/search first and exact IDs "
+    "returned by the tool. send/reply are real external effects: verify content, "
+    "treat acceptance as not delivery, and never replay an accepted request. "
+    "Media may be partial; one poller consumes each bot account. Login/config "
+    "belongs to the owner setup procedure."
 )
 
 

--- a/tests/test_wechat_settings.py
+++ b/tests/test_wechat_settings.py
@@ -269,3 +269,29 @@ def test_manual_anchors_strict_input_order_and_other_actions_are_unchanged(
     )
     assert result["status"] == "ok"
     assert result["accounts"] == ["default"]
+
+
+def test_manual_routes_each_show_anchor_without_routine_send_gate():
+    body = WECHAT_PLUGIN.skill_body
+    assert "Use the schema for routine calls" in body
+    assert "Avatar sessions must not reconfigure" in body
+    for key in SETTING_KEYS:
+        section = body.split(f"## setting-{key.replace('_', '-')}\n", 1)[1]
+        section = section.split("\n## ", 1)[0]
+        assert f"reference/setup.md#setting-{key.replace('_', '-')}" in section
+    setup = (Path(WECHAT_PLUGIN.skill_path).parent / "reference/setup.md").read_text()
+    assert "positive finite" in setup
+    assert "SETTINGS_UNAVAILABLE" in setup
+    assert "from lingtai.mcp_servers.wechat.login import cli_login" in setup
+
+
+def test_manual_distinguishes_unknown_media_from_delivery_evidence():
+    root = Path(WECHAT_PLUGIN.skill_path).parent
+    media = " ".join((root / "reference/media.md").read_text().split())
+    operations = " ".join((root / "reference/operations.md").read_text().split())
+    assert "`unknown`" in media and "no warning" in media
+    assert "Unknown/unreadable bytes fail" not in media
+    assert "after symlink" in media
+    assert "missing sent record" in operations
+    assert "later text chunk" in operations
+    assert "booleans" in operations


### PR DESCRIPTION
## Summary
- Streamline the WeChat manual entry and three references; remove the duplicate action table and per-send reading ritual while preserving the strict action envelope, exact IDs, owner/avatar boundaries and one-poller safety.
- Keep six SHOW routes directly navigable; explain five fully redacted rows, startup snapshot timing, endpoint/default precedence, inert manager cdn_base_url and whole-inventory SETTINGS_UNAVAILABLE.
- Correct unknown media versus validation success, inbound magic warnings, outbound path/read ordering, strict acknowledgement types, and uncertain text-chunk/file-read/persistence outcomes. These are documentation of existing behavior, not runtime fixes.
- Add two focused guidance regressions. Production AST and public schema shape are unchanged except descriptions. 8 files, +294/-348.

## Validation
Exact base: `f0dd73eeb2bb420e5e11a05097e98d0bfeec31b3`. Used the repository's existing Python 3.11 venv; no dependency changes.

```text
python -B -m pytest -q --continue-on-collection-errors tests/test_wechat_config_resolution.py tests/test_wechat_history_index.py tests/test_wechat_inbound_replay.py tests/test_wechat_login.py tests/test_wechat_media_official_cdn.py tests/test_wechat_media_upload_diagnostics.py tests/test_wechat_media_validation.py tests/test_wechat_media_warning_integration.py tests/test_wechat_notification_metadata.py tests/test_wechat_reply_read_state.py tests/test_wechat_settings.py tests/test_wechat_toolfamily_ltpv2.py tests/test_skills.py tests/test_mcp_skill_manuals.py tests/test_signpost_tool_descriptions.py tests/test_tool_prose_section_gate.py tests/test_tool_plugin_declaration.py tests/test_tool_settings_contract.py tests/test_prompt_catalog.py tests/test_docs_governance.py tests/test_architecture_documents.py
# candidate: 425 passed / 4 failed; control: 423 passed / 4 failed
python -B -m pytest -q tests/test_wechat_settings.py
# 8 passed; two new documentation checks failed before correction
python -B scripts/check_docs_governance.py --check
# 400 governed Markdown documents + docs.yaml PASS
python -B src/lingtai/intrinsic_skills/lingtai-kernel-anatomy/scripts/check_anatomy_drift.py --check
# six pre-existing findings, byte-identical to control
git diff --check
# PASS
```
All four complete failure blocks match after checkout/temp/separator normalization: existing System standalone skill assertion, two prompt-catalog assertions, and existing Psyche graph orphans. No collection errors/warnings. The intermediate omitted-search assertion was owned and corrected, not classified as baseline; a test-only str/Path error was also corrected with failed logs preserved.

Actual task-local `setup.py build_py` (Rust skipped), real Agent complete prompt (31,644 chars), exactly one host add_tool WeChat mount, four built manuals byte-equal, 11 relative links and six SHOW rows PASS. Mock LLM and blocked sockets; recording-only transport proved outside-path zero-send, partial media handling, later-text-chunk failure without a sent record, media unknown/mismatch truth and 4 accepted/6 rejected acknowledgement cases. AccountLock replaced only in this hermetic proof; no real poller or shared lock state.

## Scope and residuals
- Entry body 4,184 → 2,948 (−29.5%); four bodies 17,003 → 13,453 (−20.9%). Public schema + family descriptions −97 characters; server instructions −24 separately. Not measured token or cost savings.
- No engine/contract-promise change. Reviewed the governing Anatomy/Contract routes and actual implementation; no structural ownership change. Existing partial-outcome persistence gaps are not fixed.
- No real MCP stdio, WeChat API/CDN, login, poller, production E2E, native Windows, wheel/install or full-repository validation. No rollout, configuration, credentials, release or cleanup.
- Original native LingTai Luna worker draft; owner 知微 reviewed all removed/current guidance, corrected and validated. No replacement worker or additional CLI.

Telegram: @lingtaidev1bot | Nickname: 知微
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
