### PR TITLE
docs(email): simplify manuals and clarify delivery boundaries

### DIFF
--- a/src/lingtai/tools/email/_family_schema.py
+++ b/src/lingtai/tools/email/_family_schema.py
@@ -1,35 +1,16 @@
-"""Schema data — canonical per-action ``input`` schemas for the ``email`` family.
+"""Canonical closed per-action input schemas and first-call action guidance.
 
-This module holds only data: one strict, closed ``input_schema`` per
-operational/manual ``email`` action (:data:`INPUT_SCHEMAS`), the canonical
-pre-settings action order
-(:data:`ACTION_ORDER`), and the canonical English action prose
-(:data:`ACTION_ENUM_DESCRIPTION`).  ``__init__.py`` composes these into the
-public model-facing schema via the generic ``ToolFamily`` infra
-(``lingtai.tools.tool_family``) — see ``__init__.py::get_schema``.
+The generic ``ToolFamily`` composes this data into the public LTP v2 envelope;
+the legacy flat schema remains the internal ``EmailManager`` interface. See
+email-manual for depth.
 
-Why a new module rather than reshaping ``schema.py``: ``schema.py``'s flat
-``get_schema()`` is still the *internal* ``EmailManager.handle`` argument
-shape (the same seam ``shell`` kept when its ``ShellManager`` stayed flat —
-``tools/CONTRACT.md`` "Relationship to current runtime"), and
-``tests/test_layers_email.py`` pins several of its facts.  Keeping the
-per-action data here means the model-facing composition and the legacy flat
-shape have one owner each, and the ledger in the migration report can name
-exactly what each file is for.
+``ACTION_ORDER`` owns registration order; the generic declaration inserts
+``settings`` before ``manual``. Field depth lives in email-manual rather than
+being repeated in the schema module.
 
-Field descriptions retain the first-call semantics of ``schema.py``'s flat
-properties while moving rationale, catalogs, and examples to ``email-manual``
-references. ``ACTION_ORDER`` owns the operational/manual order and child
-registration order in ``__init__.py``. The generic declaration opt-in inserts
-``settings`` immediately before ``manual`` and consequently composes the public
-``input.anyOf``/``allOf`` order without adding a hand-authored schema here.
-
-Optional fields are declared in the provider-compatible nullable
-representation (``"type": [..., "null"]`` plus membership in ``required``) per
-``tools/CONTRACT.md`` "Envelope": a strict OpenAI schema has no other way to
-express an optional field.  ``__init__.py`` strips those nulls back to
-*absent* before the pre-existing ``EmailManager`` handlers run, so their
-``args.get("folder", "inbox")``-style defaulting — and the difference between
+Optional fields use provider-compatible nullable schemas; ``__init__.py``
+strips nulls to absent before pre-existing handlers run, so their
+existing defaulting — and the difference between
 "folder omitted" and "folder null" that ``_read``/``_search`` genuinely
 depend on — is preserved exactly.
 """
@@ -50,31 +31,27 @@ ACTION_ORDER: tuple[str, ...] = (
     "manual",
 )
 
-# --- Shared field descriptions, verbatim from the pre-migration flat schema ---
-
-_ADDRESS_DESCRIPTION = "Bare name/path for send; string or list."
+# Short schema guidance routes depth to the installed email-manual.
+_ADDRESS_DESCRIPTION = "Peer name/path for send; string or list; abs needs explicit authorization."
 _CC_DESCRIPTION = "Visible CC addresses."
 _BCC_DESCRIPTION = "Hidden BCC addresses."
-_ATTACHMENTS_DESCRIPTION = "Attachment paths for send."
+_ATTACHMENTS_DESCRIPTION = "Authorized source paths to attach."
 _SUBJECT_DESCRIPTION = "Subject."
-_MESSAGE_DESCRIPTION = "Body; max 50,000 characters."
-_EMAIL_ID_DESCRIPTION = "Own mailbox ID list; replies use one ID."
-_N_DESCRIPTION = "Max messages for check; default 10."
-_QUERY_DESCRIPTION = "Regex query over sender, subject, and body."
-_FOLDER_DESCRIPTION = "Folder; check inbox/search both; sent is read-only."
-_DELAY_DESCRIPTION = "Delivery delay in seconds; default 0."
+_MESSAGE_DESCRIPTION = "Body; max 50,000 Unicode characters."
+_EMAIL_ID_DESCRIPTION = "ID from this mailbox; replies use one ID."
+_N_DESCRIPTION = "Max check messages; default 10."
+_QUERY_DESCRIPTION = "Regex over sender, subject, and body."
+_FOLDER_DESCRIPTION = "Folder; check defaults inbox, search inbox+sent, read all; sent is read-only."
+_DELAY_DESCRIPTION = "Seconds before one delivery attempt; default 0."
 _TYPE_DESCRIPTION = "Send type; default normal."
 _NAME_DESCRIPTION = "Contact name."
 _NOTE_DESCRIPTION = "Contact note."
 
-# The ``filter`` object for ``check`` keeps the flat schema's property set,
-# defaults, and first-call matching semantics; its long catalog and examples
-# live in the Email manual. ``additionalProperties: False`` is added because a
-# migrated family's ``input`` branches are closed all the way down
-# (``tools/CONTRACT.md`` "Envelope": "Action branches are closed").
+# ``check.filter`` retains the flat property set/defaults; depth is in email-manual.
+# Branches stay closed so cross-action keys cannot reach a handler.
 _FILTER_SCHEMA: dict[str, Any] = {
     "type": ["object", "null"],
-    "description": "Optional check filters; see email-manual for fields and defaults.",
+    "description": "Optional check filters; fields/defaults are in email-manual.",
     "properties": {
         "sort": {
             "type": ["string", "null"],
@@ -123,13 +100,7 @@ _FILTER_SCHEMA: dict[str, Any] = {
 
 
 def _mode_property() -> dict[str, Any]:
-    """``send``'s optional address-mode field, nullable-wrapped.
-
-    Reuses ``primitives.mode_field`` — the one owned definition of this
-    field's enum and its long routing description — rather than restating it,
-    so the peer/abs guidance cannot drift between the legacy flat schema and
-    this one. Only the nullable representation is added on top.
-    """
+    """Return the shared nullable ``send.mode`` field without changing its enum."""
     field = dict(mode_field())
     field["type"] = ["string", "null"]
     field["enum"] = [*field["enum"], None]
@@ -380,13 +351,12 @@ INPUT_SCHEMAS: dict[str, dict[str, Any]] = {
 # choice and critical safety guidance; action procedures and examples live in
 # the Email manual references (``tools/CONTRACT.md`` "Dispatch and actions").
 ACTION_ENUM_DESCRIPTION = (
-    "Choose one action; put only that action's fields in input. send: new internal "
-    "message (address and message required; body max 50,000 characters). check: "
-    "list/filter mail. read: fetch mailbox IDs and mark them read; dismiss: mark "
-    "handled IDs read without returning bodies. Unread bodies are injected in full "
-    "into persistent Email notifications: prefer dismiss after handling; use read "
-    "for source records or attachments. reply/reply_all: answer existing mail on "
-    "the arrival channel. search: regex lookup. archive/delete: move or remove "
-    "inbox/archive mail. contacts actions manage the address book. settings is "
-    "read-only. manual returns this manual without mailbox I/O."
+    "Choose one action and put only its fields in input. send: internal mail "
+    "(address/message required; body max 50,000 Unicode characters). check: "
+    "list/filter. read: fetch IDs and mark read; dismiss: mark handled IDs read "
+    "without bodies. Unread bodies are injected in full into persistent Email "
+    "notifications: prefer dismiss after handling; use "
+    "read for source records or attachments. reply/reply_all: answer on the "
+    "arrival channel. search: regex; archive/delete: move/remove mail; contacts "
+    "manage the private book; settings is read-only; manual returns this procedure."
 )

--- a/src/lingtai/tools/email/manual/SKILL.md
+++ b/src/lingtai/tools/email/manual/SKILL.md
@@ -2,12 +2,11 @@
 name: email-manual
 description: >
   Internal LingTai mail: send/read/dismiss/reply, bare-path addressing,
-  delayed self-send time capsules, and the full-body persistent notification
-  contract. Not internet email (see `mcp-manual`) or recurring schedules
-  (see `shell-manual`).
+  delayed self-send time capsules, and full-body persistent notifications.
+  Not internet email (see `mcp-manual`) or recurring schedules (see `shell-manual`).
 version: 1.3.0
 tags: [capabilities, email, communication]
-last_changed_at: "2026-09-06T00:00:00Z"
+last_changed_at: "2026-09-09T10:17:00Z"
 related_files:
 - src/lingtai/tools/email/__init__.py
 - src/lingtai/tools/email/_family_schema.py
@@ -25,154 +24,88 @@ maintenance: |
   Tracks the routed source/resources it summarizes; update when the underlying capability or its sub-references change.
 ---
 
-# Email Manual — the internal `email` tool
+# Email Manual — internal mail
 
-> Internal LingTai mail only. It moves JSON files inside a shared `.lingtai/`
-> network; it is not Gmail, Outlook, IMAP, SMTP, DNS, or any other internet mail.
+**Internal `.lingtai/` mail, not internet email.** Use the schema for routine
+calls; this manual owns the exceptions. `action`, action-local `input`, and root
+`reasoning` are required. Unknown/cross-action fields fail before mailbox I/O;
+optional `null` means omitted. Root `summarize` is not an input field.
 
-## 0. Call envelope
+## First action
 
-Every call has `action`, `input`, and `reasoning`; `input` contains only the
-fields for the selected action. `reasoning` is required and `summarize` is an
-optional root result control, never an input field.
+- **Arrival already visible:** reply on Email with `reply`/`reply_all`, then
+  `dismiss` the handled ID. Current replies do not clear unread state; see the
+  [documented Contract discrepancy](reference/addressing-and-replies/SKILL.md#same-channel-reply).
+  Use `read` for source records or attachments rather than rereading visible text.
+- **Browse:** `email(action="check", input={}, reasoning="inspect inbox")`.
+  Use returned own-mailbox IDs; `search` is regex search. Never send raw local IDs
+  as references in mail/public prose.
+- **New message:** verify the recipient directory, then `send` with `address`
+  and `message`. Ordinary `peer` addressing is bare/path-based, with no `@`;
+  `abs` requires an explicitly authorized cross-network target, not guessed routing.
+- Address a sender by non-empty `sender_nickname`, else `sender_name`. Reply on
+  the arrival channel, not private text output. Read the routing reference before
+  an exceptional channel pivot.
 
-```python
-email(action="check", input={}, reasoning="check for new mail")
-email(action="read", input={"email_id": ["<id>"]}, reasoning="read the request")
-email(action="send", input={"address": "peer", "message": "done"},
-      reasoning="report completion")
-```
+A `sent` receipt is scheduling evidence, not recipient acceptance. Do not blindly
+retry a bounce or failed call: earlier deliveries may exist. Delayed mail depends
+on this process staying alive. Non-self POSIX delivery snapshots attachments;
+self-send does not. There is no attachment source-root/size limit: share only
+explicitly authorized files. Details below; none of these limits authorizes
+configuration changes, lifecycle intervention, or cleanup.
 
-The family rejects unknown root fields and cross-action input keys before
-mailbox I/O, delivery, or read-state mutation. Call
-`email(action="manual", input={}, reasoning="learn Email")` to return this
-installed router and its host-local path.
+## Routing table
 
-`check`, `read`, and `search` can return bulky listings or bodies: use
-`summarize=true` only when exact IDs, addresses, or body text are not needed.
-Leave it false for receipts, contacts, settings, and `manual`.
+| Need | Read |
+|---|---|
+| Recipient discovery, `peer`/`abs`, return routes, identity, replies | [Addressing and replies](reference/addressing-and-replies/SKILL.md) |
+| Filters/folders, self-send, attachments, storage and retention | [Actions and storage](reference/actions-and-storage/SKILL.md) |
+| Liveness, delivery ordering, bounces, unread/overflow handling | [Notifications and delivery](reference/notifications-and-delivery/SKILL.md) |
+| SHOW sources, changes, timing and redaction | [Settings reference](reference/settings-reference/SKILL.md) |
 
-## 1. Choose an action
+## Settings anchors
 
-| Action | Use | Required input / critical note |
-|---|---|---|
-| `send` | Start new internal mail | `address`, `message`; body max 50,000 characters |
-| `check` | List mail | Optional `folder`, `n`, and structured `filter` |
-| `read` | Fetch source-of-truth mail | `email_id` list; marks inbox IDs read |
-| `dismiss` | Clear handled mail without fetching bodies | `email_id` list; marks inbox IDs read |
-| `reply` / `reply_all` | Answer existing mail | `email_id` list (one ID) and `message`; use the arrival channel |
-| `search` | Regex search | `query`; optional `folder` |
-| `archive` | Move inbox mail out of the inbox | `email_id` list |
-| `delete` | Permanently remove mail | `email_id` list; inbox/archive only, never `sent` |
-| `contacts` | List the private address book | no input |
-| `add_contact` | Add or update a contact | `address`, `name`; optional `note` |
-| `remove_contact` | Remove a contact | `address` |
-| `edit_contact` | Update contact fields | `address`; optional `name`/`note` |
-| `settings` | Show Email policy/source truth | input must be `{}`; read-only |
-| `manual` | Load this procedure | input must be `{}`; no mailbox I/O |
-
-For action-specific fields, defaults, filters, persistence, and examples, read
-[Actions and storage](reference/actions-and-storage/SKILL.md). For address modes,
-reply routing, sender names, and local-ID privacy, read
-[Addressing and replies](reference/addressing-and-replies/SKILL.md).
-
-## 2. Non-negotiable routing and privacy
-
-- **Reply on the channel where the message arrived.** For Email, use `reply` or
-  `reply_all`, not a new `send`; never answer through text output (that is a
-  private diary). If a dead sender forces a channel change, explain the pivot in
-  the message first.
-- Use the sender's `sender_nickname` when non-empty, otherwise `sender_name`.
-- Addresses are bare names/paths inside `.lingtai/`, not `@` addresses. For
-  internet mail, use the separately owned `imap` MCP addon. `mode="peer"` is
-  normally enough; `mode="abs"` is restricted to explicitly authorized
-  cross-network paths and does not bypass delivery checks.
-- Mailbox IDs are local to this working directory. Pass IDs read from your own
-  notification or listing to Email actions, but never put raw IDs in mail or
-  public prose. See [Addressing and replies](reference/addressing-and-replies/SKILL.md).
-
-Sending writes sender-side state before starting one daemon delivery thread per
-recipient. Even with no delay, `status="sent"` can precede delivery; a target
-must have valid agent metadata and a fresh heartbeat. Delivery failures are
-reported as `email.bounce` system events, not queued for later. Full delivery,
-refresh-window, and recovery semantics are in
-[Notifications and delivery](reference/notifications-and-delivery/SKILL.md).
-
-## 3. Read state and notifications
-
-Unread bodies are injected in full into
-`_meta.agent_meta.notifications.persistent.email`. After handling content already
-shown there, prefer `dismiss`; use `read` for a source-of-truth refresh,
-attachments, or deliberate audit. `read`, `dismiss`, `archive`, and `delete`
-refresh the producer-owned `.notification/email.json` mirror. A handled message
-stays visible until one of those producer verbs changes its read state.
-
-The mirror's attention hook carries IDs while the persistent lane carries full
-entries. If the model-visible block overflows, follow its `overflow` marker to the
-local spill file or use the producer action; do not infer missing content.
-Detailed payload shape, caps, refresh behavior, and the distinction from generic
-notification dismissal are in
-[Notifications and delivery](reference/notifications-and-delivery/SKILL.md).
-
-## 4. Settings anchors
-
-`settings` is SHOW-only: every row has exactly `key`, `current`, `default`,
-`configurable`, and `comment`. It performs no mailbox I/O and never exposes
-paths, identities, addresses, contacts, content, attachments, or read state.
-Comments below are stable anchors used by the settings provider; each short stub
-routes to the full source/precedence/procedure reference.
+`settings` takes `{}` and performs no mailbox I/O. Rows contain exactly `key`,
+`current`, `default`, `configurable`, `comment`; missing applied truth fails the
+whole inventory as `SETTINGS_UNAVAILABLE`, with no partial rows/private detail.
+`manual` also takes `{}` and returns the installed body/path without mailbox I/O.
+Keep exact IDs/bodies when needed; reserve result summarization for bulky reads,
+not short receipts or procedures being followed.
 
 ### Send body character limit
-
-`send.body_char_limit` is the installed 50,000-character send/reply cap; see
-[the settings reference](reference/settings-reference/SKILL.md#send-body-character-limit).
+`send.body_char_limit`: [body cap](reference/settings-reference/SKILL.md#send-body-character-limit).
 
 ### Duplicate send loop guard
-
-`send.duplicate_free_passes` is the installed consecutive-duplicate guard; see
-[the settings reference](reference/settings-reference/SKILL.md#duplicate-send-loop-guard).
+`send.duplicate_free_passes`: [recipient/body guard](reference/settings-reference/SKILL.md#duplicate-send-loop-guard).
 
 ### Check result token limit
-
-`check.result_token_limit` is the installed `check` result budget; see
-[the settings reference](reference/settings-reference/SKILL.md#check-result-token-limit).
+`check.result_token_limit`: [check budget](reference/settings-reference/SKILL.md#check-result-token-limit).
 
 ### Unread notification entry limit
-
-`unread.max_entries` limits projected unread entries while preserving total count;
-see [the settings reference](reference/settings-reference/SKILL.md#unread-notification-entry-limit).
+`unread.max_entries`: [entry projection](reference/settings-reference/SKILL.md#unread-notification-entry-limit).
 
 ### Pseudo-agent subscriptions
+`manifest.pseudo_agent_subscriptions`: [redacted applied snapshot](reference/settings-reference/SKILL.md#pseudo-agent-subscriptions).
 
-`manifest.pseudo_agent_subscriptions` is the configurable, fully redacted
-construction snapshot; see [the settings reference](reference/settings-reference/SKILL.md#pseudo-agent-subscriptions).
+## Cleanup / Footprint
 
-## 5. Self-send and delay
+Email owns `mailbox/` and `.notification/email.json`; keep decision/handoff evidence.
+Use the [retention and inspection procedure](reference/actions-and-storage/SKILL.md#cleanup--footprint),
+not ad-hoc deletion. Bug filing goes through `lingtai-issue-report` with permission.
 
-Mail to your own address is a durable inbox note that survives molt and remains
-in the unread lane until handled. `delay` is seconds before one delivery attempt:
-the outbox record is written immediately and a daemon thread waits. Delayed
-self-send is a one-shot future nudge, not delayed tool execution or recurring
-scheduling. For recurring work, use the host scheduler routed by `shell-manual`.
-See [Actions and storage](reference/actions-and-storage/SKILL.md#self-send-and-time-capsules).
+## Nested reference catalog
 
-## 6. Cleanup and footprint
-
-Email persists inbox/archive/sent messages, attachments, contacts, and read state.
-Do not blindly delete mail that is the only copy of a decision, handoff, or
-attachment. Prefer the Email `archive`/`delete` actions over filesystem removal.
-For a dry-run footprint inspection and explicit-consent cleanup procedure, load
-the shared [cleanup-footprint contract](../../skills/manual/reference/cleanup-footprint-contract.md#shared-footprint-check-recipe).
-
-## Reference map
-
-- [Addressing and replies](reference/addressing-and-replies/SKILL.md) — bare-path
-  addresses, `peer`/`abs`, same-channel replies, identity, and ID privacy.
-- [Actions and storage](reference/actions-and-storage/SKILL.md) — action details,
-  filters, folders, self-send, time capsules, and durable layout.
-- [Notifications and delivery](reference/notifications-and-delivery/SKILL.md) —
-  liveness, bounce/recovery, unread payloads, overflow, and read-state refresh.
-- [Settings reference](reference/settings-reference/SKILL.md) — five rows,
-  effective sources, redaction, timing, and SHOW-only behavior.
-
-> Found a bug? Load the `lingtai-issue-report` skill and follow its procedure.
+```yaml
+- name: email-manual-addressing-and-replies
+  location: reference/addressing-and-replies/SKILL.md
+  description: Nested Email reference for recipient discovery and replies.
+- name: email-manual-actions-and-storage
+  location: reference/actions-and-storage/SKILL.md
+  description: Nested Email reference for fields, attachments and retention.
+- name: email-manual-notifications-and-delivery
+  location: reference/notifications-and-delivery/SKILL.md
+  description: Nested Email reference for delivery, bounces and unread state.
+- name: email-manual-settings-reference
+  location: reference/settings-reference/SKILL.md
+  description: Nested Email reference for SHOW sources and authorized changes.
+```

--- a/src/lingtai/tools/email/manual/reference/actions-and-storage/SKILL.md
+++ b/src/lingtai/tools/email/manual/reference/actions-and-storage/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: email-manual-actions-and-storage
 description: >
-  Focused Email reference for action inputs, folders, check filters, delivery
-  side effects, self-send/time capsules, contacts, and mailbox persistence.
-  Read after email-manual when an operation needs more than the first-call map.
+  Focused Email reference for action inputs, folders, check filters, delivery,
+  self-send/time capsules, contacts, attachments, and mailbox persistence.
+  Read when the schema and first-call map are not enough.
 version: 1.0.0
 tags: [lingtai, email, actions, mailbox, storage]
-last_changed_at: "2026-09-06T00:00:00Z"
+last_changed_at: "2026-09-09T10:17:00Z"
 related_files:
 - src/lingtai/tools/email/manual/SKILL.md
 - src/lingtai/tools/email/_family_schema.py
@@ -20,110 +20,89 @@ maintenance: |
 
 # Email actions and storage
 
-The root manual is the first-call router. This page supplies action-level detail;
-input keys remain closed to the action that owns them. Omitted optional values
-use the action defaults. An explicit `null` is treated as omitted at the family
+The root manual is the first-call router and the schema is authoritative. This
+page covers action details that need care; action input objects remain closed.
+Omitted optional values use defaults, and explicit `null` is omitted at the family
 boundary.
 
-## Sending
+## Send
 
 ```python
 email(action="send", input={
     "address": "peer", "subject": "status", "message": "ready",
     "cc": ["human"], "bcc": [], "attachments": [], "delay": 0,
+    "mode": "peer", "type": "normal",
 }, reasoning="report status")
 ```
 
-`address` is a bare peer name (or an authorized absolute path in `abs` mode).
-`cc` is visible to recipients; `bcc` is stored in the sender's copy but hidden
-from recipients. `attachments` contains source file paths. Each recipient
-adapter validates every path before creating that recipient's inbox entry; a
-missing or non-file path leaves no partial recipient inbox entry. Accepted files
-are copied into the message's recipient-local `attachments/` directory before
-atomic publication, and `message.json` records those snapshot paths. Duplicate
-basenames receive `-1`, `-2`, ... suffixes before the extension. Email enforces
-no attachment-size or source-root-containment limit, so callers must select only
-explicitly authorized files. This is separate from `message`, which is capped at
-50,000 Unicode characters at send time; oversize bodies are rejected with the
-limit and actual size rather than truncated.
+`address` is a bare peer name, or an explicitly authorized absolute path with
+`mode="abs"`. CC is visible to recipients; BCC is stored only in the sender's
+copy. `attachments` are source paths: for non-self POSIX delivery the adapter
+validates every path before publishing that recipient's inbox entry, copies files
+into recipient-local `attachments/`, and suffixes duplicate basenames. Source
+paths are resolved/read at delivery time, so preserve their bytes until delivery;
+there is no send-time frozen snapshot. No attachment-size or source-root-containment
+limit is enforced: select only files you are authorized to share. A self-send bypasses this adapter
+and does not validate or copy attachments; its inbox note can retain a missing
+source path. Do not treat self-mail as an attachment backup. The message body is capped at 50,000 Unicode characters and is rejected,
+not truncated, when oversized.
 
-A send writes sender-side outbox/sent state synchronously, then starts one daemon
-mailman thread per recipient. A successful `{status: "sent"}` receipt means the
-attempt was scheduled, not necessarily delivered. `delay` is a non-negative
-number of seconds before the one delivery attempt; the outbox record exists while
-the thread waits. See [Notifications and delivery](../notifications-and-delivery/SKILL.md)
-for liveness and bounce behavior. Identical consecutive sends are guarded as a
-loop; the installed pass count is in [Settings reference](../settings-reference/SKILL.md).
+Each recipient's outbox is written before its thread starts; the unified sent
+record follows all thread starts. `status="sent"` is scheduling, not acceptance.
+Use a non-negative integer `delay` for one future attempt, not tool execution;
+the schema does not enforce a non-negative bound. For partial failures and restart
+limits read [Notifications and delivery](../notifications-and-delivery/SKILL.md).
+The duplicate guard compares recipient/body, not the whole message; see
+[Settings reference](../settings-reference/SKILL.md#duplicate-send-loop-guard).
 
-## Listing and filtering
+## Check and search
 
-`check` lists newest-first by default from `inbox`; `folder` can be `inbox`,
-`sent`, or `archive`, and `n` defaults to 10. Its optional `filter` is owned by
-`check` alone:
+`check` lists newest first from `inbox`; `folder` may be `inbox`, `sent`, or
+`archive`, and `n` defaults to 10. Its only filter object supports:
 
-```python
-email(action="check", input={
-    "folder": "inbox", "n": 20,
-    "filter": {
-        "sort": "newest", "from": "peer", "subject": "status",
-        "contains": "blocker", "after": "2026-04-01T00:00:00Z",
-        "before": "2026-05-01T00:00:00Z", "unread_only": True,
-        "has_attachments": False, "truncate": 500,
-    },
-}, reasoning="find unread status mail")
-```
+- `sort`: `newest` (default) or `oldest`;
+- `from`, `subject`, `contains`: case-insensitive substrings;
+- `after`, `before`: ISO 8601 timestamps;
+- `unread_only`, `has_attachments`: boolean selectors;
+- `truncate`: preview characters, default 500; `0` requests the full body.
 
-`sort` is `newest` (default) or `oldest`; `from`, `subject`, and `contains`
-are case-insensitive substring filters; `after`/`before` accept ISO 8601
-timestamps; the two boolean filters select unread or attachment-bearing mail.
-`truncate` controls preview characters (default 500); `0` requests the full
-body. A check result can be trimmed by Email's token budget and reports that
-fact. Prefer filtering in the call rather than retrieving a large mailbox and
-post-filtering mentally.
+Email may trim a large `check` result to its token budget and reports that fact.
+`search` takes a regex `query` and optional `folder`, searches sender/subject/body,
+and rejects invalid regex; it accepts neither `filter` nor `n`. With no folder,
+`search` covers inbox + sent. Folder-less `read` searches inbox, sent, then archive;
+only inbox records are marked read.
 
-`search` takes a regular-expression `query` and optional `folder`; it searches
-sender, subject, and body and rejects invalid regexes. It does not accept
-`filter` or `n`.
+## Read, mutate, and contacts
 
-## Reading, mutating, and contacts
+- `read` takes mailbox IDs, returns source records including attachments, and marks
+  inbox IDs read. `dismiss` marks handled inbox IDs read without returning bodies.
+- `reply`/`reply_all` take one ID and a message; routing and subject derivation are
+  in [Addressing and replies](../addressing-and-replies/SKILL.md).
+- `archive` moves inbox IDs to `mailbox/archive` and removes them from the read set.
+  `delete` permanently removes inbox/archive IDs and refuses `sent`.
+- `contacts` lists the private book; `add_contact` upserts; `remove_contact` deletes;
+  `edit_contact` changes only supplied name/note fields. Contact writes use a
+  temporary file and atomic replacement.
 
-- `read` takes a list of mailbox IDs, returns source records (including
-  attachments), and marks inbox IDs read.
-- `dismiss` takes a list of IDs and marks handled inbox mail read without
-  returning bodies. Prefer it after handling a body already in persistent
-  notification context.
-- `reply` and `reply_all` take one ID and a message and route from the original
-  mail. Recipient selection, subject derivation, and the absence of persistent
-  thread metadata are owned by [Addressing and replies](../addressing-and-replies/SKILL.md#same-channel-reply-discipline).
-  Both obey the root manual's same-channel rule.
-- `archive` moves inbox IDs to `mailbox/archive`; it removes them from the read
-  set as part of the move. `delete` permanently removes IDs from inbox or
-  archive and refuses `sent`.
-- `contacts` lists the private address book. `add_contact` upserts by address;
-  `remove_contact` deletes by address; `edit_contact` changes supplied name or
-  note fields. Contact writes use a temporary file and atomic replacement.
-
-All IDs must come from the current agent's own notification or mailbox result.
-Stale IDs produce a not-found hint; an ID from another working directory has no
-meaning here.
+IDs must come from this agent's current notification or mailbox result. Stale or
+foreign-working-directory IDs have no meaning and produce a not-found hint.
 
 ## Self-send and time capsules
 
-Sending to your own bare address creates an ordinary unread inbox message that
-survives molt, can be searched later, and remains in the unread lane until
-`dismiss`, `read`, `archive`, or `delete`. Add `delay` to make a one-shot time
-capsule: the outbox is written immediately, and the daemon mailman thread waits
-until the deadline. A delayed self-send is a future nudge, not delayed tool
-execution. Recurring sends are not supported; use a host scheduler through
-`shell-manual` for recurring work.
+An already-delivered self-note survives molt; `dismiss`/`read` clear unread status
+but retain the message, `archive` moves it, and `delete` removes it. Before delivery,
+a delayed self-note depends on the current mailman daemon thread staying alive;
+outbox persistence does not make that timer survive process exit. Use it as a
+one-shot time capsule, not delayed tool execution or a durable scheduler.
+Recurring or restart-resilient work belongs to `shell-manual`.
 
-## Mailbox layout
+## Mailbox layout and retention
 
 Paths are relative to the agent working directory:
 
 ```text
 mailbox/inbox/<id>/message.json       received mail
-mailbox/sent/<id>/message.json        sent copy (one record per send call)
+mailbox/sent/<id>/message.json        one sent record per call
 mailbox/archive/<id>/message.json     archived inbox mail
 mailbox/outbox/<id>/message.json      pending/delayed send
 mailbox/read.json                     read-ID set
@@ -131,7 +110,24 @@ mailbox/contacts.json                 private contact book
 .notification/email.json              producer-owned unread mirror
 ```
 
-Message JSON uses UTF-8. Mailbox message files are direct writes; contact writes
-are the atomic exception. BCC data is not exposed to recipients. The unread
-mirror is refreshed by every read-state mutation; its payload and delivery
-semantics are in the notifications reference.
+Message JSON is UTF-8. Non-self POSIX recipient entries use staging + atomic
+publication; self-inbox, outbox and unified sent records use direct writes.
+`read.json` and contacts use temporary-file replacement. BCC is not exposed in
+recipient payloads. Do not infer crash durability from these different write paths.
+
+## Cleanup / Footprint
+
+Email leaves the paths above, recipient attachment snapshots, and ordinary Agent
+logs/bounce events. Before mailbox retirement or when attachment growth matters,
+inspect only this Agent's `mailbox/` and `.notification/email.json` with the
+shared read-only count/byte recipe in `skills-manual` →
+`reference/cleanup-footprint-contract.md#shared-footprint-check-recipe`.
+Inspect metadata without broadcasting private bodies/addresses. Keep sole copies
+of decisions, handoffs, attachments, contacts and pending/evidence records.
+
+Show a dry-run report listing what would stay or go, obtain explicit human consent,
+then prefer authorized `archive`/`delete` actions over filesystem removal. Do not
+clean active outbox state. Cleanup is optional; without consent stop at the report.
+If recording the audit, separately opt into the shared `logs/cleanup.jsonl` append
+(timestamp, Email label, dry-run/apply, count, bytes, non-secret path summary,
+approval). Inspection alone writes nothing; approved apply records actual results.

--- a/src/lingtai/tools/email/manual/reference/addressing-and-replies/SKILL.md
+++ b/src/lingtai/tools/email/manual/reference/addressing-and-replies/SKILL.md
@@ -3,10 +3,10 @@ name: email-manual-addressing-and-replies
 description: >
   Focused Email reference for bare-path addressing, peer/abs resolution, safe
   same-channel replies, sender identity display, and local mailbox-ID privacy.
-  Read after email-manual when routing or answering internal mail.
+  Read when routing or answering internal mail.
 version: 1.0.0
 tags: [lingtai, email, routing, replies, privacy]
-last_changed_at: "2026-09-06T00:00:00Z"
+last_changed_at: "2026-09-09T10:17:00Z"
 related_files:
 - src/lingtai/tools/email/manual/SKILL.md
 - src/lingtai/tools/email/primitives.py
@@ -18,70 +18,58 @@ maintenance: |
 
 # Email addressing and replies
 
-## Bare-path addresses
+## Bare paths and recipient verification
 
-Internal Email addresses are names of directories inside `.lingtai/`, with no
-`@`, domain, or slash in ordinary peer mode:
-
-- `human` addresses the operator mailbox;
-- `mimo-1` addresses an agent directory;
-- your own agent name addresses a durable self-inbox.
-
-`address` accepts one string or a list. Discover real agents by globbing `.lingtai/*/.agent.json` and use each file's
-`agent_name`; do not invent an address. A refused target creates no recipient
-inbox entry and is reported as an `email.bounce` system event.
+Use a verified recipient working-directory basename or path, not an internet
+`@` address. Inspect that directory's `.agent.json` to identify its owner;
+`agent_name` is a display identity and need not equal the routing basename.
+`human` is the usual operator mailbox; your own address is a self-inbox.
+Do not invent targets or broaden a metadata scan to unrelated networks.
 
 ## `peer` and `abs`
 
-`mode` belongs to `send` and is normally omitted:
+`mode` belongs to `send` and is normally omitted. `peer` (default) resolves a bare
+name against the parent of this working directory. `abs` treats `address` as a
+literal absolute working-directory path in another, explicitly authorized
+`.lingtai/` network on the same machine. The resolver also accepts paths in peer
+mode; that capability is not cross-network authorization. Non-self POSIX delivery
+requires manifest presence and Core liveness; human/self exceptions and bounce
+limits are in [Notifications and delivery](../notifications-and-delivery/SKILL.md).
+`abs` does not bypass those checks.
 
-- `peer` (default) resolves a bare agent name against the parent of your own
-  working directory. It is the normal mode for the human, fellow agents, and
-  self-send.
-- `abs` treats `address` as a literal absolute working-directory path in a
-  different, explicitly authorized `.lingtai/` network on the same machine.
-  It is for cross-network/project messaging only.
+Absolute sends embed a `_return_route` with sender workdir and identity. Replies
+use that route first, then an absolute `from`, then a bare peer `from`. The manager
+refuses a bare route that would resolve to the responder's own workdir when the
+original identity names a different agent: do not guess; use an explicitly
+authorized `abs` send instead. Older messages without `_return_route` retain the
+absolute-`from` fallback.
 
-Both modes require the target's valid `.agent.json` and fresh heartbeat. `abs`
-does not bypass the handshake or liveness check. Absolute sends embed a
-`_return_route` containing the sender workdir and agent identity; this protects
-replies when separate `.lingtai/` networks contain agents with the same short
-name. Older messages without that field still use the absolute-`from` fallback.
+## Same-channel reply
 
-## Same-channel reply discipline
+**Email must be answered with `reply` or `reply_all` on Email.** Do not replace it
+with a new `send`, Telegram, IM, or text output (text is a private diary). If the
+sender is dead and a channel pivot is unavoidable, explain the pivot in the new
+message before sending elsewhere.
 
-**Reply on the channel where the message arrived.** An Email message must be
-answered with `reply` or `reply_all`, not a new `send`, Telegram, IM, or text
-output. Text output is a private diary, not a communication channel. If the
-original sender is unavailable and a channel pivot is unavoidable, explain that
-pivot in the message before sending elsewhere.
+`reply` addresses the resolved sender. `reply_all` also keeps original `to`/`cc`
+recipients except self and the primary target. Both derive `Re: ` unless a subject
+is supplied; they do not create thread metadata. Review the complete fan-out
+including CC/BCC before delivery; reply actions use the first supplied ID.
 
-`reply` addresses the resolved sender. `reply_all` also carries the original
-`to` and `cc` recipients except self and the primary reply target, so CC
-participants are not silently dropped. Unless explicitly overridden, both derive
-a `Re: ` subject from the original subject (or its first body line when absent).
-They do not persist an `in_reply_to` field or thread ID; continuity comes from
-recipient selection and the derived subject. The manager resolves a reply target
-in this order: embedded `_return_route`, an absolute `from`, then a bare peer
-`from`. It refuses an ambiguous peer route that would resolve to the responder's
-own workdir while the original identity names a different agent.
+**Contract discrepancy:** current `reply` and `reply_all` do not mark the source inbox ID read
+or rerender its unread mirror, despite the source Contract's stated invariant.
+After handling, call `dismiss` explicitly (or `read` when you need its body).
+This describes the observed implementation and workaround, not a relaxation of
+the Contract or an engine fix.
 
-## Sender display and local IDs
+## Identity and local IDs
 
-Inbound messages carry an `identity` block. In prose, call the sender by its
-non-empty `sender_nickname`; otherwise use `sender_name`. The `from` value is a
-routing address, not a display name.
+Inbound mail carries an identity card. In prose use non-empty `sender_nickname`,
+otherwise `sender_name`; `from` remains a routing address. A mailbox UUID is local
+to one working directory: pass IDs copied from this agent's notification or `check`
+result to `read`, `dismiss`, `reply`, or `reply_all`, never into mail or public
+prose. Refer to another agent's mail by subject, sender, and approximate time.
 
-A mailbox UUID (`email_id`) is local to one working directory. Pass IDs copied
-from your own persistent notification or `check` result to `read`, `dismiss`,
-`reply`, or `reply_all`; never paste a raw ID into mail or public prose. When referring to mail to another agent, use subject, sender, and approximate
-time.
-
-## Adjacent surfaces
-
-This manual owns only the kernel-intrinsic `email` tool. Real internet mail
-(Gmail, Outlook, IMAP/SMTP) belongs to the `imap` or `cloud_mail` MCP addon;
-Telegram, Feishu, WeChat, and WhatsApp belong to their respective MCP addons.
-Recurring agent-side work belongs to a host scheduler through `shell-manual`.
-Do not use Email for an external address: an unknown target is refused without a
-recipient inbox entry and is reported as a bounce.
+Internet mail (Gmail, Outlook, IMAP/SMTP), Telegram, Feishu, WeChat, and WhatsApp
+belong to their MCP addons. Recurring work belongs to `shell-manual`; do not use
+internal Email for external addresses.

--- a/src/lingtai/tools/email/manual/reference/notifications-and-delivery/SKILL.md
+++ b/src/lingtai/tools/email/manual/reference/notifications-and-delivery/SKILL.md
@@ -2,12 +2,11 @@
 name: email-manual-notifications-and-delivery
 description: >
   Focused Email reference for daemon delivery, heartbeat/liveness, bounce
-  recovery, unread notification payloads, persistent bodies, overflow, and
-  read-state mirror refresh. Read after email-manual when delivery or notices
-  need diagnosis.
+  recovery, unread payloads, persistent bodies, overflow, and read-state refresh.
+  Read when delivery or notices need diagnosis.
 version: 1.0.0
 tags: [lingtai, email, notifications, delivery, recovery]
-last_changed_at: "2026-09-06T00:00:00Z"
+last_changed_at: "2026-09-09T10:17:00Z"
 related_files:
 - src/lingtai/tools/email/manual/SKILL.md
 - src/lingtai/tools/email/manual/reference/actions-and-storage/SKILL.md
@@ -21,88 +20,70 @@ maintenance: |
 
 # Email notifications and delivery
 
-## Delivery and liveness
+## Delivery, liveness, and recovery
 
-`send` writes the sender's outbox/sent record before creating one daemon
-`_mailman` thread per recipient. `delay=0` still permits a sent receipt before
-the delivery attempt finishes. A normal agent target must have valid
-`.agent.json` metadata and a fresh `.agent.heartbeat` (normally under two
-seconds); a human target (`admin: null`) does not need a heartbeat. A refreshing
-or relaunching target can therefore bounce as `not running`; Email does not
-queue the attempt for later. The sender receives the eventual failure as an
-`email.bounce` event in `.notification/system.json`.
+`send` writes each recipient's outbox entry, then starts that recipient's daemon
+`_mailman` thread before that call's unified sent record is written. Even `delay=0`
+can return `sent` before delivery finishes. A later thread-start or persistence
+failure can leave earlier deliveries; neither a failed call nor a missing sent
+record proves zero effect. Delay waits in a daemon thread: this is not a restart-resilient queue.
+A process exit can strand outbox files; no automatic replay is promised.
 
-A process can appear in `ps` before publishing a fresh heartbeat. If a CPR
-(child-process restart) attempt also exits because the duplicate-process guard
-finds the existing same-workdir process, these observations are compatible:
-do not stack CPR attempts. Wait for a fresh heartbeat and retry Email once. Use
-CPR only if the existing startup exits or never becomes live.
+Non-self POSIX targets need `.agent.json` presence and a Core-fresh
+`.agent.heartbeat`; use current kernel liveness policy, not a fixed Email timeout.
+Core currently counts even malformed manifests as present; a valid manifest with
+missing/null `admin` identifies a human and bypasses heartbeat checks. This is
+implementation truth, not permission to deliver to an unverified owner. Self-send
+bypasses this transport handshake. Refresh/relaunch windows can produce
+`not running`; refused attempts are not queued for a later retry. Failures publish
+`email.bounce` in `.notification/system.json`.
 
-For an explicitly authorized `abs` target, the same metadata/heartbeat handshake
-applies. An absolute address is not a liveness or authorization bypass.
+A process may appear in `ps` before a fresh heartbeat. If a CPR attempt exits
+because the duplicate-process guard sees the existing same-workdir process, do not
+stack CPR attempts: wait for a heartbeat. Any lifecycle intervention needs its
+own authorization and diagnosis, not just a bounce. An authorized non-self `abs`
+target has the same handshake.
+
+For a known POSIX pre-publication refusal (unknown/dead recipient or rejected
+attachment), no entry was published for that target. A generic bounce is not a
+universal zero-effect receipt: custom adapters or post-publication exceptions can
+fail after an effect, and other fan-out targets may already have received mail.
+Inspect the exact failure and recipient state; retry once only when a safe
+pre-delivery refusal is established and the cause is corrected. Never guess a
+replacement address or replay the whole fan-out blindly.
 
 ## Unread producer mirror
 
-Mail arrival and every read-state mutation render the current unread set to
-`.notification/email.json`. The kernel's next heartbeat sync exposes that data
-through `notification(action="check")`. A typical producer envelope is:
+Arrival and every read-state mutation render the current unread set to
+`.notification/email.json`; the next heartbeat exposes it through
+`notification(action="check")`. Its relevant shape is:
 
 ```json
-{
-  "header": "3 unread emails",
-  "icon": "📧",
-  "priority": "normal",
-  "published_at": "<timestamp>",
-  "instructions": "Handle the mail, then prefer email.dismiss or use email.read/reply.",
-  "data": {
-    "count": 3,
-    "newest_received_at": "<timestamp>",
-    "email_ids": ["<local-id>"],
-    "emails": [{
-      "id": "<local-id>", "from": "peer", "subject": "...",
-      "message": "full body", "message_chars": 10,
-      "message_truncated": false
-    }]
-  }
-}
+{"instructions":"handle, then prefer email.dismiss or email.read/reply",
+ "data":{"count":3,"newest_received_at":"<time>",
+         "email_ids":["<local-id>"],
+         "emails":[{"id":"<local-id>","from":"peer",
+                    "subject":"...","message":"full body",
+                    "message_chars":10,"message_truncated":false}]}}
 ```
 
-`instructions` is producer-owned guidance: Email knows whether a message is a
-full-body context entry and which producer verb clears its source state. The
-attention lane is a high-attention hook carrying IDs; full structured entries
-live in `_meta.agent_meta.notifications.persistent.email`. There is no separate
-per-mail notification pair.
+The attention lane carries IDs; full structured entries live in
+`_meta.agent_meta.notifications.persistent.email`. New bodies are not truncated.
+The send layer rejects bodies over 50,000 characters; only legacy records may be
+marked `message_truncated=true`. The projection limits newest entries (see
+`unread.max_entries`) but preserves total unread count.
 
-Ordinary new messages are rendered without truncating their bodies. The send
-layer rejects bodies over 50,000 characters; only legacy over-limit records may
-carry `message_truncated=true` defensively. The unread projection limits the
-number of newest entries but keeps total unread count exact.
+## Handling and overflow
 
-## Handling persistent mail and overflow
+Persistent context can make `read` unnecessary for ordinary text. After handling a
+visible entry, call `dismiss` to mark it read without returning another body. Use
+`read` for source metadata, attachments, or deliberate refresh. `read`, `dismiss`,
+`archive`, and `delete` rerender the Email mirror, which disappears when no unread
+mail remains. Replies currently leave the source unread; see the
+[Contract discrepancy and explicit-dismiss workaround](../addressing-and-replies/SKILL.md#same-channel-reply).
 
-The persistent lane can make `read` unnecessary merely to see ordinary text.
-After handling a visible entry, call `email(action="dismiss", input={"email_id":
-[...]}, ...)` to mark it read without returning another body. Use `read` when
-source-of-truth metadata, attachments, or a deliberate refresh is required.
-`reply` and `reply_all` both mark the source inbox ID read as part of handling.
-`archive` and `delete` also update read state. All four mutation paths rerender
-the Email mirror, which disappears when no unread mail remains.
-
-If the full persistent notification exceeds its model-visible block cap, the
-kernel spills it to a local `logs/notification-overflow-<timestamp>.json` and
-adds an `overflow` marker. Follow that marker or call the producer action for
-full content; do not assume a truncated body is complete. The exact block cap
-and environment ownership belong to `notification-manual`.
-
-A generic
-`notification(action="dismiss_channel", input={"channel": "email", ...}, ...)`
-only clears the mirror. It does not mark source messages read and is not a
-substitute for Email's `dismiss`, `read`, `reply`, `archive`, or `delete`.
-
-## Bounce and retry interpretation
-
-A bounce means no recipient inbox record was queued for that attempt. Inspect the
-bounce event and target metadata/heartbeat. For a target in a refresh window,
-wait for its heartbeat and retry once; do not assume that a successful `sent`
-receipt proves delivery. For an unknown or invalid address, correct the address
-from local metadata rather than guessing.
+If persistent context has an `overflow` marker, follow its local spill file or use
+the Email producer action; do not assume the body is complete. Generic
+`notification(action="dismiss_channel", input={"channel":"email", ...})` only
+clears the mirror: it does not mark source messages read and cannot replace Email
+`dismiss`, `read`, `archive`, or `delete`.

--- a/src/lingtai/tools/email/manual/reference/settings-reference/SKILL.md
+++ b/src/lingtai/tools/email/manual/reference/settings-reference/SKILL.md
@@ -3,10 +3,10 @@ name: email-manual-settings-reference
 description: >
   Focused Email settings reference for the five SHOW rows, installed limits,
   manifest subscription source, redaction, precedence, timing, and the
-  read-only boundary. Read after email-manual when interpreting settings rows.
+  read-only boundary. Read when interpreting settings rows.
 version: 1.0.0
 tags: [lingtai, email, settings, privacy, configuration]
-last_changed_at: "2026-09-06T00:00:00Z"
+last_changed_at: "2026-09-09T10:17:00Z"
 related_files:
 - src/lingtai/tools/email/manual/SKILL.md
 - src/lingtai/tools/email/settings.py
@@ -21,90 +21,66 @@ maintenance: |
 # Email settings reference
 
 Call `email(action="settings", input={}, reasoning="inventory Email policy")` to
-show the effective Email inventory. It is SHOW-only: no set/reset/writer exists,
-non-empty input is refused, and mailbox I/O is not performed. A successful
-response is `{"settings": [...]}` with exactly `key`, `current`, `default`,
-`configurable`, and `comment` in every row. The complete response is bounded at
-65,536 UTF-8 bytes. If applied truth or a provider row is unavailable, the whole
-action fails with fixed `SETTINGS_UNAVAILABLE`; it never returns partial rows or
-exception detail.
+show effective Email policy. It is SHOW-only: non-empty input is refused, no writer
+exists, and it performs no mailbox I/O. Success is `{"settings": [...]}` with
+exactly `key`, `current`, `default`, `configurable`, and `comment` in every row.
+The complete response is bounded at 65,536 UTF-8 bytes. If applied truth or a
+provider row is unavailable, the whole action fails with fixed
+`SETTINGS_UNAVAILABLE`, never partial rows or exception detail.
 
-The five rows are ordered as follows:
+## Installed-code rows
 
-| Key | Current | Default | Configurable | Comment anchor |
-|---|---:|---:|---|---|
-| `send.body_char_limit` | `50000` | `50000` | `false` | `email-manual#send-body-character-limit` |
-| `send.duplicate_free_passes` | `2` | `2` | `false` | `email-manual#duplicate-send-loop-guard` |
-| `check.result_token_limit` | `10000` | `10000` | `false` | `email-manual#check-result-token-limit` |
-| `unread.max_entries` | `10` | `10` | `false` | `email-manual#unread-notification-entry-limit` |
-| `manifest.pseudo_agent_subscriptions` | `<redacted>` | `<redacted>` | `true` | `email-manual#pseudo-agent-subscriptions` |
+These four values come from Email's installed `settings.py` constants. There is
+no environment/owner-file override; changing them needs reviewed code/package
+bytes plus full relaunch, then another SHOW. Their row order is the order below.
 
 ## Send body character limit
 
-- **Key:** `send.body_char_limit`; installed integer `50000`.
-- **Meaning:** maximum accepted internal-email body length in Unicode
-  characters. Oversize `send` and `reply` bodies are refused before delivery.
-- **Source/configuration:** installed code; no environment variable or owner
-  settings file. `configurable` is false.
-- **Timing:** only a reviewed product-code/package change plus full agent
-  relaunch changes it; SHOW never writes. Verify with SHOW after relaunch.
+`send.body_char_limit`: current/default 50,000, configurable false. Counts Unicode
+body characters for send/reply; oversize bodies are refused before scheduling.
 
 ## Duplicate send loop guard
 
-- **Key:** `send.duplicate_free_passes`; installed integer `2`.
-- **Meaning:** consecutive identical sends allowed per recipient before Email
-  blocks the next duplicate as a loop.
-- **Source/configuration:** installed `email/settings.py` constant; no
-  environment variable or owner settings file. `configurable` is false.
-- **Timing:** only reviewed code/package change plus full relaunch changes it;
-  verify with a second SHOW.
+`send.duplicate_free_passes`: current/default 2, configurable false. Two consecutive
+same-body calls per recipient are allowed; the next is blocked. Only recipient
+and body are compared: subject, attachment paths, and mode are not compared.
+The counter advances after sender persistence/scheduling, not recipient acceptance;
+a later bounce does not undo it. A different body or new EmailManager resets the
+relevant history. `blocked` is not a delivery receipt; do not vary text to bypass it.
 
 ## Check result token limit
 
-- **Key:** `check.result_token_limit`; installed integer `10000`.
-- **Meaning:** one `check` result's token budget; summaries are removed until
-  the serialized response fits.
-- **Source/configuration:** installed `email/settings.py` constant; no
-  environment variable or owner settings file. `configurable` is false.
-- **Timing:** only reviewed code/package change plus full relaunch changes it;
-  verify with a second SHOW.
+`check.result_token_limit`: current/default 10,000, configurable false. Summary
+entries are removed to fit a `check` result; `truncated_by_budget` reports the
+number omitted, so result size alone is not the mailbox total.
 
 ## Unread notification entry limit
 
-- **Key:** `unread.max_entries`; installed integer `10`.
-- **Meaning:** maximum newest unread entries projected into one Email
-  notification mirror; total unread count remains exact.
-- **Source/configuration:** installed `email/settings.py` constant; no
-  environment variable or owner settings file. `configurable` is false.
-- **Timing:** only reviewed code/package change plus full relaunch changes it;
-  verify with a second SHOW.
+`unread.max_entries`: current/default 10, configurable false. Projects newest
+unread entries while preserving the total unread count. This is not a per-body
+truncation or mailbox retention limit.
 
 ## Pseudo-agent subscriptions
 
-- **Key:** `manifest.pseudo_agent_subscriptions`; current and default always
-  `<redacted>`. The raw values are path lists and never appear in SHOW output.
-- **Meaning:** pseudo-agent directories whose outboxes the POSIX mail adapter
-  polls in addition to this agent's inbox.
-- **Accepted values:** JSON list of path strings; `[]` disables subscriptions.
-  If absent, the launcher's meaningful default is `["../human"]`. The init
-  schema requires a list, and an element that cannot be interpreted as a path
-  fails adapter construction rather than being silently ignored.
-- **Source/precedence:** exactly the `manifest.pseudo_agent_subscriptions`
-  field in `init.json`; no Email environment variable or owner-file peer. The
-  resolved list is sensitive local routing data and must not be inferred from
-  SHOW or copied from logs.
-- **Timing/change procedure:** after explicit owner/human authorization, edit
-  that exact manifest field with the existing File or Shell capability, then
-  perform a full agent relaunch. Ordinary refresh does not reconstruct the mail
-  adapter. Call SHOW again after relaunch; it proves availability and redaction,
-  never the paths.
+`manifest.pseudo_agent_subscriptions` is a sensitive construction snapshot.
+Current/default stay `<redacted>`; raw path lists never appear in SHOW. Accepted
+configuration is a JSON list of paths (`[]` disables subscriptions); when absent,
+the launcher default is `["../human"]`. Invalid path elements fail adapter
+construction rather than being ignored.
 
-## Privacy and ownership boundaries
+For the normal CLI launcher the source is that exact `init.json` manifest field;
+embedders can supply the POSIX constructor argument directly. There is no Email
+environment or owner-file peer. After explicit authorization, edit the owning
+source and fully relaunch so the adapter is reconstructed. Public System refresh
+uses a process relaunch; the internal in-process `_setup_from_init()` only rebuilds
+the EmailManager and keeps the existing mail adapter snapshot. SHOW proves
+availability and redaction, never the paths. This distinction corrects the source
+Contract's unqualified “ordinary refresh” wording without changing runtime.
 
-Mailbox/session paths, addresses, identities, contacts, messages, attachments,
-and read/archive state are runtime/domain data, not settings. They are excluded,
-not merely redacted. `LINGTAI_AGENT_ALIVE_THRESHOLD_SEC` remains kernel liveness
-policy and `LINGTAI_NOTIFICATION_MAX_CHARS` remains Notification presentation
-policy; Email does not claim either variable. The legacy 200-character digest
-renderer wording is not an effective Email setting because live unread publishing
-uses full-body entries.
+## Privacy boundary
+
+Mailbox/session paths, addresses, identities, contacts, messages, attachments, and
+read/archive state are runtime data and are excluded, not merely redacted.
+`LINGTAI_AGENT_ALIVE_THRESHOLD_SEC` remains kernel liveness policy and
+`LINGTAI_NOTIFICATION_MAX_CHARS` remains Notification presentation policy; Email
+does not claim either variable.

--- a/src/lingtai/tools/email/primitives.py
+++ b/src/lingtai/tools/email/primitives.py
@@ -27,7 +27,7 @@ def mode_field(lang: str = "en") -> dict:
     return {
         "type": "string",
         "enum": ["peer", "abs"],
-        "description": "Address mode for send; usually omit it. peer (default) resolves a bare name in your own .lingtai/ network. abs accepts a literal absolute workdir only for an explicitly authorized cross-network recipient. Both require valid .agent.json and a fresh heartbeat; abs does not bypass delivery checks. See email-manual.",
+        "description": "Send routing: peer (default) uses this network; abs requires an explicitly authorized absolute cross-network path. Non-self POSIX delivery checks manifest presence and Core liveness (human exception); abs does not bypass checks. See email-manual.",
     }
 
 

--- a/src/lingtai/tools/email/schema.py
+++ b/src/lingtai/tools/email/schema.py
@@ -17,14 +17,12 @@ from .primitives import mode_field
 
 
 def get_description(lang: str = "en") -> str:
-    return ("Internal .lingtai mailbox only — not internet email (use the imap tool for Gmail/Outlook). "
-            "Use bare agent/path addresses; the closed envelope is action + input + reasoning, "
-            "with only the selected action's fields in input. Cross-action fields are rejected "
-            "before mailbox I/O. Reply on the channel the message arrived on (prefer reply or "
-            "reply_all); never reply in text output. Address senders by sender_nickname, else "
-            "sender_name. Unread bodies are injected in full into persistent Email notifications; "
-            "prefer dismiss after handling and use read for source records or attachments. Call "
-            "email(action='manual', input={}) for the email-manual router.")
+    return ("Internal .lingtai mailbox only, not internet email (use imap for external mail). "
+            "Use the closed action/input/reasoning envelope and only selected-action fields. "
+            "Reply on the arrival channel with reply/reply_all, never in text output; use sender_nickname, else "
+            "sender_name. Unread bodies are injected in full into persistent Email notifications; prefer "
+            "dismiss after handling; use read "
+            "for source records or attachments. email(action='manual', input={}) loads the router.")
 
 
 def get_schema(lang: str = "en") -> dict:
@@ -39,23 +37,20 @@ def get_schema(lang: str = "en") -> dict:
                     "contacts", "add_contact", "remove_contact", "edit_contact",
                     "manual",
                 ],
-                "description": ("Choose one action; put only its fields in input. send: new internal "
-                                "message (address/message required; body max 50,000 characters). "
-                                "check: list/filter mail. read: fetch IDs and mark read; dismiss: "
-                                "mark handled IDs read without returning bodies. Unread bodies are "
-                                "injected in full into persistent Email notifications: prefer dismiss "
-                                "after handling; use read for source records or attachments. "
-                                "reply/reply_all: answer existing mail. search: regex lookup. "
-                                "archive/delete: move or remove inbox/archive mail. contacts actions "
-                                "manage the address book. settings is read-only. manual returns this "
-                                "manual without mailbox I/O."),
+                "description": ("Choose one action and put only its fields in input. send: new "
+                                "internal message (address/message required; body max 50,000). "
+                                "check: list/filter; read: fetch IDs and mark read; dismiss: mark "
+                                "handled IDs read without bodies; reply/reply_all: answer on the "
+                                "arrival channel. search: regex; archive/delete: move/remove mail; "
+                                "contacts manage the private book; settings is read-only; manual "
+                                "returns this procedure without mailbox I/O."),
             },
             "address": {
                 "oneOf": [
                     {"type": "string"},
                     {"type": "array", "items": {"type": "string"}},
                 ],
-                "description": 'Bare name/path for send; string or list.',
+                "description": 'Peer name/path for send; abs needs explicit authorization.',
             },
             "cc": {
                 "type": "array",
@@ -70,14 +65,14 @@ def get_schema(lang: str = "en") -> dict:
             "attachments": {
                 "type": "array",
                 "items": {"type": "string"},
-                "description": 'Attachment paths for send.',
+                "description": 'Authorized source paths to attach.',
             },
             "subject": {"type": "string", "description": 'Subject.'},
-            "message": {"type": "string", "description": 'Body; max 50,000 characters.'},
+            "message": {"type": "string", "description": 'Body; max 50,000 Unicode characters.'},
             "email_id": {
                 "type": "array",
                 "items": {"type": "string"},
-                "description": 'Own mailbox ID list; replies use one ID.',
+                "description": 'ID from this mailbox; replies use one ID.',
             },
             "n": {
                 "type": "integer",
@@ -91,7 +86,7 @@ def get_schema(lang: str = "en") -> dict:
             "folder": {
                 "type": "string",
                 "enum": ["inbox", "sent", "archive"],
-                "description": "Folder; check inbox/search both; sent is read-only.",
+                "description": "Folder; check defaults inbox, search inbox+sent, read all; sent is read-only.",
             },
             "delay": {
                 "type": "integer",

--- a/tests/test_email_settings.py
+++ b/tests/test_email_settings.py
@@ -177,3 +177,35 @@ def test_operational_constants_are_the_inventory_constants():
     assert manager.EMAIL_BODY_CHAR_LIMIT == EMAIL_BODY_CHAR_LIMIT
     assert manager.EMAIL_DUPLICATE_FREE_PASSES == EMAIL_DUPLICATE_FREE_PASSES
     assert manager.EMAIL_CHECK_RESULT_TOKEN_LIMIT == EMAIL_CHECK_RESULT_TOKEN_LIMIT
+
+def test_manual_routes_each_show_anchor_without_repeating_action_schema():
+    root = Path(email_tool.__file__).with_name('manual')
+    text = (root / 'SKILL.md').read_text()
+    assert '## Nested reference catalog' in text
+    assert '| Action | Input' not in text
+    for heading in ('Send body character limit', 'Duplicate send loop guard',
+                    'Check result token limit', 'Unread notification entry limit',
+                    'Pseudo-agent subscriptions'):
+        section = text.split(f'### {heading}\n', 1)[1].split('\n### ', 1)[0]
+        assert 'reference/settings-reference/SKILL.md#' in section
+    for topic in ('addressing-and-replies', 'actions-and-storage',
+                  'notifications-and-delivery', 'settings-reference'):
+        assert f'location: reference/{topic}/SKILL.md' in text
+
+
+def test_manual_preserves_observed_delivery_limits_and_explicit_dismiss():
+    root = Path(email_tool.__file__).with_name('manual')
+    routing = (root / 'reference/addressing-and-replies/SKILL.md').read_text()
+    delivery = (root / 'reference/notifications-and-delivery/SKILL.md').read_text()
+    actions = (root / 'reference/actions-and-storage/SKILL.md').read_text()
+    settings = (root / 'reference/settings-reference/SKILL.md').read_text()
+    assert 'do not mark the source inbox ID read' in routing
+    assert 'Contract discrepancy' in routing
+    assert '`dismiss`' in routing
+    assert 'not a restart-resilient queue' in delivery
+    assert 'under two' not in delivery
+    assert 'before that call\'s unified sent record' in delivery
+    assert 'self-send bypasses this adapter' in actions
+    assert 'does not validate or copy attachments' in actions
+    assert 'subject, attachment paths, and mode are not compared' in settings
+    assert 'in-process `_setup_from_init()`' in settings


### PR DESCRIPTION
## Summary

- Make routine Email calls schema-sufficient; remove the duplicate action catalog and keep direct routes for addressing, storage, delivery and all five SHOW anchors.
- Correct source-verified guidance: directory address vs display name; non-self POSIX vs self-send attachments; outbox → per-recipient daemon thread → unified sent ordering; delayed mail is not a restart-resilient queue; recipient/body duplicate guard; public relaunch vs internal in-process adapter snapshot.
- Preserve same-channel replies, local-ID privacy, CC/BCC review, explicit cross-network authority, overflow/read-state handling and consent-based retention. Add two focused documentation regressions.

**Guidance only:** no engine, public schema structure, or Contract changes. Existing reply/read-state and unqualified refresh Contract discrepancies are explicitly documented, not silently weakened or claimed fixed.

## Measured size

Body characters excluding frontmatter: root 7,995 → 4,605 (−42.4%); five bodies 26,306 → 21,036 (−20.0%). Actions/storage grows 252 characters to preserve operational hazards and retention guidance.

Public schema description occurrences: 4,432 → 4,743; family description 646 → 470, **net +135 characters**. This is not a token/cost measurement; module comments and legacy flat schema are not counted as resident savings.

## Validation

Pinned clean base: `4c6c08657fe554106fa0cd18d968928813ba5a3a`.

- Repository Python 3.11, 19 complete files: candidate **369 passed / 4 failed**, clean control **367 / same 4 failures**. All four complete normalized error blocks match (checkout/pytest temporary paths and section delimiters only); no collection errors.
- Full changed `test_email_settings.py`: **9 passed**; the two added documentation cases failed before correction.
- Baseline failures: standalone System skill copy assertion, two prompt-catalog assertions, and pre-existing Psyche Anatomy orphans. Not repaired by this PR.
- Docs governance: 400 documents + docs.yaml PASS. Six drift findings byte-identical to control. `git diff --check` PASS.
- Actual task-local `setup.py build_py`, real Agent using built Python package, one official Email mount, complete 31,535-character prompt, five built/installed manuals byte-equal, 16 installed relative links, five SHOW routes and redacted subscription snapshot PASS.
- Real public Email handlers on candidate/control with recording-only thread scheduling: replies leave source unread and notification unchanged; explicit dismiss works; self-send bypasses attachment copy/validation; guard ignores subject/attachment changes; sender scheduling order verified.
- AST equal except prose across all three changed Python modules; public schema equal except descriptions.

Limits: mock LLM, sockets blocked, no real peer delivery/listener, no live process-restart experiment, no native Windows, no full repository suite, no production E2E. Build skips Rust and is not wheel/install validation. The first package-proof harness incorrectly compared intrinsic full manual text with frontmatter-stripped text; corrected from the canonical loader in v2 without product changes. Failed evidence retained.

## Scope

9 files, 415 additions / 544 deletions. Original one native LingTai Luna worker draft plus owner review/corrections. No replacement worker, CLI takeover, runtime rollout, configuration/auth change, release or cleanup. This is part of the human-authorized one-tool/one-PR manual batch, merge only after owner review and validation.

Telegram: @lingtaidev1bot | Nickname: 知微
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
