### PR TITLE
docs(avatar): simplify guidance and preserve actual spawn boundaries

### DIFF
--- a/src/lingtai/tools/avatar/__init__.py
+++ b/src/lingtai/tools/avatar/__init__.py
@@ -1,40 +1,14 @@
-"""Avatar capability — spawn independent peer agents (分身).
+"""Avatar capability: spawn independent peer agents (分身) as detached processes.
 
-Shallow (初生): Copy init.json to a new working dir, strip name, launch.
-    The avatar gets the same LLM config + capabilities but no identity,
-    no pad, no history.  A fresh life — but its own, not yours.
+Shallow copies ``init.json`` plus narrow Psyche owner inputs; deep additionally
+copies durable identity/knowledge state. Both start a fresh conversation, use
+an append-only spawn ledger, and outlive the parent's context.
 
-Deep (二重身): Copy identity files (system/), knowledge/, and exports/
-    plus init.json to a new dir, strip name + history, launch.
-    The avatar is a doppelgänger — same character, pad, knowledge —
-    but starts a fresh conversation.
-
-Both modes launch `lingtai-agent run <dir>` as a fully detached process.
-The avatar is an independent life — its existence does not depend on yours.
-
-Maintains an append-only ledger (delegates/ledger.jsonl) that records
-every spawn event.
-
-Usage (LTP v2 envelope — one action, one strict child input):
-    Agent(capabilities=["avatar"])
-    # avatar(action="spawn", input={"name": "researcher"}, reasoning="...")
-    # avatar(action="spawn", input={"name": "clone", "type": "deep"}, reasoning="...")
-    # avatar(action="settings", input={}, reasoning="...")
-    # avatar(action="manual", input={}, reasoning="...")
-
-Avatar no longer owns a rules-distribution action or an automatic post-spawn
-rules fan-out; the shared `.rules` heartbeat signal/consumer described in
-`src/lingtai/kernel/base_agent/lifecycle.py` is unchanged, and any agent may
-still write a `.rules` file to an explicitly targeted path (e.g. via `shell`).
-See `psyche-manual` for that protocol.
-
-The spawn mission brief is root ``reasoning`` (normalized to ``_reasoning`` by
-ToolExecutor), never an ``input`` property — see ``handle()``.
-
-This module is the static declared official plugin slice: its binder receives
-only the `workdir` and Avatar-specific parent-context ports, while the kernel
-registrar alone reserves and mounts the public `avatar` name. The package-local
-manual child deliberately keeps Avatar's current local-manual behavior.
+The single public ``avatar`` tool exposes strict ``spawn``, read-only ``settings``,
+and package-local ``manual`` actions. Spawn's mission is root ``reasoning``
+(normalized to ``_reasoning``), never nested input. Avatar has no rules action or
+automatic rules fan-out; the shared ``.rules`` protocol remains kernel/Psyche
+state. The declared plugin receives only its workdir and Avatar-parent ports.
 """
 from __future__ import annotations
 
@@ -138,39 +112,24 @@ _SPAWN_INPUT_SCHEMA: dict[str, Any] = {
     "properties": {
         "name": {
             "type": "string",
-            "description": (
-                "Avatar name and sibling-directory basename: one segment of "
-                "letters/digits/_/-; 1-64 chars, with no dots or slashes."
-            ),
+            "description": "Canonical sibling basename: 1-64 Unicode letters/digits/_/-; no dots or slashes.",
         },
         "type": {
             "type": ["string", "null"],
             "enum": [*SPAWN_TYPES, None],
-            "description": (
-                "Spawn type: 'shallow' (default) copies init.json plus narrow "
-                "Psyche inputs; 'deep' also copies identity/knowledge. Null uses "
-                "shallow."
-            ),
+            "description": "'shallow' (default) copies init plus narrow Psyche inputs; 'deep' adds identity/knowledge. Null uses shallow.",
         },
         "comment": {
             "type": ["string", "null"],
-            "description": (
-                "Persistent child-prompt note; not inherited. Null or empty means "
-                "no note. See avatar-manual for placement and lifetime."
-            ),
+            "description": "Persistent child-prompt note; not inherited. Null or empty means none.",
         },
         "dry_run": {
             "type": ["boolean", "null"],
-            "description": (
-                "Preview with no files or process created; null defaults to false."
-            ),
+            "description": "Preview without writes/process, not launch admission; null is false.",
         },
         "confirm": {
             "type": ["boolean", "null"],
-            "description": (
-                "Acknowledge the mission review; required for empty/short/"
-                "placeholder reasoning. Null defaults to false."
-            ),
+            "description": "Acknowledge reviewed empty/short/placeholder reasoning; null is false.",
         },
     },
     "required": ["name", "type", "comment", "dry_run", "confirm"],
@@ -184,14 +143,13 @@ _DECLARED_CHILD_SPECS: tuple[tuple[str, dict[str, Any]], ...] = (
 )
 
 _DESCRIPTION = (
-    "Spawn an independent, detached avatar, show its fixed settings, or read "
-    "the manual. Use an explicit action and strict input; there is no default. "
-    "Read avatar-manual first. Before the first spawn, call "
-    "avatar(action='manual', input={}, "
-    "reasoning='...'). For spawn, input.name is the canonical sibling-directory "
-    "basename, input.type is shallow (default) or deep, and root reasoning is "
-    "the required mission/first prompt. Use dry_run to preview and confirm only "
-    "after reviewing the mission. settings and manual are read-only."
+    "Spawn an independent detached avatar or inspect its fixed settings/manual. "
+    "Use explicit action and strict input; there is no default. For spawn, "
+    "input.name is the canonical sibling basename, input.type is shallow "
+    "(default) or deep, and root reasoning is the mission/first prompt. "
+    "Use dry_run to preview; confirm acknowledges only mission review. "
+    "settings and manual are read-only. Read avatar-manual for unfamiliar or "
+    "consequential lifecycle, authority, recovery, or footprint decisions."
 )
 
 

--- a/src/lingtai/tools/avatar/manual/SKILL.md
+++ b/src/lingtai/tools/avatar/manual/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: avatar-manual
 description: |
-  Read before spawning a persistent avatar, choosing shallow or deep mode, or
-  deciding whether a disposable daemon is the right substrate.
-version: 1.4.0
-last_changed_at: 2026-09-06T00:00:00Z
+  Use for an unfamiliar or consequential Avatar spawn, shallow/deep choice,
+  detached lifecycle, recovery, or footprint review. Routine schema-sufficient
+  spawns can use the tool directly.
+version: 1.5.0
+last_changed_at: 2026-09-09T11:24:00Z
 related_files:
 - src/lingtai/tools/avatar/__init__.py
 - src/lingtai/tools/avatar/settings.py
@@ -18,122 +19,93 @@ related_files:
 - src/lingtai/kernel/base_agent/lifecycle.py
 - src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
 maintenance: |
-  Tracks the avatar guidance router and its nested references. Keep the router
-  short, preserve the settings anchors and first-call guard, and update the
-  focused reference when spawn, authority, lifecycle, or cleanup semantics change.
+  Keep this router and its two references short, direct, and aligned with Avatar
+  schema, spawn/authority/lifecycle semantics, and the package-local manual
+  loader. Keep the settings anchors and cleanup route stable; update the focused
+  reference when its owned hazard changes.
 ---
 
-# Avatar Manual — Router
+# Avatar Manual
 
-Avatar creates a **persistent, independent agent process** (他我). Read this
-router before choosing Avatar. It is not an in-process worker: use `daemon` for
-a disposable session whose conclusion is enough, and `shell` for one-off host
-commands.
+Avatar creates a **persistent, independent peer** as a detached process. Use
+`daemon` for disposable work and `shell` for a one-off command. After launch,
+communicate by mail/email; there is no ongoing Avatar handle.
 
-## First-call prerequisite
+## Routine spawn: direct path
 
-Before the first spawn, call the read-only manual action and keep its exact
-body:
-
-```text
-avatar(action="manual", input={}, reasoning="read avatar guidance before spawning")
-```
-
-`action`, `input`, and root `reasoning` are required. `input` is closed: spawn
-owns `name`, `type`, `comment`, `dry_run`, and `confirm`; `settings` and `manual`
-own `{}` only. The mission is root `reasoning`, never an input field. There is
-no default action, and Avatar has no `rules` action. The manual call performs no
-spawn or ledger I/O. Use the routes below for depth rather than guessing.
-
-## Quick routes
-
-| Need | Read |
-|---|---|
-| Select shallow/deep, validate the canonical name, write a mission, preview, or confirm a spawn | [Spawn and identity](reference/spawn.md) |
-| Understand detached life, ledger/state, authority boundaries, boot observation, escalation, or platform launch | [Lifecycle and authority](reference/lifecycle.md) |
-| `.rules` heartbeat and prompt protocol | [Psyche manual](../../../intrinsic_skills/psyche-manual/SKILL.md) |
-| Inspect Avatar's immutable settings | `avatar(action="settings", input={}, reasoning="inspect Avatar policy")`; anchors are below |
-| Inspect footprint or consider retirement | [Shared footprint recipe](../../skills/manual/reference/cleanup-footprint-contract.md#shared-footprint-check-recipe) |
-
-## Tool essentials
+The schema is enough for a routine call; do not load this manual as a ritual.
+Use all five strict spawn-input keys and put the mission in root `reasoning`:
 
 ```text
 avatar(action="spawn",
        input={"name": "researcher", "type": null, "comment": null,
               "dry_run": false, "confirm": false},
-       reasoning="<mission>")
-avatar(action="spawn",
-       input={"name": "clone", "type": "deep", "comment": null,
-              "dry_run": false, "confirm": false},
-       reasoning="<mission>")
-avatar(action="settings", input={}, reasoning="inspect Avatar policy")
+       reasoning="Inspect the heartbeat regression; report evidence by mail and change no code.")
 ```
 
-The strict model-facing `spawn` branch requires all five input keys; use `null`
-for a defaulted value. `name` is the canonical sibling-directory basename.
-`type` is `shallow` or `deep` and defaults to `shallow`; `dry_run` previews
-without files or a process; `confirm` acknowledges review when the mission is
-empty, short, or placeholder-like. Null values mean absent. A spawn is an
-external side effect and an independent life; do not batch it with unrelated
-calls.
+State objective, resources, reporting route, done condition, and constraints.
+`name` is the canonical sibling basename, not a separate display name. Spawn
+creates an independent life: obtain authorization, and do not batch it with
+unrelated calls. `dry_run=true` previews without writes or a process, **not**
+launch admissibility; `confirm=true` acknowledges only mission review.
 
-## Settings
+| Need | Read |
+|---|---|
+| Payload choice, exact mission/name gates, preview limits, comment/preset inheritance | [Spawn and identity](reference/spawn.md) |
+| Boot result, detached life, authority, platform, failed launch, retirement | [Lifecycle and authority](reference/lifecycle.md) |
 
-`avatar(action="settings", input={}, reasoning="inspect Avatar policy")` is
-SHOW-only. Its 16 rows each contain exactly `key`, `current`, `default`,
-`configurable`, and `comment`. Every row is immutable (`configurable:false`):
-the fixed values in `avatar/settings.py` are both the fresh effective `current`
-and truthful `default`. Avatar has no settings file, `LINGTAI_AVATAR_*`
-environment source, alternate precedence, or set/reset action. A per-call spawn
-input affects only that invocation.
+`avatar(action="manual", input={}, reasoning="load Avatar guidance")` returns
+this **package-local** body and `manual_path`; resolve its links from that path,
+not from an Agent's installed skill copy. Avatar has no rules action or fan-out:
+use `psyche(action="manual", input={}, reasoning="locate rules guidance")` for
+the kernel/Psyche `.rules` protocol.
 
-The 16 exposed policy values are non-sensitive and unredacted. SHOW writes
-nothing and omits parent identity, runtime/venv/auth, inherited environment
-contents, handoff values, and invocation/session state. If the inventory cannot
-be read or serialized safely, it fails as one result capped at 65,536 UTF-8
-bytes, without partial rows or raw exception detail. There is no runtime setting
-change procedure: an authorized permanent policy change requires source/manual
-review, `tests/test_tool_family_avatar_migration.py` plus the shared
-`tests/test_tool_settings_contract.py`, and a relaunch; call SHOW again after
-relaunch to verify the effective values. The anchors below define each row group.
+## Read-only settings
+
+`avatar(action="settings", input={}, reasoning="inspect Avatar policy")`
+returns 16 fresh five-field rows: `key`, `current`, `default`, `configurable`,
+`comment`. Every row is fixed, `current=default`, `configurable:false`.
+The source is `tools/avatar/settings.py`; there is no Avatar settings file,
+`LINGTAI_AVATAR_*` override, or set/reset action. Per-call inputs do not change
+SHOW. Changing fixed policy requires an authorized source change, tests and
+owner relaunch, then SHOW again. Values are public policy, not identity,
+credentials, environment contents, or live session state. An unavailable row
+fails the whole action as bounded `SETTINGS_UNAVAILABLE`, without partial rows.
 
 ### Spawn call defaults
 
-Absent or `null` values use `type="shallow"`, `comment=""`,
-`dry_run=false`, and `confirm=false`. These are fixed source defaults, not
-settings-file or environment values. Per-call inputs never change later SHOW
-results. Permanent policy changes require source review, focused tests, and a
-relaunch. The persistent `comment` is rendered after `meta_guidance` and before `rules`; its position does not override later sections.
+`type` is `shallow`, `comment` is empty, `dry_run` and `confirm` are false when
+nullable inputs are omitted/null. These four rows describe call defaults only.
+Shallow copies rewritten init plus narrow Psyche inputs; deep adds durable
+identity/knowledge state. See the payload reference before assuming isolation.
 
 ### Spawn validation policy
 
-Allowed types are `shallow` and `deep`. Names are 1–64 characters and must be a
-single Unicode word segment using letters, digits, `_`, or `-`; dots, slashes,
-spaces, and a leading dot are forbidden. Missions under 20 characters or equal
-to/starting with `bar`, `check`, `debug`, `foo`, `temp`, `test`, or `tmp` require
-`confirm=true`. These are fixed package policies.
+Five rows: allowed types `shallow`/`deep`; name minimum 1 and maximum 64
+characters; mission minimum 20 trimmed characters; placeholder tokens `bar`,
+`check`, `debug`, `foo`, `temp`, `test`, `tmp`. Names use Unicode-aware
+`^[\w-]+$` plus explicit length/dot checks: supply letters/digits/underscore/
+hyphen only. Exact mission token/space behavior is in the spawn reference.
 
 ### Spawn lifecycle policy
 
-Boot observation waits 5.0 seconds and polls every 0.1 seconds; early-exit
-stderr is capped at its final 2,000 bytes. Avatar uses the parent's default
-preset, inherits the launcher process environment without exposing it, launches
-a detached independent life, and clears newborn admin. A slow observation
-releases the parent-side handle without terminating the child.
+Seven rows: boot wait 5.0 seconds, poll 0.1 seconds, stderr tail 2,000 bytes;
+preset policy `parent-default`, environment `inherit-launcher-process`,
+lifecycle `detached-independent`, and admin inheritance `none`.
+Heartbeat presence is not a freshness or human-delivery proof; raw stderr may
+be sensitive. The lifecycle reference owns result/error and authority details.
+Preset rewriting is conditional on a configured default; see spawn reference.
 
-## Safety boundaries
+## Cleanup / Footprint
 
-- Avatar receives only its granted workdir and avatar-parent ports; it never
-  receives the parent `Agent` or a parent in-process handle.
-- The child directory is a direct sibling under the network root. The canonical
-  `name` is both the public identity and path basename; path escape is refused.
-- Shallow spawn is a blank slate with `init.json` plus narrow Psyche owner
-  inputs. Deep spawn additionally copies durable identity/knowledge state, but
-  still starts a fresh conversation. Neither mode inherits parent admin,
-  identity, brief, or addons.
-- Avatar no longer distributes rules. `.rules` remains kernel/Psyche state;
-  read the Psyche route above instead of treating it as an Avatar action.
+Targets are sibling `<network-root>/<name>/` and the parent's append-only
+`delegates/ledger.jsonl`, not cache. For read-only counts/bytes, the packaged
+[shared footprint recipe](../../skills/manual/reference/cleanup-footprint-contract.md#shared-footprint-check-recipe)
+accepts explicit target paths and writes/deletes nothing. Consider a report
+after an avatar-heavy session or before retirement; logging it to
+`logs/cleanup.jsonl` is optional and requires consent.
 
-For procedures, storage layout, authority markers, boot receipts, caring for a
-quiet avatar, and cleanup boundaries, open the two nested references. They are
-part of this manual's source of truth, not optional examples.
+Never delete directories, ledger, active processes, or recovery/audit state
+blindly. Capture a handoff, check current liveness, report footprint, then seek
+exact authorization for the specific lifecycle or destructive action. If the
+user is unavailable, stop after the report.

--- a/src/lingtai/tools/avatar/manual/reference/lifecycle.md
+++ b/src/lingtai/tools/avatar/manual/reference/lifecycle.md
@@ -1,13 +1,13 @@
 ---
 name: avatar-lifecycle-reference
 description: |
-  Avatar-manual reference for detached lifecycle, ledger/state, derived-child
-  authority markers, boot verification, escalation, platform boundaries, and
-  footprint safety.
-version: 1.0.0
-last_changed_at: 2026-09-06T00:00:00Z
+  Avatar lifecycle reference: detached life, ledger/state, derived-child
+  authority, boot verification, platform launch, escalation, and footprint.
+version: 1.1.0
+last_changed_at: 2026-09-09T11:24:00Z
 related_files:
 - src/lingtai/tools/avatar/manual/SKILL.md
+- src/lingtai/tools/avatar/manual/reference/spawn.md
 - src/lingtai/tools/avatar/__init__.py
 - src/lingtai/tools/avatar/_launcher.py
 - src/lingtai/tools/avatar/CONTRACT.md
@@ -19,113 +19,90 @@ related_files:
 - src/lingtai/tools/skills/manual/reference/cleanup-footprint-contract.md
 - src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
 maintenance: |
-  Tracks Avatar's detached-process and care boundaries. Keep it aligned with
-  launcher/CLI authority behavior and the router; do not turn lifecycle details
-  into schema prose or add a cleanup command here.
+  Keep this reference aligned with launcher/CLI authority, boot observation,
+  ledger, and cleanup behavior. Keep the parent router concise; do not add an
+  Avatar cleanup command or turn lifecycle facts into schema prose.
 ---
 
 # Avatar lifecycle and authority
 
-Nested reference for the Avatar Manual. This page covers what happens after the
-spawn request passes the identity and mission gates.
+The [Avatar Manual](../SKILL.md) owns the direct call, SHOW and footprint route;
+[spawn and identity](spawn.md) owns copy/mission/preview rules.
 
-## Independent life, not disposable work
+## Independent life and state
 
-An avatar is a fully detached agent process with its own directory, history,
-molts, and lifecycle. Its existence does not depend on the parent's context
-window. Use `daemon` for an ephemeral emanation that shares the task workdir
-and returns a conclusion; use `shell` for a one-off command. After a successful
-spawn, communicate through the normal mail/email channels rather than expecting
-an in-process handle.
-
-The parent does not manage ongoing sleep, suspend, or retirement through Avatar.
-A quiet avatar is not proof of completion: do not send probe mails. Report the
-silence to your own parent, who can decide whether to use lifecycle controls or
-accept the loss.
-
-## State and ledger
-
-Paths are relative to the parent working directory and its network root:
+An avatar is a detached process with its own directory, history, molts and
+lifecycle; it outlives the parent's context. Communicate by mail/email, not an
+in-process handle. Quiet is not completion: do not send probe mail or retry
+forever. Report blockers and the decision needed before handing off or molting.
 
 ```text
-<parent>/delegates/ledger.jsonl       # append-only spawn audit
-<network-root>/<name>/                 # sibling child directory
-  init.json
-  settings/psyche.json
-  .prompt                              # one-time first-turn signal
-  logs/spawn.stderr                    # early-boot stderr
-  logs/agent.log                       # child runtime log
-  .lingtai-derived-child.json         # Driver-derived state, when granted
-  system/ knowledge/ exports/ combo.json  # deep payload where applicable
+<parent>/delegates/ledger.jsonl        # append-only audit
+<network-root>/<name>/                # direct sibling
+  init.json  settings/psyche.json  .prompt
+  logs/spawn.stderr  logs/agent.log
+  .lingtai-derived-child.json         # only when Driver-granted
+  system/ knowledge/ exports/ combo.json  # deep payload as applicable
 ```
 
-A call that reaches provider admission appends an
-`avatar_admission_decision` record. A separate full `avatar` record is appended
-only after the process launches; it carries the canonical name, sibling-directory
-basename, mission, type, pid, boot status, and any bounded boot error. Earlier
-validation/gate returns and dry-run have no full spawn record. The ledger is
-append-only. Matching-name records are consulted for liveness through their
-stored `working_dir` value, while an existing sibling target directory is
-separately refused before child creation.
+Provider admission records `avatar_admission_decision` **before** real path /
+existing-directory checks, so a rejected spawn can leave an admission audit.
+The full `avatar` record follows launch and boot observation: name/basename,
+mission, type, PID, boot status/error. Dry-run and mission-gate returns write
+no record. Ledger liveness consults the stored `working_dir`; do not treat a
+ledger line as current health evidence. Exceptions can leave a partial child
+directory/init/`.prompt`; there is no atomic rollback promise. Preserve evidence
+and inspect before retrying or cleaning; do not retry under a different name
+to evade a refusal.
 
-## Derived-child authority boundary
+## Derived-child authority
 
-Only a Driver-approved child-endpoint lease permits Avatar to write
-`.lingtai-derived-child.json` before launch. The marker is outside the child's
-managed `system/` namespace. A legacy `system/derived_child.json` is also
-restrictive for upgrade compatibility. Missing both markers is the only relaxed
-case; malformed or unexpected state remains restrictive.
+Only a Driver-approved child-endpoint lease permits writing
+`.lingtai-derived-child.json` before launch, outside managed `system/`.
+Presence is restrictive—including malformed contents, directory or symlink;
+legacy `system/derived_child.json` is restrictive too. Only both missing
+relaxes the requirement. Unknown/I/O-error state is not absence.
 
-The marker is not a credential, parent identity, or authorization bearer. It
-protects against accidental launch-path/configuration loss in the trusted
-same-user model, not a child that can edit its own directory. The one-use opaque
-lease is handed only to the POSIX launcher and is closed if launch does not
-reach that port. The launch environment marker is redundant immediate defense,
-not authority.
-
-At child boot, `cli.run()` reads the durable marker and turns it into the
-restrictive nested-launch requirement. Authority is not smuggled through the
-environment, parent prompt, or a public Avatar input. Windows closes and rejects
-a supplied child-endpoint lease rather than launching without its approved
-endpoint.
+Markers are not credentials or parent identity. They protect trusted same-user
+launch/config continuity, not against a child editing its own directory. The
+one-use opaque POSIX lease is consumed at launch; the inherited descriptor's
+environment locator is not itself authority. CLI boot reads durable/environment
+markers and requires real authority for nested daemon/avatar launches. Public
+input, prompt and marker edits cannot grant it. Windows closes/rejects a POSIX
+lease rather than silently dropping the restriction.
 
 ## Launch and boot observation
 
-Avatar resolves the interpreter from `init.json` and submits the exact detached
-argv `[python, "-m", "lingtai", "run", <dir>]` to the launcher Port. Standard
-input/output are disconnected; stderr is captured at `logs/spawn.stderr`.
-The production Port returns a positive PID and opaque adapter handle. Polling is
-nonblocking and returns the exact child exit code or `None`.
+The selected child-init Python launches `[python, "-m", "lingtai", "run", <dir>]`.
+stdin/stdout are disconnected; stderr goes to `logs/spawn.stderr`. A positive
+PID and opaque handle permit nonblocking poll/release, not continuing ownership
+of the peer. Launcher environment is inherited; newborn admin is cleared.
 
-The manager waits up to 5.0 seconds, checking `.agent.heartbeat` every 0.1
-seconds. Heartbeat-first precedence wins; if the child exits first, spawn is
-`failed` with a bounded final 2,000-byte stderr tail. If neither handshake nor
-exit occurs within the window, spawn is `slow` with a warning. Releasing the
-parent-side handle after a slow observation never terminates the child.
+The manager checks `.agent.heartbeat` as a file every 0.1 seconds for up to
+5.0 seconds **before** checking process exit. It does not verify freshness or
+heartbeat contents. Boot `ok` therefore is not a live capability or human
+receipt. Early process exit yields boot `failed` and an outer `error` response;
+neither event within the window yields boot `slow` in a top-level `status=ok`
+response with a warning. Handle release after slow does not terminate the child.
 
-POSIX uses a new session; `terminate` and `force_terminate` affect exactly the
-owned process, never its tree. Windows uses detached creation flags and
-`close_fds`; both termination methods are forceful `TerminateProcess` calls.
-Unsupported platforms fail loudly rather than silently selecting an adapter.
+For an early-exit diagnostic the manager reads the entire stderr file, then
+keeps the last 2,000 bytes plus a truncation prefix when needed, decodes with
+replacement and includes exit code/path context. This is not a 2,000-byte total
+response or a bounded file read. The returned stderr/path is **not redacted**;
+it can contain private data. Inspect locally and sanitize before forwarding.
 
-## Care, escalation, and footprint
+The selector uses POSIX when `os.name == "posix"`, otherwise Windows when
+`sys.platform == "win32"`; unsupported hosts fail without a fallback. POSIX
+starts a new session and termination targets only its owned process, not its
+tree. Windows uses detached creation flags/`close_fds`; both termination methods
+are forceful `TerminateProcess`. No parent-side handle release kills the child.
 
-After a spawn, record the address, mission, and delegation reason in pad. If an
-avatar encounters a blocker, scope ambiguity, broken peer, budget pressure, or
-security concern, it must report concretely to its parent: what it tried, what
-failed, and what decision is needed. Do not silently retry forever or molt with
-an unreported blocker.
+## Care and retirement
 
-Avatar directories and ledger records are lives, not cache files. Never delete
-an avatar directory or ledger entry without explicit retirement approval and a
-captured handoff. For inspection, use the [shared footprint recipe](../../../skills/manual/reference/cleanup-footprint-contract.md#shared-footprint-check-recipe);
-inspection writes nothing. Prefer authorized lifecycle controls such as sleep,
-suspend, or nirvana over filesystem deletion.
-
-## Rules route
-
-Avatar does not own rules distribution. `.rules` is an unchanged kernel/Psyche
-signal consumed into `system/rules.md` and the protected prompt section. An
-agent may explicitly target a `.rules` path with its own permitted tool, but a
-spawn does not broadcast it. Read the [Psyche manual](../../../../intrinsic_skills/psyche-manual/SKILL.md)
-for replacement, empty/no-op, flush, and canonical/effective verification.
+Record address, mission and delegation reason in Pad. Report scope ambiguity,
+silence, budget or security concerns with evidence and an actionable decision.
+For retirement follow the root footprint route: capture a handoff, check
+liveness, report bytes, and get exact approval. Sleep, suspend and nirvana are
+not interchangeable; nirvana is **permanent destruction** requiring its own
+privileges and explicit owner authorization. Do not substitute filesystem
+deletion. When the user is unavailable, stop after the report.

--- a/src/lingtai/tools/avatar/manual/reference/spawn.md
+++ b/src/lingtai/tools/avatar/manual/reference/spawn.md
@@ -1,11 +1,10 @@
 ---
 name: avatar-spawn-reference
 description: |
-  Avatar-manual reference for spawn calls: canonical identity/path gates,
-  shallow/deep payloads, mission quality, dry-run/confirmation, and prompt
-  inheritance.
-version: 1.0.0
-last_changed_at: 2026-09-06T00:00:00Z
+  Avatar spawn reference: identity/path gates, shallow/deep payloads,
+  mission review, dry-run, confirmation, and prompt inheritance.
+version: 1.1.0
+last_changed_at: 2026-09-09T11:24:00Z
 related_files:
 - src/lingtai/tools/avatar/manual/SKILL.md
 - src/lingtai/tools/avatar/__init__.py
@@ -15,101 +14,77 @@ related_files:
 - src/lingtai/tools/psyche/CONTRACT.md
 - src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
 maintenance: |
-  Tracks Avatar's spawn and identity procedure. Keep it aligned with the
-  Avatar implementation, contract, settings anchors, and parent router; move
-  detailed procedure here rather than expanding the top manual.
+  Keep this reference aligned with Avatar spawn validation, serialization, and
+  prompt inheritance. Put procedure detail here rather than expanding the
+  parent router; preserve the router's settings anchors and direct spawn path.
 ---
 
 # Avatar spawn and identity
 
-Nested reference for the Avatar Manual. Open this after the first-call manual
-read when preparing a real spawn.
+The [Avatar Manual](../SKILL.md) has the direct call and defaults. `action`,
+`input`, and root `reasoning` are required. The closed spawn input contains only
+`name`, `type`, `comment`, `dry_run`, `confirm`; nullable values use defaults.
+Reasoning is the mission/first prompt, never an input property. Do not nest
+`reasoning`, `_reasoning`, or `summarize`.
 
-## Call contract
+## Canonical identity and path gate
 
-The canonical call is:
+`name` is the public routing identity and sibling-directory basename. Supply
+1–64 Unicode letters/digits/underscore/hyphen, with no dots, separators, spaces,
+control characters, or leading dot. There is no alternate directory input.
+Real spawn checks resolved sibling containment and refuses an existing target
+or live ledger peer. Confirmation does not bypass these or launch authority.
 
-```text
-avatar(action="spawn",
-       input={"name": "researcher", "type": "shallow", "comment": null,
-              "dry_run": false, "confirm": false},
-       reasoning="A concrete mission of at least 20 characters")
-```
+## Select the payload
 
-The root `reasoning` is the mission brief and becomes the child's first prompt.
-It is not a member of `input`; putting `reasoning`, `_reasoning`, or `summarize`
-in nested input is invalid. `input` is strict and action-specific. Optional
-`type`, `comment`, `dry_run`, and `confirm` may be null, which means absent and
-uses the fixed default. `action` is explicit and has no default.
+- **Shallow (default):** rewritten `init.json`, narrow Psyche base/covenant
+  inputs, and the new comment; it does not copy parent `system/`, knowledge,
+  exports, or conversation history.
+- **Deep:** also copies `system/`, `knowledge/`, `exports/`, and `combo.json`
+  when present. This includes durable character, Pad, summaries and existing
+  `system/rules.md`; a fresh conversation does not mean empty durable memory.
 
-## Canonical name and path gate
+Both set `manifest.agent_name`, clear `manifest.admin`, blank the `lingtai`
+seed, remove `lingtai_file`, old top-level prompt pairs/brief and top-level
+`addons`. This is **not a blanket purge of init fields**: other declarations,
+including an explicit `mcp` block, are not removed by this rewrite. Check
+integration ownership before authorizing a child that could share a poller.
 
-`input.name` is both the avatar's public agent name and the basename of its
-working directory. It must be 1–64 characters and match the Unicode-aware
-`^[\w-]+$` rule: letters, digits, underscore, and hyphen only. No dot, slash,
-space, control character, or leading dot is accepted. The target is a direct
-sibling of the parent directory and must remain inside the network root. The
-manager checks the resolved path before creating the child directory or launching
-a process; an existing target or an active ledger peer is refused.
+Only when `manifest.preset.default` is truthy does the rewrite select that
+preset as active and remove materialized `manifest.llm` and
+`manifest.capabilities` for first-boot materialization. A configuration
+without a default retains those fields and its existing active selection.
+Relative `default`, `active`, and `allowed` preset paths are re-rooted against
+the parent workdir; absolute and tilde-prefixed paths keep their meaning.
+Do not infer first-boot capabilities solely from the two ports granted to the
+Avatar **tool** binder: those ports are not the child's capability list.
 
-Do not supply an alternate directory. A name-shaped public call is the only
-supported identity/path input, which keeps ledger identity and filesystem
-identity canonical.
+## Mission review, preview, and confirmation
 
-## Choose a payload
+Make the mission actionable: objective, resources, reporting route, done
+condition, constraints. A trimmed mission shorter than 20 characters or whose
+lowercase text equals a placeholder token, or begins with that token followed
+by an **ASCII space**, needs `confirm=true`. Tokens are listed in SHOW's
+validation section. This is not arbitrary prefix matching: `testing ...` and
+`test ...` differ. Review the returned preview before acknowledging.
 
-- **Shallow (default, 初生):** copies the parent's `init.json` and only the
-  narrow Psyche base/covenant owner inputs. It is a blank slate: no parent
-  identity, pad, knowledge, history, brief, addons, or admin privileges.
-- **Deep (二重身):** also copies `system/`, `knowledge/`, `exports/`, and
-  `combo.json`, while retaining a fresh conversation. It is a character/knowledge
-  doppelgänger, not a second in-process handle. Normal deep copy includes an
-  existing `system/rules.md`; Avatar does not create or distribute rules.
+`dry_run=true` is a preview, **not launch admission**. It validates name/type,
+checks the ledger, and reads parent init/Psyche settings, but returns before
+provider admission, resolved-path containment and existing-directory checks.
+It may therefore preview a target that a real spawn would refuse. It skips the
+mission gate and creates no directory, ledger record, marker, `.prompt`, or
+process. Neither preview nor `confirm=true` grants authority.
 
-Both modes set the child `agent_name`, blank the inherited `lingtai` seed,
-strip identity/history and kernel/secretary overrides, and pin the parent's
-default preset. Relative preset paths are re-rooted against the parent's
-working directory. The child receives no inherited parent comment or brief.
+## Child prompt and comment
 
-## Mission, preview, and confirmation
+`settings/psyche.json` uses Psyche's v1 owner serializer for only base/covenant
+pairs plus the new spawn comment. Parent relative pointers are anchored to the
+parent workdir. The parent's comment and comment-file pointer are not
+inherited; null/empty new comment means none. This persistent note survives
+refresh/molt/wake and renders after `meta_guidance` and before `rules`—position,
+not precedence. Deep copying does not copy the parent's `settings/` directory.
 
-Write `reasoning` as an actionable brief: objective, relevant paths/resources,
-reporting route, done condition, and constraints. The parent identity/address
-is supplied by the system prompt; do not rely on a vague one-line rationale.
-
-Before any filesystem mutation, the mission-quality gate flags an empty mission,
-a mission shorter than 20 characters, or a mission equal to/starting with the
-placeholder tokens `bar`, `check`, `debug`, `foo`, `temp`, `test`, and `tmp`.
-The result is `status="confirmation_needed"` with a preview unless
-`confirm=true`. `confirm` is an acknowledgement, not a grant of authority;
-it does not bypass name/path or host lifecycle checks.
-
-Use `dry_run=true` to preview after loading the parent's `init.json`. Dry-run
-short-circuits before creating a directory, writing a ledger, marker, or
-`.prompt`, and before launching a process. It is exempt from the mission-quality
-gate so an inspection can show whether confirmation would be needed.
-
-## Child prompt and persistent comment
-
-Avatar builds a child `init.json` from the parent while clearing newborn admin,
-materialized `llm`/`capabilities`, inert legacy prompt fields, addon state, and
-other parent-only overrides. The child re-materializes from the parent's
-**default** preset on first boot.
-
-The separate `settings/psyche.json` retains only the Psyche base/covenant owner
-inputs, anchors relative pointers to the parent workdir, replaces `comment`
-with the new spawn comment, and omits `comment_file`. The comment is rendered
-after `meta_guidance` and before `rules`; that is its position, not precedence
-over later sections. It is not inherited and survives refresh, molt, and wake.
-Leave it empty unless it is a fact the child must always remember.
-
-The parent identity and mission are delivered through a separate `.prompt` signal
-file, consumed once. The `lingtai` character seed is blanked rather than being
-used as a hidden mission channel.
-
-## No automatic rules side effect
-
-Avatar has no `rules` action and a successful shallow or deep spawn does not
-write a `.rules` signal or broadcast rules. The `.rules` heartbeat and
-`system/rules.md` persistence remain kernel state; use the Psyche manual for
-that protocol.
+Parent identity and mission travel in a separate one-time `.prompt` signal,
+consumed by the child watcher. The blank `lingtai` seed is not that channel.
+Avatar writes no `.rules` signal and distributes no rules. For that protocol,
+use `psyche(action="manual", input={}, reasoning="locate rules guidance")`.

--- a/tests/test_layers_avatar.py
+++ b/tests/test_layers_avatar.py
@@ -654,25 +654,25 @@ class TestMissionQualityGate:
             "spawn", "settings", "manual"
         ]
 
-    def test_description_points_to_avatar_manual_after_prompt_compaction(self):
-        """The terse tool description should route safety guidance to the manual.
+    def test_description_routes_only_consequential_avatar_guidance(self):
+        """Routine schema-sufficient spawn needs no mandatory manual round trip.
 
-        Prompt-token compaction moved verbose WARNING copy out of the always-on
-        tool description and into avatar-manual. The safety contract now lives
-        in the schema gates (dry_run/confirm, now inside the spawn branch of
-        ``input.anyOf``) plus the manual pointer, not in a long description
-        string.
+        The always-on description stays mechanical and points to avatar-manual
+        only for unfamiliar or consequential lifecycle decisions. Spawn's strict
+        schema still exposes the dry_run/confirm gates in its input branch.
         """
         from lingtai.tools.avatar import get_description, get_schema
         desc = get_description("en")
         schema = get_schema("en")
         assert "avatar-manual" in desc
-        assert "Before the first spawn, call avatar(action='manual'" in desc
+        assert "Read avatar-manual for unfamiliar or consequential" in desc
+        assert "Before the first spawn" not in desc
         assert "WARNING" not in desc
         manual = (
             Path(__file__).parents[1] / "src/lingtai/tools/avatar/manual/SKILL.md"
         ).read_text(encoding="utf-8")
-        assert "Before the first spawn" in manual
+        assert "Routine schema-sufficient" in manual
+        assert "do not load this manual as a ritual" in manual
         assert "reference/spawn.md" in manual
         assert "reference/lifecycle.md" in manual
         spawn_props = {
@@ -894,3 +894,39 @@ class TestUnifiedAvatarTool:
 
         manual_result = mgr.handle({"action": "manual", "input": {}})
         assert manual_result["status"] == "ok"
+
+
+def test_avatar_manual_package_links_resolve_from_returned_path():
+    import re
+    from lingtai.tools.avatar import _manual_payload
+    result = _manual_payload({})
+    root = Path(result["manual_path"])
+    for page in [root, *sorted((root.parent / "reference").glob("*.md"))]:
+        for target in re.findall(r"\[[^\]]*\]\(([^)]+)\)", page.read_text()):
+            if "://" not in target and not target.startswith("#"):
+                assert (page.parent / target.split("#")[0]).resolve().exists(), (page, target)
+
+
+def test_avatar_guidance_distinguishes_preview_and_conditional_init():
+    from lingtai.tools.avatar import _SPAWN_INPUT_SCHEMA
+    manual = Path(__file__).parents[1] / "src/lingtai/tools/avatar/manual"
+    text = (manual / "reference/spawn.md").read_text()
+    assert "not launch admission" in text
+    assert "Only when" in text and "manifest.preset.default" in text
+    assert "without a default" in text
+    assert "ASCII space" in text
+    props = _SPAWN_INPUT_SCHEMA["properties"]
+    assert "identity/knowledge" in props["type"]["description"]
+    assert "not inherited" in props["comment"]["description"]
+    assert "empty/short/placeholder" in props["confirm"]["description"]
+
+
+def test_avatar_guidance_preserves_boot_and_settings_limits():
+    manual = Path(__file__).parents[1] / "src/lingtai/tools/avatar/manual"
+    lifecycle = (manual / "reference/lifecycle.md").read_text()
+    root = (manual / "SKILL.md").read_text()
+    assert "freshness" in lifecycle and "not redacted" in lifecycle
+    assert "reads the entire" in lifecycle and "truncation prefix" in lifecycle
+    assert "permanent destruction" in lifecycle
+    assert "LINGTAI_AVATAR_*" in root
+    assert "relaunch" in root and "current=default" in root

--- a/tests/test_tool_family_avatar_migration.py
+++ b/tests/test_tool_family_avatar_migration.py
@@ -426,8 +426,12 @@ def test_avatar_manual_states_the_real_spawn_comment_prompt_position() -> None:
     )
     order = SystemPromptManager._DEFAULT_ORDER
 
-    assert "rendered last, after memory" not in manual
-    assert "after `meta_guidance` and before `rules`" in manual
+    assert "reference/spawn.md" in manual
+    spawn = (Path(avatar.__file__).parent / "manual/reference/spawn.md").read_text(
+        encoding="utf-8"
+    )
+    assert "rendered last, after memory" not in manual + spawn
+    assert "after `meta_guidance` and before `rules`" in " ".join(spawn.split())
     assert order.index("meta_guidance") < order.index("comment") < order.index("rules")
 
 


### PR DESCRIPTION
## Summary
- Simplify Avatar's entry and two references: entry **26.0%**, complete three-body corpus **19.7%** smaller. Keep a strict direct call; load manuals for unfamiliar/consequential work instead of a ritual first call.
- Restore useful schema payload/comment/confirmation meanings; public schema descriptions and family description total **310 fewer characters** (not measured token/cost savings).
- Correct package-local links, conditional default-preset rewrite, preview-versus-admission, tool-port/child-capability distinction, exact mission token matching, 16 fixed SHOW rows, raw boot diagnostics, and detached/retirement authority boundaries.
- Preserve runtime semantics and schema shape. No launcher, ownership-policy, provider, process, credential or configuration logic changes.

## Validation
Frozen base `6685837656043df759e4fe51e8dc85a0578123bc`. Final patch SHA-256 `8e5663e9be0e26d9fff13d8958ad21449b3bf604019b9d410d77266033cef7a7`.
- Sixteen complete test files: candidate **320 passed / 4 failed / 1 skipped**, clean base **317 / 4 / 1**. All four complete error blocks equal after only checkout/pytest-temp path normalization and outside-block separator removal. Existing failures: System standalone-skill copy, two prompt catalog assertions, Psyche Anatomy orphans. Not an all-green claim.
- Three new guidance regressions failed before correction. Complete touched `test_layers_avatar.py`: **44 passed**. The existing comment-position assertion now checks the linked owning reference and retains the real prompt-order assertion. Two task-added intentional measurement failures were preserved outside the PR then removed; never classified as baseline.
- Docs governance: **400 documents + docs.yaml**; identical six-item Anatomy drift; `git diff --check` clean.
- Actual task-local `build_py` (Rust build skipped), real isolated Agent and complete **31,691-character** prompt; one official Avatar mount; all three **package-local** manual bodies byte-equal; six links/anchors and sixteen SHOW routes pass.
- Actual ToolExecutor normalizes root reasoning into the mission. Recording launcher proves preview of existing directory without admission/write/launch, mission gate, admission audit before real-directory refusal, old heartbeat presence winning exit poll, raw fake stderr >2,000 total bytes, and slow `status=ok` with handle release. **Zero real child processes**; socket connect blocked and mocked LLM. Slow branch uses a task-only zero-second wait override, not a real five-second observation.
- Conditional init rewrite is locally proven with/without default; explicit other init fields remain. This is not a live child first-boot/capability or Telegram-delivery proof.

## Boundaries
No full repository suite/native Windows/real detached spawn/provider/channel E2E. No runtime rollout, shared install, configuration/auth changes or protected cleanup. Legacy heartbeat/diagnostic/preview limits are documented, not fixed or redefined by weakening Contracts.

Telegram: @lingtaidev1bot | Nickname: 知微
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
