### PR TITLE
docs(telegram): encourage scenario-aware rendering modes

### DIFF
--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -768,7 +768,7 @@ DESCRIPTION = (
     "with `check`, `read`, or `search`; use `send` only for an authorized new "
     "message to a real numeric chat_id, or `reply` with a copied compound "
     "message_id from `read`/`search`. Content-bearing send/reply/edit defaults to "
-    "Markdown; use `media.type='document'` for generated files and `photo` only "
+    "Markdown; choose `rendering_mode` to fit the scenario; use `media.type='document'` for generated files and `photo` only "
     "for an inline preview. `placeholder` is progress-only: edit phases, then "
     "send the final answer separately. `read` marks returned records read; "
     "`check` counts incoming unread; `search` uses a regex. `edit` and `delete` "


### PR DESCRIPTION
## Summary

- encourage the agent to choose Telegram `rendering_mode` to fit the scenario
- keep the existing Markdown default, schema shape, available modes, and runtime behavior unchanged
- change exactly one Tool-description line; add no API, framework, test, or documentation surface

## Validation

- `106 passed` — Telegram schema, rich-formatting, send-media contract, and MCP SDK v2 suites
- direct `DESCRIPTION` probe confirms the guidance appears exactly once
- `python -m py_compile src/lingtai/mcp_servers/telegram/manager.py`
- `git diff --check`

Telegram: @lingtaidev3bot | Nickname: 澄一

Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai