### PR TITLE
fix(llm): preserve raw output items in stateless Responses replay

### DIFF
--- a/src/lingtai/llm/interface_converters.py
+++ b/src/lingtai/llm/interface_converters.py
@@ -8,7 +8,9 @@ Naming convention:
 from __future__ import annotations
 
 import copy
+import hashlib
 import json
+import math
 from typing import Any
 
 from lingtai.kernel.llm.interface import (
@@ -19,6 +21,129 @@ from lingtai.kernel.llm.interface import (
     ToolCallBlock,
     ToolResultBlock,
 )
+
+
+_RESPONSES_OUTPUT_ITEMS_KEY = "openai_responses_output_items"
+_RESPONSES_REPLAY_FINGERPRINT_KEY = "openai_responses_replay_fingerprint"
+
+
+def _responses_replay_fingerprint(content: list[ContentBlock]) -> str:
+    """Fingerprint visible canonical blocks that validate raw Responses replay.
+
+    Provider metadata is intentionally excluded: changing a summary, message,
+    or tool call in canonical history must invalidate the raw provider snapshot,
+    while an opaque provider field must not become part of the validity token.
+    """
+    blocks: list[dict[str, Any]] = []
+    for block in content:
+        if isinstance(block, TextBlock):
+            blocks.append({"type": "text", "text": block.text})
+        elif isinstance(block, ThinkingBlock):
+            blocks.append({"type": "thinking", "text": block.text})
+        elif isinstance(block, ToolCallBlock):
+            blocks.append({
+                "type": "tool_call",
+                "id": block.id,
+                "name": block.name,
+                "args": block.args,
+            })
+        elif isinstance(block, ToolResultBlock):
+            blocks.append({
+                "type": "tool_result",
+                "id": block.id,
+                "name": block.name,
+                "content": block.content,
+            })
+        else:  # pragma: no cover - ContentBlock is a closed union today.
+            blocks.append({"type": type(block).__name__, "value": repr(block)})
+    try:
+        encoded = json.dumps(
+            blocks,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        )
+    except (TypeError, ValueError):
+        # Canonical blocks are normally JSON-shaped.  A malformed/manual block
+        # still needs a stable validity token, but it must never be serialized
+        # as a provider snapshot or invented with ``default=str``.
+        encoded = repr(blocks)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _responses_snapshot_is_json(value: Any) -> bool:
+    """Accept only values that can exist in a JSON Responses snapshot."""
+    if value is None or isinstance(value, (str, bool, int)):
+        return True
+    if isinstance(value, float):
+        return math.isfinite(value)
+    if isinstance(value, list):
+        return all(_responses_snapshot_is_json(item) for item in value)
+    if isinstance(value, dict):
+        return all(
+            isinstance(key, str) and _responses_snapshot_is_json(item)
+            for key, item in value.items()
+        )
+    return False
+
+
+def _responses_snapshot_ids_are_unique(items: list[dict]) -> bool:
+    """Reject duplicate stable IDs in a persisted output-item snapshot."""
+    seen: set[tuple[str, str]] = set()
+    for item in items:
+        for field_name in ("id", "call_id"):
+            value = item.get(field_name)
+            if not isinstance(value, str) or not value:
+                continue
+            identity = (field_name, value)
+            if identity in seen:
+                return False
+            seen.add(identity)
+    return True
+
+
+def _contains_redacted_value(value: Any) -> bool:
+    """Reject redacted opaque values from raw upstream replay."""
+    if isinstance(value, str):
+        return value.startswith("<REDACTED:") and value.endswith(">")
+    if isinstance(value, dict):
+        return any(_contains_redacted_value(v) for v in value.values())
+    if isinstance(value, (list, tuple)):
+        return any(_contains_redacted_value(v) for v in value)
+    return False
+
+
+def _responses_replay_items_for_entry(entry: Any) -> list[dict] | None:
+    """Return a valid immutable-copy raw output snapshot for one entry.
+
+    Missing metadata, a changed canonical entry, or redacted provider data all
+    deliberately fall back to the normal lossy projection for compatibility
+    with old/manual histories. The returned list is always a deep copy so a
+    provider SDK cannot mutate canonical history during conversion.
+    """
+    provider_data = getattr(entry, "provider_data", None)
+    if not isinstance(provider_data, dict):
+        return None
+    items = provider_data.get(_RESPONSES_OUTPUT_ITEMS_KEY)
+    fingerprint = provider_data.get(_RESPONSES_REPLAY_FINGERPRINT_KEY)
+    if not isinstance(items, list) or not isinstance(fingerprint, str):
+        return None
+    if fingerprint != _responses_replay_fingerprint(getattr(entry, "content", [])):
+        return None
+    try:
+        if _contains_redacted_value(items):
+            return None
+        if not _responses_snapshot_is_json(items):
+            return None
+        if not all(isinstance(item, dict) for item in items):
+            return None
+        if not _responses_snapshot_ids_are_unique(items):
+            return None
+        return copy.deepcopy(items)
+    except Exception:
+        # Malformed/cyclic manually-created metadata is an invalid snapshot.
+        return None
 
 
 _RUNTIME_ROOTS = frozenset({"tool_meta", "agent_meta"})
@@ -404,7 +529,11 @@ def _pair_responses_orphan_function_calls(items: list[dict]) -> list[dict]:
     return patched
 
 
-def to_responses_input(iface: ChatInterface) -> list[dict]:
+def to_responses_input(
+    iface: ChatInterface,
+    *,
+    replay_raw_output_items: bool = False,
+) -> list[dict]:
     """Convert canonical interface to OpenAI Responses API ``input`` items.
 
     System entries are excluded (the Responses API takes the system prompt
@@ -417,8 +546,17 @@ def to_responses_input(iface: ChatInterface) -> list[dict]:
       * assistant thought -> ``{"type": "reasoning", "summary": [{"type": "summary_text", "text": <str>}]}``
       * tool result     -> ``{"type": "function_call_output", "call_id", "output": <str>}``
 
-    Used by stateless Responses sessions (e.g. Codex) that must replay the
-    full conversation each turn instead of relying on ``previous_response_id``.
+    Used by stateless Responses sessions that must replay the full conversation
+    each turn instead of relying on ``previous_response_id``. Provider-specific
+    sessions choose whether to opt into the raw-output sidecar below.
+    Successful generic stateless turns may carry a provider-data snapshot;
+    when its canonical validity fingerprint still matches, this converter
+    deep-copies and emits those raw output items in their original order.
+    Changed, redacted, old, and manually-created entries use the projections
+    below instead. Raw output replay is opt-in at this converter seam via
+    ``replay_raw_output_items=True``; generic stateless Responses sessions and
+    MiMo/DeepSeek opt in, while native Codex deliberately keeps its existing
+    canonical projection.
 
     Before returning, the wire-layer guard
     :func:`_pair_responses_orphan_function_calls` synthesizes a
@@ -471,6 +609,18 @@ def to_responses_input(iface: ChatInterface) -> list[dict]:
                     "content": "\n".join(text_parts) if text_parts else "",
                 })
         elif entry.role == "assistant":
+            raw_items = (
+                _responses_replay_items_for_entry(entry)
+                if replay_raw_output_items
+                else None
+            )
+            if raw_items is not None:
+                # A successful stateless Responses turn is replayed as the
+                # provider returned it: item/content order, field presence,
+                # phases, and argument strings all remain intact.  The helper
+                # deep-copies and validates the snapshot before this point.
+                items.extend(raw_items)
+                continue
             text_parts: list[str] = []
             reasoning_items: list[dict] = []
             tool_calls: list[dict] = []

--- a/src/lingtai/llm/mimo/adapter.py
+++ b/src/lingtai/llm/mimo/adapter.py
@@ -166,7 +166,10 @@ class MimoResponsesSession(_StandaloneCompactionMixin, OpenAIResponsesSession):
         items = (
             compacted_replay
             if compacted_replay is not None
-            else to_responses_input(self._interface)
+            else to_responses_input(
+                self._interface,
+                replay_raw_output_items=True,
+            )
         )
         self._pending_request_representation = items
         return items
@@ -216,7 +219,10 @@ class MimoResponsesSession(_StandaloneCompactionMixin, OpenAIResponsesSession):
             return []
         temp_interface = ChatInterface()
         temp_interface.entries.extend(entries)
-        return to_responses_input(temp_interface)
+        return to_responses_input(
+            temp_interface,
+            replay_raw_output_items=True,
+        )
 
     def _compact_now(self) -> None:
         """Call standalone MiMo compaction and store the opaque replay basis.

--- a/src/lingtai/llm/openai/ANATOMY.md
+++ b/src/lingtai/llm/openai/ANATOMY.md
@@ -115,7 +115,7 @@ mechanism on `OpenAIAdapter` / `OpenAIChatSession` / `OpenAIResponsesSession`:
   that lack it (per-turn-unique stub via `_fallback_reasoning_for`; real captured
   `ThinkingBlock`s are never overwritten). On the Responses wire,
   `_inject_responses_reasoning_fallback` inserts per-turn-unique `reasoning`
-  input items after the first `function_call` for assistant turns that lack one.
+  input items after the first `function_call` for legacy canonical assistant text that lacks one; raw `type="message"` items and array-valued content pass through unchanged (`adapter.py:2276-2310`).
   On by default (env `LINGTAI_INJECT_REASONING_FALLBACK` to disable); an
   explicit constructor/provider-config value wins over the env.
 - `reasoning_effort_vocab` (`str`, default `openai`) — selects the retained

--- a/src/lingtai/llm/openai/ANATOMY.md
+++ b/src/lingtai/llm/openai/ANATOMY.md
@@ -55,12 +55,12 @@ OpenAI adapter — wraps the `openai` SDK for Chat Completions and Responses API
 
 | Class | Lines | Role |
 |-------|-------|------|
-| `OpenAIChatSession` | `adapter.py:1267` | Chat Completions session with context overflow auto-recovery; sends optional `prompt_cache_key` |
-| `OpenAIResponsesSession` | `adapter.py:1782` | Responses API session. Official OpenAI mode is server-stateful via `previous_response_id`; custom/OpenAI-compatible mode can be internally stateless (`stateless_replay=True`) and replays full canonical history via `to_responses_input` while recording assistant turns and exposing no resume id (`adapter.py:1806-1807`, `adapter.py:1974-1975`, `adapter.py:1985-1986`, `adapter.py:2092-2103`). |
-| `OpenAIAdapter` | `adapter.py:2126` | `LLMAdapter` implementation; dispatches to Completions or Responses path; receives injected `compact_threshold`; derives the default `prompt_cache_key` via `_default_prompt_cache_key` / `_resolve_prompt_cache_key`; carries the internal `_responses_stateless_replay` constructor mode into Responses sessions (`adapter.py:2184`, `adapter.py:2189`, `adapter.py:2282-2334`). |
-| `_StandaloneCompactionMixin` | `adapter.py:2561` | Shared standalone `/responses/compact` machinery extracted from `CodexResponsesSession`: projected-token trigger, turn-aware boundary selection (`_prepare_compact_request`, `adapter.py:2736`), opaque compacted-prefix-plus-delta replay. Mixed into both `CodexResponsesSession` (non-fatal failure policy) and MiMo's `MimoResponsesSession` (`src/lingtai/llm/mimo/adapter.py`, hard-failure policy) — see "Standalone Codex compaction" below. |
-| `CodexResponsesSession` | `adapter.py:3060` | Responses session for ChatGPT-backed Codex running the `full`/`incremental` additive continuation state machine over a selectable transport (REST default, WebSocket opt-in): every real send resolves the current context-owned account binding before building the request, account switches reset the wire epoch, and a trusted pre-event REST `401/token_expired` can reload the same account and replay the complete request exactly once; `store=false` always, encrypted reasoning include/replay and self-heal remain native, and standalone daemon-task compaction uses `POST /responses/compact`. |
-| `CodexOpenAIAdapter` | `adapter.py:5323` | The one Codex provider specialization shared by `codex`/`codex-pool` aliases. It creates one `_CodexAccountContext` per `ChatInterface`, owning that context’s generation-numbered binding, safe selection, molt marker, exclusion chain, authenticated client, and native request headers; the adapter remains the shared source/factory owner and validates token-refresh ownership before atomically publishing a binding to context and REST/WS transport state. If selection ends in `NoCandidateError`, it attaches only allowlisted pool/exclusion/quota-scan counts and booleans for the kernel terminal event; this is observation-only and does not change selection or AED. It also owns cache/session ids, installation id, endpoint/service-tier settings, and Codex’s explicit default `reasoning.effort = "xhigh"`; no pool-specific session or retry adapter exists. |
+| `OpenAIChatSession` | `adapter.py:2338` | Chat Completions session with context overflow auto-recovery; sends optional `prompt_cache_key` |
+| `OpenAIResponsesSession` | `adapter.py:2903` | Responses API session. Official OpenAI mode is server-stateful via `previous_response_id`; custom/OpenAI-compatible mode can be internally stateless (`stateless_replay=True`) and replays full canonical history via `to_responses_input` while recording assistant turns and exposing no resume id (`adapter.py:2930`, `adapter.py:3090-3110`, `adapter.py:3119-3240`). |
+| `OpenAIAdapter` | `adapter.py:3293` | `LLMAdapter` implementation; dispatches to Completions or Responses path; receives injected `compact_threshold`; derives the default `prompt_cache_key` via `_default_prompt_cache_key` / `_resolve_prompt_cache_key`; carries the internal `_responses_stateless_replay` constructor mode into Responses sessions (`adapter.py:3487-3549`). |
+| `_StandaloneCompactionMixin` | `adapter.py:3858` | Shared standalone `/responses/compact` machinery extracted from `CodexResponsesSession`: projected-token trigger, turn-aware boundary selection (`_prepare_compact_request`, `adapter.py:4033`), opaque compacted-prefix-plus-delta replay. Mixed into both `CodexResponsesSession` (non-fatal failure policy) and MiMo's `MimoResponsesSession` (`src/lingtai/llm/mimo/adapter.py`, hard-failure policy) — see "Standalone Codex compaction" below. |
+| `CodexResponsesSession` | `adapter.py:4121` | Responses session for ChatGPT-backed Codex running the `full`/`incremental` additive continuation state machine over a selectable transport (REST default, WebSocket opt-in): every real send resolves the current context-owned account binding before building the request, account switches reset the wire epoch, and a trusted pre-event REST `401/token_expired` can reload the same account and replay the complete request exactly once; `store=false` always, encrypted reasoning include/replay and self-heal remain native, and standalone daemon-task compaction uses `POST /responses/compact`. |
+| `CodexOpenAIAdapter` | `adapter.py:6717` | The one Codex provider specialization shared by `codex`/`codex-pool` aliases. It creates one `_CodexAccountContext` per `ChatInterface`, owning that context’s generation-numbered binding, safe selection, molt marker, exclusion chain, authenticated client, and native request headers; the adapter remains the shared source/factory owner and validates token-refresh ownership before atomically publishing a binding to context and REST/WS transport state. If selection ends in `NoCandidateError`, it attaches only allowlisted pool/exclusion/quota-scan counts and booleans for the kernel terminal event; this is observation-only and does not change selection or AED. It also owns cache/session ids, installation id, endpoint/service-tier settings, and Codex’s explicit default `reasoning.effort = "xhigh"`; no pool-specific session or retry adapter exists. |
 
 ### adapter.py helpers
 
@@ -78,10 +78,11 @@ OpenAI adapter — wraps the `openai` SDK for Chat Completions and Responses API
 | `_build_tools()` | `adapter.py:975` | `FunctionSchema` → OpenAI CC tool format (`{type, function: {name, description, parameters}}`) |
 | `_build_responses_tools()` | `adapter.py:1055` | `FunctionSchema` → Responses API flat format (`{type, name, description, parameters}`); scrubs disallowed top-level JSON-Schema combinators (`allOf`, `oneOf`, etc.) |
 | `_parse_response()` | `adapter.py:1104` | ChatCompletion → `LLMResponse` (extracts reasoning from `reasoning_content` or `reasoning`) |
-| `_handle_responses_reasoning_event()` | `adapter.py:1171` | Responses stream reasoning-summary event handler; accumulates `summary_text` deltas/done fallback without raw reasoning text |
-| `_parse_responses_api_response()` | `adapter.py:1217` | Responses API output → `LLMResponse` (handles `message`, `function_call`, `reasoning` output items) |
-| `_decode_responses_sse_text()` | `adapter.py:1370` | Strictly decodes a completed SSE body when a compatible gateway ignores a non-streaming Responses request and the SDK exposes the body as `str`; malformed/non-SSE strings fail loud. |
-| `_consume_responses_stream()` | `adapter.py:1431` | Shared Responses event accumulator for normal SDK streams and locally decoded forced-SSE bodies; returns the finalized response plus response id without a second provider request. |
+| `_handle_responses_reasoning_event()` | `adapter.py:1492` | Responses stream reasoning-summary event handler; accumulates `summary_text` deltas/done fallback without raw reasoning text |
+| `_parse_responses_api_response()` | `adapter.py:2023` | Responses API output → `LLMResponse` (handles `message`, `function_call`, `reasoning` output items) |
+| `_decode_responses_sse_text()` | `adapter.py:2079` | Strictly decodes a completed SSE body when a compatible gateway ignores a non-streaming Responses request and the SDK exposes the body as `str`; malformed/non-SSE strings fail loud. |
+| `_consume_responses_stream()` | `adapter.py:2141` | Shared Responses event accumulator for normal SDK streams and locally decoded forced-SSE bodies; returns the finalized response plus response id without a second provider request. |
+| `_ResponsesStreamOutputRecorder` | `adapter.py:1621` | Records complete ordered output items from a response trailer or all item-done events; incomplete streams do not commit raw replay metadata. |
 
 ## Connections
 
@@ -90,15 +91,15 @@ OpenAI adapter — wraps the `openai` SDK for Chat Completions and Responses API
 - **Interface converters** — imports `to_openai` and `to_responses_input` from `lingtai.llm.interface_converters` (`adapter.py:44`).
 - **Streaming** — imports `StreamingAccumulator` from `lingtai.kernel.llm.streaming` (`adapter.py:45`).
 - **HTTP client** — imports `httpx` for timeout construction (`adapter.py:23`); `openai` SDK for all API calls (`adapter.py:24`).
-- **Subclass hooks** — `_session_class` (`adapter.py:2134`) for Completions path; `_adapter_extra_body()` (`adapter.py:2395`) for provider-specific `extra_body`; `_default_prompt_cache_key()` (`adapter.py:2196`) for the provider-namespaced cache key.
+- **Subclass hooks** — `_session_class` (`adapter.py:3293`) for Completions path; `_adapter_extra_body()` (`adapter.py:3661`) for provider-specific `extra_body`; `_default_prompt_cache_key()` (`adapter.py:3398`) for the provider-namespaced cache key.
 
 ## Composition
 
 ### Two session paths
 
-The adapter forks at `create_chat()` (`adapter.py:2243`) via `_should_use_responses()` (`adapter.py:2224`):
-1. **Responses API** (`_create_responses_session`, `adapter.py:2282`) — when canonical `wire_api="responses"`, or when `wire_api="auto"` and legacy `use_responses=True` AND (`base_url` is None OR `force_responses=True`). Builds `OpenAIResponsesSession`, threading the adapter's `_responses_stateless_replay` into its `stateless_replay` kwarg (`adapter.py:2333`) — so a custom/OpenAI-compatible Responses adapter builds a stateless-replay session while official OpenAI stays stateful.
-2. **Chat Completions** (`_create_completions_session`, `adapter.py:2336`) — fallback for compatible providers and when `wire_api="chat_completions"`. Builds `self._session_class` (subclass-overridable).
+The adapter forks at `create_chat()` (`adapter.py:3448`) via `_should_use_responses()` (`adapter.py:3429`):
+1. **Responses API** (`_create_responses_session`, `adapter.py:3487`) — when canonical `wire_api="responses"`, or when `wire_api="auto"` and legacy `use_responses=True` AND (`base_url` is None OR `force_responses=True`). Builds `OpenAIResponsesSession`, threading the adapter's `_responses_stateless_replay` into its `stateless_replay` kwarg (`adapter.py:3546`) — so a custom/OpenAI-compatible Responses adapter builds a stateless-replay session while official OpenAI stays stateful.
+2. **Chat Completions** (`_create_completions_session`, `adapter.py:3583`) — fallback for compatible providers and when `wire_api="chat_completions"`. Builds `self._session_class` (subclass-overridable).
 
 Both paths return sessions wrapped via `_wrap_with_gate()` for rate limiting. Canonical `wire_api` wins over legacy `use_responses`/`force_responses`; when `wire_api` is absent/`auto`, existing behavior is preserved.
 
@@ -642,8 +643,23 @@ In-flight official/stateful Responses and Codex sessions keep no-op prompt/tool 
 ### Streaming
 
 - **CC streaming** (`adapter.py:1712`) — `stream=True, stream_options={include_usage: True}`. Uses `StreamingAccumulator` for text + tool deltas. Reasoning deltas captured from `delta.reasoning` or `delta.reasoning_content`. The post-build pairing validator runs before stream open, matching the non-streaming path. Overflow recovery wraps stream open + first chunk in the Chat Completions send-stream path.
-- **Responses streaming** (`adapter.py:1995`) — event types: `response.reasoning_summary_text.delta/done` (summary thoughts only), `response.output_text.delta`, `response.function_call_arguments.delta`, `response.output_item.added/done`, `response.completed`. The event consumer is shared with the non-streaming forced-SSE compatibility path. Custom/stateless mode snapshots before staging, replays full canonical history, records the finalized assistant turn, and restores the pre-send snapshot on enforce, serialization, stream-open, iteration, callback, finalize, or record failure (`adapter.py:2002-2089`).
+- **Responses streaming** (`adapter.py:2141`) — event types: `response.reasoning_summary_text.delta/done` (summary thoughts only), `response.output_text.delta`, `response.function_call_arguments.delta`, `response.output_item.added/done`, `response.completed`. The event consumer is shared with the non-streaming forced-SSE compatibility path. Custom/stateless mode snapshots before staging, replays full canonical history, records the finalized assistant turn, and restores the pre-send snapshot on enforce, serialization, stream-open, iteration, callback, finalize, or record failure (`adapter.py:3119-3240`).
 - **Codex streaming** — forces `stream=True` even on `send()`. Runs the `full`/`incremental` planner per request over the selected transport (REST default / WebSocket opt-in): REST carries the whole converted interface in both modes; WebSocket carries the whole interface for `full` and delta + `previous_response_id` for `incremental`. Captured summary thoughts and raw encrypted reasoning items are persisted as ThinkingBlocks so `to_responses_input` replays reasoning items before function calls; if Codex later rejects a raw encrypted item as unverifiable, the adapter strips only that opaque replay state and retries once with summary/plain transcript. Optional diagnostics (`LINGTAI_CODEX_RESPONSES_TRACE=1`) append safe per-event metadata to `logs/codex_responses_trace.jsonl` without changing accumulator/persistence behavior.
+
+### Generic stateless raw output replay
+
+Custom/OpenAI-compatible stateless Responses sessions retain a deep-copied,
+ordered output-item snapshot on the assistant `InterfaceEntry.provider_data`
+sidecar after a complete non-stream response, response-completed stream trailer,
+or complete item-done stream. `to_responses_input` uses that snapshot only while
+its canonical-block fingerprint still matches, so edits, summaries, deletion,
+redaction, and old/manual entries fall back to the existing visible projection.
+The generic stateless callsites and MiMo/DeepSeek explicitly opt into this seam;
+native Codex keeps its existing canonical converter so a shared interface cannot
+send generic output-schema items to its endpoint. Raw fields such as message
+`phase`, empty reasoning summaries, opaque reasoning content, and exact
+function-call argument strings are never reconstructed from lossy blocks;
+incomplete streams do not commit a raw snapshot.
 
 ### Authentication paths
 

--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -54,7 +54,12 @@ from lingtai.kernel.llm.reasoning_effort import (
 from lingtai.llm.base import LLMAdapter
 from .codex_effort import CodexEffortDescriptor, resolve_codex_effort_descriptor
 from lingtai.kernel.llm.interface import ChatInterface, TextBlock, ThinkingBlock, ToolCallBlock
-from ..interface_converters import to_openai, to_responses_input
+from ..interface_converters import (
+    _responses_replay_fingerprint,
+    _responses_snapshot_ids_are_unique,
+    to_openai,
+    to_responses_input,
+)
 from lingtai.kernel.llm.streaming import StreamingAccumulator
 from lingtai.llm.identity_headers import lingtai_user_agent, merge_lingtai_identity_headers
 from lingtai.kernel.token_counter import count_tokens
@@ -1530,6 +1535,491 @@ def _handle_responses_reasoning_event(
     return False
 
 
+_RESPONSES_OUTPUT_ITEMS_KEY = "openai_responses_output_items"
+_RESPONSES_REPLAY_FINGERPRINT_KEY = "openai_responses_replay_fingerprint"
+_RESPONSES_MISSING = object()
+
+
+_RESPONSES_INVALID = object()
+
+
+def _responses_json_value(value: Any) -> Any:
+    """Copy only JSON-shaped SDK/simple event values.
+
+    OpenAI response models are dumped in JSON mode and the local fixtures use
+    ``SimpleNamespace``.  Any other leaf is rejected rather than stringified;
+    the caller then declines the complete raw snapshot and uses canonical
+    blocks instead.
+    """
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else _RESPONSES_INVALID
+    if isinstance(value, dict):
+        converted: dict[str, Any] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                return _RESPONSES_INVALID
+            item = _responses_json_value(item)
+            if item is _RESPONSES_INVALID:
+                return _RESPONSES_INVALID
+            converted[key] = item
+        return converted
+    if isinstance(value, (list, tuple)):
+        converted_list = [_responses_json_value(item) for item in value]
+        return (
+            _RESPONSES_INVALID
+            if any(item is _RESPONSES_INVALID for item in converted_list)
+            else converted_list
+        )
+    if isinstance(value, SimpleNamespace):
+        return _responses_json_value(vars(value))
+    return _RESPONSES_INVALID
+
+
+def _responses_item_to_dict(item: Any) -> dict | None:
+    """Serialize one documented SDK/dict/fixture output item."""
+    try:
+        if isinstance(item, dict):
+            converted = _responses_json_value(item)
+            return converted if isinstance(converted, dict) else None
+        if isinstance(item, SimpleNamespace):
+            converted = _responses_json_value(vars(item))
+            return converted if isinstance(converted, dict) else None
+        model_dump = getattr(item, "model_dump", None)
+        if not callable(model_dump):
+            return None
+        converted = model_dump(mode="json", exclude_unset=True)
+        converted = _responses_json_value(converted)
+        return converted if isinstance(converted, dict) else None
+    except Exception:
+        # A cyclic fixture or SDK serialization failure is an invalid snapshot,
+        # not a reason to weaken the JSON boundary or stringify the object.
+        return None
+
+
+def _responses_output_items_from_response(raw: Any) -> list[dict] | None:
+    """Return a complete non-stream Responses output list, when supplied."""
+    if getattr(raw, "status", None) not in (None, "completed"):
+        return None
+    output = getattr(raw, "output", _RESPONSES_MISSING)
+    if output is _RESPONSES_MISSING or output is None:
+        return None
+    if isinstance(output, (str, bytes, dict)):
+        return None
+    try:
+        raw_items = list(output)
+    except TypeError:
+        return None
+    items = [_responses_item_to_dict(item) for item in raw_items]
+    if any(item is None for item in items):
+        return None
+    converted = [item for item in items if item is not None]
+    return converted if _responses_snapshot_ids_are_unique(converted) else None
+
+
+class _ResponsesStreamOutputRecorder:
+    """Collect complete Responses output items without trusting projections."""
+
+    def __init__(self) -> None:
+        self._order: list[str] = []
+        self._added: set[str] = set()
+        self._done: set[str] = set()
+        self._items: dict[str, dict] = {}
+        self._indices: dict[str, int | None] = {}
+        self._item_ids: dict[str, str] = {}
+        self._index_keys: dict[int, str] = {}
+        self._id_keys: dict[str, str] = {}
+        self._completed = False
+        self._terminal_invalid = False
+        self._completion_output: Any = _RESPONSES_MISSING
+        self._anonymous_index = 0
+        self._summary_item_ids: set[str] = set()
+        self._saw_output_text = False
+        self._saw_reasoning_summary = False
+        self._saw_function_arguments = False
+        self._incomplete_done_item = False
+        self._active_function_key: str | None = None
+        self._function_argument_deltas: dict[str, str] = {}
+        self._function_argument_done: dict[str, str] = {}
+
+    @staticmethod
+    def _output_index(event: Any, item: Any) -> int | None | object:
+        index = getattr(event, "output_index", _RESPONSES_MISSING)
+        if index is _RESPONSES_MISSING or index is None:
+            index = getattr(item, "output_index", _RESPONSES_MISSING)
+        if index is _RESPONSES_MISSING or index is None:
+            return None
+        if isinstance(index, bool) or not isinstance(index, int) or index < 0:
+            return _RESPONSES_INVALID
+        return index
+
+    @staticmethod
+    def _item_id(item: Any, event: Any) -> str | None:
+        item_id = (
+            getattr(item, "id", None)
+            or getattr(item, "call_id", None)
+            or getattr(event, "item_id", None)
+        )
+        return item_id if isinstance(item_id, str) and item_id else None
+
+    def _key_for_item_id(self, item_id: str | None) -> str | None:
+        if item_id and item_id in self._id_keys:
+            return self._id_keys[item_id]
+        return self._active_function_key
+
+    def _record_key(self, item: Any, event: Any, *, done: bool) -> str | None:
+        item_type = getattr(item, "type", None) or "unknown"
+        item_id = self._item_id(item, event)
+        index = self._output_index(event, item)
+        if index is _RESPONSES_INVALID:
+            self._terminal_invalid = True
+            return None
+        existing_by_index = self._index_keys.get(index) if index is not None else None
+        existing_by_id = self._id_keys.get(item_id) if item_id else None
+        if (
+            existing_by_index is not None
+            and existing_by_id is not None
+            and existing_by_index != existing_by_id
+        ):
+            self._terminal_invalid = True
+            return None
+        key = existing_by_index or existing_by_id
+        if key is None and not item_id and index is None and done:
+            # A few gateways omit both identity axes on output_item.done. Pair
+            # that event with the first unmatched same-type added item; this is
+            # deterministic, but only the all-unindexed path may use it.
+            key = next(
+                (
+                    candidate
+                    for candidate in self._order
+                    if candidate not in self._done
+                    and self._indices.get(candidate) is None
+                    and self._item_ids.get(candidate) is None
+                    and candidate.startswith(f"{item_type}:")
+                ),
+                None,
+            )
+        if key is None:
+            if item_id:
+                key = f"{item_type}:{item_id}"
+            elif index is not None:
+                key = f"{item_type}:index:{index}"
+            else:
+                self._anonymous_index += 1
+                key = f"{item_type}:anonymous:{self._anonymous_index}"
+            if key in self._order:
+                self._terminal_invalid = True
+                return None
+            if index is not None and index in self._index_keys:
+                self._terminal_invalid = True
+                return None
+            if item_id and item_id in self._id_keys:
+                self._terminal_invalid = True
+                return None
+            self._order.append(key)
+            self._indices[key] = index
+            self._item_ids[key] = item_id
+            if index is not None:
+                self._index_keys[index] = key
+            if item_id:
+                self._id_keys[item_id] = key
+        else:
+            previous_index = self._indices.get(key)
+            previous_id = self._item_ids.get(key)
+            if (
+                previous_index is not None
+                and index is not None
+                and previous_index != index
+            ) or (previous_id and item_id and previous_id != item_id):
+                self._terminal_invalid = True
+                return None
+            if index is not None and previous_index is None:
+                if index in self._index_keys and self._index_keys[index] != key:
+                    self._terminal_invalid = True
+                    return None
+                self._indices[key] = index
+                self._index_keys[index] = key
+            if item_id and previous_id is None:
+                if item_id in self._id_keys and self._id_keys[item_id] != key:
+                    self._terminal_invalid = True
+                    return None
+                self._item_ids[key] = item_id
+                self._id_keys[item_id] = key
+            if (done and key in self._done) or (not done and key in self._added):
+                # Repeated identity/index events must not silently overwrite an
+                # earlier output item. A single added -> done pair is allowed.
+                self._terminal_invalid = True
+                return None
+        return key
+
+    def observe(self, event: Any) -> None:
+        event_type = getattr(event, "type", None)
+        if event_type in {"response.failed", "response.incomplete"}:
+            self._terminal_invalid = True
+            self._completed = False
+            return
+        if event_type == "response.output_text.delta":
+            self._saw_output_text = True
+        elif event_type in {
+            "response.reasoning_summary_text.delta",
+            "response.reasoning_summary_text.done",
+        }:
+            self._saw_reasoning_summary = True
+            item_id = getattr(event, "item_id", None)
+            if isinstance(item_id, str) and item_id:
+                self._summary_item_ids.add(item_id)
+        elif event_type in {
+            "response.function_call_arguments.delta",
+            "response.function_call_arguments.done",
+        }:
+            self._saw_function_arguments = True
+            key = self._key_for_item_id(getattr(event, "item_id", None))
+            if key:
+                if event_type.endswith("delta"):
+                    delta = getattr(event, "delta", None)
+                    if isinstance(delta, str):
+                        self._function_argument_deltas[key] = (
+                            self._function_argument_deltas.get(key, "") + delta
+                        )
+                else:
+                    arguments = getattr(event, "arguments", None)
+                    if isinstance(arguments, str):
+                        self._function_argument_done[key] = arguments
+        if event_type in {
+            "response.output_item.added",
+            "response.output_item.done",
+        }:
+            item = getattr(event, "item", None)
+            if item is None:
+                self._terminal_invalid = True
+                return
+            done = event_type.endswith("done")
+            key = self._record_key(item, event, done=done)
+            if key is None:
+                return
+            if not done:
+                self._added.add(key)
+                if getattr(item, "type", None) == "function_call":
+                    self._active_function_key = key
+                return
+            serialized = _responses_item_to_dict(item)
+            if serialized is None:
+                self._incomplete_done_item = True
+                return
+            item_type = serialized.get("type")
+            if item_type == "function_call" and "arguments" not in serialized:
+                arguments = (
+                    self._function_argument_done.get(key)
+                    or self._function_argument_deltas.get(key)
+                )
+                if arguments is not None:
+                    serialized["arguments"] = arguments
+            if item_type == "function_call" and "arguments" not in serialized:
+                self._incomplete_done_item = True
+            if item_type == "message" and "content" not in serialized:
+                self._incomplete_done_item = True
+            if (
+                item_type == "reasoning"
+                and self._item_ids.get(key) in self._summary_item_ids
+                and "summary" not in serialized
+            ):
+                self._incomplete_done_item = True
+            self._done.add(key)
+            self._items[key] = serialized
+            return
+        if event_type == "response.completed":
+            self._completed = True
+            response = getattr(event, "response", None)
+            status = getattr(response, "status", _RESPONSES_MISSING)
+            if status is not _RESPONSES_MISSING and status not in {None, "completed"}:
+                self._terminal_invalid = True
+            self._completion_output = getattr(
+                response, "output", _RESPONSES_MISSING,
+            )
+
+    @staticmethod
+    def _valid_item_list(raw_items: Any) -> list[dict] | None:
+        if isinstance(raw_items, (str, bytes, dict)):
+            return None
+        try:
+            raw_items = list(raw_items)
+        except TypeError:
+            return None
+        items = [_responses_item_to_dict(item) for item in raw_items]
+        if any(item is None for item in items):
+            return None
+        converted = [item for item in items if item is not None]
+        return converted if _responses_snapshot_ids_are_unique(converted) else None
+
+    def _finalized_done_items(self) -> list[dict] | None:
+        """Return a complete, safely ordered item-done snapshot, if provable."""
+        if not self._done or self._added - self._done or self._incomplete_done_item:
+            return None
+        done_items = [self._items[key] for key in self._order if key in self._done]
+        if self._summary_item_ids - {
+            self._item_ids.get(key) for key in self._done if self._item_ids.get(key)
+        }:
+            return None
+        if self._saw_output_text and not any(
+            item.get("type") == "message" for item in done_items
+        ):
+            return None
+        indices = [self._indices.get(key) for key in self._done]
+        if any(index is not None for index in indices):
+            if any(index is None for index in indices):
+                return None
+            ordered_indices = sorted(index for index in indices if index is not None)
+            if ordered_indices != list(range(len(done_items))):
+                return None
+            keys = sorted(
+                (key for key in self._done),
+                key=lambda key: self._indices[key],
+            )
+            return [self._items[key] for key in keys]
+        return done_items
+
+    def finalized_items(self) -> list[dict] | None:
+        if not self._completed or self._terminal_invalid:
+            return None
+        if self._completion_output is not _RESPONSES_MISSING and self._completion_output is not None:
+            items = self._valid_item_list(self._completion_output)
+            if items is None:
+                return None
+            # An empty trailer is not authoritative when deltas or item events
+            # already proved that output existed. Reconcile complete item-done
+            # evidence when possible; otherwise fall back to canonical blocks.
+            if not items and (
+                self._order
+                or self._summary_item_ids
+                or self._saw_output_text
+                or self._saw_reasoning_summary
+                or self._saw_function_arguments
+                or self._function_argument_deltas
+                or self._function_argument_done
+            ):
+                return self._finalized_done_items()
+            return items
+
+        # A compatible stream may omit response.output entirely. Item-done is
+        # sufficient only when every observed item has reached done; added-only
+        # or partial output is deliberately not committed as complete.
+        return self._finalized_done_items()
+
+
+def _responses_normalized_response(
+    items: list[dict],
+    usage: UsageMetadata,
+) -> LLMResponse | None:
+    """Normalize complete raw output items without using lossy projections.
+
+    This is intentionally limited to the documented output item forms that the
+    streaming accumulator already understands. Unknown or malformed shapes do
+    not become a falsely successful raw replay; callers fall back to the
+    accumulator and decline the raw sidecar.
+    """
+    text_parts: list[str] = []
+    thoughts: list[str] = []
+    tool_calls: list[ToolCall] = []
+    for item in items:
+        item_type = item.get("type")
+        if item_type == "message":
+            content = item.get("content")
+            if not isinstance(content, list):
+                return None
+            for part in content:
+                if not isinstance(part, dict):
+                    return None
+                part_type = part.get("type")
+                if part_type != "output_text":
+                    return None
+                text = part.get("text")
+                if not isinstance(text, str):
+                    return None
+                text_parts.append(text)
+        elif item_type == "reasoning":
+            summary = item.get("summary")
+            if not isinstance(summary, list):
+                return None
+            for part in summary:
+                if not isinstance(part, dict) or part.get("type") != "summary_text":
+                    return None
+                text = part.get("text")
+                if not isinstance(text, str):
+                    return None
+                if text:
+                    thoughts.append(text)
+        elif item_type == "function_call":
+            name = item.get("name")
+            arguments = item.get("arguments")
+            if not isinstance(name, str) or not isinstance(arguments, str):
+                return None
+            try:
+                args = json.loads(arguments) if arguments else {}
+            except (json.JSONDecodeError, TypeError):
+                args = {}
+            if not isinstance(args, dict):
+                args = {}
+            call_id = item.get("call_id")
+            tool_calls.append(
+                ToolCall(
+                    name=name,
+                    args=args,
+                    id=call_id if isinstance(call_id, str) else None,
+                )
+            )
+        else:
+            return None
+    return LLMResponse(
+        # StreamingAccumulator concatenates text deltas across content parts
+        # and output messages without inserting separators. Match that same
+        # projection while retaining the original boundaries in the raw items.
+        text="".join(text_parts),
+        tool_calls=tool_calls,
+        usage=usage,
+        thoughts=thoughts,
+    )
+
+
+def _responses_responses_match(left: LLMResponse, right: LLMResponse) -> bool:
+    """Compare normalized stream output without hiding observed portions."""
+    if right.text and (not left.text or left.text != right.text):
+        return False
+    if right.thoughts:
+        if not left.thoughts:
+            return False
+        left_thoughts = iter(left.thoughts)
+        if not all(
+            any(candidate == thought for candidate in left_thoughts)
+            for thought in right.thoughts
+        ):
+            return False
+    if right.tool_calls:
+        for observed in right.tool_calls:
+            if not any(
+                candidate.id == observed.id
+                and candidate.name == observed.name
+                and candidate.args == observed.args
+                for candidate in left.tool_calls
+            ):
+                return False
+    return True
+
+
+def _responses_merge_normalized_response(
+    trailer: LLMResponse,
+    accumulated: LLMResponse,
+) -> LLMResponse:
+    """Fill only portions omitted by a complete trailer from observed deltas."""
+    return LLMResponse(
+        text=trailer.text or accumulated.text,
+        tool_calls=trailer.tool_calls or accumulated.tool_calls,
+        usage=trailer.usage,
+        thoughts=trailer.thoughts or accumulated.thoughts,
+        raw=trailer.raw,
+    )
+
+
 def _parse_responses_api_response(raw) -> LLMResponse:
     """Parse a raw OpenAI Responses API response into a provider-agnostic LLMResponse."""
     text_parts = []
@@ -1657,8 +2147,11 @@ def _consume_responses_stream(
     response_id = None
     usage = UsageMetadata()
     seen_reasoning_summary_items: set[str] = set()
+    output_recorder = _ResponsesStreamOutputRecorder()
+    saw_output_text_delta = False
 
     for event in stream:
+        output_recorder.observe(event)
         # Any lifecycle event may carry the response id (``response.created``,
         # ``response.in_progress``, ``response.incomplete``, ``response.failed``,
         # ``response.completed``).  Latch the newest one so a stream that ends
@@ -1670,6 +2163,7 @@ def _consume_responses_stream(
         if _handle_responses_reasoning_event(event, acc, seen_reasoning_summary_items):
             continue
         if event.type == "response.output_text.delta":
+            saw_output_text_delta = saw_output_text_delta or bool(event.delta)
             acc.add_text(event.delta)
             if on_chunk:
                 on_chunk(event.delta)
@@ -1705,7 +2199,31 @@ def _consume_responses_stream(
                     cached_tokens=cached_tokens,
                 )
 
-    return acc.finalize(usage=usage), response_id
+    accumulated = acc.finalize(usage=usage)
+    output_items = output_recorder.finalized_items()
+    response = accumulated
+    if output_items is not None:
+        # A completion trailer is also the only complete output source for
+        # several forced-SSE gateways. Normalize it for the caller instead of
+        # leaving tool calls/text hidden in the private replay sidecar.
+        normalized = _responses_normalized_response(output_items, usage)
+        if normalized is not None and _responses_responses_match(normalized, accumulated):
+            response = _responses_merge_normalized_response(normalized, accumulated)
+            if on_chunk and not saw_output_text_delta and normalized.text:
+                on_chunk(normalized.text)
+        else:
+            # Contradictory or unsupported trailer shape cannot safely claim a
+            # raw/canonical round trip. Keep an already observed projection;
+            # with no projection at all, fail instead of claiming a successful
+            # tool turn whose only output is not normalized.
+            if not accumulated.text and not accumulated.thoughts and not accumulated.tool_calls:
+                raise ValueError("Responses stream trailer could not be normalized safely")
+            output_items = None
+    # Keep the raw replay candidate private to this transient response. The
+    # stateless session records it only after the whole stream has finalized;
+    # incomplete/error streams therefore cannot commit partial raw history.
+    setattr(response, "_openai_responses_output_items", output_items)
+    return response, response_id
 
 
 # ---------------------------------------------------------------------------
@@ -2530,7 +3048,11 @@ class OpenAIResponsesSession(ChatSession):
         self._interface._pending_system = restored._pending_system
         self._interface.tool_result_recovery_lookup = recovery_lookup
 
-    def _record_assistant_response(self, response: LLMResponse) -> None:
+    def _record_assistant_response(
+        self,
+        response: LLMResponse,
+        output_items: list[dict] | None = None,
+    ) -> None:
         blocks: list = []
         for thought in response.thoughts:
             if thought:
@@ -2541,8 +3063,20 @@ class OpenAIResponsesSession(ChatSession):
             blocks.append(ToolCallBlock(id=tc.id or "", name=tc.name, args=tc.args))
         if not blocks:
             blocks.append(TextBlock(text=""))
+
+        provider_data: dict[str, Any] = {}
+        if output_items is not None:
+            # This metadata is an immutable-by-convention snapshot of the
+            # completed provider output. Validity is tied to the visible
+            # canonical blocks so edits/summaries cannot resurrect stale raw
+            # fields; the converter deep-copies it on every replay.
+            provider_data = {
+                _RESPONSES_OUTPUT_ITEMS_KEY: copy.deepcopy(output_items),
+                _RESPONSES_REPLAY_FINGERPRINT_KEY: _responses_replay_fingerprint(blocks),
+            }
         self._interface.add_assistant_message(
             blocks,
+            provider_data=provider_data,
             model=self._model,
             provider="openai",
             usage={
@@ -2567,7 +3101,10 @@ class OpenAIResponsesSession(ChatSession):
         a per-turn-unique fallback item injected (generic version of the
         former DeepSeek behavior).
         """
-        items = to_responses_input(self._interface)
+        items = to_responses_input(
+            self._interface,
+            replay_raw_output_items=True,
+        )
         if self._inject_reasoning_fallback:
             return _inject_responses_reasoning_fallback(items)
         return items
@@ -2629,8 +3166,18 @@ class OpenAIResponsesSession(ChatSession):
             else:
                 response = _parse_responses_api_response(raw)
                 response_id = raw.id
+                setattr(
+                    response,
+                    "_openai_responses_output_items",
+                    _responses_output_items_from_response(raw),
+                )
             if self._stateless_replay:
-                self._record_assistant_response(response)
+                self._record_assistant_response(
+                    response,
+                    output_items=getattr(
+                        response, "_openai_responses_output_items", None
+                    ),
+                )
             else:
                 self._adopt_response_id(response_id)
             return response
@@ -2678,7 +3225,12 @@ class OpenAIResponsesSession(ChatSession):
             stream = self._client.responses.create(**kwargs)
             response, response_id = _consume_responses_stream(stream, on_chunk)
             if self._stateless_replay:
-                self._record_assistant_response(response)
+                self._record_assistant_response(
+                    response,
+                    output_items=getattr(
+                        response, "_openai_responses_output_items", None
+                    ),
+                )
             else:
                 self._adopt_response_id(response_id)
             return response
@@ -5152,7 +5704,7 @@ class CodexResponsesSession(_StandaloneCompactionMixin, OpenAIResponsesSession):
         ``notification_guidance`` copy, without mutating canonical history.
         """
         return _freeze_responses_outputs(
-            to_responses_input(iface),
+            to_responses_input(iface, replay_raw_output_items=False),
             self._ws_frozen_outputs,
         )
 

--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -2278,12 +2278,12 @@ def _inject_responses_reasoning_fallback(items: list[dict]) -> list[dict]:
 
     Responses items are a flat list; a single assistant turn can span
     multiple items (reasoning, text, function_call). After the first
-    ``function_call`` item we must ensure every later assistant turn
-    carries a ``reasoning`` item — the Responses analogue of
-    ``_inject_chat_reasoning_fallback``. We walk the list, track
-    whether a ``function_call`` has been seen, and for each ``assistant``
-    text item that follows a call without an immediately-preceding
-    reasoning item, insert one before it.
+    ``function_call`` item, legacy canonical assistant text can receive a
+    ``reasoning`` fallback, as in ``_inject_chat_reasoning_fallback``.
+    Raw Responses messages and array-valued content are authoritative and
+    pass through unchanged. For eligible legacy text after a call with no
+    immediately preceding reasoning item, insert a per-turn fallback.
+    Missing legacy text retains the historical empty-text fallback.
     """
     seen_function_call = False
     turn_idx = 0
@@ -2293,11 +2293,11 @@ def _inject_responses_reasoning_fallback(items: list[dict]) -> list[dict]:
             seen_function_call = True
             out.append(item)
             continue
-        if seen_function_call and item.get("role") == "assistant":
+        if (seen_function_call and item.get("role") == "assistant"
+                and item.get("type") != "message"
+                and (item.get("content") is None or isinstance(item.get("content"), str))):
+            # Only legacy text is repaired; valid raw output is never synthesized.
             turn_idx += 1
-            # Insert a fallback reasoning item before this assistant text
-            # item unless the immediately preceding item already carries
-            # reasoning (real thinking was preserved).
             if not (out and out[-1].get("type") == "reasoning"):
                 out.append(
                     _fallback_responses_reasoning_item(

--- a/tests/test_custom_responses_stateless.py
+++ b/tests/test_custom_responses_stateless.py
@@ -158,6 +158,74 @@ def _stream_tool_events(response_id: str):
     ]
 
 
+def _stream_raw_mixed_events(response_id: str):
+    output = [
+        SimpleNamespace(
+            type="message",
+            id="msg_mixed",
+            phase="commentary",
+            content=[SimpleNamespace(type="output_text", text="visible")],
+        ),
+        SimpleNamespace(type="reasoning", id="rs_mixed", summary=[]),
+        SimpleNamespace(
+            type="function_call",
+            id="fc_mixed",
+            status="completed",
+            call_id="call_mixed",
+            name="lookup",
+            arguments='{"query":"x","n":1}',
+        ),
+    ]
+    return [
+        SimpleNamespace(
+            type="response.output_item.added",
+            item=SimpleNamespace(type="message", id="msg_mixed"),
+        ),
+        SimpleNamespace(type="response.output_text.delta", delta="visible"),
+        SimpleNamespace(
+            type="response.output_item.done",
+            item=output[0],
+        ),
+        SimpleNamespace(
+            type="response.output_item.added",
+            item=SimpleNamespace(type="reasoning", id="rs_mixed"),
+        ),
+        SimpleNamespace(
+            type="response.output_item.done",
+            item=output[1],
+        ),
+        SimpleNamespace(
+            type="response.output_item.added",
+            item=SimpleNamespace(
+                type="function_call",
+                id="fc_mixed",
+                call_id="call_mixed",
+                name="lookup",
+            ),
+        ),
+        SimpleNamespace(
+            type="response.function_call_arguments.delta",
+            delta='{"query"',
+        ),
+        SimpleNamespace(
+            type="response.function_call_arguments.delta",
+            delta=':"x","n":1}',
+        ),
+        SimpleNamespace(
+            type="response.output_item.done",
+            item=output[2],
+        ),
+        SimpleNamespace(
+            type="response.completed",
+            response=SimpleNamespace(
+                id=response_id,
+                output=output,
+                usage=_usage(input_tokens=15, output_tokens=8, reasoning_tokens=2),
+            ),
+        ),
+    ]
+
+
 def _forced_sse_tool_response(response_id: str) -> str:
     """SSE body from a provider that ignored a non-streaming request."""
     events = [
@@ -312,12 +380,17 @@ def test_custom_responses_nonstreaming_replays_full_history_and_records_assistan
             "type": "reasoning",
             "summary": [{"type": "summary_text", "text": "Need tool."}],
         },
-        {"role": "assistant", "content": "Checking."},
+        {
+            "type": "message",
+            "content": [
+                {"type": "output_text", "text": "Checking."},
+            ],
+        },
         {
             "type": "function_call",
             "call_id": "call_1",
             "name": "lookup",
-            "arguments": '{"query": "x"}',
+            "arguments": '{"query":"x"}',
         },
         {
             "type": "function_call_output",
@@ -368,6 +441,50 @@ def test_custom_responses_nonstreaming_parses_provider_forced_sse_without_retry(
         "thinking_tokens": 3,
         "cached_tokens": 4,
     }
+
+
+@pytest.mark.parametrize("status", ["failed", "incomplete"])
+def test_nonstream_noncompleted_status_does_not_commit_raw_snapshot(status):
+    raw = _text_raw("resp_partial", "partial")
+    raw.status = status
+    adapter = create_custom_adapter(
+        api_key="fake", api_compat="openai",
+        base_url="https://sub2api.example/v1", wire_api="responses",
+    )
+    adapter._client = _Client(_Responses([raw]))
+    session = adapter.create_chat("gpt-test", "system")
+    session.send("first")
+    assert "openai_responses_output_items" not in (
+        session.interface.entries[2].provider_data or {}
+    )
+
+
+def test_forced_sse_partial_item_done_does_not_commit_partial_raw_replay():
+    adapter = create_custom_adapter(
+        api_key="fake",
+        api_compat="openai",
+        base_url="https://sub2api.example/v1",
+        wire_api="responses",
+    )
+    adapter._client = _Client(
+        _Responses([
+            _forced_sse_tool_response("resp_forced"),
+            _text_raw("resp_next", "done"),
+        ])
+    )
+    session = adapter.create_chat("gpt-test", "system", tools=[_tool()])
+
+    session.send("first")
+    session.send([
+        ToolResultBlock(id="call_forced", name="lookup", content={"ok": True}),
+    ])
+
+    replay = adapter._client.responses.kwargs[1]["input"]
+    assert {item["type"] for item in replay if "type" in item} >= {
+        "reasoning",
+        "function_call",
+    }
+    assert not any(item.get("type") == "message" for item in replay)
 
 
 def test_forced_sse_completed_without_usage_does_not_crash():
@@ -501,6 +618,316 @@ def test_custom_responses_streaming_replays_reasoning_tool_result_full_history()
         "thinking_tokens": 2,
         "cached_tokens": 1,
     }
+
+
+def _stream_empty_completion_after_visible_delta(response_id: str):
+    return [
+        SimpleNamespace(
+            type="response.output_item.done",
+            item=SimpleNamespace(
+                type="message",
+                id="msg_empty_trailer",
+                content=[SimpleNamespace(type="output_text", text="visible")],
+            ),
+        ),
+        SimpleNamespace(type="response.output_text.delta", delta="visible"),
+        SimpleNamespace(
+            type="response.completed",
+            response=SimpleNamespace(
+                id=response_id,
+                output=[],
+                usage=_usage(),
+            ),
+        ),
+    ]
+
+
+def _stream_trailer_only_output(response_id: str):
+    return [
+        SimpleNamespace(
+            type="response.completed",
+            response=SimpleNamespace(
+                id=response_id,
+                output=[
+                    SimpleNamespace(
+                        type="message",
+                        id="msg_trailer_only",
+                        content=[SimpleNamespace(type="output_text", text="trailer text")],
+                    ),
+                    SimpleNamespace(
+                        type="function_call",
+                        id="fc_trailer_only",
+                        call_id="call_trailer_only",
+                        name="lookup",
+                        arguments='{"query":"trailer"}',
+                    ),
+                ],
+                usage=_usage(),
+            ),
+        ),
+    ]
+
+
+def _stream_done_only_indexed(response_id: str, rows):
+    events = [
+        SimpleNamespace(
+            type="response.output_item.done",
+            output_index=index,
+            item=SimpleNamespace(
+                type="message",
+                id=item_id,
+                content=[SimpleNamespace(type="output_text", text=text)],
+            ),
+        )
+        for index, item_id, text in rows
+    ]
+    events.append(
+        SimpleNamespace(
+            type="response.completed",
+            response=SimpleNamespace(id=response_id, usage=_usage()),
+        )
+    )
+    return events
+
+
+def test_custom_stream_empty_completion_output_keeps_observed_projection():
+    adapter = create_custom_adapter(
+        api_key="fake",
+        api_compat="openai",
+        base_url="https://sub2api.example/v1",
+        wire_api="responses",
+    )
+    adapter._client = _Client(
+        _StreamResponses([
+            _stream_empty_completion_after_visible_delta("resp_empty"),
+            _stream_text("resp_next", "done"),
+        ])
+    )
+    session = adapter.create_chat("gpt-test", "system")
+
+    first = session.send_stream("first")
+    assert first.text == "visible"
+    session.send_stream("second")
+
+    assert adapter._client.responses.kwargs[1]["input"][1] == {
+        "type": "message",
+        "id": "msg_empty_trailer",
+        "content": [{"type": "output_text", "text": "visible"}],
+    }
+    assert session.interface.entries[2].provider_data["openai_responses_output_items"]
+
+
+def test_custom_stream_trailer_only_normalizes_visible_output_and_tool_call():
+    adapter = create_custom_adapter(
+        api_key="fake",
+        api_compat="openai",
+        base_url="https://sub2api.example/v1",
+        wire_api="responses",
+    )
+    adapter._client = _Client(
+        _StreamResponses([
+            _stream_trailer_only_output("resp_trailer_only"),
+            _stream_text("resp_next", "done"),
+        ])
+    )
+    session = adapter.create_chat("gpt-test", "system", tools=[_tool()])
+
+    chunks: list[str] = []
+    first = session.send_stream("first", on_chunk=chunks.append)
+    assert first.text == "trailer text"
+    assert chunks == ["trailer text"]
+    assert [(call.id, call.name, call.args) for call in first.tool_calls] == [
+        ("call_trailer_only", "lookup", {"query": "trailer"}),
+    ]
+    session.send_stream([
+        ToolResultBlock(id="call_trailer_only", name="lookup", content={"ok": True}),
+    ])
+
+    assert adapter._client.responses.kwargs[1]["input"][1:4] == [
+        {
+            "type": "message",
+            "id": "msg_trailer_only",
+            "content": [{"type": "output_text", "text": "trailer text"}],
+        },
+        {
+            "type": "function_call",
+            "id": "fc_trailer_only",
+            "call_id": "call_trailer_only",
+            "name": "lookup",
+            "arguments": '{"query":"trailer"}',
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_trailer_only",
+            "output": '{"ok": true}',
+        },
+    ]
+    assert [type(block) for block in session.interface.entries[2].content] == [
+        TextBlock,
+        ToolCallBlock,
+    ]
+
+
+@pytest.mark.parametrize(
+    "rows",
+    [
+        [(0, "msg_gap_0", "zero"), (2, "msg_gap_2", "two")],
+        [(0, "msg_duplicate", "first"), (1, "msg_duplicate", "second")],
+    ],
+    ids=["indexed_gap", "duplicate_id"],
+)
+def test_custom_stream_done_only_unsafe_identity_falls_back_to_canonical(rows):
+    adapter = create_custom_adapter(
+        api_key="fake",
+        api_compat="openai",
+        base_url="https://sub2api.example/v1",
+        wire_api="responses",
+    )
+    adapter._client = _Client(
+        _StreamResponses([
+            _stream_done_only_indexed("resp_unsafe", rows),
+            _stream_text("resp_next", "done"),
+        ])
+    )
+    session = adapter.create_chat("gpt-test", "system")
+
+    session.send_stream("first")
+    session.send_stream("second")
+
+    # Empty canonical assistant projections were already omitted by the
+    # converter. Unsafe raw item identities must not reappear in the request.
+    assert adapter._client.responses.kwargs[1]["input"] == [
+        {"role": "user", "content": "first"},
+        {"role": "user", "content": "second"},
+    ]
+    assert "openai_responses_output_items" not in (
+        session.interface.entries[2].provider_data or {}
+    )
+
+
+@pytest.mark.parametrize("separate_messages", [False, True])
+def test_custom_stream_multiple_text_parts_preserve_raw_boundaries(separate_messages):
+    parts = [
+        SimpleNamespace(type="output_text", text="first"),
+        SimpleNamespace(type="output_text", text="second"),
+    ]
+    output = [SimpleNamespace(type="message", id="msg_1", content=parts)]
+    expected = [{
+        "type": "message", "id": "msg_1",
+        "content": [{"type": "output_text", "text": part.text} for part in parts],
+    }]
+    if separate_messages:
+        output = [
+            SimpleNamespace(type="message", id=f"msg_{index}", phase=phase, content=[part])
+            for index, (phase, part) in enumerate(
+                zip(("commentary", "final_answer"), parts), 1,
+            )
+        ]
+        expected = [
+            {"type": "message", "id": item.id, "phase": item.phase,
+             "content": [{"type": "output_text", "text": item.content[0].text}]}
+            for item in output
+        ]
+    events = [
+        SimpleNamespace(type="response.output_text.delta", delta=part.text)
+        for part in parts
+    ]
+    events.append(SimpleNamespace(
+        type="response.completed",
+        response=SimpleNamespace(id="resp_parts", output=output, usage=_usage()),
+    ))
+    adapter = create_custom_adapter(
+        api_key="fake", api_compat="openai",
+        base_url="https://sub2api.example/v1", wire_api="responses",
+    )
+    adapter._client = _Client(_StreamResponses([events, _stream_text("resp_next", "done")]))
+    session = adapter.create_chat("gpt-test", "system")
+    chunks = []
+    response = session.send_stream("first", on_chunk=chunks.append)
+    assert response.text == "firstsecond"
+    assert chunks == ["first", "second"]
+    session.send_stream("next")
+    assert adapter._client.responses.kwargs[1]["input"][1:-1] == expected
+
+
+def test_custom_stream_done_only_uses_output_index_order():
+    adapter = create_custom_adapter(
+        api_key="fake",
+        api_compat="openai",
+        base_url="https://sub2api.example/v1",
+        wire_api="responses",
+    )
+    adapter._client = _Client(
+        _StreamResponses([
+            _stream_done_only_indexed(
+                "resp_indexed",
+                [(1, "msg_one", "one"), (0, "msg_zero", "zero")],
+            ),
+            _stream_text("resp_next", "done"),
+        ])
+    )
+    session = adapter.create_chat("gpt-test", "system")
+
+    session.send_stream("first")
+    session.send_stream("second")
+
+    assert adapter._client.responses.kwargs[1]["input"][1:3] == [
+        {
+            "type": "message",
+            "id": "msg_zero",
+            "content": [{"type": "output_text", "text": "zero"}],
+        },
+        {
+            "type": "message",
+            "id": "msg_one",
+            "content": [{"type": "output_text", "text": "one"}],
+        },
+    ]
+
+
+def test_custom_stream_replays_completion_output_items_without_projection_or_duplication():
+    adapter = create_custom_adapter(
+        api_key="fake",
+        api_compat="openai",
+        base_url="https://sub2api.example/v1",
+        wire_api="responses",
+    )
+    adapter._client = _Client(
+        _StreamResponses([
+            _stream_raw_mixed_events("resp_mixed"),
+            _stream_text("resp_next", "done"),
+        ])
+    )
+    session = adapter.create_chat("gpt-test", "system", tools=[_tool()])
+
+    session.send_stream("first")
+    session.send_stream([
+        ToolResultBlock(id="call_mixed", name="lookup", content={"ok": True}),
+    ])
+
+    assert adapter._client.responses.kwargs[1]["input"] == [
+        {"role": "user", "content": "first"},
+        {
+            "type": "message",
+            "id": "msg_mixed",
+            "phase": "commentary",
+            "content": [{"type": "output_text", "text": "visible"}],
+        },
+        {"type": "reasoning", "id": "rs_mixed", "summary": []},
+        {
+            "type": "function_call",
+            "id": "fc_mixed",
+            "status": "completed",
+            "call_id": "call_mixed",
+            "name": "lookup",
+            "arguments": '{"query":"x","n":1}',
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_mixed",
+            "output": '{"ok": true}',
+        },
+    ]
 
 
 def test_send_none_replays_pre_staged_notification_style_pair():
@@ -645,7 +1072,8 @@ def test_stateless_send_rolls_back_if_enforce_or_serialize_fails_after_staging(
 
         monkeypatch.setattr(session.interface, "enforce_tool_pairing", fail_enforce)
     else:
-        def fail_serialize(_iface):
+        def fail_serialize(_iface, *, replay_raw_output_items=False):
+            assert replay_raw_output_items is True
             raise RuntimeError("serialize")
 
         monkeypatch.setattr(openai_adapter_module, "to_responses_input", fail_serialize)
@@ -746,7 +1174,10 @@ def test_stateless_history_round_trips_for_recreated_session_restart():
 
     assert adapter._client.responses.kwargs[0]["input"] == [
         {"role": "user", "content": "first"},
-        {"role": "assistant", "content": "one"},
+        {
+            "type": "message",
+            "content": [{"type": "output_text", "text": "one"}],
+        },
         {"role": "user", "content": "second"},
     ]
 

--- a/tests/test_custom_responses_stateless.py
+++ b/tests/test_custom_responses_stateless.py
@@ -42,6 +42,28 @@ def _text_raw(response_id: str, text: str = "ok"):
     )
 
 
+def _text_raw_assistant_list(response_id: str, text: str):
+    """A raw output message with the SDK's assistant role and list content."""
+    return SimpleNamespace(
+        id=response_id,
+        output=[
+            SimpleNamespace(
+                type="message",
+                role="assistant",
+                content=[SimpleNamespace(type="output_text", text=text)],
+            )
+        ],
+        usage=_usage(),
+    )
+
+
+def _tool_raw_with_assistant_message_role():
+    """Raw tool turn whose output message carries the SDK role field."""
+    raw = _tool_raw()
+    raw.output[1].role = "assistant"
+    return raw
+
+
 def _tool_raw():
     return SimpleNamespace(
         id="resp_tool",
@@ -103,6 +125,94 @@ def _stream_text(response_id: str, text: str = "ok"):
         SimpleNamespace(
             type="response.completed",
             response=SimpleNamespace(id=response_id, usage=_usage()),
+        ),
+    ]
+
+
+def _stream_raw_tool_turn(response_id: str):
+    """Stream a reasoning + function-call turn with a complete raw trailer."""
+    output = [
+        SimpleNamespace(
+            type="reasoning",
+            id="rs_raw_tool",
+            summary=[SimpleNamespace(type="summary_text", text="Need tool.")],
+        ),
+        SimpleNamespace(
+            type="message",
+            id="msg_raw_tool",
+            role="assistant",
+            content=[SimpleNamespace(type="output_text", text="Checking.")],
+        ),
+        SimpleNamespace(
+            type="function_call",
+            id="fc_raw_tool",
+            call_id="call_1",
+            name="lookup",
+            arguments='{"query":"x"}',
+        ),
+    ]
+    return [
+        SimpleNamespace(
+            type="response.output_item.added",
+            item=SimpleNamespace(type="reasoning", id="rs_raw_tool"),
+        ),
+        SimpleNamespace(
+            type="response.reasoning_summary_text.delta",
+            delta="Need tool.",
+            item_id="rs_raw_tool",
+        ),
+        SimpleNamespace(
+            type="response.reasoning_summary_text.done",
+            text="Need tool.",
+            item_id="rs_raw_tool",
+        ),
+        SimpleNamespace(type="response.output_text.delta", delta="Checking."),
+        SimpleNamespace(
+            type="response.output_item.added",
+            item=SimpleNamespace(
+                type="function_call",
+                call_id="call_1",
+                name="lookup",
+            ),
+        ),
+        SimpleNamespace(
+            type="response.function_call_arguments.delta",
+            delta='{"query":"x"}',
+            item_id="call_1",
+        ),
+        SimpleNamespace(
+            type="response.output_item.done",
+            item=output[-1],
+        ),
+        SimpleNamespace(
+            type="response.completed",
+            response=SimpleNamespace(
+                id=response_id,
+                output=output,
+                usage=_usage(reasoning_tokens=2),
+            ),
+        ),
+    ]
+
+
+def _stream_raw_plain_list_turn(response_id: str, text: str = "final"):
+    output = [
+        SimpleNamespace(
+            type="message",
+            id="msg_raw_plain",
+            role="assistant",
+            content=[SimpleNamespace(type="output_text", text=text)],
+        )
+    ]
+    return [
+        SimpleNamespace(type="response.output_text.delta", delta=text),
+        SimpleNamespace(
+            type="response.completed",
+            response=SimpleNamespace(
+                id=response_id,
+                output=output,
+                usage=_usage(),
+            ),
         ),
     ]
 
@@ -928,6 +1038,105 @@ def test_custom_stream_replays_completion_output_items_without_projection_or_dup
             "output": '{"ok": true}',
         },
     ]
+
+
+@pytest.mark.parametrize("streaming", [False, True])
+def test_raw_message_without_reasoning_stays_authoritative_across_three_calls(
+    monkeypatch,
+    streaming,
+):
+    """Raw output remains an exact prefix; fallback only repairs canonical text."""
+    # This exercises the shipped default rather than an explicit opt-out.
+    monkeypatch.delenv("LINGTAI_INJECT_REASONING_FALLBACK", raising=False)
+    adapter = create_custom_adapter(
+        api_key="fake",
+        api_compat="openai",
+        base_url="https://sub2api.example/v1",
+        wire_api="responses",
+    )
+    if streaming:
+        responses = _StreamResponses([
+            _stream_raw_tool_turn("resp_1"),
+            _stream_raw_plain_list_turn("resp_2"),
+            _stream_text("resp_3", "next"),
+        ])
+    else:
+        responses = _Responses([
+            _tool_raw_with_assistant_message_role(),
+            _text_raw_assistant_list("resp_2", "final"),
+            _text_raw_assistant_list("resp_3", "next"),
+        ])
+    adapter._client = _Client(responses)
+    session = adapter.create_chat("gpt-test", "system", tools=[_tool()])
+    send = session.send_stream if streaming else session.send
+
+    first = send("start")
+    assert first.tool_calls[0].id == "call_1"
+    second = send([
+        ToolResultBlock(id="call_1", name="lookup", content={"value": 1}),
+    ])
+    assert second.text == "final"
+    send("next")
+
+    requests = adapter._client.responses.kwargs
+    assert len(requests) == 3
+    tool_request = requests[1]["input"]
+    continuation_request = requests[2]["input"]
+    # The first assistant output is replayed exactly, including item order and
+    # list-valued message content, before the real tool result.
+    assert tool_request[0] == {"role": "user", "content": "start"}
+    assert [item.get("type") for item in tool_request[1:4]] == [
+        "reasoning", "message", "function_call",
+    ]
+    assert tool_request[2]["content"] == [
+        {"type": "output_text", "text": "Checking."},
+    ]
+    assert tool_request[4] == {
+        "type": "function_call_output",
+        "call_id": "call_1",
+        "output": '{"value": 1}',
+    }
+
+    expected_plain = (
+        {
+            "type": "message",
+            "id": "msg_raw_plain",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "final"}],
+        }
+        if streaming
+        else {
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "final"}],
+        }
+    )
+    assert continuation_request == [*tool_request, expected_plain, {
+        "role": "user", "content": "next",
+    }]
+
+
+@pytest.mark.parametrize("content", ["legacy final", "", None])
+def test_reasoning_fallback_only_repairs_legacy_string_assistant_items(content):
+    raw_message = {
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "output_text", "text": "raw final"}],
+        "phase": "final_answer",
+    }
+    items = [
+        {"type": "function_call", "call_id": "c1", "name": "f1", "arguments": "{}"},
+        {"type": "function_call_output", "call_id": "c1", "output": "ok"},
+        {"role": "assistant", "content": content},
+        raw_message,
+    ]
+
+    out = openai_adapter_module._inject_responses_reasoning_fallback(items)
+
+    assert out[2]["type"] == "reasoning"
+    assert out[3] == {"role": "assistant", "content": content}
+    assert out[4] is raw_message
+    assert out[4] == raw_message
 
 
 def test_send_none_replays_pre_staged_notification_style_pair():

--- a/tests/test_responses_converter.py
+++ b/tests/test_responses_converter.py
@@ -2,7 +2,13 @@
 
 from __future__ import annotations
 
-from lingtai.llm.interface_converters import to_responses_input
+import pytest
+
+from lingtai.llm.interface_converters import (
+    _responses_replay_fingerprint,
+    to_responses_input,
+)
+from lingtai.llm.openai.adapter import CodexOpenAIAdapter
 from lingtai.kernel.llm.interface import (
     ChatInterface,
     TextBlock,
@@ -62,3 +68,170 @@ def test_responses_input_omits_empty_thinking_blocks():
     assert to_responses_input(iface) == [
         {"role": "assistant", "content": "visible"},
     ]
+
+
+def test_responses_input_replays_valid_raw_items_in_original_order_and_without_mutation():
+    iface = ChatInterface()
+    iface.add_user_message("start")
+    blocks = [
+        ThinkingBlock(text=""),
+        TextBlock(text="visible"),
+        ToolCallBlock(id="call_raw", name="lookup", args={"query": "x"}),
+    ]
+    raw_items = [
+        {
+            "type": "message",
+            "id": "msg_raw",
+            "phase": "commentary",
+            "content": [{"type": "output_text", "text": "visible"}],
+        },
+        {
+            "type": "reasoning",
+            "id": "rs_raw",
+            "summary": [],
+            "encrypted_content": "opaque",
+        },
+        {
+            "type": "function_call",
+            "id": "fc_raw",
+            "status": "completed",
+            "call_id": "call_raw",
+            "name": "lookup",
+            "arguments": '{"query":"x"}',
+        },
+    ]
+    iface.add_assistant_message(
+        blocks,
+        provider_data={
+            "openai_responses_output_items": raw_items,
+            "openai_responses_replay_fingerprint": _responses_replay_fingerprint(blocks),
+        },
+    )
+    iface.add_tool_results([
+        ToolResultBlock(id="call_raw", name="lookup", content={"ok": True}),
+    ])
+
+    first = to_responses_input(iface, replay_raw_output_items=True)
+    first[1]["phase"] = "mutated locally"
+    second = to_responses_input(iface, replay_raw_output_items=True)
+
+    assert second[1:4] == raw_items
+    assert second[1]["phase"] == "commentary"
+    assert second[4] == {
+        "type": "function_call_output",
+        "call_id": "call_raw",
+        "output": '{"ok": true}',
+    }
+
+
+def test_responses_input_invalidates_raw_items_when_canonical_content_changes():
+    iface = ChatInterface()
+    iface.add_user_message("start")
+    blocks = [ThinkingBlock(text="old summary"), TextBlock(text="old text")]
+    iface.add_assistant_message(
+        blocks,
+        provider_data={
+            "openai_responses_output_items": [
+                {
+                    "type": "message",
+                    "phase": "commentary",
+                    "content": [{"type": "output_text", "text": "old text"}],
+                },
+            ],
+            "openai_responses_replay_fingerprint": _responses_replay_fingerprint(blocks),
+        },
+    )
+    blocks[1].text = "edited text"
+
+    assert to_responses_input(iface, replay_raw_output_items=True) == [
+        {"role": "user", "content": "start"},
+        {
+            "type": "reasoning",
+            "summary": [{"type": "summary_text", "text": "old summary"}],
+        },
+        {"role": "assistant", "content": "edited text"},
+    ]
+
+
+@pytest.mark.parametrize("bad_leaf", [object(), float("nan"), {1: "non-string key"}])
+def test_responses_input_rejects_non_json_raw_snapshot_leaves(bad_leaf):
+    iface = ChatInterface()
+    blocks = [TextBlock(text="visible")]
+    iface.add_assistant_message(
+        blocks,
+        provider_data={
+            "openai_responses_output_items": [
+                {
+                    "type": "message",
+                    "content": [{"type": "output_text", "text": bad_leaf}],
+                },
+            ],
+            "openai_responses_replay_fingerprint": _responses_replay_fingerprint(blocks),
+        },
+    )
+
+    assert to_responses_input(iface, replay_raw_output_items=True) == [
+        {"role": "assistant", "content": "visible"},
+    ]
+
+
+def test_codex_conversion_keeps_generic_raw_sidecar_opt_in_only():
+    iface = ChatInterface()
+    blocks = [TextBlock(text="visible")]
+    iface.add_assistant_message(
+        blocks,
+        provider_data={
+            "openai_responses_output_items": [
+                {
+                    "type": "message",
+                    "id": "generic_message",
+                    "phase": "commentary",
+                    "content": [{"type": "output_text", "text": "visible"}],
+                },
+            ],
+            "openai_responses_replay_fingerprint": _responses_replay_fingerprint(blocks),
+        },
+    )
+
+    generic = to_responses_input(iface, replay_raw_output_items=True)
+    adapter = CodexOpenAIAdapter(
+        api_key="fake",
+        base_url="http://fake",
+        use_responses=True,
+        force_responses=True,
+    )
+    codex = adapter.create_chat("gpt-5.5", "system", interface=iface)
+
+    assert generic[0]["phase"] == "commentary"
+    assert codex._frozen_responses_input(iface) == [
+        {"role": "assistant", "content": "visible"},
+    ]
+
+
+def test_responses_input_never_replays_redacted_raw_value():
+    iface = ChatInterface()
+    iface.add_assistant_message(
+        [ThinkingBlock(text="visible summary")],
+        provider_data={
+            "openai_responses_output_items": [
+                {
+                    "type": "reasoning",
+                    "summary": [],
+                    "encrypted_content": "<REDACTED:secret>",
+                },
+            ],
+            "openai_responses_replay_fingerprint": _responses_replay_fingerprint(
+                [ThinkingBlock(text="visible summary")]
+            ),
+        },
+    )
+
+    replay = to_responses_input(iface, replay_raw_output_items=True)
+
+    assert replay == [
+        {
+            "type": "reasoning",
+            "summary": [{"type": "summary_text", "text": "visible summary"}],
+        },
+    ]
+    assert "REDACTED" not in str(replay)


### PR DESCRIPTION
## Summary

Preserve completed, original Responses output items when a generic OpenAI-compatible stateless session replays its canonical conversation, instead of reconstructing them from normalized text/reasoning/tool blocks.

- Store an ordered, JSON-shaped raw-output snapshot on the existing assistant entry `provider_data`, bound to a fingerprint of its canonical content. No parallel conversation cache, Session ID, or pool hash-rule change.
- Replay field presence, empty/nonempty reasoning summaries, opaque reasoning, message `phase`, item order, and original function-call argument strings. Edited/redacted/stale snapshots fall back to the existing canonical converter.
- Capture complete non-stream responses and completed streaming output; reconcile item-done ordering/identity, normalize trailer-only text/tools, and avoid inserting text separators that invalidate multipart streaming replay. Failed/incomplete statuses do not acquire a complete raw snapshot.
- Keep raw replay opt-in at the internal converter seam. Generic stateless Responses and MiMo/DeepSeek opt in; native Codex retains its canonical conversion/account/transport/compaction path.
- Add focused regression coverage and update the OpenAI implementation Anatomy. This is an internal adapter/protocol change; no new public config, tool, prompt, i18n surface, or independent architectural component.

Base: `76e9810a3740343cb22109e30e9fd11a9bd4effd` (fresh `origin/main` equality checked before publication).

## Validation

Parent-owned validation; native LingTai Luna implementation/correction workers were file-only and did not claim to run tests.

The final task-local Python 3.11 runner invoked `pytest.main` with `-q -p no:cacheprovider --basetemp <isolated-task-temp>` on these exact files, with plugin autoload disabled, isolated HOME/TMP, and network/child execution denied except the three exact read-only `git ls-files` forms needed by docs checks:

```text
tests/test_custom_responses_stateless.py
tests/test_responses_converter.py
tests/test_openai_responses_streaming.py
tests/test_mimo_responses_compaction.py
tests/test_deepseek_reasoning_effort.py
tests/test_codex_raw_reasoning_replay.py
tests/test_docs_governance.py
tests/test_architecture_documents.py
```

**297 passed, 1 failed (4.58s).** The single failure is the existing architecture-reachability assertion for these two unchanged Psyche manual files:

```text
src/lingtai/intrinsic_skills/psyche-manual/reference/network-rules/SKILL.md
src/lingtai/intrinsic_skills/psyche-manual/reference/settings/SKILL.md
```

Exact clean-base docs/architecture control: **74 passed, the same 1 failure**. No unrelated orphan repair is included.

```text
python -B scripts/check_docs_governance.py --check
  OK: 400 documents (+ docs.yaml itself) validated.
git diff --check
  PASS
python -B src/lingtai/intrinsic_skills/lingtai-kernel-anatomy/scripts/check_anatomy_drift.py --check
  Six existing out-of-range citations; candidate/control output identical.
```

Actual candidate generic client + installed pool package ASGI app + mocked upstream, OpenAI SDK 2.53.0, sockets/children denied:

- Streaming and non-streaming A1/B1/A2/B2: `matched=[false,false,true,true]`, record counts `[1,2,2,2]`, exact original mixed output replay verified in both continuations.
- Recreating an unchanged canonical history: still matches, records remain 2.
- Canonical text edit, opaque-field redaction, or changed instructions: genuine misses; no redacted marker reaches the request.
- No `previous_response_id`; no pool matching-rule relaxation.

An independent read-only review held the first candidate. Its four concrete stream/JSON findings and Codex scope boundary were corrected; parent final review also fixed multipart text normalization, non-stream completion gating, fixture signatures/expectations, and the invalidation test's opt-in. This is not a claim of a second independent final-head review.

## Limits / non-goals

- Not a full-repository suite, native Windows/Linux acceptance, live-provider retry, or real CLI-process integration trial. The pool proof is actual installed code through ASGI with a mock upstream, not a network-endpoint result.
- Gateways without complete usable output evidence deliberately do not get a fidelity claim. The existing canonical fallback remains; complete but unsupported trailer-only shapes may fail rather than expose a falsely successful hidden tool turn.
- The added stream recorder is the main maintenance cost of this change; it reconciles compatible-gateway completion evidence, not pool/session scheduling.
- No Agent cutover, installation, pool-account/auth changes, merge, release, or `Lingtai-AI/lingtai#950` action is included.

Telegram: @lingtaidev1bot | Nickname: 知微
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
