### PR TITLE
fix(responses): preserve raw messages through reasoning fallback

### DIFF
--- a/src/lingtai/llm/openai/ANATOMY.md
+++ b/src/lingtai/llm/openai/ANATOMY.md
@@ -115,7 +115,7 @@ mechanism on `OpenAIAdapter` / `OpenAIChatSession` / `OpenAIResponsesSession`:
   that lack it (per-turn-unique stub via `_fallback_reasoning_for`; real captured
   `ThinkingBlock`s are never overwritten). On the Responses wire,
   `_inject_responses_reasoning_fallback` inserts per-turn-unique `reasoning`
-  input items after the first `function_call` for assistant turns that lack one.
+  input items after the first `function_call` for legacy canonical assistant text that lacks one; raw `type="message"` items and array-valued content pass through unchanged (`adapter.py:2276-2310`).
   On by default (env `LINGTAI_INJECT_REASONING_FALLBACK` to disable); an
   explicit constructor/provider-config value wins over the env.
 - `reasoning_effort_vocab` (`str`, default `openai`) — selects the retained

--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -2278,12 +2278,12 @@ def _inject_responses_reasoning_fallback(items: list[dict]) -> list[dict]:
 
     Responses items are a flat list; a single assistant turn can span
     multiple items (reasoning, text, function_call). After the first
-    ``function_call`` item we must ensure every later assistant turn
-    carries a ``reasoning`` item — the Responses analogue of
-    ``_inject_chat_reasoning_fallback``. We walk the list, track
-    whether a ``function_call`` has been seen, and for each ``assistant``
-    text item that follows a call without an immediately-preceding
-    reasoning item, insert one before it.
+    ``function_call`` item, legacy canonical assistant text can receive a
+    ``reasoning`` fallback, as in ``_inject_chat_reasoning_fallback``.
+    Raw Responses messages and array-valued content are authoritative and
+    pass through unchanged. For eligible legacy text after a call with no
+    immediately preceding reasoning item, insert a per-turn fallback.
+    Missing legacy text retains the historical empty-text fallback.
     """
     seen_function_call = False
     turn_idx = 0
@@ -2293,11 +2293,11 @@ def _inject_responses_reasoning_fallback(items: list[dict]) -> list[dict]:
             seen_function_call = True
             out.append(item)
             continue
-        if seen_function_call and item.get("role") == "assistant":
+        if (seen_function_call and item.get("role") == "assistant"
+                and item.get("type") != "message"
+                and (item.get("content") is None or isinstance(item.get("content"), str))):
+            # Only legacy text is repaired; valid raw output is never synthesized.
             turn_idx += 1
-            # Insert a fallback reasoning item before this assistant text
-            # item unless the immediately preceding item already carries
-            # reasoning (real thinking was preserved).
             if not (out and out[-1].get("type") == "reasoning"):
                 out.append(
                     _fallback_responses_reasoning_item(

--- a/tests/test_custom_responses_stateless.py
+++ b/tests/test_custom_responses_stateless.py
@@ -42,6 +42,28 @@ def _text_raw(response_id: str, text: str = "ok"):
     )
 
 
+def _text_raw_assistant_list(response_id: str, text: str):
+    """A raw output message with the SDK's assistant role and list content."""
+    return SimpleNamespace(
+        id=response_id,
+        output=[
+            SimpleNamespace(
+                type="message",
+                role="assistant",
+                content=[SimpleNamespace(type="output_text", text=text)],
+            )
+        ],
+        usage=_usage(),
+    )
+
+
+def _tool_raw_with_assistant_message_role():
+    """Raw tool turn whose output message carries the SDK role field."""
+    raw = _tool_raw()
+    raw.output[1].role = "assistant"
+    return raw
+
+
 def _tool_raw():
     return SimpleNamespace(
         id="resp_tool",
@@ -103,6 +125,94 @@ def _stream_text(response_id: str, text: str = "ok"):
         SimpleNamespace(
             type="response.completed",
             response=SimpleNamespace(id=response_id, usage=_usage()),
+        ),
+    ]
+
+
+def _stream_raw_tool_turn(response_id: str):
+    """Stream a reasoning + function-call turn with a complete raw trailer."""
+    output = [
+        SimpleNamespace(
+            type="reasoning",
+            id="rs_raw_tool",
+            summary=[SimpleNamespace(type="summary_text", text="Need tool.")],
+        ),
+        SimpleNamespace(
+            type="message",
+            id="msg_raw_tool",
+            role="assistant",
+            content=[SimpleNamespace(type="output_text", text="Checking.")],
+        ),
+        SimpleNamespace(
+            type="function_call",
+            id="fc_raw_tool",
+            call_id="call_1",
+            name="lookup",
+            arguments='{"query":"x"}',
+        ),
+    ]
+    return [
+        SimpleNamespace(
+            type="response.output_item.added",
+            item=SimpleNamespace(type="reasoning", id="rs_raw_tool"),
+        ),
+        SimpleNamespace(
+            type="response.reasoning_summary_text.delta",
+            delta="Need tool.",
+            item_id="rs_raw_tool",
+        ),
+        SimpleNamespace(
+            type="response.reasoning_summary_text.done",
+            text="Need tool.",
+            item_id="rs_raw_tool",
+        ),
+        SimpleNamespace(type="response.output_text.delta", delta="Checking."),
+        SimpleNamespace(
+            type="response.output_item.added",
+            item=SimpleNamespace(
+                type="function_call",
+                call_id="call_1",
+                name="lookup",
+            ),
+        ),
+        SimpleNamespace(
+            type="response.function_call_arguments.delta",
+            delta='{"query":"x"}',
+            item_id="call_1",
+        ),
+        SimpleNamespace(
+            type="response.output_item.done",
+            item=output[-1],
+        ),
+        SimpleNamespace(
+            type="response.completed",
+            response=SimpleNamespace(
+                id=response_id,
+                output=output,
+                usage=_usage(reasoning_tokens=2),
+            ),
+        ),
+    ]
+
+
+def _stream_raw_plain_list_turn(response_id: str, text: str = "final"):
+    output = [
+        SimpleNamespace(
+            type="message",
+            id="msg_raw_plain",
+            role="assistant",
+            content=[SimpleNamespace(type="output_text", text=text)],
+        )
+    ]
+    return [
+        SimpleNamespace(type="response.output_text.delta", delta=text),
+        SimpleNamespace(
+            type="response.completed",
+            response=SimpleNamespace(
+                id=response_id,
+                output=output,
+                usage=_usage(),
+            ),
         ),
     ]
 
@@ -928,6 +1038,105 @@ def test_custom_stream_replays_completion_output_items_without_projection_or_dup
             "output": '{"ok": true}',
         },
     ]
+
+
+@pytest.mark.parametrize("streaming", [False, True])
+def test_raw_message_without_reasoning_stays_authoritative_across_three_calls(
+    monkeypatch,
+    streaming,
+):
+    """Raw output remains an exact prefix; fallback only repairs canonical text."""
+    # This exercises the shipped default rather than an explicit opt-out.
+    monkeypatch.delenv("LINGTAI_INJECT_REASONING_FALLBACK", raising=False)
+    adapter = create_custom_adapter(
+        api_key="fake",
+        api_compat="openai",
+        base_url="https://sub2api.example/v1",
+        wire_api="responses",
+    )
+    if streaming:
+        responses = _StreamResponses([
+            _stream_raw_tool_turn("resp_1"),
+            _stream_raw_plain_list_turn("resp_2"),
+            _stream_text("resp_3", "next"),
+        ])
+    else:
+        responses = _Responses([
+            _tool_raw_with_assistant_message_role(),
+            _text_raw_assistant_list("resp_2", "final"),
+            _text_raw_assistant_list("resp_3", "next"),
+        ])
+    adapter._client = _Client(responses)
+    session = adapter.create_chat("gpt-test", "system", tools=[_tool()])
+    send = session.send_stream if streaming else session.send
+
+    first = send("start")
+    assert first.tool_calls[0].id == "call_1"
+    second = send([
+        ToolResultBlock(id="call_1", name="lookup", content={"value": 1}),
+    ])
+    assert second.text == "final"
+    send("next")
+
+    requests = adapter._client.responses.kwargs
+    assert len(requests) == 3
+    tool_request = requests[1]["input"]
+    continuation_request = requests[2]["input"]
+    # The first assistant output is replayed exactly, including item order and
+    # list-valued message content, before the real tool result.
+    assert tool_request[0] == {"role": "user", "content": "start"}
+    assert [item.get("type") for item in tool_request[1:4]] == [
+        "reasoning", "message", "function_call",
+    ]
+    assert tool_request[2]["content"] == [
+        {"type": "output_text", "text": "Checking."},
+    ]
+    assert tool_request[4] == {
+        "type": "function_call_output",
+        "call_id": "call_1",
+        "output": '{"value": 1}',
+    }
+
+    expected_plain = (
+        {
+            "type": "message",
+            "id": "msg_raw_plain",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "final"}],
+        }
+        if streaming
+        else {
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "final"}],
+        }
+    )
+    assert continuation_request == [*tool_request, expected_plain, {
+        "role": "user", "content": "next",
+    }]
+
+
+@pytest.mark.parametrize("content", ["legacy final", "", None])
+def test_reasoning_fallback_only_repairs_legacy_string_assistant_items(content):
+    raw_message = {
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "output_text", "text": "raw final"}],
+        "phase": "final_answer",
+    }
+    items = [
+        {"type": "function_call", "call_id": "c1", "name": "f1", "arguments": "{}"},
+        {"type": "function_call_output", "call_id": "c1", "output": "ok"},
+        {"role": "assistant", "content": content},
+        raw_message,
+    ]
+
+    out = openai_adapter_module._inject_responses_reasoning_fallback(items)
+
+    assert out[2]["type"] == "reasoning"
+    assert out[3] == {"role": "assistant", "content": content}
+    assert out[4] is raw_message
+    assert out[4] == raw_message
 
 
 def test_send_none_replays_pre_staged_notification_style_pair():


### PR DESCRIPTION
## Summary

Stacked on #1692 (`fix/responses-raw-replay-20260910`, base `e2d8b1a2c6a44ab3411d53272881ef1c7ef8b1de`). Do not merge independently of that base.

Preserve authoritative Responses output when the legacy reasoning fallback runs after raw replay. A tool call followed by an ordinary raw assistant message and another user turn previously reached `.replace()` on array-valued `content`, crashing before the next request. Merely flattening the array would still invent a reasoning item and break faithful replay.

The fallback now repairs only legacy canonical assistant text (including its existing empty/null behavior). Raw `type="message"` and array-valued content pass through unchanged. No pool matching changes, new flag, session cache, native Codex migration, or runtime/configuration changes.

Adds default-enabled three-call regression coverage for nonstreaming and streaming, legacy text compatibility cases, and one clarification in the existing OpenAI Anatomy.

## Validation

Parent-run in the repository Python 3.11 venv with explicit candidate source, isolated HOME/TMP, no external network/child execution apart from bounded read-only documentation inventory:

- `python -m pytest -q tests/test_custom_responses_stateless.py tests/test_deepseek_adapter.py tests/test_deepseek_reasoning_effort.py tests/test_codex_raw_reasoning_replay.py tests/test_architecture_documents.py tests/test_docs_governance.py`: **239 passed, 1 failed**. The failure is the two pre-existing unreachable Psyche manual references (`network-rules`, `settings`).
- Exact unmodified #1692 base, same docs tests/environment: **74 passed, the same 1 failed**. This is not an all-green or full-repository result.
- Actual candidate generic client → installed pool ASGI application → mocked upstream: complete three-call default-enabled streaming/tool/continuation cycle passes; exact raw prefix, matched `[false,true,true]`, one current record, pure local addition, 17-byte SSE chunking, no identifier/opaque fixture logging. Synthetic HTTP401 stops after one attempt.
- `git diff --check`: passed.
- Anatomy drift `--check`: same six existing drift items outside this change; retained rather than repaired out of scope.

### Bounded real evidence and remaining gate

- #1692 itself: eight actual nonstreaming Astra calls passed A/B interleaving, four true continuations, record replacement, encrypted reasoning/raw message replay, and content-only/config-only misses.
- This stacked candidate: **3 actual streaming calls completed**, including one pure addition tool, its result, and a further continuation. Step checks pass: matched `[false,true,true]`, record count `[1,1,1]`, exact raw replay, no extra tool execution; HTTP200 and normal stream completion for all three.
- **The overall streaming acceptance receipt is failed/incomplete**, not PASS: this tiny real workload returned only function_call/message output items, never a reasoning item, so its predeclared real-streaming reasoning-shape gate was not met. No additional requests or retries were made to manufacture coverage. Real streamed reasoning/tool combination remains unverified.
- All task CLI services stopped; old pool configuration unchanged. The resident Agent remains on #1692; no standalone-pool resident migration, merge or release is claimed.

## Scope and review

Native Luna produced the bounded source candidate; the parent reviewed it, preserved legacy empty/null behavior, and ran validation. Independent native Luna source-only review passed with no blockers; parent final validation and live limitations above remain distinct from that review. No worker was granted shell/API/Git publication authority.

Telegram: @lingtaidev1bot | Nickname: 知微
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
