### PR TITLE
fix(claude-code): isolate the CLI from ambient host MCP

### DIFF
--- a/src/lingtai/llm/claude_code/adapter.py
+++ b/src/lingtai/llm/claude_code/adapter.py
@@ -686,7 +686,10 @@ class ClaudeCodeAdapter(LLMAdapter):
         self._context_window = context_window
         self._setup_gate(max_rpm)
         # Neutral, empty cwd so the CLI does not load a project's CLAUDE.md,
-        # settings, or MCP servers (which could inject context or extra tools).
+        # settings, or *project*-level MCP servers (which could inject context
+        # or extra tools). User/global config and account-level MCP connectors
+        # ignore cwd; those are isolated separately by the --strict-mcp-config
+        # + empty --mcp-config pair emitted when the command is built.
         self._cwd = Path(tempfile.gettempdir()) / "lingtai-claude-brain"
         try:
             self._cwd.mkdir(parents=True, exist_ok=True)
@@ -889,6 +892,20 @@ class ClaudeCodeAdapter(LLMAdapter):
             cmd += ["--tools", ""]
         elif self._disallowed:
             cmd += ["--disallowedTools", *self._disallowed]
+        # Isolate the CLI from ALL ambient MCP. The neutral cwd (see __init__)
+        # only blocks *project*-level MCP; user/global config and account
+        # connectors otherwise load and inject host tools the model could call
+        # outside LingTai's JSON-action loop. ``--strict-mcp-config`` restricts
+        # the CLI to servers from ``--mcp-config``; the inline empty map supplies
+        # none. Emitted unconditionally (not gated on the built-in-tools branch
+        # above) so the ``--disallowedTools`` path is isolated too. Verified: the
+        # session ``mcp_servers`` is empty with these flags on Claude Code 2.1.260
+        # and 2.1.265 (the empty ``tools`` seen on 2.1.260 is the ``--tools ""``
+        # default path, not a strict guarantee — strict isolates MCP only). On
+        # 2.1.265 an unrecognized flag errors (exit 1), so a CLI lacking the flag
+        # is expected to fail loud rather than silently re-leak; older versions
+        # are not verified.
+        cmd += ["--strict-mcp-config", "--mcp-config", '{"mcpServers":{}}']
         if system_prompt_file is _UNSET:
             system_prompt_file = self._system_prompt_file
         if system_prompt_file:

--- a/tests/test_claude_code_adapter.py
+++ b/tests/test_claude_code_adapter.py
@@ -265,6 +265,13 @@ def test_command_includes_print_json_model_and_disables_all_builtin_tools():
     assert "--tools" in cmd
     assert cmd[cmd.index("--tools") + 1] == ""
     assert "--disallowedTools" not in cmd
+    # Host-MCP isolation: the CLI must load zero ambient MCP. The neutral cwd
+    # only blocks *project*-level MCP; --strict-mcp-config plus an inline empty
+    # --mcp-config make the session's mcp_servers empty regardless of
+    # user/global config or account connectors.
+    assert "--strict-mcp-config" in cmd
+    assert "--mcp-config" in cmd
+    assert cmd[cmd.index("--mcp-config") + 1] == '{"mcpServers":{}}'
     # prompt is piped via stdin, not argv
     assert captured["kw"]["input"]
     # Stable context (protocol/system/tools) lives in the system-prompt file
@@ -303,6 +310,36 @@ def test_explicit_disallowed_tools_keeps_disallowed_tools_flag():
     assert "--disallowedTools" in cmd
     assert "Bash" in cmd and "Read" in cmd
     assert "--tools" not in cmd
+    # Host-MCP isolation is emitted UNCONDITIONALLY, so the --disallowedTools
+    # path is isolated from ambient MCP too — not only the --tools "" default.
+    assert "--strict-mcp-config" in cmd
+    assert cmd[cmd.index("--mcp-config") + 1] == '{"mcpServers":{}}'
+
+
+def test_command_isolates_host_mcp_regardless_of_tool_mode():
+    """--strict-mcp-config + inline empty --mcp-config appear in every mode.
+
+    This is the leak fix: without it the CLI loads user/global config and
+    account connectors (verified: claude.ai connectors present in the session
+    mcp_servers on 2.1.265; empty tools/mcp_servers with the flags on
+    2.1.260/2.1.265). The two flags are a fixed pair and independent of the
+    built-in-tool disabling mode.
+    """
+    for kwargs in ({}, {"disallowed_tools": ["Bash"]}):
+        ad = ClaudeCodeAdapter(model="opus", **kwargs)
+        sess = ad.create_chat("opus", "sys", None)
+        captured = {}
+
+        def fake_run(cmd, **kw):
+            captured["cmd"] = cmd
+            return _FakeProc(stdout=_envelope('{"action":"final","text":"ok"}'))
+
+        with patch("lingtai.llm.claude_code.adapter.subprocess.run", side_effect=fake_run):
+            sess.send("hi")
+        cmd = captured["cmd"]
+        assert "--strict-mcp-config" in cmd, kwargs
+        mc = cmd.index("--mcp-config")
+        assert cmd[mc + 1] == '{"mcpServers":{}}', kwargs
 
 
 def test_append_system_prompt_mode_keeps_legacy_flag():


### PR DESCRIPTION
## Problem
The `claude-code` adapter runs the `claude` CLI with `--tools ""` (or `--disallowedTools`) but never restricts MCP. The neutral cwd in `ClaudeCodeAdapter.__init__` only blocks *project*-level MCP; user/global config and account-level connectors still load, injecting host tools the model can call **outside** LingTai's JSON-action loop. This is the host-MCP leak seen during the LingTai↔Puffo E2E.

## Fix
Emit `--strict-mcp-config --mcp-config '{"mcpServers":{}}'` **unconditionally** (right after the `--tools`/`--disallowedTools` if/elif), so the CLI session loads zero ambient MCP in every tool mode — including the explicit `--disallowedTools` path, which a default-branch-only placement would leave leaking (`_disable_all_builtin_tools = disallowed_tools is None`). On the validated path (`disallowed_tools is None`) the argv is byte-identical to the C/D-validated command. `_run_once` (adapter.py) is the package's sole CLI spawn site (both the chat `send` and one-shot `generate` paths funnel through it), so every invocation carries the flags.

## Verification (run, not asserted)
Via the CLI's own `stream-json` init manifest (`--output-format stream-json --verbose`):
- **without** the flags (adapter today): `mcp_servers = [claude.ai Gmail, Google Calendar, Google Drive]`
- **with** the flags: `mcp_servers = []`

Scope of the claim, kept precise:
- **strict isolates MCP**: with the flags the session `mcp_servers` is empty on **2.1.260** (@peter-stei, real agent workspace) and **2.1.265** (this author; host connectors evicted 3→0 — needs-auth, so this is the service-registration layer). The empty `tools` observed on 2.1.260 comes from the `--tools ""` **default** path, not from strict; strict does not by itself empty `tools` in other tool modes.
- **failure mode**: on **2.1.265**, an unrecognized flag errors (`error: unknown option`, exit 1). A CLI lacking `--strict-mcp-config` is therefore *expected* to fail loud rather than silently re-leak — but **older versions are not verified**; treat this as "unsupported ⇒ expected error", not "all old versions safe".

This is a **CLI flag behavior**, so the guarantee is pinned to the tested versions (2.1.260 + 2.1.265).

## Tests
- `test_command_includes_...disables_all_builtin_tools` and `test_explicit_disallowed_tools_keeps_disallowed_tools_flag` extended to assert the strict pair in both tool modes.
- New `test_command_isolates_host_mcp_regardless_of_tool_mode`.
- `tests/test_claude_code_adapter.py` + `tests/test_claude_code_effort.py`: **56 passed**.

## Anatomy / Contract
No structural or interface-graph change (two static command flags); governed like the sibling `--tools ""` behavior via code comment + adapter command tests (no local `llm/CONTRACT.md`). `tests/test_architecture_documents.py`: a **pre-existing, unrelated** failure (`test_every_tracked_file_climbs_the_anatomy_graph`, two `psyche-manual/reference/**/SKILL.md` files) reproduces on the untouched `origin/main@76e9810a` base with my files reverted; the other 4 checks pass.

Base: `origin/main@76e9810a`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
