### PR TITLE
fix(telegram): add Async Work icon

### DIFF
--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -274,7 +274,7 @@ def _telegram_task_card_html(text: str) -> str:
                     rows = identity_rows(payload)
                 else:
                     rows = [f"<b>Status</b> · {html_escape(payload, quote=False)}"]
-                rendered.extend((heading, *rows))
+                rendered.extend((f"⚙️ {heading}" if section == "async" else heading, *rows))
                 previous_metadata_section = section
                 continue
             if previous_metadata_section == "async":

--- a/tests/test_task_card_event_projection_shared.py
+++ b/tests/test_task_card_event_projection_shared.py
@@ -165,7 +165,7 @@ def test_shared_render_stays_unchanged_while_telegram_relayouts_metadata() -> No
         "<b>Device</b> · dev-1\n"
         "<b>Path</b> · <code>/tmp/taskcard</code>\n"
         "\n"
-        "<b>ASYNC WORK</b>\n"
+        "⚙️ <b>ASYNC WORK</b>\n"
         "<b>Status</b> · running 1\n"
         "🕒 Last Updated: 02:30:00 U+8\n"
         "💬 <i>Ask agent for \"Task Card\"</i>"


### PR DESCRIPTION
## Summary
- add a ⚙️ icon before Telegram's **Async Work** Task Card header
- apply the same Telegram-only heading treatment to English and Chinese frames
- update the owning exact HTML expectation while leaving shared Task Card text unchanged

## Validation
- direct English/Chinese Telegram converter smoke: PASS
- `python -m py_compile src/lingtai/mcp_servers/telegram/manager.py`: PASS
- `git diff --check`: PASS
- focused pytest was not runnable in the current runtime environment because it does not include `pytest` (`No module named pytest`); CI remains the authoritative full check