### PR TITLE
fix(openai): retain original Responses stream completion metadata

### DIFF
--- a/src/lingtai/llm/openai/ANATOMY.md
+++ b/src/lingtai/llm/openai/ANATOMY.md
@@ -81,7 +81,7 @@ OpenAI adapter — wraps the `openai` SDK for Chat Completions and Responses API
 | `_handle_responses_reasoning_event()` | `adapter.py:1492` | Responses stream reasoning-summary event handler; accumulates `summary_text` deltas/done fallback without raw reasoning text |
 | `_parse_responses_api_response()` | `adapter.py:2023` | Responses API output → `LLMResponse` (handles `message`, `function_call`, `reasoning` output items) |
 | `_decode_responses_sse_text()` | `adapter.py:2079` | Strictly decodes a completed SSE body when a compatible gateway ignores a non-streaming Responses request and the SDK exposes the body as `str`; malformed/non-SSE strings fail loud. |
-| `_consume_responses_stream()` | `adapter.py:2141` | Shared Responses event accumulator for normal SDK streams and locally decoded forced-SSE bodies; returns the finalized response plus response id without a second provider request. |
+| `_consume_responses_stream()` | `adapter.py:2141` | Shared Responses event accumulator for normal SDK streams and locally decoded forced-SSE bodies; returns the finalized response plus response id without a second provider request. The original `response.completed.response` object is retained transiently in `LLMResponse.raw`, matching non-streaming access to usage detail, field presence, and provider extensions; it is not copied into canonical replay or `UsageMetadata.extra`. |
 | `_ResponsesStreamOutputRecorder` | `adapter.py:1621` | Records complete ordered output items from a response trailer or all item-done events; incomplete streams do not commit raw replay metadata. |
 
 ## Connections

--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -2145,6 +2145,7 @@ def _consume_responses_stream(
     """Consume typed SDK events or locally decoded Responses SSE events."""
     acc = StreamingAccumulator()
     response_id = None
+    raw_response = None
     usage = UsageMetadata()
     seen_reasoning_summary_items: set[str] = set()
     output_recorder = _ResponsesStreamOutputRecorder()
@@ -2181,6 +2182,7 @@ def _consume_responses_stream(
                 acc.set_tool_args_if_empty(getattr(event.item, "arguments", None))
                 acc.finish_tool()
         elif event.type == "response.completed":
+            raw_response = getattr(event, "response", None)
             # Locally decoded gateway SSE is raw JSON, not an SDK model: every
             # field here is optional and must be probed, never dotted.
             raw_usage = getattr(getattr(event, "response", None), "usage", None)
@@ -2222,6 +2224,9 @@ def _consume_responses_stream(
     # Keep the raw replay candidate private to this transient response. The
     # stateless session records it only after the whole stream has finalized;
     # incomplete/error streams therefore cannot commit partial raw history.
+    # Match non-streaming LLMResponse.raw without projecting provider metadata
+    # into canonical history or the safe token-ledger extension.
+    response.raw = raw_response
     setattr(response, "_openai_responses_output_items", output_items)
     return response, response_id
 

--- a/tests/test_openai_responses_streaming.py
+++ b/tests/test_openai_responses_streaming.py
@@ -721,3 +721,71 @@ def test_openai_responses_stream_captures_summary_thoughts():
     result = session.send_stream("think")
 
     assert result.thoughts == ["I should call the report tool."]
+
+
+@pytest.mark.parametrize("cached", ["absent", None, 0, 8192])
+@pytest.mark.parametrize("wire", ["sdk", "forced_sse"])
+def test_responses_stream_preserves_original_completion_metadata(cached, wire):
+    from openai._models import construct_type
+    from openai.types.responses import Response
+    from lingtai.llm.openai.adapter import (
+        _consume_responses_stream, _decode_responses_sse_text,
+        _parse_responses_api_response,
+    )
+
+    details = {} if cached == "absent" else {"cached_tokens": cached}
+    body = {
+        "id": "resp_metadata", "status": "completed", "model": "returned-model",
+        "service_tier": "default", "metadata": {"probe": "not logged"},
+        "output": [{"type": "message", "role": "assistant", "content": [
+            {"type": "output_text", "text": "hello", "annotations": []},
+        ]}],
+        "usage": {
+            "input_tokens": 10000, "output_tokens": 32, "total_tokens": 10032,
+            "input_tokens_details": details,
+            "output_tokens_details": {"reasoning_tokens": 11},
+            "provider_extension": {"sentinel": 17},
+        },
+    }
+    if wire == "sdk":
+        raw = construct_type(type_=Response, value=body)
+        events = [Event("response.completed", response=raw)]
+    else:
+        events = _decode_responses_sse_text(
+            "event: response.completed\ndata: "
+            + json.dumps({"type": "response.completed", "response": body}) + "\n\n"
+        )
+        raw = events[0].response
+    response, response_id = _consume_responses_stream(events)
+    nonstream = _parse_responses_api_response(raw)
+    assert response.raw is raw
+    assert response.raw is nonstream.raw
+    assert response_id == raw.id
+    assert response.usage == nonstream.usage
+    assert response.usage.cached_tokens == (8192 if cached == 8192 else 0)
+    assert response.usage.thinking_tokens == 11
+    assert response.raw.usage.total_tokens == 10032
+    assert response.raw.model == "returned-model"
+    assert response.raw.service_tier == "default"
+    detail = response.raw.usage.input_tokens_details
+    if cached == "absent":
+        fields = getattr(detail, "model_fields_set", vars(detail))
+        assert "cached_tokens" not in fields
+    else:
+        assert detail.cached_tokens == cached
+    # Original metadata stays transient: never copy raw response/request data
+    # into the safe per-call token-ledger extension or canonical replay items.
+    assert response.usage.extra == {}
+    assert "usage" not in response._openai_responses_output_items[0]
+
+
+def test_responses_stream_without_completion_does_not_invent_raw_response():
+    from lingtai.llm.openai.adapter import _consume_responses_stream
+
+    response, response_id = _consume_responses_stream([
+        Event("response.created", response=SimpleNamespace(id="resp_partial")),
+        Event("response.output_text.delta", delta="partial"),
+    ])
+    assert response.text == "partial"
+    assert response_id == "resp_partial"
+    assert response.raw is None


### PR DESCRIPTION
## Summary
- Preserve the original `response.completed.response` object in `LLMResponse.raw` for generic Responses streaming and locally decoded forced-SSE replies, matching non-streaming access.
- Keep provider usage detail, field presence (`absent` / `null` / explicit `0`), model/tier and extension metadata available to the caller without rewriting normalized counters.
- Leave raw metadata out of canonical replay and `UsageMetadata.extra`; no request/response logging, cache policy, provider configuration, or live runtime change.

This is an information-access fix, **not a cache-hit or quota-saving fix**. A separate synthetic offline HTTP/SSE→proxy→kernel probe confirmed nonzero cached/reasoning counts already survive normalization. The change does not explain an upstream explicitly reporting zero cache.

## Validation
Executed using the existing task Python3.11 virtualenv (`P`), from the isolated candidate checkout:
```sh
"$P" -m pytest -q tests/test_openai_responses_streaming.py -k 'preserves_original_completion_metadata or without_completion_does_not_invent'
# Before production change: 8 failed, 1 passed (expected missing raw object).
"$P" -m pytest -q tests/test_openai_responses_streaming.py
# After change: 51 passed.
"$P" -m pytest -q tests/test_openai_responses_streaming.py tests/test_custom_responses_stateless.py tests/test_openai_compact_threshold.py tests/test_openai_prompt_cache_key.py tests/test_responses_converter.py
# 143 passed.
"$P" -m pytest -q tests/test_architecture_documents.py tests/test_docs_governance.py
# Candidate: 74 passed, 1 failed. Untouched exact base 953a2cce: same 74 passed / same failure.
# Failure: existing unreachable Psyche manual reference/network-rules and reference/settings files.
"$P" scripts/check_docs_governance.py --check
# OK: 400 documents (+ docs.yaml itself) validated.
"$P" src/lingtai/intrinsic_skills/lingtai-kernel-anatomy/scripts/check_anatomy_drift.py --check --root src/lingtai/llm/openai
# No anatomy drift found across 1 file.
git diff --check
# passed
```
- SDK and forced-SSE regressions cover missing/null/zero/nonzero cached counts, preserved reasoning counts and no invented raw response when completion is absent.
- Owning Anatomy checked/updated; no new governed component, Port or replay/ledger behavior. No public i18n surface added.
- No real-provider cache experiment, deployment, runtime refresh or full-suite claim belongs to this patch's acceptance.

Telegram: @lingtaidev2bot | Nickname: 观一
Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
