### PR TITLE
fix(telegram): ignore rendered Task Card clock ticks

### DIFF
--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -3544,7 +3544,7 @@ class TelegramManager:
         session_prefixes = ("Session · ", "会话 · ")
         stable_lines: list[str] = []
         for line in automatic.splitlines():
-            if line.startswith(time_prefixes):
+            if line.removeprefix("🕒 ").startswith(time_prefixes):
                 continue
             if line.startswith(session_prefixes):
                 line = re.sub(

--- a/src/lingtai/mcp_servers/telegram/task_card/CONTRACT.md
+++ b/src/lingtai/mcp_servers/telegram/task_card/CONTRACT.md
@@ -1,6 +1,6 @@
 ---
 name: telegram-task-card-projection
-contract_version: 9
+contract_version: 10
 root_contract: CONTRACT.md
 related_files:
   - src/lingtai/mcp_servers/telegram/task_card/ANATOMY.md
@@ -200,6 +200,15 @@ this component.
     exact static HTML lines, so dynamic text never becomes markup; programmable
     HTML is producer-authored and is not rewritten by Telegram. Non-Telegram
     consumers keep the shared Markdown frame unchanged.
+15. Automatic Task Card transport must remain diff-only on meaningful content.
+    Its stable fingerprint excludes only the renderer-owned wall-clock
+    `Last Updated` field (whether raw or wrapped in Telegram's exact static
+    presentation prefix) and the numeric seconds in the canonical active-session
+    field; lifecycle and every other row, footer, and metadata change remain
+    transport-visible. Renderer HTML or emoji decoration must never turn those
+    volatile-only ticks back into edits. This is rate-limit-critical behavior:
+    regressing it produces no-op Bot API writes on every projection poll and can
+    trigger Telegram `429 Too Many Requests` throttling.
 
 ## Tests
 


### PR DESCRIPTION
## Summary

- ignore Telegram's exact static `🕒 ` decorator before applying the existing locale-owned `Last Updated` fingerprint rule
- preserve the existing 5-second observation path and immediate edits for real content changes
- codify this rate-limit-critical invariant in the owning Telegram Task Card contract so renderer decoration cannot reintroduce no-op edits and Telegram 429 pressure

## Validation

- [x] `git diff --check`
- [x] `/Users/huangzesen/work/GitHub/lingtai-kernel/.venv/bin/python -m pytest -q tests/test_telegram_task_card_event_tail.py::test_active_seconds_tick_does_not_edit_after_interval tests/test_telegram_task_card_event_tail.py::test_fingerprint_ignores_only_wall_clock_ticks` — 2 passed
- [x] disposable production-HTML fingerprint probe — timestamp-only change deduped; content change retained
- [x] `/Users/huangzesen/work/GitHub/lingtai-kernel/.venv/bin/python -m py_compile src/lingtai/mcp_servers/telegram/manager.py`
- [x] `/Users/huangzesen/work/GitHub/lingtai-kernel/.venv/bin/python scripts/check_docs_governance.py --check` — 400 documents plus `docs.yaml` validated
- [x] `/Users/huangzesen/work/GitHub/lingtai-kernel/.venv/bin/python -m pytest -q tests/test_docs_governance.py` — 70 passed
- [ ] `tests/test_architecture_documents.py` — 74 passed, 1 failed on the same three unrelated exact-base orphan paths; no candidate-only drift

## Notes

- No tests were added, per maintainer direction.
- No cadence, timer, retry, configuration, or unrelated Task Card behavior changed.
- Dev-3 is live on the production-code commit for maintainer inspection; this follow-up commit changes only the owning contract, so no second refresh is needed.

Telegram: @lingtaidev3bot | Nickname: 澄一

Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
