### PR TITLE
feat(telegram): default Task Cards on with three rows

### DIFF
--- a/src/lingtai/mcp_servers/telegram/SKILL.md
+++ b/src/lingtai/mcp_servers/telegram/SKILL.md
@@ -251,7 +251,7 @@ and fully restart the MCP.
 stopping mechanics. Use `/taskcard on|off`, then `/taskcard` and SHOW.
 
 ### Task Card normal rows
-`automatic.normal_rows` is the rolling API-call-group window (default `1`,
+`automatic.normal_rows` is the rolling API-call-group window (default `3`,
 accepted `1..10`), not a tool-row count. Use `/taskcard N` and SHOW;
 compatibility `max_refreshes` is not an active Telegram runtime ceiling.
 

--- a/src/lingtai/mcp_servers/telegram/account.py
+++ b/src/lingtai/mcp_servers/telegram/account.py
@@ -188,7 +188,7 @@ class TelegramAccount:
         # this account is one of several Telegram bots/chats.
         self._taskcard_enabled = taskcard_enabled or (lambda: True)
         self._set_taskcard_enabled = set_taskcard_enabled
-        self._taskcard_normal_rows = taskcard_normal_rows or (lambda: 1)
+        self._taskcard_normal_rows = taskcard_normal_rows or (lambda: 3)
         self._set_taskcard_normal_rows = set_taskcard_normal_rows
         self._taskcard_locale = taskcard_locale or (lambda: "en")
         self._set_taskcard_locale = set_taskcard_locale

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -50,6 +50,7 @@ from . import _family
 from . import updates as tg_updates
 from .plugin import TELEGRAM_PLUGIN
 from .account import TelegramRateLimitError
+from .service import _TASKCARD_DEFAULT_NORMAL_ROWS
 
 if TYPE_CHECKING:
     from lingtai.kernel.notification_store import NotificationStorePort
@@ -154,7 +155,7 @@ _TELEGRAM_TASK_CARD_PARSE_MODE = "HTML"
 # "current: X" suffix is appended per-render from the manager's live
 # normal-row setting; see ``_task_card_footer``.
 _TASK_CARD_FOOTER = TaskCardEventProjection.FOOTER
-_TASK_CARD_DEFAULT_NORMAL_ROWS = TaskCardEventProjection.DEFAULT_NORMAL_ROWS
+_TASK_CARD_DEFAULT_NORMAL_ROWS = _TASKCARD_DEFAULT_NORMAL_ROWS
 _TASK_CARD_METADATA_MAX_CHARS = TaskCardEventProjection.METADATA_MAX_CHARS
 
 # Canonical AgentState values that render without a /refresh hint; "stuck" is
@@ -189,6 +190,10 @@ def _telegram_task_card_html(text: str) -> str:
     asks = {
         'Ask agent for "Task Card"': 'Ask agent for "Task Card"',
         '向 agent 询问 "Task Card"': '向 agent 询问 "Task Card"',
+    }
+    settings_hints = {
+        'Ask agent for "Task Card"': 'Settings: /taskcard on|off · /taskcard N (1-10)',
+        '向 agent 询问 "Task Card"': '设置: /taskcard on|off · /taskcard N (1-10)',
     }
     metadata_prefixes = (
         ("Session · ", "📊 <b>SESSION</b>", "session"),
@@ -295,7 +300,8 @@ def _telegram_task_card_html(text: str) -> str:
         if line in headers:
             safe = f"📋 <b>{headers[line]}</b>"
         elif line in asks:
-            safe = f"💬 <i>{html_escape(asks[line], quote=False)}</i>"
+            rendered.append(f"💬 <i>{html_escape(asks[line], quote=False)}</i>")
+            safe = f"⚙️ <i>{html_escape(settings_hints[line], quote=False)}</i>"
         elif line.startswith(("Last Updated: ", "最后更新: ")):
             safe = f"🕒 {safe}"
         rendered.append(safe)

--- a/src/lingtai/mcp_servers/telegram/service.py
+++ b/src/lingtai/mcp_servers/telegram/service.py
@@ -21,7 +21,8 @@ from .account import TelegramAccount
 
 logger = logging.getLogger(__name__)
 
-_TASKCARD_DEFAULT_NORMAL_ROWS = 1
+_TASKCARD_DEFAULT_ENABLED = True
+_TASKCARD_DEFAULT_NORMAL_ROWS = 3
 _TASKCARD_MIN_NORMAL_ROWS = 1
 _TASKCARD_MAX_NORMAL_ROWS = 10
 # Both the default AND the global hard ceiling: no per-agent setting may
@@ -91,7 +92,7 @@ class TelegramService:
     @staticmethod
     def _taskcard_defaults() -> tuple[bool, int, int, str, tuple[str, ...] | None]:
         return (
-            True,
+            _TASKCARD_DEFAULT_ENABLED,
             _TASKCARD_DEFAULT_NORMAL_ROWS,
             _TASKCARD_DEFAULT_MAX_REFRESHES,
             _TASKCARD_DEFAULT_LOCALE,
@@ -105,7 +106,7 @@ class TelegramService:
         enabled = data.get("taskcard")
         if type(enabled) is not bool:
             logger.warning("Invalid Telegram taskcard state field; defaulting enabled to True")
-            enabled = True
+            enabled = _TASKCARD_DEFAULT_ENABLED
         normal_rows = data.get("normal_rows", _TASKCARD_DEFAULT_NORMAL_ROWS)
         if (
             type(normal_rows) is not int

--- a/src/lingtai/mcp_servers/telegram/settings.py
+++ b/src/lingtai/mcp_servers/telegram/settings.py
@@ -7,6 +7,10 @@ from pathlib import Path
 from typing import Any
 
 from lingtai.mcp_servers.task_card.event_projection import TaskCardEventProjection
+from lingtai.mcp_servers.telegram.service import (
+    _TASKCARD_DEFAULT_ENABLED,
+    _TASKCARD_DEFAULT_NORMAL_ROWS,
+)
 from lingtai.tools.tool_family import SettingRow, SettingsProvider
 
 DEFAULT_AUTOMATIC_POLL_INTERVAL_SECONDS = 5.0
@@ -112,11 +116,11 @@ def telegram_setting_rows(manager: Any | None) -> Iterable[SettingRow]:
             "telegram-mcp-manual#task-card-poll-interval",
         ),
         SettingRow(
-            "automatic.enabled", enabled, True, True,
+            "automatic.enabled", enabled, _TASKCARD_DEFAULT_ENABLED, True,
             "telegram-mcp-manual#task-card-delivery",
         ),
         SettingRow(
-            "automatic.normal_rows", normal_rows, 1, True,
+            "automatic.normal_rows", normal_rows, _TASKCARD_DEFAULT_NORMAL_ROWS, True,
             "telegram-mcp-manual#task-card-normal-rows",
         ),
         SettingRow(

--- a/src/lingtai/mcp_servers/telegram/task_card/CONTRACT.md
+++ b/src/lingtai/mcp_servers/telegram/task_card/CONTRACT.md
@@ -131,7 +131,9 @@ semantics live here. The public producer contract lives in
     remains authored content: its Telegram-targeted
     producer must emit valid Telegram HTML or common plain text. Invalid provider
     markup is an ordinary failed edit/send and preserves the last committed card.
-    Feishu and other consumers keep their own rendering mode.
+    Feishu and other consumers keep their own rendering mode. Telegram appends a
+    concise `/taskcard on|off` and `/taskcard N (1-10)` settings hint immediately
+    after the existing ask-agent line.
 
 ## Port
 

--- a/tests/test_task_card_event_projection_shared.py
+++ b/tests/test_task_card_event_projection_shared.py
@@ -168,7 +168,15 @@ def test_shared_render_stays_unchanged_while_telegram_relayouts_metadata() -> No
         "⚙️ <b>ASYNC WORK</b>\n"
         "<b>Status</b> · running 1\n"
         "🕒 Last Updated: 02:30:00 U+8\n"
-        "💬 <i>Ask agent for \"Task Card\"</i>"
+        "💬 <i>Ask agent for \"Task Card\"</i>\n"
+        "⚙️ <i>Settings: /taskcard on|off · /taskcard N (1-10)</i>"
+    )
+
+
+def test_telegram_html_converter_localizes_taskcard_settings_hint() -> None:
+    assert _telegram_task_card_html('向 agent 询问 "Task Card"') == (
+        '💬 <i>向 agent 询问 "Task Card"</i>\n'
+        "⚙️ <i>设置: /taskcard on|off · /taskcard N (1-10)</i>"
     )
 
 

--- a/tests/test_telegram_settings.py
+++ b/tests/test_telegram_settings.py
@@ -150,7 +150,7 @@ def test_show_returns_exact_keys_values_defaults_and_manual_pointers(
     assert rows["automatic.enabled"]["current"] is False
     assert rows["automatic.enabled"]["default"] is True
     assert rows["automatic.normal_rows"]["current"] == 4
-    assert rows["automatic.normal_rows"]["default"] == 1
+    assert rows["automatic.normal_rows"]["default"] == 3
     assert rows["automatic.locale"]["current"] == "zh"
     assert rows["automatic.locale"]["default"] == "en"
     assert rows["automatic.display_expression"]["current"] == ["footer", "header"]

--- a/tests/test_telegram_task_card_blockers.py
+++ b/tests/test_telegram_task_card_blockers.py
@@ -180,9 +180,10 @@ def test_timestamped_moderate_rows_stay_under_text_limit():
         if ln.startswith(("•", "✓")):
             assert "04:08:08 UTC-07" not in ln
     # The bottom line is the single render-time stamp, distinct from row stamps.
-    assert text.splitlines()[-2:] == [
+    assert text.splitlines()[-3:] == [
         "🕒 Last Updated: 17:18:36 U-7",
         '💬 <i>Ask agent for "Task Card"</i>',
+        "⚙️ <i>Settings: /taskcard on|off · /taskcard N (1-10)</i>",
     ]
 
 
@@ -214,9 +215,10 @@ def test_extreme_row_count_exceeds_budget_but_keeps_every_row():
     assert not text.endswith("…")
     # The fixed footer and the single render-time line still render.
     assert _TASK_CARD_FOOTER in text
-    assert text.splitlines()[-2:] == [
+    assert text.splitlines()[-3:] == [
         "🕒 Last Updated: 17:18:36 U-7",
         '💬 <i>Ask agent for "Task Card"</i>',
+        "⚙️ <i>Settings: /taskcard on|off · /taskcard N (1-10)</i>",
     ]
 
 

--- a/tests/test_telegram_task_card_display_expression.py
+++ b/tests/test_telegram_task_card_display_expression.py
@@ -143,7 +143,7 @@ def test_service_display_expression_persists_and_reloads(tmp_path: Path) -> None
     reborn = _service(tmp_path)
     assert reborn.taskcard_display_expression() == ("footer", "header")
     assert reborn.taskcard_enabled() is True
-    assert reborn.taskcard_normal_rows() == 1
+    assert reborn.taskcard_normal_rows() == 3
 
 
 def test_manager_broadcast_composes_with_custom_display_expression(
@@ -171,7 +171,7 @@ def test_manager_broadcast_composes_with_custom_display_expression(
     assert calls and calls[0][0] == "send"
     sent_text = calls[0][2]
     header = "📋 <b>ACTIVITIES</b>"
-    footer = TaskCardEventProjection.footer(1, "en").strip("_")
+    footer = TaskCardEventProjection.footer(3, "en").strip("_")
     assert sent_text == f"{footer}\n{header}"
 
 
@@ -229,7 +229,7 @@ def test_hot_reload_reaches_the_live_manager_projection(
 
     state_path = tmp_path / "telegram" / "taskcard.json"
     data = json.loads(state_path.read_text(encoding="utf-8")) if state_path.exists() else {
-        "taskcard": True, "normal_rows": 1, "max_refreshes": 1000, "locale": "en",
+        "taskcard": True, "normal_rows": 3, "max_refreshes": 1000, "locale": "en",
     }
     data["display_expression"] = ["footer", "header"]
     state_path.parent.mkdir(parents=True, exist_ok=True)
@@ -239,7 +239,7 @@ def test_hot_reload_reaches_the_live_manager_projection(
     manager._broadcast_task_card_event_window(force=True)
     assert calls
     header = "📋 <b>ACTIVITIES</b>"
-    footer = TaskCardEventProjection.footer(1, "en").strip("_")
+    footer = TaskCardEventProjection.footer(3, "en").strip("_")
     assert calls[-1][-1] == f"{footer}\n{header}"
 
 

--- a/tests/test_telegram_task_card_rows.py
+++ b/tests/test_telegram_task_card_rows.py
@@ -39,7 +39,7 @@ def test_footer_renders_with_current_row_count_suffix():
     ])
     assert (
         "Don't reply to this Task Card. Use /taskcard on|off to toggle; "
-        "/taskcard N sets normal rows (1-10, current: 1)."
+        "/taskcard N sets normal rows (1-10, current: 3)."
     ) in text
 
 

--- a/tests/test_telegram_task_card_timestamp.py
+++ b/tests/test_telegram_task_card_timestamp.py
@@ -52,9 +52,10 @@ def test_manager_renders_current_time_line_from_render_instant_not_row_start():
     ], now=_NOW)
     lines = text.splitlines()
     # The render-time stamp precedes the approved ask-agent final line.
-    assert lines[-2:] == [
+    assert lines[-3:] == [
         "🕒 Last Updated: 17:18:36 U-7",
         '💬 <i>Ask agent for "Task Card"</i>',
+        "⚙️ <i>Settings: /taskcard on|off · /taskcard N (1-10)</i>",
     ]
 
 
@@ -96,9 +97,10 @@ def test_current_time_line_present_even_when_no_row_has_a_stamp():
     assert "bash.run" in text
     # Last Updated never depends on any row carrying a stamp — it always
     # reflects the render instant.
-    assert text.splitlines()[-2:] == [
+    assert text.splitlines()[-3:] == [
         "🕒 Last Updated: 17:18:36 U-7",
         '💬 <i>Ask agent for "Task Card"</i>',
+        "⚙️ <i>Settings: /taskcard on|off · /taskcard N (1-10)</i>",
     ]
     # Tool rows never render an inline stamp even when one is supplied.
     for ln in text.splitlines():
@@ -119,7 +121,8 @@ def test_api_error_row_never_carries_a_stamp_alongside_a_tool_row():
     assert "UTC" not in bash_line
     api_line = next(ln for ln in text.splitlines() if "API error" in ln)
     assert "UTC" not in api_line
-    assert text.splitlines()[-2:] == [
+    assert text.splitlines()[-3:] == [
         "🕒 Last Updated: 17:18:36 U-7",
         '💬 <i>Ask agent for "Task Card"</i>',
+        "⚙️ <i>Settings: /taskcard on|off · /taskcard N (1-10)</i>",
     ]

--- a/tests/test_telegram_task_card_toggle.py
+++ b/tests/test_telegram_task_card_toggle.py
@@ -90,8 +90,11 @@ def test_taskcard_state_defaults_true_and_is_shared_across_accounts(tmp_path: Pa
     service = _service(tmp_path, "one", "two")
 
     assert service.taskcard_enabled() is True
+    assert service.taskcard_normal_rows() == 3
     assert service.get_account("one")._taskcard_enabled() is True
+    assert service.get_account("one")._taskcard_normal_rows() == 3
     assert service.get_account("two")._taskcard_enabled() is True
+    assert service.get_account("two")._taskcard_normal_rows() == 3
     assert not (tmp_path / "telegram" / "taskcard.json").exists()
 
 
@@ -110,7 +113,7 @@ def test_taskcard_state_persists_false_and_true_across_service_instances(tmp_pat
     state_path = tmp_path / "telegram" / "taskcard.json"
     assert json.loads(state_path.read_text(encoding="utf-8")) == {
         "taskcard": False,
-        "normal_rows": 1,
+        "normal_rows": 3,
         "max_refreshes": 1000,
         "locale": "en",
         "display_expression": None,
@@ -120,7 +123,7 @@ def test_taskcard_state_persists_false_and_true_across_service_instances(tmp_pat
     service.set_taskcard_enabled(True)
     assert json.loads(state_path.read_text(encoding="utf-8")) == {
         "taskcard": True,
-        "normal_rows": 1,
+        "normal_rows": 3,
         "max_refreshes": 1000,
         "locale": "en",
         "display_expression": None,
@@ -729,7 +732,7 @@ def test_old_message_projection_changes_with_current_state_without_record_rewrit
 
 def test_taskcard_normal_rows_persist_and_are_shared_across_accounts(tmp_path: Path) -> None:
     service = _service(tmp_path, "one", "two")
-    assert service.taskcard_normal_rows() == 1
+    assert service.taskcard_normal_rows() == 3
     service.set_taskcard_normal_rows(7)
     assert service.taskcard_normal_rows() == 7
     assert service.get_account("one")._taskcard_normal_rows() == 7
@@ -768,13 +771,13 @@ def test_taskcard_normal_rows_write_failure_preserves_memory_and_file(
     assert state_path.read_bytes() == before
 
 
-def test_taskcard_legacy_boolean_state_defaults_normal_rows_to_one(tmp_path: Path) -> None:
+def test_taskcard_legacy_boolean_state_defaults_normal_rows_to_three(tmp_path: Path) -> None:
     state_path = tmp_path / "telegram" / "taskcard.json"
     state_path.parent.mkdir(parents=True)
     state_path.write_text('{"taskcard": false}', encoding="utf-8")
     service = _service(tmp_path, "main")
     assert service.taskcard_enabled() is False
-    assert service.taskcard_normal_rows() == 1
+    assert service.taskcard_normal_rows() == 3
 
 
 def test_taskcard_numeric_command_is_strict_and_does_not_toggle(

--- a/tests/test_telegram_toolfamily_ltpv2.py
+++ b/tests/test_telegram_toolfamily_ltpv2.py
@@ -168,7 +168,7 @@ def test_taskcard_refresh_setting_defaults_invalid_values_preserves_valid_siblin
         service = TelegramService(tmp_path, [{"alias": "acct", "bot_token": "x"}], lambda *_: None)
         assert any("max_refreshes" in record.message for record in caplog.records)
         assert service.taskcard_enabled() is payload.get("taskcard", True)
-        assert service.taskcard_normal_rows() == payload.get("normal_rows", 1)
+        assert service.taskcard_normal_rows() == payload.get("normal_rows", 3)
         assert service.taskcard_max_refreshes() == 1000
         service.set_taskcard_max_refreshes(7)
         persisted = json.loads(path.read_text())


### PR DESCRIPTION
## Summary

- keep Telegram Task Cards enabled by default and make that default explicit in the service/settings owner
- default the Telegram automatic Task Card window to 3 recent API-call groups while preserving every persisted `/taskcard N` override
- add a concise `/taskcard on|off · /taskcard N (1-10)` hint immediately after “Ask agent for \"Task Card\"”
- keep the shared projection default unchanged, so Feishu and other consumers are unaffected

## Validation

- [x] `git diff --check`
- [x] `env -u PYTHONPATH /Users/huangzesen/work/GitHub/lingtai-kernel/.venv/bin/python -m pytest -q -x tests/test_telegram_task_card_toggle.py tests/test_telegram_toolfamily_ltpv2.py tests/test_telegram_settings.py tests/test_telegram_task_card_display_expression.py tests/test_telegram_task_card_rows.py tests/test_task_card_event_projection_shared.py tests/test_telegram_task_card_timestamp.py tests/test_telegram_task_card_blockers.py` — 176 passed
- [x] `env -u PYTHONPATH /Users/huangzesen/work/GitHub/lingtai-kernel/.venv/bin/python -m pytest -q -x tests/test_task_card_event_projection_shared.py` — 13 passed after the localized hint assertion was added
- [x] `env -u PYTHONPATH /Users/huangzesen/work/GitHub/lingtai-kernel/.venv/bin/python -m pytest -q -x tests/test_docs_governance.py tests/test_mcp_skill_manuals.py` — 94 passed
- [x] `env -u PYTHONPATH /Users/huangzesen/work/GitHub/lingtai-kernel/.venv/bin/python -m pytest -q tests/test_architecture_documents.py -k 'not every_tracked_file_climbs_the_anatomy_graph'` — 4 passed, 1 deselected
- [x] `env -u PYTHONPATH /Users/huangzesen/work/GitHub/lingtai-kernel/.venv/bin/python scripts/check_docs_governance.py --check` — 400 documents validated
- [x] exact-candidate import smoke — fresh service/account defaults are enabled + 3 rows, settings SHOW reports the same defaults, and the rendered hint matches

## Notes

- Current main already behaved as enabled-by-default. This PR names that Telegram-owned default explicitly and reuses it in SHOW; the behavioral default change is the row window from 1 to 3.
- The full architecture-document test stops on three pre-existing orphan files already present on exact `origin/main`; this PR changes none of those paths. Every other architecture-document test passes.
- Logs, screenshots, and examples contain no secrets.

Telegram: @lingtaidev2bot | Nickname: 观一

Powered by LingTai AI: https://github.com/Lingtai-AI/lingtai
